### PR TITLE
feat: add LogManager with channels, formatters, and level-based routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ packages/admin/.nuxt/
 packages/admin/.output/
 packages/admin/node_modules/
 
+# Storage (compiled artifacts)
+storage/
+
 # Worktrees
 .worktrees/
 

--- a/composer.lock
+++ b/composer.lock
@@ -949,6 +949,88 @@
             "time": "2024-09-25T14:21:43+00:00"
         },
         {
+            "name": "symfony/http-foundation",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-21T16:25:55+00:00"
+        },
+        {
             "name": "symfony/messenger",
             "version": "v7.4.6",
             "source": {
@@ -2303,7 +2385,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/access",
@@ -2338,7 +2420,7 @@
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/ai-agent",
@@ -2373,7 +2455,7 @@
         },
         {
             "name": "waaseyaa/ai-pipeline",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/ai-pipeline",
@@ -2408,7 +2490,7 @@
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/ai-schema",
@@ -2442,7 +2524,7 @@
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/ai-vector",
@@ -2476,7 +2558,7 @@
         },
         {
             "name": "waaseyaa/api",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/api",
@@ -2513,7 +2595,7 @@
         },
         {
             "name": "waaseyaa/cache",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/cache",
@@ -2552,7 +2634,7 @@
         },
         {
             "name": "waaseyaa/cli",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/cli",
@@ -2591,7 +2673,7 @@
         },
         {
             "name": "waaseyaa/config",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/config",
@@ -2626,7 +2708,7 @@
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/database-legacy",
@@ -2659,7 +2741,7 @@
         },
         {
             "name": "waaseyaa/entity",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/entity",
@@ -2699,7 +2781,7 @@
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/entity-storage",
@@ -2737,7 +2819,7 @@
         },
         {
             "name": "waaseyaa/field",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/field",
@@ -2773,19 +2855,21 @@
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/foundation",
-                "reference": "81b1deb9a9533186528c548d29b6944f1256f320"
+                "reference": "f8c1367c3ee576f020e31271caed8b951ab0b5dd"
             },
             "require": {
                 "doctrine/dbal": "^4.0",
                 "php": ">=8.3",
                 "symfony/dependency-injection": "^7.0",
                 "symfony/event-dispatcher": "^7.0",
+                "symfony/http-foundation": "^7.0",
                 "symfony/messenger": "^7.0",
-                "symfony/uid": "^7.0"
+                "symfony/uid": "^7.0",
+                "waaseyaa/queue": "@dev"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2811,7 +2895,7 @@
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/i18n",
@@ -2844,7 +2928,7 @@
         },
         {
             "name": "waaseyaa/mcp",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/mcp",
@@ -2881,7 +2965,7 @@
         },
         {
             "name": "waaseyaa/media",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/media",
@@ -2915,7 +2999,7 @@
         },
         {
             "name": "waaseyaa/menu",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/menu",
@@ -2949,7 +3033,7 @@
         },
         {
             "name": "waaseyaa/node",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/node",
@@ -2984,7 +3068,7 @@
         },
         {
             "name": "waaseyaa/path",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/path",
@@ -3018,7 +3102,7 @@
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/plugin",
@@ -3052,7 +3136,7 @@
         },
         {
             "name": "waaseyaa/queue",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/queue",
@@ -3086,7 +3170,7 @@
         },
         {
             "name": "waaseyaa/routing",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/routing",
@@ -3123,7 +3207,7 @@
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/ssr",
@@ -3159,7 +3243,7 @@
         },
         {
             "name": "waaseyaa/state",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/state",
@@ -3193,7 +3277,7 @@
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/taxonomy",
@@ -3228,7 +3312,7 @@
         },
         {
             "name": "waaseyaa/telescope",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/telescope",
@@ -3261,7 +3345,7 @@
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/typed-data",
@@ -3295,7 +3379,7 @@
         },
         {
             "name": "waaseyaa/user",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/user",
@@ -3330,7 +3414,7 @@
         },
         {
             "name": "waaseyaa/validation",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/validation",
@@ -3366,7 +3450,7 @@
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/workflows",
@@ -5124,7 +5208,7 @@
         },
         {
             "name": "waaseyaa/testing",
-            "version": "dev-refactor/aurora-to-waaseyaa",
+            "version": "dev-feature/laravel-integration",
             "dist": {
                 "type": "path",
                 "url": "packages/testing",

--- a/docs/plans/2026-03-01-laravel-integration-layer-design.md
+++ b/docs/plans/2026-03-01-laravel-integration-layer-design.md
@@ -1,0 +1,432 @@
+# Laravel Integration Layer Design
+
+**Date:** 2026-03-01
+**Status:** Approved
+**Scope:** Package auto-discovery, middleware pipelines, config caching
+
+## Context
+
+Waaseyaa absorbed many Laravel 12 patterns implicitly (service providers, typed config, attribute routing, queue semantics, typed entities, component rendering, CLI scaffolding, real-time broadcasting). Three high-leverage improvements remain unaddressed:
+
+1. **Package auto-discovery** — self-registering packages via manifests + attribute scanning
+2. **Middleware everywhere** — typed middleware pipelines for HTTP, events, and jobs
+3. **Config caching** — compiled config for zero-parse production boot
+
+These are foundational and compound across everything else in the architecture.
+
+## Approach: Separate Compilers, CLI-driven Build Step
+
+Three focused compilers, each independently invocable, orchestrated by `waaseyaa optimize`:
+
+| Feature | Compiler | Artifact |
+|---------|----------|----------|
+| Package auto-discovery | `PackageManifestCompiler` | `storage/framework/packages.php` |
+| Middleware stacks | `MiddlewarePipelineCompiler` | `storage/framework/middleware.php` |
+| Config cache | `ConfigCacheCompiler` | `storage/framework/config.php` |
+
+Dev: auto-compilation on first use. Prod: `waaseyaa optimize` pre-compiles everything.
+
+## 1. Package Auto-Discovery
+
+### Manifest format (coarse-grained)
+
+Extends existing `extra.waaseyaa` in each package's `composer.json`:
+
+```json
+{
+  "extra": {
+    "waaseyaa": {
+      "providers": ["Waaseyaa\\Node\\NodeServiceProvider"],
+      "commands": ["Waaseyaa\\Node\\Command\\NodeCreateCommand"],
+      "routes": ["Waaseyaa\\Node\\NodeRouteProvider"],
+      "migrations": "migrations/",
+      "config": "config/"
+    }
+  }
+}
+```
+
+### Attribute scanning (fine-grained)
+
+PHP 8 attributes on classes, scanned at compile time within declared autoload namespaces:
+
+```php
+#[AsFieldType(id: 'text', label: 'Text')]
+final class TextField implements FieldTypeInterface { ... }
+
+#[AsListener(event: EntitySaved::class)]
+final class InvalidateCacheOnSave { ... }
+
+#[AsMiddleware(pipeline: 'http', priority: 100)]
+final class TenantResolverMiddleware implements HttpMiddlewareInterface { ... }
+```
+
+### PackageManifestCompiler
+
+- Reads `vendor/composer/installed.json` for manifest declarations
+- Scans declared autoload namespaces for PHP 8 attributes
+- Produces `storage/framework/packages.php`
+- Returns typed `PackageManifest` object
+
+Cached artifact structure:
+
+```php
+return [
+    'providers' => ['Waaseyaa\\Node\\NodeServiceProvider', ...],
+    'commands' => ['Waaseyaa\\Node\\Command\\NodeCreateCommand', ...],
+    'routes' => ['Waaseyaa\\Node\\NodeRouteProvider', ...],
+    'migrations' => ['waaseyaa/node' => '/path/to/migrations/', ...],
+    'field_types' => ['text' => 'Waaseyaa\\Field\\Plugin\\TextField', ...],
+    'listeners' => [
+        'Waaseyaa\\Entity\\Event\\EntitySaved' => [
+            ['class' => 'Waaseyaa\\Cache\\Listener\\InvalidateCacheOnSave', 'priority' => 0],
+        ],
+    ],
+    'middleware' => [
+        'http' => [['class' => '...', 'priority' => 100], ...],
+        'event' => [['class' => '...', 'priority' => 50], ...],
+        'job' => [['class' => '...', 'priority' => 50], ...],
+    ],
+];
+```
+
+### File locations
+
+- `packages/foundation/src/Discovery/PackageManifestCompiler.php`
+- `packages/foundation/src/Discovery/PackageManifest.php`
+- `packages/foundation/src/Attribute/AsCommand.php`
+- `packages/foundation/src/Attribute/AsEntityType.php`
+- `packages/foundation/src/Attribute/AsFieldType.php`
+- `packages/foundation/src/Attribute/AsListener.php`
+- `packages/foundation/src/Attribute/AsMiddleware.php`
+
+### Backwards compatibility
+
+`ProviderDiscovery` is preserved as-is. The new compiler delegates to it for provider discovery and extends the result with additional manifest keys.
+
+### Dev vs. prod
+
+- **Dev:** `PackageManifest::load()` checks for `packages.php`. Compiles on first access if missing.
+- **Prod:** `waaseyaa optimize` pre-compiles. Missing cache throws exception.
+
+## 2. Middleware Pipelines
+
+### Design constraint
+
+Separate typed interfaces per pipeline (HTTP, event, job). Same structural pattern (process + next), but type-safe for each context. No accidental cross-pipeline wiring.
+
+### Interfaces
+
+```php
+// HTTP
+interface HttpMiddlewareInterface {
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}
+interface HttpHandlerInterface {
+    public function handle(Request $request): Response;
+}
+
+// Events
+interface EventMiddlewareInterface {
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}
+interface EventHandlerInterface {
+    public function handle(DomainEvent $event): void;
+}
+
+// Jobs
+interface JobMiddlewareInterface {
+    public function process(Job $job, JobNextHandlerInterface $next): void;
+}
+interface JobNextHandlerInterface {
+    public function handle(Job $job): void;
+}
+```
+
+### Pipeline classes
+
+One per type (`HttpPipeline`, `EventPipeline`, `JobPipeline`). Each composes a stack of middleware around a final handler using the onion pattern:
+
+```php
+final class HttpPipeline
+{
+    /** @param HttpMiddlewareInterface[] $middleware */
+    public function __construct(private readonly array $middleware) {}
+
+    public function handle(Request $request, HttpHandlerInterface $finalHandler): Response
+    {
+        $handler = $finalHandler;
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements HttpHandlerInterface {
+                public function __construct(
+                    private readonly HttpMiddlewareInterface $middleware,
+                    private readonly HttpHandlerInterface $next,
+                ) {}
+                public function handle(Request $request): Response {
+                    return $this->middleware->process($request, $this->next);
+                }
+            };
+        }
+        return $handler->handle($request);
+    }
+}
+```
+
+### EventBus integration
+
+Event middleware wraps around the sync dispatch in `EventBus::dispatch()`:
+
+```php
+public function dispatch(DomainEvent $event): void
+{
+    $this->eventStore?->append($event);
+    $this->eventPipeline->handle($event, new class($this->syncDispatcher) implements EventHandlerInterface {
+        public function handle(DomainEvent $event): void {
+            $this->syncDispatcher->dispatch($event);
+        }
+    });
+    $this->asyncBus->dispatch($event);
+    $this->broadcaster->broadcast($event);
+}
+```
+
+### JobHandler integration
+
+Job middleware wraps around `Job::handle()` in `JobHandler`:
+
+```php
+public function handle(object $message): void
+{
+    $message->incrementAttempts();
+    $this->jobPipeline->handle($message, new class implements JobNextHandlerInterface {
+        public function handle(Job $job): void {
+            $job->handle();
+        }
+    });
+}
+```
+
+### Built-in middleware
+
+| Middleware | Pipeline | Purpose |
+|-----------|----------|---------|
+| `TenantScopeMiddleware` | event, job | Ensures tenant context is set |
+| `LogContextMiddleware` | event, job | Adds structured log context |
+| `ThrottleMiddleware` | job | Rate limits job execution |
+| `UniqueJobMiddleware` | job | Prevents duplicate dispatch |
+| `WithoutOverlappingMiddleware` | job | Mutex lock on job key |
+| `TenantResolverMiddleware` | http | Resolves tenant from request |
+| `LanguageNegotiatorMiddleware` | http | Sets language from Accept-Language |
+
+### Registration
+
+Two paths, both discovered by the manifest compiler:
+
+1. **Attribute** (auto-discovered): `#[AsMiddleware(pipeline: 'event', priority: 50)]`
+2. **Service provider tag** (explicit): `$this->tag(LogContextMiddleware::class, 'middleware.event')`
+
+### Compiled artifact
+
+`storage/framework/middleware.php` — middleware pre-sorted by priority:
+
+```php
+return [
+    'http' => [
+        ['class' => 'Waaseyaa\\...\\TenantResolverMiddleware', 'priority' => 100],
+        ['class' => 'Waaseyaa\\...\\LanguageNegotiatorMiddleware', 'priority' => 90],
+    ],
+    'event' => [
+        ['class' => 'Waaseyaa\\...\\TenantScopeMiddleware', 'priority' => 100],
+        ['class' => 'Waaseyaa\\...\\LogContextMiddleware', 'priority' => 50],
+    ],
+    'job' => [
+        ['class' => 'Waaseyaa\\...\\TenantScopeMiddleware', 'priority' => 100],
+        ['class' => 'Waaseyaa\\...\\ThrottleMiddleware', 'priority' => 90],
+    ],
+];
+```
+
+### File locations
+
+- `packages/foundation/src/Middleware/HttpMiddlewareInterface.php`
+- `packages/foundation/src/Middleware/HttpHandlerInterface.php`
+- `packages/foundation/src/Middleware/HttpPipeline.php`
+- `packages/foundation/src/Middleware/EventMiddlewareInterface.php`
+- `packages/foundation/src/Middleware/EventHandlerInterface.php`
+- `packages/foundation/src/Middleware/EventPipeline.php`
+- `packages/foundation/src/Middleware/JobMiddlewareInterface.php`
+- `packages/foundation/src/Middleware/JobNextHandlerInterface.php`
+- `packages/foundation/src/Middleware/JobPipeline.php`
+- `packages/foundation/src/Middleware/MiddlewarePipelineCompiler.php`
+- `packages/foundation/src/Middleware/Builtin/TenantScopeMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/TenantResolverMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/LogContextMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/LanguageNegotiatorMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/ThrottleMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/UniqueJobMiddleware.php`
+- `packages/foundation/src/Middleware/Builtin/WithoutOverlappingMiddleware.php`
+
+## 3. Config Caching
+
+### ConfigCacheCompiler
+
+- Reads all config from active storage
+- Resolves environment overrides (WAASEYAA_CONFIG__* env vars)
+- Validates against config schemas (optional)
+- Produces `storage/framework/config.php`
+
+### Cached artifact
+
+Single PHP file returning a flat associative array:
+
+```php
+return [
+    'system.site' => ['name' => 'My Site', 'slogan' => '...', 'langcode' => 'en'],
+    'node.type.article' => ['id' => 'article', 'label' => 'Article', ...],
+    'user.settings' => ['register' => 'visitors', ...],
+];
+```
+
+One `opcache_compile_file()` puts it in shared memory. No YAML parsing, no file I/O.
+
+### CachedConfigFactory (decorator)
+
+Wraps existing `ConfigFactory` with cache awareness:
+
+```php
+final class CachedConfigFactory implements ConfigFactoryInterface
+{
+    private ?array $cache = null;
+
+    public function __construct(
+        private readonly ConfigFactoryInterface $inner,
+        private readonly string $cachePath,
+    ) {}
+
+    public function get(string $name): ConfigInterface
+    {
+        if ($this->cache === null) {
+            $this->cache = $this->loadCache();
+        }
+        if ($this->cache !== null && isset($this->cache[$name])) {
+            return new Config($name, $this->cache[$name]);
+        }
+        return $this->inner->get($name);
+    }
+
+    private function loadCache(): ?array
+    {
+        $path = $this->cachePath . '/config.php';
+        return is_file($path) ? require $path : null;
+    }
+}
+```
+
+### Environment override convention
+
+```
+WAASEYAA_CONFIG__SYSTEM_SITE__NAME="Production Site"
+```
+
+Double underscore `__` separates config name from key path. The compiler bakes resolved values into the cached array.
+
+### Cache invalidation
+
+1. `waaseyaa optimize:clear` — deletes cache file
+2. `ConfigManager::import()` — auto-deletes cache via `ConfigEvent::IMPORT` listener
+3. Any config write — `ConfigCacheInvalidator` listener deletes cache on `ConfigEvent` dispatch
+
+### Multi-tenancy seam
+
+Cache path includes optional tenant prefix:
+
+```
+storage/framework/config.php                # default
+storage/framework/config.tenant-abc.php     # tenant overlay
+```
+
+`CachedConfigFactory` checks tenant-specific cache first, then default. Seam is ready; single-tenant initially.
+
+### Dev vs. prod
+
+| Scenario | Behavior |
+|----------|----------|
+| Dev, no cache | Falls through to FileStorage |
+| Dev, cache exists | Uses cache, auto-invalidated on write |
+| Prod, no cache | Exception: run `waaseyaa optimize` |
+| Prod, cache exists | Single `require`, no file I/O |
+
+### File locations
+
+- `packages/config/src/Cache/ConfigCacheCompiler.php`
+- `packages/config/src/Cache/CachedConfigFactory.php`
+- `packages/config/src/Listener/ConfigCacheInvalidator.php`
+
+## 4. CLI Orchestration
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `waaseyaa optimize` | Run all compilers in order |
+| `waaseyaa optimize:clear` | Delete all cached artifacts |
+| `waaseyaa optimize:manifest` | Compile package manifest only |
+| `waaseyaa optimize:middleware` | Compile middleware pipelines only |
+| `waaseyaa optimize:config` | Compile config cache only |
+
+### Compilation order
+
+Manifest first (middleware and config compilers may need it):
+
+```
+optimize:manifest → optimize:middleware → optimize:config
+```
+
+### Storage directory
+
+```
+storage/
+└── framework/
+    ├── packages.php
+    ├── middleware.php
+    └── config.php
+```
+
+Gitignored. Created automatically by compilers.
+
+### File locations
+
+- `packages/cli/src/Command/Optimize/OptimizeCommand.php`
+- `packages/cli/src/Command/Optimize/OptimizeClearCommand.php`
+- `packages/cli/src/Command/Optimize/OptimizeManifestCommand.php`
+- `packages/cli/src/Command/Optimize/OptimizeMiddlewareCommand.php`
+- `packages/cli/src/Command/Optimize/OptimizeConfigCommand.php`
+
+## Pillar Mapping
+
+| Improvement | Primary Pillar | Secondary Pillars |
+|------------|---------------|-------------------|
+| Package auto-discovery | 1 (Service Providers) | 11 (DX), 3 (Migrations) |
+| Middleware pipelines | 2 (Domain Events) | 12 (Queue), 13 (Broadcasting) |
+| Config caching | 6 (Config Versioning) | 16 (Caching), 8 (Multi-Tenancy) |
+
+## File Summary
+
+~28 new files across 3 existing packages (foundation, config, cli). No new packages.
+
+### foundation (19 files)
+
+- 5 attributes in `src/Attribute/`
+- 2 discovery classes in `src/Discovery/`
+- 12 middleware classes in `src/Middleware/` (3 interfaces, 3 handlers, 3 pipelines, 1 compiler, 7 built-in)
+
+### config (3 files)
+
+- `src/Cache/ConfigCacheCompiler.php`
+- `src/Cache/CachedConfigFactory.php`
+- `src/Listener/ConfigCacheInvalidator.php`
+
+### cli (5 files)
+
+- 5 commands in `src/Command/Optimize/`

--- a/docs/plans/2026-03-01-laravel-integration-layer-implementation.md
+++ b/docs/plans/2026-03-01-laravel-integration-layer-implementation.md
@@ -1,0 +1,2837 @@
+# Laravel Integration Layer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add package auto-discovery, typed middleware pipelines, and config caching to Waaseyaa's foundation layer.
+
+**Architecture:** Three independent compilers (PackageManifestCompiler, MiddlewarePipelineCompiler, ConfigCacheCompiler) produce cached PHP artifacts in `storage/framework/`. A `waaseyaa optimize` CLI command orchestrates all three. Dev auto-compiles on first use; prod requires explicit compilation.
+
+**Tech Stack:** PHP 8.3, Symfony Console 7.x, Symfony HttpFoundation, PHPUnit 10.5
+
+---
+
+### Task 1: Add storage/framework/ directory and gitignore
+
+**Files:**
+- Modify: `.gitignore`
+
+**Step 1: Add storage/ to .gitignore**
+
+Append to `.gitignore`:
+```
+# Compiled framework cache
+storage/
+```
+
+**Step 2: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: gitignore storage/ directory for compiled framework cache"
+```
+
+---
+
+### Task 2: AsMiddleware attribute
+
+**Files:**
+- Create: `packages/foundation/src/Attribute/AsMiddleware.php`
+- Test: `packages/foundation/tests/Unit/Attribute/AsMiddlewareTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsMiddleware::class)]
+final class AsMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function attribute_is_discoverable_on_class(): void
+    {
+        $ref = new \ReflectionClass(SampleMiddleware::class);
+        $attrs = $ref->getAttributes(AsMiddleware::class);
+
+        $this->assertCount(1, $attrs);
+
+        $instance = $attrs[0]->newInstance();
+        $this->assertSame('http', $instance->pipeline);
+        $this->assertSame(100, $instance->priority);
+    }
+
+    #[Test]
+    public function default_priority_is_zero(): void
+    {
+        $attr = new AsMiddleware(pipeline: 'event');
+
+        $this->assertSame(0, $attr->priority);
+    }
+
+    #[Test]
+    public function pipeline_must_be_valid(): void
+    {
+        $attr = new AsMiddleware(pipeline: 'job', priority: 50);
+
+        $this->assertSame('job', $attr->pipeline);
+        $this->assertSame(50, $attr->priority);
+    }
+}
+
+#[AsMiddleware(pipeline: 'http', priority: 100)]
+final class SampleMiddleware {}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter AsMiddlewareTest`
+Expected: FAIL — class `AsMiddleware` not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMiddleware
+{
+    public function __construct(
+        public readonly string $pipeline,
+        public readonly int $priority = 0,
+    ) {}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter AsMiddlewareTest`
+Expected: PASS (3 tests, 3 assertions)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Attribute/AsMiddleware.php packages/foundation/tests/Unit/Attribute/AsMiddlewareTest.php
+git commit -m "feat: add AsMiddleware attribute for pipeline middleware discovery"
+```
+
+---
+
+### Task 3: AsFieldType and AsEntityType attributes
+
+**Files:**
+- Create: `packages/foundation/src/Attribute/AsFieldType.php`
+- Create: `packages/foundation/src/Attribute/AsEntityType.php`
+- Test: `packages/foundation/tests/Unit/Attribute/AsFieldTypeTest.php`
+- Test: `packages/foundation/tests/Unit/Attribute/AsEntityTypeTest.php`
+
+**Step 1: Write failing tests**
+
+`packages/foundation/tests/Unit/Attribute/AsFieldTypeTest.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsFieldType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsFieldType::class)]
+final class AsFieldTypeTest extends TestCase
+{
+    #[Test]
+    public function attribute_carries_id_and_label(): void
+    {
+        $ref = new \ReflectionClass(SampleFieldType::class);
+        $attrs = $ref->getAttributes(AsFieldType::class);
+
+        $this->assertCount(1, $attrs);
+
+        $instance = $attrs[0]->newInstance();
+        $this->assertSame('text', $instance->id);
+        $this->assertSame('Text', $instance->label);
+    }
+}
+
+#[AsFieldType(id: 'text', label: 'Text')]
+final class SampleFieldType {}
+```
+
+`packages/foundation/tests/Unit/Attribute/AsEntityTypeTest.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsEntityType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsEntityType::class)]
+final class AsEntityTypeTest extends TestCase
+{
+    #[Test]
+    public function attribute_carries_id_and_label(): void
+    {
+        $ref = new \ReflectionClass(SampleEntityType::class);
+        $attrs = $ref->getAttributes(AsEntityType::class);
+
+        $this->assertCount(1, $attrs);
+
+        $instance = $attrs[0]->newInstance();
+        $this->assertSame('node', $instance->id);
+        $this->assertSame('Content', $instance->label);
+    }
+}
+
+#[AsEntityType(id: 'node', label: 'Content')]
+final class SampleEntityType {}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./vendor/bin/phpunit --filter "AsFieldTypeTest|AsEntityTypeTest"`
+Expected: FAIL — classes not found.
+
+**Step 3: Write implementations**
+
+`packages/foundation/src/Attribute/AsFieldType.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsFieldType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}
+```
+
+`packages/foundation/src/Attribute/AsEntityType.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsEntityType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit --filter "AsFieldTypeTest|AsEntityTypeTest"`
+Expected: PASS (2 tests, 2 assertions each)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Attribute/AsFieldType.php packages/foundation/src/Attribute/AsEntityType.php packages/foundation/tests/Unit/Attribute/AsFieldTypeTest.php packages/foundation/tests/Unit/Attribute/AsEntityTypeTest.php
+git commit -m "feat: add AsFieldType and AsEntityType discovery attributes"
+```
+
+---
+
+### Task 4: PackageManifest value object
+
+**Files:**
+- Create: `packages/foundation/src/Discovery/PackageManifest.php`
+- Test: `packages/foundation/tests/Unit/Discovery/PackageManifestTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Discovery;
+
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PackageManifest::class)]
+final class PackageManifestTest extends TestCase
+{
+    #[Test]
+    public function creates_from_array(): void
+    {
+        $data = [
+            'providers' => ['App\\FooProvider'],
+            'commands' => ['App\\FooCommand'],
+            'routes' => [],
+            'migrations' => ['waaseyaa/foo' => '/path/to/migrations'],
+            'field_types' => ['text' => 'App\\TextField'],
+            'entity_types' => [],
+            'listeners' => [],
+            'middleware' => ['http' => [], 'event' => [], 'job' => []],
+        ];
+
+        $manifest = PackageManifest::fromArray($data);
+
+        $this->assertSame(['App\\FooProvider'], $manifest->providers);
+        $this->assertSame(['App\\FooCommand'], $manifest->commands);
+        $this->assertSame(['text' => 'App\\TextField'], $manifest->fieldTypes);
+        $this->assertSame(['waaseyaa/foo' => '/path/to/migrations'], $manifest->migrations);
+    }
+
+    #[Test]
+    public function creates_empty_manifest(): void
+    {
+        $manifest = PackageManifest::empty();
+
+        $this->assertSame([], $manifest->providers);
+        $this->assertSame([], $manifest->commands);
+        $this->assertSame([], $manifest->routes);
+        $this->assertSame([], $manifest->migrations);
+        $this->assertSame([], $manifest->fieldTypes);
+        $this->assertSame([], $manifest->entityTypes);
+        $this->assertSame([], $manifest->listeners);
+        $this->assertSame(['http' => [], 'event' => [], 'job' => []], $manifest->middleware);
+    }
+
+    #[Test]
+    public function converts_to_array_for_caching(): void
+    {
+        $manifest = PackageManifest::empty();
+        $data = $manifest->toArray();
+
+        $this->assertArrayHasKey('providers', $data);
+        $this->assertArrayHasKey('middleware', $data);
+
+        $restored = PackageManifest::fromArray($data);
+        $this->assertEquals($manifest, $restored);
+    }
+
+    #[Test]
+    public function loads_from_cache_file(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/waaseyaa_test_' . uniqid();
+        mkdir($tmpDir, 0777, true);
+
+        $data = PackageManifest::empty()->toArray();
+        file_put_contents($tmpDir . '/packages.php', '<?php return ' . var_export($data, true) . ';');
+
+        $manifest = PackageManifest::load($tmpDir);
+
+        $this->assertInstanceOf(PackageManifest::class, $manifest);
+
+        // Cleanup
+        unlink($tmpDir . '/packages.php');
+        rmdir($tmpDir);
+    }
+
+    #[Test]
+    public function load_returns_null_when_no_cache_file(): void
+    {
+        $manifest = PackageManifest::load('/nonexistent/path');
+
+        $this->assertNull($manifest);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter PackageManifestTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Discovery;
+
+final class PackageManifest
+{
+    /**
+     * @param list<class-string> $providers
+     * @param list<class-string> $commands
+     * @param list<class-string> $routes
+     * @param array<string, string> $migrations Package name => path
+     * @param array<string, class-string> $fieldTypes Field type ID => class
+     * @param array<string, class-string> $entityTypes Entity type ID => class
+     * @param array<class-string, list<array{class: class-string, priority: int}>> $listeners Event class => listener entries
+     * @param array{http: list<array{class: class-string, priority: int}>, event: list<array{class: class-string, priority: int}>, job: list<array{class: class-string, priority: int}>} $middleware
+     */
+    public function __construct(
+        public readonly array $providers,
+        public readonly array $commands,
+        public readonly array $routes,
+        public readonly array $migrations,
+        public readonly array $fieldTypes,
+        public readonly array $entityTypes,
+        public readonly array $listeners,
+        public readonly array $middleware,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self(
+            providers: [],
+            commands: [],
+            routes: [],
+            migrations: [],
+            fieldTypes: [],
+            entityTypes: [],
+            listeners: [],
+            middleware: ['http' => [], 'event' => [], 'job' => []],
+        );
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            providers: $data['providers'] ?? [],
+            commands: $data['commands'] ?? [],
+            routes: $data['routes'] ?? [],
+            migrations: $data['migrations'] ?? [],
+            fieldTypes: $data['field_types'] ?? [],
+            entityTypes: $data['entity_types'] ?? [],
+            listeners: $data['listeners'] ?? [],
+            middleware: $data['middleware'] ?? ['http' => [], 'event' => [], 'job' => []],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'providers' => $this->providers,
+            'commands' => $this->commands,
+            'routes' => $this->routes,
+            'migrations' => $this->migrations,
+            'field_types' => $this->fieldTypes,
+            'entity_types' => $this->entityTypes,
+            'listeners' => $this->listeners,
+            'middleware' => $this->middleware,
+        ];
+    }
+
+    public static function load(string $cachePath): ?self
+    {
+        $file = $cachePath . '/packages.php';
+        if (!is_file($file)) {
+            return null;
+        }
+
+        $data = require $file;
+
+        return self::fromArray($data);
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter PackageManifestTest`
+Expected: PASS (5 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Discovery/PackageManifest.php packages/foundation/tests/Unit/Discovery/PackageManifestTest.php
+git commit -m "feat: add PackageManifest value object for compiled discovery cache"
+```
+
+---
+
+### Task 5: PackageManifestCompiler
+
+**Files:**
+- Create: `packages/foundation/src/Discovery/PackageManifestCompiler.php`
+- Test: `packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Discovery;
+
+use Waaseyaa\Foundation\Attribute\AsFieldType;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PackageManifestCompiler::class)]
+final class PackageManifestCompilerTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_manifest_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/packages.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function compiles_manifest_from_installed_data(): void
+    {
+        $installed = [
+            'packages' => [
+                [
+                    'name' => 'waaseyaa/node',
+                    'extra' => [
+                        'waaseyaa' => [
+                            'providers' => ['Waaseyaa\\Node\\NodeServiceProvider'],
+                            'commands' => ['Waaseyaa\\Node\\Command\\NodeCreateCommand'],
+                            'routes' => ['Waaseyaa\\Node\\NodeRouteProvider'],
+                            'migrations' => 'migrations/',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $compiler = new PackageManifestCompiler();
+        $manifest = $compiler->compileFromArray($installed);
+
+        $this->assertContains('Waaseyaa\\Node\\NodeServiceProvider', $manifest->providers);
+        $this->assertContains('Waaseyaa\\Node\\Command\\NodeCreateCommand', $manifest->commands);
+        $this->assertContains('Waaseyaa\\Node\\NodeRouteProvider', $manifest->routes);
+    }
+
+    #[Test]
+    public function skips_packages_without_waaseyaa_extra(): void
+    {
+        $installed = [
+            'packages' => [
+                ['name' => 'symfony/console', 'extra' => []],
+            ],
+        ];
+
+        $compiler = new PackageManifestCompiler();
+        $manifest = $compiler->compileFromArray($installed);
+
+        $this->assertSame([], $manifest->providers);
+    }
+
+    #[Test]
+    public function scans_classes_for_attributes(): void
+    {
+        $compiler = new PackageManifestCompiler();
+        $manifest = $compiler->compileFromArray(
+            installed: ['packages' => []],
+            classesToScan: [
+                CompilerTestFieldType::class,
+                CompilerTestMiddleware::class,
+            ],
+        );
+
+        $this->assertSame(['test_text' => CompilerTestFieldType::class], $manifest->fieldTypes);
+        $this->assertCount(1, $manifest->middleware['http']);
+        $this->assertSame(CompilerTestMiddleware::class, $manifest->middleware['http'][0]['class']);
+        $this->assertSame(100, $manifest->middleware['http'][0]['priority']);
+    }
+
+    #[Test]
+    public function writes_cache_file(): void
+    {
+        $compiler = new PackageManifestCompiler();
+        $manifest = $compiler->compileFromArray(['packages' => []]);
+
+        $compiler->writeCache($manifest, $this->tmpDir);
+
+        $this->assertFileExists($this->tmpDir . '/packages.php');
+
+        $loaded = PackageManifest::load($this->tmpDir);
+        $this->assertNotNull($loaded);
+        $this->assertEquals($manifest, $loaded);
+    }
+
+    #[Test]
+    public function middleware_sorted_by_priority_descending(): void
+    {
+        $compiler = new PackageManifestCompiler();
+        $manifest = $compiler->compileFromArray(
+            installed: ['packages' => []],
+            classesToScan: [
+                CompilerTestMiddleware::class,
+                CompilerTestLowPriorityMiddleware::class,
+            ],
+        );
+
+        $httpMiddleware = $manifest->middleware['http'];
+        $this->assertCount(2, $httpMiddleware);
+        // Higher priority first
+        $this->assertSame(100, $httpMiddleware[0]['priority']);
+        $this->assertSame(10, $httpMiddleware[1]['priority']);
+    }
+}
+
+#[AsFieldType(id: 'test_text', label: 'Test Text')]
+final class CompilerTestFieldType {}
+
+#[AsMiddleware(pipeline: 'http', priority: 100)]
+final class CompilerTestMiddleware {}
+
+#[AsMiddleware(pipeline: 'http', priority: 10)]
+final class CompilerTestLowPriorityMiddleware {}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter PackageManifestCompilerTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Discovery;
+
+use Waaseyaa\Foundation\Attribute\AsEntityType;
+use Waaseyaa\Foundation\Attribute\AsFieldType;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Event\Attribute\Listener;
+
+final class PackageManifestCompiler
+{
+    /**
+     * Compile a manifest from Composer's installed.json data and optional class scanning.
+     *
+     * @param array $installed Parsed installed.json content
+     * @param list<class-string> $classesToScan Additional classes to scan for attributes
+     */
+    public function compileFromArray(array $installed, array $classesToScan = []): PackageManifest
+    {
+        $providers = [];
+        $commands = [];
+        $routes = [];
+        $migrations = [];
+        $fieldTypes = [];
+        $entityTypes = [];
+        $listeners = [];
+        $middleware = ['http' => [], 'event' => [], 'job' => []];
+
+        foreach ($installed['packages'] ?? [] as $package) {
+            $extra = $package['extra']['waaseyaa'] ?? null;
+            if ($extra === null) {
+                continue;
+            }
+
+            foreach ($extra['providers'] ?? [] as $class) {
+                $providers[] = $class;
+            }
+            foreach ($extra['commands'] ?? [] as $class) {
+                $commands[] = $class;
+            }
+            foreach ($extra['routes'] ?? [] as $class) {
+                $routes[] = $class;
+            }
+            if (isset($extra['migrations'])) {
+                $migrations[$package['name']] = $extra['migrations'];
+            }
+        }
+
+        foreach ($classesToScan as $className) {
+            $this->scanClass($className, $fieldTypes, $entityTypes, $listeners, $middleware);
+        }
+
+        // Sort middleware by priority descending within each pipeline
+        foreach ($middleware as $pipeline => $entries) {
+            usort($entries, static fn(array $a, array $b): int => $b['priority'] <=> $a['priority']);
+            $middleware[$pipeline] = $entries;
+        }
+
+        return new PackageManifest(
+            providers: $providers,
+            commands: $commands,
+            routes: $routes,
+            migrations: $migrations,
+            fieldTypes: $fieldTypes,
+            entityTypes: $entityTypes,
+            listeners: $listeners,
+            middleware: $middleware,
+        );
+    }
+
+    public function writeCache(PackageManifest $manifest, string $cachePath): void
+    {
+        if (!is_dir($cachePath)) {
+            mkdir($cachePath, 0777, true);
+        }
+
+        $content = "<?php\n\nreturn " . var_export($manifest->toArray(), true) . ";\n";
+        file_put_contents($cachePath . '/packages.php', $content);
+    }
+
+    private function scanClass(
+        string $className,
+        array &$fieldTypes,
+        array &$entityTypes,
+        array &$listeners,
+        array &$middleware,
+    ): void {
+        $ref = new \ReflectionClass($className);
+
+        foreach ($ref->getAttributes(AsFieldType::class) as $attr) {
+            $instance = $attr->newInstance();
+            $fieldTypes[$instance->id] = $className;
+        }
+
+        foreach ($ref->getAttributes(AsEntityType::class) as $attr) {
+            $instance = $attr->newInstance();
+            $entityTypes[$instance->id] = $className;
+        }
+
+        foreach ($ref->getAttributes(Listener::class) as $attr) {
+            $instance = $attr->newInstance();
+            // Determine event class from __invoke parameter type
+            if ($ref->hasMethod('__invoke')) {
+                $params = $ref->getMethod('__invoke')->getParameters();
+                if (isset($params[0])) {
+                    $type = $params[0]->getType();
+                    if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                        $eventClass = $type->getName();
+                        $listeners[$eventClass] ??= [];
+                        $listeners[$eventClass][] = ['class' => $className, 'priority' => $instance->priority];
+                    }
+                }
+            }
+        }
+
+        foreach ($ref->getAttributes(AsMiddleware::class) as $attr) {
+            $instance = $attr->newInstance();
+            $pipeline = $instance->pipeline;
+            if (isset($middleware[$pipeline])) {
+                $middleware[$pipeline][] = ['class' => $className, 'priority' => $instance->priority];
+            }
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter PackageManifestCompilerTest`
+Expected: PASS (5 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Discovery/PackageManifestCompiler.php packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+git commit -m "feat: add PackageManifestCompiler for hybrid manifest + attribute discovery"
+```
+
+---
+
+### Task 6: HTTP middleware interfaces and pipeline
+
+**Files:**
+- Create: `packages/foundation/src/Middleware/HttpMiddlewareInterface.php`
+- Create: `packages/foundation/src/Middleware/HttpHandlerInterface.php`
+- Create: `packages/foundation/src/Middleware/HttpPipeline.php`
+- Test: `packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\HttpPipeline;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(HttpPipeline::class)]
+final class HttpPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_calls_final_handler(): void
+    {
+        $pipeline = new HttpPipeline([]);
+        $request = Request::create('/test');
+
+        $response = $pipeline->handle($request, new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response {
+                return new Response('final');
+            }
+        });
+
+        $this->assertSame('final', $response->getContent());
+    }
+
+    #[Test]
+    public function middleware_wraps_final_handler(): void
+    {
+        $middleware = new class implements HttpMiddlewareInterface {
+            public function process(Request $request, HttpHandlerInterface $next): Response {
+                $response = $next->handle($request);
+                $response->headers->set('X-Wrapped', 'true');
+                return $response;
+            }
+        };
+
+        $pipeline = new HttpPipeline([$middleware]);
+        $request = Request::create('/test');
+
+        $response = $pipeline->handle($request, new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response {
+                return new Response('body');
+            }
+        });
+
+        $this->assertSame('body', $response->getContent());
+        $this->assertSame('true', $response->headers->get('X-Wrapped'));
+    }
+
+    #[Test]
+    public function middleware_executes_in_order(): void
+    {
+        $order = [];
+
+        $first = new class($order) implements HttpMiddlewareInterface {
+            private array &$order;
+            public function __construct(array &$order) { $this->order = &$order; }
+            public function process(Request $request, HttpHandlerInterface $next): Response {
+                $this->order[] = 'first-before';
+                $response = $next->handle($request);
+                $this->order[] = 'first-after';
+                return $response;
+            }
+        };
+
+        $second = new class($order) implements HttpMiddlewareInterface {
+            private array &$order;
+            public function __construct(array &$order) { $this->order = &$order; }
+            public function process(Request $request, HttpHandlerInterface $next): Response {
+                $this->order[] = 'second-before';
+                $response = $next->handle($request);
+                $this->order[] = 'second-after';
+                return $response;
+            }
+        };
+
+        $pipeline = new HttpPipeline([$first, $second]);
+
+        $pipeline->handle(Request::create('/'), new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response {
+                return new Response('ok');
+            }
+        });
+
+        $this->assertSame(['first-before', 'second-before', 'second-after', 'first-after'], $order);
+    }
+
+    #[Test]
+    public function middleware_can_short_circuit(): void
+    {
+        $middleware = new class implements HttpMiddlewareInterface {
+            public function process(Request $request, HttpHandlerInterface $next): Response {
+                return new Response('blocked', 403);
+            }
+        };
+
+        $pipeline = new HttpPipeline([$middleware]);
+        $finalCalled = false;
+
+        $response = $pipeline->handle(Request::create('/'), new class($finalCalled) implements HttpHandlerInterface {
+            private bool &$called;
+            public function __construct(bool &$called) { $this->called = &$called; }
+            public function handle(Request $request): Response {
+                $this->called = true;
+                return new Response('ok');
+            }
+        });
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertFalse($finalCalled);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter HttpPipelineTest`
+Expected: FAIL — interfaces/class not found.
+
+**Step 3: Write the implementation**
+
+`packages/foundation/src/Middleware/HttpMiddlewareInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpMiddlewareInterface
+{
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}
+```
+
+`packages/foundation/src/Middleware/HttpHandlerInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpHandlerInterface
+{
+    public function handle(Request $request): Response;
+}
+```
+
+`packages/foundation/src/Middleware/HttpPipeline.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HttpPipeline
+{
+    /** @param HttpMiddlewareInterface[] $middleware */
+    public function __construct(private readonly array $middleware) {}
+
+    public function handle(Request $request, HttpHandlerInterface $finalHandler): Response
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements HttpHandlerInterface {
+                public function __construct(
+                    private readonly HttpMiddlewareInterface $middleware,
+                    private readonly HttpHandlerInterface $next,
+                ) {}
+
+                public function handle(Request $request): Response
+                {
+                    return $this->middleware->process($request, $this->next);
+                }
+            };
+        }
+
+        return $handler->handle($request);
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter HttpPipelineTest`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Middleware/HttpMiddlewareInterface.php packages/foundation/src/Middleware/HttpHandlerInterface.php packages/foundation/src/Middleware/HttpPipeline.php packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php
+git commit -m "feat: add typed HTTP middleware pipeline with onion pattern"
+```
+
+---
+
+### Task 7: Event middleware interfaces and pipeline
+
+**Files:**
+- Create: `packages/foundation/src/Middleware/EventMiddlewareInterface.php`
+- Create: `packages/foundation/src/Middleware/EventHandlerInterface.php`
+- Create: `packages/foundation/src/Middleware/EventPipeline.php`
+- Test: `packages/foundation/tests/Unit/Middleware/EventPipelineTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+use Waaseyaa\Foundation\Middleware\EventHandlerInterface;
+use Waaseyaa\Foundation\Middleware\EventMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\EventPipeline;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventPipeline::class)]
+final class EventPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_calls_final_handler(): void
+    {
+        $pipeline = new EventPipeline([]);
+        $called = false;
+
+        $pipeline->handle(
+            new TestEvent('node', '1'),
+            new class($called) implements EventHandlerInterface {
+                private bool &$called;
+                public function __construct(bool &$called) { $this->called = &$called; }
+                public function handle(DomainEvent $event): void { $this->called = true; }
+            }
+        );
+
+        $this->assertTrue($called);
+    }
+
+    #[Test]
+    public function middleware_wraps_handler(): void
+    {
+        $order = [];
+
+        $middleware = new class($order) implements EventMiddlewareInterface {
+            private array &$order;
+            public function __construct(array &$order) { $this->order = &$order; }
+            public function process(DomainEvent $event, EventHandlerInterface $next): void {
+                $this->order[] = 'before';
+                $next->handle($event);
+                $this->order[] = 'after';
+            }
+        };
+
+        $pipeline = new EventPipeline([$middleware]);
+        $pipeline->handle(
+            new TestEvent('node', '1'),
+            new class($order) implements EventHandlerInterface {
+                private array &$order;
+                public function __construct(array &$order) { $this->order = &$order; }
+                public function handle(DomainEvent $event): void { $this->order[] = 'handler'; }
+            }
+        );
+
+        $this->assertSame(['before', 'handler', 'after'], $order);
+    }
+
+    #[Test]
+    public function middleware_can_short_circuit(): void
+    {
+        $middleware = new class implements EventMiddlewareInterface {
+            public function process(DomainEvent $event, EventHandlerInterface $next): void {
+                // Don't call $next — short-circuit
+            }
+        };
+
+        $pipeline = new EventPipeline([$middleware]);
+        $handlerCalled = false;
+
+        $pipeline->handle(
+            new TestEvent('node', '1'),
+            new class($handlerCalled) implements EventHandlerInterface {
+                private bool &$called;
+                public function __construct(bool &$called) { $this->called = &$called; }
+                public function handle(DomainEvent $event): void { $this->called = true; }
+            }
+        );
+
+        $this->assertFalse($handlerCalled);
+    }
+}
+
+final class TestEvent extends DomainEvent
+{
+    public function getPayload(): array { return []; }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter EventPipelineTest`
+Expected: FAIL — interfaces/class not found.
+
+**Step 3: Write the implementation**
+
+`packages/foundation/src/Middleware/EventMiddlewareInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+interface EventMiddlewareInterface
+{
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}
+```
+
+`packages/foundation/src/Middleware/EventHandlerInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+interface EventHandlerInterface
+{
+    public function handle(DomainEvent $event): void;
+}
+```
+
+`packages/foundation/src/Middleware/EventPipeline.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+final class EventPipeline
+{
+    /** @param EventMiddlewareInterface[] $middleware */
+    public function __construct(private readonly array $middleware) {}
+
+    public function handle(DomainEvent $event, EventHandlerInterface $finalHandler): void
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements EventHandlerInterface {
+                public function __construct(
+                    private readonly EventMiddlewareInterface $middleware,
+                    private readonly EventHandlerInterface $next,
+                ) {}
+
+                public function handle(DomainEvent $event): void
+                {
+                    $this->middleware->process($event, $this->next);
+                }
+            };
+        }
+
+        $handler->handle($event);
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter EventPipelineTest`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Middleware/EventMiddlewareInterface.php packages/foundation/src/Middleware/EventHandlerInterface.php packages/foundation/src/Middleware/EventPipeline.php packages/foundation/tests/Unit/Middleware/EventPipelineTest.php
+git commit -m "feat: add typed event middleware pipeline"
+```
+
+---
+
+### Task 8: Job middleware interfaces and pipeline
+
+**Files:**
+- Create: `packages/foundation/src/Middleware/JobMiddlewareInterface.php`
+- Create: `packages/foundation/src/Middleware/JobNextHandlerInterface.php`
+- Create: `packages/foundation/src/Middleware/JobPipeline.php`
+- Test: `packages/foundation/tests/Unit/Middleware/JobPipelineTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
+use Waaseyaa\Queue\Job;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JobPipeline::class)]
+final class JobPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_calls_final_handler(): void
+    {
+        $pipeline = new JobPipeline([]);
+        $job = new TestJob();
+        $called = false;
+
+        $pipeline->handle($job, new class($called) implements JobNextHandlerInterface {
+            private bool &$called;
+            public function __construct(bool &$called) { $this->called = &$called; }
+            public function handle(Job $job): void { $this->called = true; }
+        });
+
+        $this->assertTrue($called);
+    }
+
+    #[Test]
+    public function middleware_wraps_handler(): void
+    {
+        $order = [];
+
+        $middleware = new class($order) implements JobMiddlewareInterface {
+            private array &$order;
+            public function __construct(array &$order) { $this->order = &$order; }
+            public function process(Job $job, JobNextHandlerInterface $next): void {
+                $this->order[] = 'before';
+                $next->handle($job);
+                $this->order[] = 'after';
+            }
+        };
+
+        $pipeline = new JobPipeline([$middleware]);
+        $pipeline->handle(new TestJob(), new class($order) implements JobNextHandlerInterface {
+            private array &$order;
+            public function __construct(array &$order) { $this->order = &$order; }
+            public function handle(Job $job): void { $this->order[] = 'handler'; }
+        });
+
+        $this->assertSame(['before', 'handler', 'after'], $order);
+    }
+
+    #[Test]
+    public function middleware_can_short_circuit(): void
+    {
+        $middleware = new class implements JobMiddlewareInterface {
+            public function process(Job $job, JobNextHandlerInterface $next): void {
+                // Short-circuit: don't call next
+            }
+        };
+
+        $pipeline = new JobPipeline([$middleware]);
+        $handlerCalled = false;
+
+        $pipeline->handle(new TestJob(), new class($handlerCalled) implements JobNextHandlerInterface {
+            private bool &$called;
+            public function __construct(bool &$called) { $this->called = &$called; }
+            public function handle(Job $job): void { $this->called = true; }
+        });
+
+        $this->assertFalse($handlerCalled);
+    }
+}
+
+final class TestJob extends Job
+{
+    public function handle(): void {}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter JobPipelineTest`
+Expected: FAIL — interfaces/class not found.
+
+**Step 3: Write the implementation**
+
+`packages/foundation/src/Middleware/JobMiddlewareInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+interface JobMiddlewareInterface
+{
+    public function process(Job $job, JobNextHandlerInterface $next): void;
+}
+```
+
+`packages/foundation/src/Middleware/JobNextHandlerInterface.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+interface JobNextHandlerInterface
+{
+    public function handle(Job $job): void;
+}
+```
+
+`packages/foundation/src/Middleware/JobPipeline.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+final class JobPipeline
+{
+    /** @param JobMiddlewareInterface[] $middleware */
+    public function __construct(private readonly array $middleware) {}
+
+    public function handle(Job $job, JobNextHandlerInterface $finalHandler): void
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements JobNextHandlerInterface {
+                public function __construct(
+                    private readonly JobMiddlewareInterface $middleware,
+                    private readonly JobNextHandlerInterface $next,
+                ) {}
+
+                public function handle(Job $job): void
+                {
+                    $this->middleware->process($job, $this->next);
+                }
+            };
+        }
+
+        $handler->handle($job);
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter JobPipelineTest`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Middleware/JobMiddlewareInterface.php packages/foundation/src/Middleware/JobNextHandlerInterface.php packages/foundation/src/Middleware/JobPipeline.php packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
+git commit -m "feat: add typed job middleware pipeline"
+```
+
+---
+
+### Task 9: Integrate EventPipeline into EventBus
+
+**Files:**
+- Modify: `packages/foundation/src/Event/EventBus.php`
+- Modify: `packages/foundation/tests/Unit/Event/EventBusTest.php`
+
+**Step 1: Write the failing test (add to existing test file)**
+
+Append these tests to `EventBusTest.php`:
+
+```php
+#[Test]
+public function event_middleware_wraps_sync_dispatch(): void
+{
+    $middlewareCalled = false;
+    $middleware = new class($middlewareCalled) implements \Waaseyaa\Foundation\Middleware\EventMiddlewareInterface {
+        private bool &$called;
+        public function __construct(bool &$called) { $this->called = &$called; }
+        public function process(DomainEvent $event, \Waaseyaa\Foundation\Middleware\EventHandlerInterface $next): void {
+            $this->called = true;
+            $next->handle($event);
+        }
+    };
+
+    $pipeline = new \Waaseyaa\Foundation\Middleware\EventPipeline([$middleware]);
+
+    $bus = new EventBus(
+        syncDispatcher: new EventDispatcher(),
+        asyncBus: $this->createNullMessageBus(),
+        broadcaster: $this->createNullBroadcaster(),
+        eventPipeline: $pipeline,
+    );
+
+    $bus->dispatch(new TestNodeSaved('node', '42', ['title']));
+
+    $this->assertTrue($middlewareCalled);
+}
+
+#[Test]
+public function event_middleware_can_short_circuit_sync_dispatch(): void
+{
+    $syncReceived = false;
+    $dispatcher = new EventDispatcher();
+    $dispatcher->addListener(TestNodeSaved::class, function () use (&$syncReceived) {
+        $syncReceived = true;
+    });
+
+    $blockingMiddleware = new class implements \Waaseyaa\Foundation\Middleware\EventMiddlewareInterface {
+        public function process(DomainEvent $event, \Waaseyaa\Foundation\Middleware\EventHandlerInterface $next): void {
+            // Don't call $next — block sync dispatch
+        }
+    };
+
+    $pipeline = new \Waaseyaa\Foundation\Middleware\EventPipeline([$blockingMiddleware]);
+
+    $bus = new EventBus(
+        syncDispatcher: $dispatcher,
+        asyncBus: $this->createNullMessageBus(),
+        broadcaster: $this->createNullBroadcaster(),
+        eventPipeline: $pipeline,
+    );
+
+    $bus->dispatch(new TestNodeSaved('node', '42', ['title']));
+
+    $this->assertFalse($syncReceived);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./vendor/bin/phpunit --filter EventBusTest`
+Expected: FAIL — EventBus constructor doesn't accept `eventPipeline`.
+
+**Step 3: Modify EventBus to accept optional EventPipeline**
+
+Update `packages/foundation/src/Event/EventBus.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Event;
+
+use Waaseyaa\Foundation\Middleware\EventHandlerInterface;
+use Waaseyaa\Foundation\Middleware\EventPipeline;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class EventBus
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $syncDispatcher,
+        private readonly MessageBusInterface $asyncBus,
+        private readonly BroadcasterInterface $broadcaster,
+        private readonly ?EventStoreInterface $eventStore = null,
+        private readonly ?EventPipeline $eventPipeline = null,
+    ) {}
+
+    public function dispatch(DomainEvent $event): void
+    {
+        $this->eventStore?->append($event);
+
+        if ($this->eventPipeline !== null) {
+            $dispatcher = $this->syncDispatcher;
+            $this->eventPipeline->handle($event, new class($dispatcher) implements EventHandlerInterface {
+                public function __construct(private readonly EventDispatcherInterface $dispatcher) {}
+                public function handle(DomainEvent $event): void {
+                    $this->dispatcher->dispatch($event);
+                }
+            });
+        } else {
+            $this->syncDispatcher->dispatch($event);
+        }
+
+        $this->asyncBus->dispatch($event);
+        $this->broadcaster->broadcast($event);
+    }
+}
+```
+
+**Step 4: Run all EventBus tests to verify they pass**
+
+Run: `./vendor/bin/phpunit --filter EventBusTest`
+Expected: PASS (all 7 tests — 5 existing + 2 new)
+
+**Step 5: Commit**
+
+```bash
+git add packages/foundation/src/Event/EventBus.php packages/foundation/tests/Unit/Event/EventBusTest.php
+git commit -m "feat: integrate EventPipeline into EventBus for event middleware support"
+```
+
+---
+
+### Task 10: Integrate JobPipeline into JobHandler
+
+**Files:**
+- Modify: `packages/queue/src/Handler/JobHandler.php`
+- Test: `packages/queue/tests/Unit/Handler/JobHandlerTest.php`
+
+**Step 1: Write the failing test**
+
+Create `packages/queue/tests/Unit/Handler/JobHandlerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Queue\Tests\Unit\Handler;
+
+use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
+use Waaseyaa\Queue\Handler\JobHandler;
+use Waaseyaa\Queue\Job;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JobHandler::class)]
+final class JobHandlerTest extends TestCase
+{
+    #[Test]
+    public function supports_job_instances(): void
+    {
+        $handler = new JobHandler();
+
+        $this->assertTrue($handler->supports(new SimpleTestJob()));
+        $this->assertFalse($handler->supports(new \stdClass()));
+    }
+
+    #[Test]
+    public function handles_job_and_increments_attempts(): void
+    {
+        $handler = new JobHandler();
+        $job = new SimpleTestJob();
+
+        $handler->handle($job);
+
+        $this->assertSame(1, $job->getAttempts());
+        $this->assertTrue($job->wasHandled);
+    }
+
+    #[Test]
+    public function handles_job_through_middleware_pipeline(): void
+    {
+        $middlewareCalled = false;
+        $middleware = new class($middlewareCalled) implements JobMiddlewareInterface {
+            private bool &$called;
+            public function __construct(bool &$called) { $this->called = &$called; }
+            public function process(Job $job, JobNextHandlerInterface $next): void {
+                $this->called = true;
+                $next->handle($job);
+            }
+        };
+
+        $pipeline = new JobPipeline([$middleware]);
+        $handler = new JobHandler($pipeline);
+        $job = new SimpleTestJob();
+
+        $handler->handle($job);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertTrue($job->wasHandled);
+    }
+
+    #[Test]
+    public function middleware_can_prevent_job_execution(): void
+    {
+        $blockingMiddleware = new class implements JobMiddlewareInterface {
+            public function process(Job $job, JobNextHandlerInterface $next): void {
+                // Don't call $next
+            }
+        };
+
+        $pipeline = new JobPipeline([$blockingMiddleware]);
+        $handler = new JobHandler($pipeline);
+        $job = new SimpleTestJob();
+
+        $handler->handle($job);
+
+        $this->assertFalse($job->wasHandled);
+    }
+}
+
+final class SimpleTestJob extends Job
+{
+    public bool $wasHandled = false;
+
+    public function handle(): void
+    {
+        $this->wasHandled = true;
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter JobHandlerTest`
+Expected: FAIL — JobHandler constructor doesn't accept pipeline.
+
+**Step 3: Modify JobHandler**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Queue\Handler;
+
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
+use Waaseyaa\Queue\Job;
+
+final class JobHandler implements HandlerInterface
+{
+    public function __construct(
+        private readonly ?JobPipeline $pipeline = null,
+    ) {}
+
+    public function supports(object $message): bool
+    {
+        return $message instanceof Job;
+    }
+
+    public function handle(object $message): void
+    {
+        /** @var Job $message */
+        $message->incrementAttempts();
+
+        if ($this->pipeline !== null) {
+            $this->pipeline->handle($message, new class implements JobNextHandlerInterface {
+                public function handle(Job $job): void
+                {
+                    $job->handle();
+                }
+            });
+        } else {
+            $message->handle();
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit --filter JobHandlerTest`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/queue/src/Handler/JobHandler.php packages/queue/tests/Unit/Handler/JobHandlerTest.php
+git commit -m "feat: integrate JobPipeline into JobHandler for job middleware support"
+```
+
+---
+
+### Task 11: ConfigCacheCompiler
+
+**Files:**
+- Create: `packages/config/src/Cache/ConfigCacheCompiler.php`
+- Test: `packages/config/tests/Unit/Cache/ConfigCacheCompilerTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Cache;
+
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigCacheCompiler::class)]
+final class ConfigCacheCompilerTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_config_cache_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function compiles_all_config_to_cache_file(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Test', 'langcode' => 'en']);
+        $storage->write('node.type.article', ['id' => 'article', 'label' => 'Article']);
+
+        $compiler = new ConfigCacheCompiler($storage);
+        $compiler->compile($this->tmpDir);
+
+        $this->assertFileExists($this->tmpDir . '/config.php');
+
+        $cached = require $this->tmpDir . '/config.php';
+        $this->assertSame(['name' => 'Test', 'langcode' => 'en'], $cached['system.site']);
+        $this->assertSame(['id' => 'article', 'label' => 'Article'], $cached['node.type.article']);
+    }
+
+    #[Test]
+    public function applies_environment_overrides(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Dev Site', 'langcode' => 'en']);
+
+        // Simulate environment override
+        $envOverrides = ['system.site' => ['name' => 'Prod Site']];
+
+        $compiler = new ConfigCacheCompiler($storage);
+        $compiler->compile($this->tmpDir, $envOverrides);
+
+        $cached = require $this->tmpDir . '/config.php';
+        $this->assertSame('Prod Site', $cached['system.site']['name']);
+        $this->assertSame('en', $cached['system.site']['langcode']);
+    }
+
+    #[Test]
+    public function handles_empty_storage(): void
+    {
+        $storage = new MemoryStorage();
+        $compiler = new ConfigCacheCompiler($storage);
+
+        $compiler->compile($this->tmpDir);
+
+        $cached = require $this->tmpDir . '/config.php';
+        $this->assertSame([], $cached);
+    }
+
+    #[Test]
+    public function clear_removes_cache_file(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('test', ['key' => 'value']);
+
+        $compiler = new ConfigCacheCompiler($storage);
+        $compiler->compile($this->tmpDir);
+
+        $this->assertFileExists($this->tmpDir . '/config.php');
+
+        $compiler->clear($this->tmpDir);
+
+        $this->assertFileDoesNotExist($this->tmpDir . '/config.php');
+    }
+
+    #[Test]
+    public function reports_compiled_count(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('a', ['x' => 1]);
+        $storage->write('b', ['y' => 2]);
+        $storage->write('c', ['z' => 3]);
+
+        $compiler = new ConfigCacheCompiler($storage);
+        $count = $compiler->compile($this->tmpDir);
+
+        $this->assertSame(3, $count);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter ConfigCacheCompilerTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Cache;
+
+use Waaseyaa\Config\StorageInterface;
+
+final class ConfigCacheCompiler
+{
+    public function __construct(
+        private readonly StorageInterface $activeStorage,
+    ) {}
+
+    /**
+     * Compile all config into a single cached PHP file.
+     *
+     * @param string $cachePath Directory to write the cache file to
+     * @param array<string, array<string, mixed>> $envOverrides Config name => key/value overrides
+     * @return int Number of config objects compiled
+     */
+    public function compile(string $cachePath, array $envOverrides = []): int
+    {
+        $allNames = $this->activeStorage->listAll();
+        $compiled = [];
+
+        foreach ($allNames as $name) {
+            $data = $this->activeStorage->read($name);
+            if ($data === false) {
+                continue;
+            }
+
+            // Apply environment overrides
+            if (isset($envOverrides[$name])) {
+                $data = array_replace_recursive($data, $envOverrides[$name]);
+            }
+
+            $compiled[$name] = $data;
+        }
+
+        if (!is_dir($cachePath)) {
+            mkdir($cachePath, 0777, true);
+        }
+
+        $content = "<?php\n\nreturn " . var_export($compiled, true) . ";\n";
+        file_put_contents($cachePath . '/config.php', $content);
+
+        return count($compiled);
+    }
+
+    public function clear(string $cachePath): void
+    {
+        $file = $cachePath . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter ConfigCacheCompilerTest`
+Expected: PASS (5 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/config/src/Cache/ConfigCacheCompiler.php packages/config/tests/Unit/Cache/ConfigCacheCompilerTest.php
+git commit -m "feat: add ConfigCacheCompiler for single-file config caching"
+```
+
+---
+
+### Task 12: CachedConfigFactory decorator
+
+**Files:**
+- Create: `packages/config/src/Cache/CachedConfigFactory.php`
+- Test: `packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Cache;
+
+use Waaseyaa\Config\Cache\CachedConfigFactory;
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\ConfigFactory;
+use Waaseyaa\Config\ConfigFactoryInterface;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[CoversClass(CachedConfigFactory::class)]
+final class CachedConfigFactoryTest extends TestCase
+{
+    private string $tmpDir;
+    private MemoryStorage $storage;
+    private ConfigFactory $inner;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_cached_factory_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+
+        $this->storage = new MemoryStorage();
+        $this->inner = new ConfigFactory($this->storage, new EventDispatcher());
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function implements_config_factory_interface(): void
+    {
+        $factory = new CachedConfigFactory($this->inner, $this->tmpDir);
+
+        $this->assertInstanceOf(ConfigFactoryInterface::class, $factory);
+    }
+
+    #[Test]
+    public function returns_config_from_cache_when_available(): void
+    {
+        // Write config and compile cache
+        $this->storage->write('system.site', ['name' => 'Cached Site']);
+        $compiler = new ConfigCacheCompiler($this->storage);
+        $compiler->compile($this->tmpDir);
+
+        // Clear the live storage to prove we're reading from cache
+        $this->storage->deleteAll();
+
+        $factory = new CachedConfigFactory($this->inner, $this->tmpDir);
+        $config = $factory->get('system.site');
+
+        $this->assertSame('Cached Site', $config->get('name'));
+    }
+
+    #[Test]
+    public function falls_through_to_inner_when_no_cache(): void
+    {
+        $this->storage->write('system.site', ['name' => 'Live Site']);
+
+        $factory = new CachedConfigFactory($this->inner, '/nonexistent/path');
+        $config = $factory->get('system.site');
+
+        $this->assertSame('Live Site', $config->get('name'));
+    }
+
+    #[Test]
+    public function falls_through_for_config_not_in_cache(): void
+    {
+        // Compile cache with only one config
+        $this->storage->write('cached.config', ['key' => 'cached']);
+        $compiler = new ConfigCacheCompiler($this->storage);
+        $compiler->compile($this->tmpDir);
+
+        // Add another config to live storage
+        $this->storage->write('live.config', ['key' => 'live']);
+
+        $factory = new CachedConfigFactory($this->inner, $this->tmpDir);
+
+        $cached = $factory->get('cached.config');
+        $this->assertSame('cached', $cached->get('key'));
+
+        $live = $factory->get('live.config');
+        $this->assertSame('live', $live->get('key'));
+    }
+
+    #[Test]
+    public function delegates_get_editable_to_inner(): void
+    {
+        $this->storage->write('system.site', ['name' => 'Test']);
+
+        $factory = new CachedConfigFactory($this->inner, $this->tmpDir);
+        $config = $factory->getEditable('system.site');
+
+        // Should be mutable (from inner factory)
+        $config->set('name', 'Updated');
+        $this->assertSame('Updated', $config->get('name'));
+    }
+
+    #[Test]
+    public function delegates_list_all_to_inner(): void
+    {
+        $this->storage->write('a.config', []);
+        $this->storage->write('b.config', []);
+
+        $factory = new CachedConfigFactory($this->inner, $this->tmpDir);
+
+        $this->assertSame(['a.config', 'b.config'], $factory->listAll());
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter CachedConfigFactoryTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Cache;
+
+use Waaseyaa\Config\Config;
+use Waaseyaa\Config\ConfigFactoryInterface;
+use Waaseyaa\Config\ConfigInterface;
+use Waaseyaa\Config\Storage\MemoryStorage;
+
+final class CachedConfigFactory implements ConfigFactoryInterface
+{
+    private ?array $cache = null;
+    private bool $cacheLoaded = false;
+
+    public function __construct(
+        private readonly ConfigFactoryInterface $inner,
+        private readonly string $cachePath,
+    ) {}
+
+    public function get(string $name): ConfigInterface
+    {
+        if (!$this->cacheLoaded) {
+            $this->cache = $this->loadCache();
+            $this->cacheLoaded = true;
+        }
+
+        if ($this->cache !== null && array_key_exists($name, $this->cache)) {
+            $readOnlyStorage = new MemoryStorage();
+            return new Config(
+                name: $name,
+                storage: $readOnlyStorage,
+                data: $this->cache[$name],
+                immutable: true,
+                isNew: false,
+            );
+        }
+
+        return $this->inner->get($name);
+    }
+
+    public function getEditable(string $name): ConfigInterface
+    {
+        return $this->inner->getEditable($name);
+    }
+
+    public function loadMultiple(array $names): array
+    {
+        $configs = [];
+        foreach ($names as $name) {
+            $configs[$name] = $this->get($name);
+        }
+        return $configs;
+    }
+
+    public function rename(string $oldName, string $newName): static
+    {
+        $this->inner->rename($oldName, $newName);
+        return $this;
+    }
+
+    public function listAll(string $prefix = ''): array
+    {
+        return $this->inner->listAll($prefix);
+    }
+
+    private function loadCache(): ?array
+    {
+        $file = $this->cachePath . '/config.php';
+        if (!is_file($file)) {
+            return null;
+        }
+
+        return require $file;
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit --filter CachedConfigFactoryTest`
+Expected: PASS (6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/config/src/Cache/CachedConfigFactory.php packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php
+git commit -m "feat: add CachedConfigFactory decorator for cached config reads"
+```
+
+---
+
+### Task 13: ConfigCacheInvalidator listener
+
+**Files:**
+- Create: `packages/config/src/Listener/ConfigCacheInvalidator.php`
+- Test: `packages/config/tests/Unit/Listener/ConfigCacheInvalidatorTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Listener;
+
+use Waaseyaa\Config\Event\ConfigEvent;
+use Waaseyaa\Config\Listener\ConfigCacheInvalidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigCacheInvalidator::class)]
+final class ConfigCacheInvalidatorTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_invalidator_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function deletes_cache_file_on_config_event(): void
+    {
+        // Create a cache file
+        file_put_contents($this->tmpDir . '/config.php', '<?php return [];');
+        $this->assertFileExists($this->tmpDir . '/config.php');
+
+        $invalidator = new ConfigCacheInvalidator($this->tmpDir);
+        $invalidator->__invoke(new ConfigEvent('system.site', []));
+
+        $this->assertFileDoesNotExist($this->tmpDir . '/config.php');
+    }
+
+    #[Test]
+    public function does_not_throw_when_no_cache_file(): void
+    {
+        $invalidator = new ConfigCacheInvalidator($this->tmpDir);
+
+        // Should not throw
+        $invalidator->__invoke(new ConfigEvent('system.site', []));
+        $this->assertTrue(true);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter ConfigCacheInvalidatorTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Listener;
+
+use Waaseyaa\Config\Event\ConfigEvent;
+
+final class ConfigCacheInvalidator
+{
+    public function __construct(
+        private readonly string $cachePath,
+    ) {}
+
+    public function __invoke(ConfigEvent $event): void
+    {
+        $file = $this->cachePath . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter ConfigCacheInvalidatorTest`
+Expected: PASS (2 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/config/src/Listener/ConfigCacheInvalidator.php packages/config/tests/Unit/Listener/ConfigCacheInvalidatorTest.php
+git commit -m "feat: add ConfigCacheInvalidator to delete cache on config changes"
+```
+
+---
+
+### Task 14: OptimizeManifestCommand
+
+**Files:**
+- Create: `packages/cli/src/Command/Optimize/OptimizeManifestCommand.php`
+- Test: `packages/cli/tests/Unit/Command/Optimize/OptimizeManifestCommandTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeManifestCommand;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeManifestCommand::class)]
+final class OptimizeManifestCommandTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_optimize_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/packages.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function compiles_manifest_and_outputs_success(): void
+    {
+        $compiler = new PackageManifestCompiler();
+
+        $command = new OptimizeManifestCommand($compiler, $this->tmpDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('manifest', strtolower($tester->getDisplay()));
+        $this->assertFileExists($this->tmpDir . '/packages.php');
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter OptimizeManifestCommandTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:manifest',
+    description: 'Compile the package manifest cache',
+)]
+final class OptimizeManifestCommand extends Command
+{
+    public function __construct(
+        private readonly PackageManifestCompiler $compiler,
+        private readonly string $cachePath,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $manifest = $this->compiler->compileFromArray(['packages' => []]);
+        $this->compiler->writeCache($manifest, $this->cachePath);
+
+        $providerCount = count($manifest->providers);
+        $output->writeln(sprintf(
+            '<info>Compiling package manifest... done (%d providers)</info>',
+            $providerCount,
+        ));
+
+        return Command::SUCCESS;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter OptimizeManifestCommandTest`
+Expected: PASS (1 test)
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli/src/Command/Optimize/OptimizeManifestCommand.php packages/cli/tests/Unit/Command/Optimize/OptimizeManifestCommandTest.php
+git commit -m "feat: add optimize:manifest CLI command"
+```
+
+---
+
+### Task 15: OptimizeConfigCommand
+
+**Files:**
+- Create: `packages/cli/src/Command/Optimize/OptimizeConfigCommand.php`
+- Test: `packages/cli/tests/Unit/Command/Optimize/OptimizeConfigCommandTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeConfigCommand;
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeConfigCommand::class)]
+final class OptimizeConfigCommandTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_opt_config_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tmpDir . '/config.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function compiles_config_and_outputs_count(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Test']);
+        $storage->write('node.settings', ['preview' => true]);
+
+        $compiler = new ConfigCacheCompiler($storage);
+        $command = new OptimizeConfigCommand($compiler, $this->tmpDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('2', $tester->getDisplay());
+        $this->assertFileExists($this->tmpDir . '/config.php');
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter OptimizeConfigCommandTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:config',
+    description: 'Compile the config cache',
+)]
+final class OptimizeConfigCommand extends Command
+{
+    public function __construct(
+        private readonly ConfigCacheCompiler $compiler,
+        private readonly string $cachePath,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $count = $this->compiler->compile($this->cachePath);
+
+        $output->writeln(sprintf(
+            '<info>Compiling config cache... done (%d config objects)</info>',
+            $count,
+        ));
+
+        return Command::SUCCESS;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter OptimizeConfigCommandTest`
+Expected: PASS (1 test)
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli/src/Command/Optimize/OptimizeConfigCommand.php packages/cli/tests/Unit/Command/Optimize/OptimizeConfigCommandTest.php
+git commit -m "feat: add optimize:config CLI command"
+```
+
+---
+
+### Task 16: OptimizeClearCommand
+
+**Files:**
+- Create: `packages/cli/src/Command/Optimize/OptimizeClearCommand.php`
+- Test: `packages/cli/tests/Unit/Command/Optimize/OptimizeClearCommandTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeClearCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeClearCommand::class)]
+final class OptimizeClearCommandTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_opt_clear_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['packages.php', 'middleware.php', 'config.php'] as $file) {
+            $path = $this->tmpDir . '/' . $file;
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function clears_all_cache_files(): void
+    {
+        // Create cache files
+        file_put_contents($this->tmpDir . '/packages.php', '<?php return [];');
+        file_put_contents($this->tmpDir . '/middleware.php', '<?php return [];');
+        file_put_contents($this->tmpDir . '/config.php', '<?php return [];');
+
+        $command = new OptimizeClearCommand($this->tmpDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertFileDoesNotExist($this->tmpDir . '/packages.php');
+        $this->assertFileDoesNotExist($this->tmpDir . '/middleware.php');
+        $this->assertFileDoesNotExist($this->tmpDir . '/config.php');
+    }
+
+    #[Test]
+    public function succeeds_when_no_cache_files_exist(): void
+    {
+        $command = new OptimizeClearCommand($this->tmpDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter OptimizeClearCommandTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:clear',
+    description: 'Clear all compiled framework caches',
+)]
+final class OptimizeClearCommand extends Command
+{
+    private const array CACHE_FILES = ['packages.php', 'middleware.php', 'config.php'];
+
+    public function __construct(
+        private readonly string $cachePath,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $cleared = 0;
+
+        foreach (self::CACHE_FILES as $file) {
+            $path = $this->cachePath . '/' . $file;
+            if (is_file($path)) {
+                unlink($path);
+                $cleared++;
+            }
+        }
+
+        $output->writeln(sprintf(
+            '<info>Cleared %d compiled cache file(s).</info>',
+            $cleared,
+        ));
+
+        return Command::SUCCESS;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter OptimizeClearCommandTest`
+Expected: PASS (2 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli/src/Command/Optimize/OptimizeClearCommand.php packages/cli/tests/Unit/Command/Optimize/OptimizeClearCommandTest.php
+git commit -m "feat: add optimize:clear CLI command"
+```
+
+---
+
+### Task 17: OptimizeCommand (orchestrator)
+
+**Files:**
+- Create: `packages/cli/src/Command/Optimize/OptimizeCommand.php`
+- Test: `packages/cli/tests/Unit/Command/Optimize/OptimizeCommandTest.php`
+
+**Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeConfigCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeManifestCommand;
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeCommand::class)]
+final class OptimizeCommandTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/waaseyaa_opt_all_test_' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['packages.php', 'middleware.php', 'config.php'] as $file) {
+            $path = $this->tmpDir . '/' . $file;
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    #[Test]
+    public function runs_all_sub_commands_in_order(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('test.config', ['key' => 'val']);
+
+        $app = new Application();
+        $app->add(new OptimizeManifestCommand(new PackageManifestCompiler(), $this->tmpDir));
+        $app->add(new OptimizeConfigCommand(new ConfigCacheCompiler($storage), $this->tmpDir));
+        $app->add(new OptimizeCommand());
+
+        $tester = new CommandTester($app->find('optimize'));
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('optimized successfully', strtolower($display));
+        $this->assertFileExists($this->tmpDir . '/packages.php');
+        $this->assertFileExists($this->tmpDir . '/config.php');
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter OptimizeCommandTest`
+Expected: FAIL — class not found.
+
+**Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize',
+    description: 'Compile all cached framework artifacts',
+)]
+final class OptimizeCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $app = $this->getApplication();
+        if ($app === null) {
+            $output->writeln('<error>Application not available.</error>');
+            return Command::FAILURE;
+        }
+
+        $subCommands = ['optimize:manifest', 'optimize:config'];
+
+        foreach ($subCommands as $commandName) {
+            if (!$app->has($commandName)) {
+                continue;
+            }
+
+            $result = $app->find($commandName)->run(new ArrayInput([]), $output);
+            if ($result !== Command::SUCCESS) {
+                $output->writeln(sprintf('<error>Command %s failed.</error>', $commandName));
+                return Command::FAILURE;
+            }
+        }
+
+        $output->writeln('');
+        $output->writeln('<info>Application optimized successfully.</info>');
+
+        return Command::SUCCESS;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter OptimizeCommandTest`
+Expected: PASS (1 test)
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli/src/Command/Optimize/OptimizeCommand.php packages/cli/tests/Unit/Command/Optimize/OptimizeCommandTest.php
+git commit -m "feat: add optimize orchestrator command"
+```
+
+---
+
+### Task 18: Run full test suite
+
+**Step 1: Run all unit tests**
+
+Run: `./vendor/bin/phpunit --testsuite Unit`
+Expected: All tests pass. No regressions in existing tests.
+
+**Step 2: Run all tests**
+
+Run: `./vendor/bin/phpunit --configuration phpunit.xml.dist`
+Expected: All tests pass.
+
+**Step 3: Commit gitignore update from Task 1 if not done**
+
+Verify `.gitignore` has `storage/` entry.
+
+---
+
+### Task 19: Final verification and summary commit
+
+**Step 1: Verify all new files exist**
+
+Run: `find packages/foundation/src/Attribute packages/foundation/src/Discovery packages/foundation/src/Middleware packages/config/src/Cache packages/config/src/Listener packages/cli/src/Command/Optimize -name '*.php' | sort`
+
+Expected output (~27 files):
+```
+packages/cli/src/Command/Optimize/OptimizeClearCommand.php
+packages/cli/src/Command/Optimize/OptimizeCommand.php
+packages/cli/src/Command/Optimize/OptimizeConfigCommand.php
+packages/cli/src/Command/Optimize/OptimizeManifestCommand.php
+packages/config/src/Cache/CachedConfigFactory.php
+packages/config/src/Cache/ConfigCacheCompiler.php
+packages/config/src/Listener/ConfigCacheInvalidator.php
+packages/foundation/src/Attribute/AsEntityType.php
+packages/foundation/src/Attribute/AsFieldType.php
+packages/foundation/src/Attribute/AsMiddleware.php
+packages/foundation/src/Discovery/PackageManifest.php
+packages/foundation/src/Discovery/PackageManifestCompiler.php
+packages/foundation/src/Middleware/EventHandlerInterface.php
+packages/foundation/src/Middleware/EventMiddlewareInterface.php
+packages/foundation/src/Middleware/EventPipeline.php
+packages/foundation/src/Middleware/HttpHandlerInterface.php
+packages/foundation/src/Middleware/HttpMiddlewareInterface.php
+packages/foundation/src/Middleware/HttpPipeline.php
+packages/foundation/src/Middleware/JobMiddlewareInterface.php
+packages/foundation/src/Middleware/JobNextHandlerInterface.php
+packages/foundation/src/Middleware/JobPipeline.php
+```
+
+**Step 2: Run full test suite one final time**
+
+Run: `./vendor/bin/phpunit --configuration phpunit.xml.dist`
+Expected: All tests pass.
+
+**Step 3: Verify no regressions in existing EventBus and JobHandler tests**
+
+Run: `./vendor/bin/phpunit --filter "EventBusTest|JobHandlerTest"`
+Expected: All pass (existing + new tests).

--- a/packages/cli/src/Command/Optimize/OptimizeClearCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeClearCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'optimize:clear',
     description: 'Remove all cached optimization artifacts',
 )]
-class OptimizeClearCommand extends Command
+final class OptimizeClearCommand extends Command
 {
     public function __construct(
         private readonly string $storagePath,
@@ -30,7 +30,7 @@ class OptimizeClearCommand extends Command
             return Command::SUCCESS;
         }
 
-        $files = glob($frameworkPath . '/*.php');
+        $files = glob($frameworkPath . '/*.php') ?: [];
         $count = 0;
 
         foreach ($files as $file) {

--- a/packages/cli/src/Command/Optimize/OptimizeClearCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeClearCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:clear',
+    description: 'Remove all cached optimization artifacts',
+)]
+class OptimizeClearCommand extends Command
+{
+    public function __construct(
+        private readonly string $storagePath,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $frameworkPath = $this->storagePath . '/framework';
+
+        if (!is_dir($frameworkPath)) {
+            $output->writeln('No cached artifacts found.');
+            return Command::SUCCESS;
+        }
+
+        $files = glob($frameworkPath . '/*.php');
+        $count = 0;
+
+        foreach ($files as $file) {
+            if (unlink($file)) {
+                $output->writeln(sprintf('Removed: %s', basename($file)));
+                $count++;
+            }
+        }
+
+        if ($count === 0) {
+            $output->writeln('No cached artifacts found.');
+        } else {
+            $output->writeln(sprintf('%d cached artifact(s) cleared.', $count));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/cli/src/Command/Optimize/OptimizeCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize',
+    description: 'Run all optimization compilers',
+)]
+class OptimizeCommand extends Command
+{
+    /**
+     * Sub-commands to run in order.
+     */
+    private const array SUB_COMMANDS = [
+        'optimize:manifest',
+        'optimize:config',
+    ];
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $application = $this->getApplication();
+
+        if ($application === null) {
+            $output->writeln('Error: No application context available.');
+            return Command::FAILURE;
+        }
+
+        $ranAny = false;
+
+        foreach (self::SUB_COMMANDS as $commandName) {
+            if (!$application->has($commandName)) {
+                $output->writeln(sprintf('Skipping %s (not registered).', $commandName));
+                continue;
+            }
+
+            $output->writeln(sprintf('Running %s...', $commandName));
+            $subCommand = $application->find($commandName);
+            $result = $subCommand->run(
+                new ArrayInput([]),
+                $output,
+            );
+
+            if ($result !== Command::SUCCESS) {
+                $output->writeln(sprintf('%s failed.', $commandName));
+                return Command::FAILURE;
+            }
+
+            $ranAny = true;
+        }
+
+        if (!$ranAny) {
+            $output->writeln('No optimization commands are registered.');
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('All optimizations complete.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/cli/src/Command/Optimize/OptimizeCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'optimize',
     description: 'Run all optimization compilers',
 )]
-class OptimizeCommand extends Command
+final class OptimizeCommand extends Command
 {
     /**
      * Sub-commands to run in order.

--- a/packages/cli/src/Command/Optimize/OptimizeConfigCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeConfigCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'optimize:config',
     description: 'Compile and cache all configuration',
 )]
-class OptimizeConfigCommand extends Command
+final class OptimizeConfigCommand extends Command
 {
     public function __construct(
         private readonly ConfigCacheCompiler $compiler,

--- a/packages/cli/src/Command/Optimize/OptimizeConfigCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeConfigCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:config',
+    description: 'Compile and cache all configuration',
+)]
+class OptimizeConfigCommand extends Command
+{
+    public function __construct(
+        private readonly ConfigCacheCompiler $compiler,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $data = $this->compiler->compileAndCache();
+
+        $output->writeln(sprintf(
+            'Configuration cached: %d config objects compiled.',
+            count($data),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/cli/src/Command/Optimize/OptimizeManifestCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeManifestCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'optimize:manifest',
     description: 'Compile the package discovery manifest',
 )]
-class OptimizeManifestCommand extends Command
+final class OptimizeManifestCommand extends Command
 {
     public function __construct(
         private readonly PackageManifestCompiler $compiler,

--- a/packages/cli/src/Command/Optimize/OptimizeManifestCommand.php
+++ b/packages/cli/src/Command/Optimize/OptimizeManifestCommand.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\CLI\Command\Optimize;
+
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'optimize:manifest',
+    description: 'Compile the package discovery manifest',
+)]
+class OptimizeManifestCommand extends Command
+{
+    public function __construct(
+        private readonly PackageManifestCompiler $compiler,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $manifest = $this->compiler->compileAndCache();
+
+        $output->writeln(sprintf(
+            'Package manifest compiled: %d providers, %d commands, %d field types, %d middleware stacks.',
+            count($manifest->providers),
+            count($manifest->commands),
+            count($manifest->fieldTypes),
+            count($manifest->middleware),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/cli/tests/Unit/Command/Optimize/OptimizeClearCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Optimize/OptimizeClearCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\Optimize\OptimizeClearCommand;
+
+#[CoversClass(OptimizeClearCommand::class)]
+final class OptimizeClearCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_clear_test_' . uniqid();
+        mkdir($this->tempDir . '/framework', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function clears_cached_php_files(): void
+    {
+        file_put_contents($this->tempDir . '/framework/packages.php', '<?php return [];');
+        file_put_contents($this->tempDir . '/framework/config.php', '<?php return [];');
+
+        $command = new OptimizeClearCommand(storagePath: $this->tempDir);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('2 cached artifact(s) cleared', $tester->getDisplay());
+        $this->assertFileDoesNotExist($this->tempDir . '/framework/packages.php');
+        $this->assertFileDoesNotExist($this->tempDir . '/framework/config.php');
+    }
+
+    #[Test]
+    public function reports_no_artifacts_when_empty(): void
+    {
+        // framework dir exists but is empty
+        $command = new OptimizeClearCommand(storagePath: $this->tempDir);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('No cached artifacts found', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reports_no_artifacts_when_no_framework_dir(): void
+    {
+        $noFramework = sys_get_temp_dir() . '/waaseyaa_clear_nofw_' . uniqid();
+        mkdir($noFramework, 0o755, true);
+
+        $command = new OptimizeClearCommand(storagePath: $noFramework);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('No cached artifacts found', $tester->getDisplay());
+
+        rmdir($noFramework);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/cli/tests/Unit/Command/Optimize/OptimizeCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Optimize/OptimizeCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\Optimize\OptimizeCommand;
+
+#[CoversClass(OptimizeCommand::class)]
+final class OptimizeCommandTest extends TestCase
+{
+    #[Test]
+    public function skips_missing_sub_commands_gracefully(): void
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new OptimizeCommand());
+
+        $tester = new CommandTester($app->find('optimize'));
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Skipping optimize:manifest', $output);
+        $this->assertStringContainsString('Skipping optimize:config', $output);
+    }
+
+    #[Test]
+    public function runs_registered_sub_commands(): void
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new OptimizeCommand());
+
+        // Add a stub sub-command
+        $stubManifest = new class extends Command {
+            protected static $defaultName = 'optimize:manifest';
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $output->writeln('Manifest compiled.');
+                return Command::SUCCESS;
+            }
+        };
+        $stubManifest->setName('optimize:manifest');
+
+        $stubConfig = new class extends Command {
+            protected static $defaultName = 'optimize:config';
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $output->writeln('Config compiled.');
+                return Command::SUCCESS;
+            }
+        };
+        $stubConfig->setName('optimize:config');
+
+        $app->add($stubManifest);
+        $app->add($stubConfig);
+
+        $tester = new CommandTester($app->find('optimize'));
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Manifest compiled', $output);
+        $this->assertStringContainsString('Config compiled', $output);
+        $this->assertStringContainsString('All optimizations complete', $output);
+    }
+
+    #[Test]
+    public function stops_on_sub_command_failure(): void
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new OptimizeCommand());
+
+        $failingManifest = new class extends Command {
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                return Command::FAILURE;
+            }
+        };
+        $failingManifest->setName('optimize:manifest');
+        $app->add($failingManifest);
+
+        $tester = new CommandTester($app->find('optimize'));
+        $tester->execute([]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('optimize:manifest failed', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reports_when_no_commands_registered(): void
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new OptimizeCommand());
+
+        $tester = new CommandTester($app->find('optimize'));
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('No optimization commands are registered', $tester->getDisplay());
+    }
+}

--- a/packages/cli/tests/Unit/Command/Optimize/OptimizeConfigCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Optimize/OptimizeConfigCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeConfigCommand;
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeConfigCommand::class)]
+final class OptimizeConfigCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_optimize_cmd_test_' . uniqid();
+        mkdir($this->tempDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function compiles_config_and_reports_count(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Test']);
+        $storage->write('user.settings', ['register' => 'admin']);
+
+        $cachePath = $this->tempDir . '/config.php';
+        $compiler = new ConfigCacheCompiler($storage, $cachePath);
+
+        $command = new OptimizeConfigCommand($compiler);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('2 config objects', $tester->getDisplay());
+        $this->assertFileExists($cachePath);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/cli/tests/Unit/Command/Optimize/OptimizeManifestCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Optimize/OptimizeManifestCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\CLI\Tests\Unit\Command\Optimize;
+
+use Waaseyaa\CLI\Command\Optimize\OptimizeManifestCommand;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(OptimizeManifestCommand::class)]
+final class OptimizeManifestCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_cmd_test_' . uniqid();
+        mkdir($this->tempDir . '/vendor/composer', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function compiles_manifest_and_reports_counts(): void
+    {
+        $installed = [
+            'packages' => [
+                [
+                    'name' => 'waaseyaa/node',
+                    'extra' => [
+                        'waaseyaa' => [
+                            'providers' => ['App\\Provider'],
+                            'commands' => ['App\\Cmd', 'App\\Cmd2'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode($installed, JSON_THROW_ON_ERROR),
+        );
+
+        $storagePath = $this->tempDir . '/storage';
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+
+        $command = new OptimizeManifestCommand($compiler);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('1 providers', $output);
+        $this->assertStringContainsString('2 commands', $output);
+        $this->assertStringContainsString('0 field types', $output);
+        $this->assertStringContainsString('0 middleware stacks', $output);
+
+        // Verify cache file was written
+        $this->assertFileExists($storagePath . '/framework/packages.php');
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/config/src/Cache/CachedConfigFactory.php
+++ b/packages/config/src/Cache/CachedConfigFactory.php
@@ -74,7 +74,14 @@ final class CachedConfigFactory implements ConfigFactoryInterface
         $path = $this->cachePath;
 
         if (is_file($path)) {
-            $this->cache = require $path;
+            try {
+                $data = require $path;
+                if (is_array($data)) {
+                    $this->cache = $data;
+                }
+            } catch (\Throwable) {
+                // Corrupt cache — fall through to inner factory
+            }
         }
     }
 }

--- a/packages/config/src/Cache/CachedConfigFactory.php
+++ b/packages/config/src/Cache/CachedConfigFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Cache;
+
+use Waaseyaa\Config\Config;
+use Waaseyaa\Config\ConfigFactoryInterface;
+use Waaseyaa\Config\ConfigInterface;
+use Waaseyaa\Config\Storage\MemoryStorage;
+
+final class CachedConfigFactory implements ConfigFactoryInterface
+{
+    /** @var array<string, array<string, mixed>>|null */
+    private ?array $cache = null;
+
+    private bool $cacheLoaded = false;
+
+    public function __construct(
+        private readonly ConfigFactoryInterface $inner,
+        private readonly string $cachePath,
+    ) {}
+
+    public function get(string $name): ConfigInterface
+    {
+        $this->ensureCacheLoaded();
+
+        if ($this->cache !== null && array_key_exists($name, $this->cache)) {
+            return new Config(
+                name: $name,
+                storage: new MemoryStorage(),
+                data: $this->cache[$name],
+                immutable: true,
+                isNew: false,
+            );
+        }
+
+        return $this->inner->get($name);
+    }
+
+    public function getEditable(string $name): ConfigInterface
+    {
+        // Editable always goes through the inner factory
+        return $this->inner->getEditable($name);
+    }
+
+    public function loadMultiple(array $names): array
+    {
+        $configs = [];
+        foreach ($names as $name) {
+            $configs[$name] = $this->get($name);
+        }
+        return $configs;
+    }
+
+    public function rename(string $oldName, string $newName): static
+    {
+        $this->inner->rename($oldName, $newName);
+        return $this;
+    }
+
+    public function listAll(string $prefix = ''): array
+    {
+        return $this->inner->listAll($prefix);
+    }
+
+    private function ensureCacheLoaded(): void
+    {
+        if ($this->cacheLoaded) {
+            return;
+        }
+
+        $this->cacheLoaded = true;
+        $path = $this->cachePath;
+
+        if (is_file($path)) {
+            $this->cache = require $path;
+        }
+    }
+}

--- a/packages/config/src/Cache/ConfigCacheCompiler.php
+++ b/packages/config/src/Cache/ConfigCacheCompiler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Cache;
+
+use Waaseyaa\Config\StorageInterface;
+
+final class ConfigCacheCompiler
+{
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly string $cachePath,
+    ) {}
+
+    /**
+     * Compile all config into a single cached PHP file.
+     *
+     * @return array<string, array<string, mixed>> The compiled config data
+     */
+    public function compile(): array
+    {
+        $all = [];
+
+        foreach ($this->storage->listAll() as $name) {
+            $data = $this->storage->read($name);
+            if ($data !== false) {
+                $all[$name] = $data;
+            }
+        }
+
+        return $all;
+    }
+
+    /**
+     * Compile and write cache file.
+     */
+    public function compileAndCache(): array
+    {
+        $data = $this->compile();
+
+        $dir = dirname($this->cachePath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+
+        $content = '<?php return ' . var_export($data, true) . ';' . "\n";
+        file_put_contents($this->cachePath, $content);
+
+        return $data;
+    }
+
+    /**
+     * Check if cache file exists.
+     */
+    public function isCached(): bool
+    {
+        return is_file($this->cachePath);
+    }
+
+    /**
+     * Delete the cache file.
+     */
+    public function clear(): bool
+    {
+        if (is_file($this->cachePath)) {
+            return unlink($this->cachePath);
+        }
+
+        return false;
+    }
+}

--- a/packages/config/src/Cache/ConfigCacheCompiler.php
+++ b/packages/config/src/Cache/ConfigCacheCompiler.php
@@ -34,6 +34,8 @@ final class ConfigCacheCompiler
 
     /**
      * Compile and write cache file.
+     *
+     * @throws \RuntimeException If the cache directory or file cannot be written
      */
     public function compileAndCache(): array
     {

--- a/packages/config/src/Cache/ConfigCacheCompiler.php
+++ b/packages/config/src/Cache/ConfigCacheCompiler.php
@@ -40,12 +40,21 @@ final class ConfigCacheCompiler
         $data = $this->compile();
 
         $dir = dirname($this->cachePath);
-        if (!is_dir($dir)) {
-            mkdir($dir, 0o755, true);
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true)) {
+            throw new \RuntimeException(sprintf('Failed to create cache directory: %s', $dir));
         }
 
         $content = '<?php return ' . var_export($data, true) . ';' . "\n";
-        file_put_contents($this->cachePath, $content);
+        $tmpPath = $this->cachePath . '.tmp.' . getmypid();
+
+        if (file_put_contents($tmpPath, $content) === false) {
+            throw new \RuntimeException(sprintf('Failed to write config cache to %s', $this->cachePath));
+        }
+
+        if (!rename($tmpPath, $this->cachePath)) {
+            @unlink($tmpPath);
+            throw new \RuntimeException(sprintf('Failed to atomically replace config cache at %s', $this->cachePath));
+        }
 
         return $data;
     }

--- a/packages/config/src/Listener/ConfigCacheInvalidator.php
+++ b/packages/config/src/Listener/ConfigCacheInvalidator.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Listener;
+
+use Waaseyaa\Config\Event\ConfigEvent;
+
+final class ConfigCacheInvalidator
+{
+    public function __construct(
+        private readonly string $cachePath,
+    ) {}
+
+    public function __invoke(ConfigEvent $event): void
+    {
+        if (is_file($this->cachePath)) {
+            unlink($this->cachePath);
+        }
+    }
+}

--- a/packages/config/src/Listener/ConfigCacheInvalidator.php
+++ b/packages/config/src/Listener/ConfigCacheInvalidator.php
@@ -14,8 +14,12 @@ final class ConfigCacheInvalidator
 
     public function __invoke(ConfigEvent $event): void
     {
-        if (is_file($this->cachePath)) {
-            unlink($this->cachePath);
+        try {
+            if (is_file($this->cachePath)) {
+                unlink($this->cachePath);
+            }
+        } catch (\Throwable) {
+            // Best-effort: cache invalidation failure should not crash the primary request
         }
     }
 }

--- a/packages/config/src/Listener/ConfigCacheInvalidator.php
+++ b/packages/config/src/Listener/ConfigCacheInvalidator.php
@@ -18,8 +18,8 @@ final class ConfigCacheInvalidator
             if (is_file($this->cachePath)) {
                 unlink($this->cachePath);
             }
-        } catch (\Throwable) {
-            // Best-effort: cache invalidation failure should not crash the primary request
+        } catch (\Throwable $e) {
+            error_log(sprintf('ConfigCacheInvalidator: failed to delete %s: %s', $this->cachePath, $e->getMessage()));
         }
     }
 }

--- a/packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php
+++ b/packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Cache;
+
+use Waaseyaa\Config\Cache\CachedConfigFactory;
+use Waaseyaa\Config\Config;
+use Waaseyaa\Config\ConfigFactory;
+use Waaseyaa\Config\ConfigFactoryInterface;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[CoversClass(CachedConfigFactory::class)]
+final class CachedConfigFactoryTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_cached_factory_test_' . uniqid();
+        mkdir($this->tempDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function get_returns_cached_config_when_cache_exists(): void
+    {
+        $cachePath = $this->tempDir . '/config.php';
+        $cached = ['system.site' => ['name' => 'Cached Site']];
+        file_put_contents($cachePath, '<?php return ' . var_export($cached, true) . ';' . "\n");
+
+        $inner = $this->createMock(ConfigFactoryInterface::class);
+        $inner->expects($this->never())->method('get');
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->get('system.site');
+
+        $this->assertSame('system.site', $config->getName());
+        $this->assertSame(['name' => 'Cached Site'], $config->get());
+    }
+
+    #[Test]
+    public function get_falls_through_to_inner_when_not_cached(): void
+    {
+        $cachePath = $this->tempDir . '/nonexistent.php';
+
+        $storage = new MemoryStorage();
+        $storage->write('user.settings', ['register' => 'admin']);
+        $inner = new ConfigFactory($storage, new EventDispatcher());
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->get('user.settings');
+
+        $this->assertSame('user.settings', $config->getName());
+        $this->assertSame('admin', $config->get('register'));
+    }
+
+    #[Test]
+    public function get_falls_through_for_uncached_config_name(): void
+    {
+        $cachePath = $this->tempDir . '/config.php';
+        $cached = ['system.site' => ['name' => 'Cached']];
+        file_put_contents($cachePath, '<?php return ' . var_export($cached, true) . ';' . "\n");
+
+        $storage = new MemoryStorage();
+        $storage->write('other.config', ['key' => 'value']);
+        $inner = new ConfigFactory($storage, new EventDispatcher());
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->get('other.config');
+
+        $this->assertSame('value', $config->get('key'));
+    }
+
+    #[Test]
+    public function get_editable_always_goes_through_inner(): void
+    {
+        $cachePath = $this->tempDir . '/config.php';
+        $cached = ['system.site' => ['name' => 'Cached']];
+        file_put_contents($cachePath, '<?php return ' . var_export($cached, true) . ';' . "\n");
+
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Real']);
+        $inner = new ConfigFactory($storage, new EventDispatcher());
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->getEditable('system.site');
+
+        $this->assertFalse($config->isImmutable());
+    }
+
+    #[Test]
+    public function load_multiple_uses_cache(): void
+    {
+        $cachePath = $this->tempDir . '/config.php';
+        $cached = [
+            'a' => ['val' => 1],
+            'b' => ['val' => 2],
+        ];
+        file_put_contents($cachePath, '<?php return ' . var_export($cached, true) . ';' . "\n");
+
+        $inner = $this->createMock(ConfigFactoryInterface::class);
+        $inner->expects($this->never())->method('get');
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $configs = $factory->loadMultiple(['a', 'b']);
+
+        $this->assertCount(2, $configs);
+        $this->assertSame(1, $configs['a']->get('val'));
+        $this->assertSame(2, $configs['b']->get('val'));
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php
+++ b/packages/config/tests/Unit/Cache/CachedConfigFactoryTest.php
@@ -118,6 +118,38 @@ final class CachedConfigFactoryTest extends TestCase
         $this->assertSame(2, $configs['b']->get('val'));
     }
 
+    #[Test]
+    public function get_falls_through_when_cache_file_is_corrupt(): void
+    {
+        $cachePath = $this->tempDir . '/corrupt.php';
+        file_put_contents($cachePath, '<?php throw new \RuntimeException("corrupt");');
+
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'From Storage']);
+        $inner = new ConfigFactory($storage, new EventDispatcher());
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->get('system.site');
+
+        $this->assertSame('From Storage', $config->get('name'));
+    }
+
+    #[Test]
+    public function get_falls_through_when_cache_returns_non_array(): void
+    {
+        $cachePath = $this->tempDir . '/bad.php';
+        file_put_contents($cachePath, '<?php return "not an array";');
+
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Real']);
+        $inner = new ConfigFactory($storage, new EventDispatcher());
+
+        $factory = new CachedConfigFactory($inner, $cachePath);
+        $config = $factory->get('system.site');
+
+        $this->assertSame('Real', $config->get('name'));
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/packages/config/tests/Unit/Cache/ConfigCacheCompilerTest.php
+++ b/packages/config/tests/Unit/Cache/ConfigCacheCompilerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Cache;
+
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\Storage\MemoryStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigCacheCompiler::class)]
+final class ConfigCacheCompilerTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_config_test_' . uniqid();
+        mkdir($this->tempDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function compile_reads_all_config_from_storage(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'My Site']);
+        $storage->write('user.settings', ['register' => 'admin']);
+
+        $compiler = new ConfigCacheCompiler($storage, $this->tempDir . '/config.php');
+        $data = $compiler->compile();
+
+        $this->assertSame(['name' => 'My Site'], $data['system.site']);
+        $this->assertSame(['register' => 'admin'], $data['user.settings']);
+    }
+
+    #[Test]
+    public function compile_and_cache_writes_php_file(): void
+    {
+        $storage = new MemoryStorage();
+        $storage->write('system.site', ['name' => 'Test']);
+
+        $cachePath = $this->tempDir . '/framework/config.php';
+        $compiler = new ConfigCacheCompiler($storage, $cachePath);
+        $compiler->compileAndCache();
+
+        $this->assertFileExists($cachePath);
+
+        $loaded = require $cachePath;
+        $this->assertSame(['name' => 'Test'], $loaded['system.site']);
+    }
+
+    #[Test]
+    public function is_cached_returns_false_when_no_cache(): void
+    {
+        $storage = new MemoryStorage();
+        $compiler = new ConfigCacheCompiler($storage, $this->tempDir . '/nope.php');
+        $this->assertFalse($compiler->isCached());
+    }
+
+    #[Test]
+    public function is_cached_returns_true_after_compilation(): void
+    {
+        $storage = new MemoryStorage();
+        $cachePath = $this->tempDir . '/config.php';
+        $compiler = new ConfigCacheCompiler($storage, $cachePath);
+        $compiler->compileAndCache();
+
+        $this->assertTrue($compiler->isCached());
+    }
+
+    #[Test]
+    public function clear_deletes_cache_file(): void
+    {
+        $storage = new MemoryStorage();
+        $cachePath = $this->tempDir . '/config.php';
+        $compiler = new ConfigCacheCompiler($storage, $cachePath);
+        $compiler->compileAndCache();
+
+        $this->assertTrue($compiler->clear());
+        $this->assertFalse($compiler->isCached());
+    }
+
+    #[Test]
+    public function clear_returns_false_when_no_cache(): void
+    {
+        $storage = new MemoryStorage();
+        $compiler = new ConfigCacheCompiler($storage, $this->tempDir . '/nope.php');
+        $this->assertFalse($compiler->clear());
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/config/tests/Unit/Listener/ConfigCacheInvalidatorTest.php
+++ b/packages/config/tests/Unit/Listener/ConfigCacheInvalidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config\Tests\Unit\Listener;
+
+use Waaseyaa\Config\Event\ConfigEvent;
+use Waaseyaa\Config\Listener\ConfigCacheInvalidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigCacheInvalidator::class)]
+final class ConfigCacheInvalidatorTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_invalidator_test_' . uniqid();
+        mkdir($this->tempDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function deletes_cache_file_when_exists(): void
+    {
+        $cachePath = $this->tempDir . '/config.php';
+        file_put_contents($cachePath, '<?php return [];');
+
+        $invalidator = new ConfigCacheInvalidator($cachePath);
+        $invalidator(new ConfigEvent('system.site'));
+
+        $this->assertFileDoesNotExist($cachePath);
+    }
+
+    #[Test]
+    public function does_nothing_when_no_cache_file(): void
+    {
+        $cachePath = $this->tempDir . '/nonexistent.php';
+
+        $invalidator = new ConfigCacheInvalidator($cachePath);
+        // Should not throw
+        $invalidator(new ConfigEvent('system.site'));
+
+        $this->assertFileDoesNotExist($cachePath);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -8,8 +8,10 @@
         "doctrine/dbal": "^4.0",
         "symfony/dependency-injection": "^7.0",
         "symfony/event-dispatcher": "^7.0",
+        "symfony/http-foundation": "^7.0",
         "symfony/messenger": "^7.0",
-        "symfony/uid": "^7.0"
+        "symfony/uid": "^7.0",
+        "waaseyaa/queue": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/foundation/src/Attribute/AsEntityType.php
+++ b/packages/foundation/src/Attribute/AsEntityType.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsEntityType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}

--- a/packages/foundation/src/Attribute/AsFieldType.php
+++ b/packages/foundation/src/Attribute/AsFieldType.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsFieldType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}

--- a/packages/foundation/src/Attribute/AsMiddleware.php
+++ b/packages/foundation/src/Attribute/AsMiddleware.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMiddleware
+{
+    public function __construct(
+        public readonly string $pipeline,
+        public readonly int $priority = 0,
+    ) {}
+}

--- a/packages/foundation/src/Discovery/PackageManifest.php
+++ b/packages/foundation/src/Discovery/PackageManifest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Discovery;
+
+final class PackageManifest
+{
+    public function __construct(
+        /** @var string[] */ public readonly array $providers = [],
+        /** @var string[] */ public readonly array $commands = [],
+        /** @var string[] */ public readonly array $routes = [],
+        /** @var array<string, string> */ public readonly array $migrations = [],
+        /** @var array<string, string> */ public readonly array $fieldTypes = [],
+        /** @var array<string, list<array{class: string, priority: int}>> */ public readonly array $listeners = [],
+        /** @var array<string, list<array{class: string, priority: int}>> */ public readonly array $middleware = [],
+    ) {}
+
+    /**
+     * Create from a cached array (loaded from storage/framework/packages.php).
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            providers: $data['providers'] ?? [],
+            commands: $data['commands'] ?? [],
+            routes: $data['routes'] ?? [],
+            migrations: $data['migrations'] ?? [],
+            fieldTypes: $data['field_types'] ?? [],
+            listeners: $data['listeners'] ?? [],
+            middleware: $data['middleware'] ?? [],
+        );
+    }
+
+    /**
+     * Export to a cacheable array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'providers' => $this->providers,
+            'commands' => $this->commands,
+            'routes' => $this->routes,
+            'migrations' => $this->migrations,
+            'field_types' => $this->fieldTypes,
+            'listeners' => $this->listeners,
+            'middleware' => $this->middleware,
+        ];
+    }
+}

--- a/packages/foundation/src/Discovery/PackageManifest.php
+++ b/packages/foundation/src/Discovery/PackageManifest.php
@@ -16,17 +16,39 @@ final class PackageManifest
 
     /**
      * Create from a cached array (loaded from storage/framework/packages.php).
+     *
+     * @throws \InvalidArgumentException If required keys are missing or have wrong types
      */
     public static function fromArray(array $data): self
     {
+        $requiredKeys = ['providers', 'commands', 'routes', 'migrations', 'field_types', 'listeners', 'middleware'];
+        $missing = array_diff($requiredKeys, array_keys($data));
+
+        if ($missing !== []) {
+            throw new \InvalidArgumentException(sprintf(
+                'PackageManifest cache is missing required keys: %s',
+                implode(', ', $missing),
+            ));
+        }
+
+        foreach ($requiredKeys as $key) {
+            if (!is_array($data[$key])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'PackageManifest cache key "%s" must be an array, got %s',
+                    $key,
+                    get_debug_type($data[$key]),
+                ));
+            }
+        }
+
         return new self(
-            providers: $data['providers'] ?? [],
-            commands: $data['commands'] ?? [],
-            routes: $data['routes'] ?? [],
-            migrations: $data['migrations'] ?? [],
-            fieldTypes: $data['field_types'] ?? [],
-            listeners: $data['listeners'] ?? [],
-            middleware: $data['middleware'] ?? [],
+            providers: $data['providers'],
+            commands: $data['commands'],
+            routes: $data['routes'],
+            migrations: $data['migrations'],
+            fieldTypes: $data['field_types'],
+            listeners: $data['listeners'],
+            middleware: $data['middleware'],
         );
     }
 

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -65,19 +65,23 @@ final class PackageManifestCompiler
             }
 
             foreach ($ref->getAttributes(Listener::class) as $attr) {
-                $instance = $attr->newInstance();
-                // Listener classes must implement __invoke(DomainEvent)
-                $invoke = $ref->getMethod('__invoke');
-                $params = $invoke->getParameters();
-                if (count($params) > 0) {
-                    $eventType = $params[0]->getType();
-                    if ($eventType instanceof \ReflectionNamedType) {
-                        $eventClass = $eventType->getName();
-                        $listeners[$eventClass][] = [
-                            'class' => $class,
-                            'priority' => $instance->priority,
-                        ];
+                try {
+                    $instance = $attr->newInstance();
+                    $invoke = $ref->getMethod('__invoke');
+                    $params = $invoke->getParameters();
+                    if (count($params) > 0) {
+                        $eventType = $params[0]->getType();
+                        if ($eventType instanceof \ReflectionNamedType) {
+                            $eventClass = $eventType->getName();
+                            $listeners[$eventClass][] = [
+                                'class' => $class,
+                                'priority' => $instance->priority,
+                            ];
+                        }
                     }
+                } catch (\ReflectionException) {
+                    // Skip listeners with missing __invoke or invalid signatures
+                    continue;
                 }
             }
 
@@ -123,12 +127,22 @@ final class PackageManifestCompiler
         $manifest = $this->compile();
 
         $dir = $this->storagePath . '/framework';
-        if (!is_dir($dir)) {
-            mkdir($dir, 0o755, true);
+        if (!is_dir($dir) && !mkdir($dir, 0o755, true)) {
+            throw new \RuntimeException(sprintf('Failed to create cache directory: %s', $dir));
         }
 
+        $cachePath = $dir . '/packages.php';
         $content = '<?php return ' . var_export($manifest->toArray(), true) . ';' . "\n";
-        file_put_contents($dir . '/packages.php', $content);
+        $tmpPath = $cachePath . '.tmp.' . getmypid();
+
+        if (file_put_contents($tmpPath, $content) === false) {
+            throw new \RuntimeException(sprintf('Failed to write package manifest cache to %s', $cachePath));
+        }
+
+        if (!rename($tmpPath, $cachePath)) {
+            @unlink($tmpPath);
+            throw new \RuntimeException(sprintf('Failed to atomically replace package manifest at %s', $cachePath));
+        }
 
         return $manifest;
     }
@@ -140,7 +154,14 @@ final class PackageManifestCompiler
     {
         $cachePath = $this->storagePath . '/framework/packages.php';
         if (is_file($cachePath)) {
-            return PackageManifest::fromArray(require $cachePath);
+            try {
+                $data = require $cachePath;
+                if (is_array($data)) {
+                    return PackageManifest::fromArray($data);
+                }
+            } catch (\Throwable) {
+                // Corrupt cache — recompile
+            }
         }
 
         return $this->compileAndCache();

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Discovery;
+
+use Waaseyaa\Foundation\Attribute\AsEntityType;
+use Waaseyaa\Foundation\Attribute\AsFieldType;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Event\Attribute\Listener;
+
+final class PackageManifestCompiler
+{
+    public function __construct(
+        private readonly string $basePath,
+        private readonly string $storagePath,
+    ) {}
+
+    /**
+     * Compile the package manifest from composer metadata and attribute scanning.
+     */
+    public function compile(): PackageManifest
+    {
+        $providers = [];
+        $commands = [];
+        $routes = [];
+        $migrations = [];
+        $fieldTypes = [];
+        $listeners = [];
+        $middleware = [];
+
+        // Read installed packages manifest
+        $installedPath = $this->basePath . '/vendor/composer/installed.json';
+        if (is_file($installedPath)) {
+            $installed = json_decode(file_get_contents($installedPath), true, 512, JSON_THROW_ON_ERROR);
+            $packages = $installed['packages'] ?? $installed;
+
+            foreach ($packages as $package) {
+                $extra = $package['extra']['waaseyaa'] ?? null;
+                if ($extra === null) {
+                    continue;
+                }
+
+                if (isset($extra['providers'])) {
+                    array_push($providers, ...$extra['providers']);
+                }
+                if (isset($extra['commands'])) {
+                    array_push($commands, ...$extra['commands']);
+                }
+                if (isset($extra['routes'])) {
+                    array_push($routes, ...$extra['routes']);
+                }
+                if (isset($extra['migrations'])) {
+                    $packageName = $package['name'] ?? 'unknown';
+                    $migrations[$packageName] = $extra['migrations'];
+                }
+            }
+        }
+
+        // Scan classes for attributes
+        foreach ($this->scanClasses() as $class) {
+            $ref = new \ReflectionClass($class);
+
+            foreach ($ref->getAttributes(AsFieldType::class) as $attr) {
+                $instance = $attr->newInstance();
+                $fieldTypes[$instance->id] = $class;
+            }
+
+            foreach ($ref->getAttributes(Listener::class) as $attr) {
+                $instance = $attr->newInstance();
+                // Listener classes must implement __invoke(DomainEvent)
+                $invoke = $ref->getMethod('__invoke');
+                $params = $invoke->getParameters();
+                if (count($params) > 0) {
+                    $eventType = $params[0]->getType();
+                    if ($eventType instanceof \ReflectionNamedType) {
+                        $eventClass = $eventType->getName();
+                        $listeners[$eventClass][] = [
+                            'class' => $class,
+                            'priority' => $instance->priority,
+                        ];
+                    }
+                }
+            }
+
+            foreach ($ref->getAttributes(AsMiddleware::class) as $attr) {
+                $instance = $attr->newInstance();
+                $middleware[$instance->pipeline][] = [
+                    'class' => $class,
+                    'priority' => $instance->priority,
+                ];
+            }
+
+            foreach ($ref->getAttributes(AsEntityType::class) as $attr) {
+                // Entity types are tracked in providers for now
+            }
+        }
+
+        // Sort middleware by priority (descending)
+        foreach ($middleware as &$stack) {
+            usort($stack, fn(array $a, array $b) => $b['priority'] <=> $a['priority']);
+        }
+
+        // Sort listeners by priority (descending)
+        foreach ($listeners as &$eventListeners) {
+            usort($eventListeners, fn(array $a, array $b) => $b['priority'] <=> $a['priority']);
+        }
+
+        return new PackageManifest(
+            providers: $providers,
+            commands: $commands,
+            routes: $routes,
+            migrations: $migrations,
+            fieldTypes: $fieldTypes,
+            listeners: $listeners,
+            middleware: $middleware,
+        );
+    }
+
+    /**
+     * Compile and write to cache file.
+     */
+    public function compileAndCache(): PackageManifest
+    {
+        $manifest = $this->compile();
+
+        $dir = $this->storagePath . '/framework';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+
+        $content = '<?php return ' . var_export($manifest->toArray(), true) . ';' . "\n";
+        file_put_contents($dir . '/packages.php', $content);
+
+        return $manifest;
+    }
+
+    /**
+     * Load from cache or compile.
+     */
+    public function load(): PackageManifest
+    {
+        $cachePath = $this->storagePath . '/framework/packages.php';
+        if (is_file($cachePath)) {
+            return PackageManifest::fromArray(require $cachePath);
+        }
+
+        return $this->compileAndCache();
+    }
+
+    /**
+     * Scan autoloaded namespaces for classes with discovery attributes.
+     *
+     * @return string[]
+     */
+    private function scanClasses(): array
+    {
+        $classes = [];
+        $autoloadPath = $this->basePath . '/vendor/composer/autoload_classmap.php';
+
+        if (!is_file($autoloadPath)) {
+            return $classes;
+        }
+
+        $classMap = require $autoloadPath;
+
+        foreach ($classMap as $class => $file) {
+            // Only scan Waaseyaa namespace classes
+            if (!str_starts_with($class, 'Waaseyaa\\')) {
+                continue;
+            }
+
+            try {
+                $ref = new \ReflectionClass($class);
+                if ($ref->isAbstract() || $ref->isInterface() || $ref->isTrait()) {
+                    continue;
+                }
+
+                $hasDiscoveryAttribute = !empty($ref->getAttributes(AsFieldType::class))
+                    || !empty($ref->getAttributes(Listener::class))
+                    || !empty($ref->getAttributes(AsMiddleware::class))
+                    || !empty($ref->getAttributes(AsEntityType::class));
+
+                if ($hasDiscoveryAttribute) {
+                    $classes[] = $class;
+                }
+            } catch (\ReflectionException) {
+                // Skip classes that can't be reflected
+                continue;
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -121,6 +121,8 @@ final class PackageManifestCompiler
 
     /**
      * Compile and write to cache file.
+     *
+     * @throws \RuntimeException If the cache directory or file cannot be written
      */
     public function compileAndCache(): PackageManifest
     {

--- a/packages/foundation/src/Event/EventBus.php
+++ b/packages/foundation/src/Event/EventBus.php
@@ -6,6 +6,8 @@ namespace Waaseyaa\Foundation\Event;
 
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\Foundation\Middleware\EventHandlerInterface;
+use Waaseyaa\Foundation\Middleware\EventPipeline;
 
 final class EventBus
 {
@@ -14,12 +16,30 @@ final class EventBus
         private readonly MessageBusInterface $asyncBus,
         private readonly BroadcasterInterface $broadcaster,
         private readonly ?EventStoreInterface $eventStore = null,
+        private readonly ?EventPipeline $eventPipeline = null,
     ) {}
 
     public function dispatch(DomainEvent $event): void
     {
         $this->eventStore?->append($event);
-        $this->syncDispatcher->dispatch($event);
+
+        $syncHandler = new class($this->syncDispatcher) implements EventHandlerInterface {
+            public function __construct(
+                private readonly EventDispatcherInterface $dispatcher,
+            ) {}
+
+            public function handle(DomainEvent $event): void
+            {
+                $this->dispatcher->dispatch($event);
+            }
+        };
+
+        if ($this->eventPipeline !== null) {
+            $this->eventPipeline->handle($event, $syncHandler);
+        } else {
+            $syncHandler->handle($event);
+        }
+
         $this->asyncBus->dispatch($event);
         $this->broadcaster->broadcast($event);
     }

--- a/packages/foundation/src/Middleware/EventHandlerInterface.php
+++ b/packages/foundation/src/Middleware/EventHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+interface EventHandlerInterface
+{
+    public function handle(DomainEvent $event): void;
+}

--- a/packages/foundation/src/Middleware/EventMiddlewareInterface.php
+++ b/packages/foundation/src/Middleware/EventMiddlewareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+interface EventMiddlewareInterface
+{
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}

--- a/packages/foundation/src/Middleware/EventPipeline.php
+++ b/packages/foundation/src/Middleware/EventPipeline.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+
+final class EventPipeline
+{
+    /** @param EventMiddlewareInterface[] $middleware */
+    public function __construct(
+        private readonly array $middleware = [],
+    ) {}
+
+    public function handle(DomainEvent $event, EventHandlerInterface $finalHandler): void
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements EventHandlerInterface {
+                public function __construct(
+                    private readonly EventMiddlewareInterface $middleware,
+                    private readonly EventHandlerInterface $next,
+                ) {}
+
+                public function handle(DomainEvent $event): void
+                {
+                    $this->middleware->process($event, $this->next);
+                }
+            };
+        }
+
+        $handler->handle($event);
+    }
+}

--- a/packages/foundation/src/Middleware/EventPipeline.php
+++ b/packages/foundation/src/Middleware/EventPipeline.php
@@ -13,8 +13,18 @@ final class EventPipeline
         private readonly array $middleware = [],
     ) {}
 
+    public function withMiddleware(EventMiddlewareInterface $middleware): self
+    {
+        return new self([...$this->middleware, $middleware]);
+    }
+
     public function handle(DomainEvent $event, EventHandlerInterface $finalHandler): void
     {
+        if ($this->middleware === []) {
+            $finalHandler->handle($event);
+            return;
+        }
+
         $handler = $finalHandler;
 
         foreach (array_reverse($this->middleware) as $mw) {

--- a/packages/foundation/src/Middleware/HttpHandlerInterface.php
+++ b/packages/foundation/src/Middleware/HttpHandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpHandlerInterface
+{
+    public function handle(Request $request): Response;
+}

--- a/packages/foundation/src/Middleware/HttpMiddlewareInterface.php
+++ b/packages/foundation/src/Middleware/HttpMiddlewareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpMiddlewareInterface
+{
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}

--- a/packages/foundation/src/Middleware/HttpPipeline.php
+++ b/packages/foundation/src/Middleware/HttpPipeline.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HttpPipeline
+{
+    /** @param HttpMiddlewareInterface[] $middleware */
+    public function __construct(
+        private readonly array $middleware = [],
+    ) {}
+
+    public function handle(Request $request, HttpHandlerInterface $finalHandler): Response
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements HttpHandlerInterface {
+                public function __construct(
+                    private readonly HttpMiddlewareInterface $middleware,
+                    private readonly HttpHandlerInterface $next,
+                ) {}
+
+                public function handle(Request $request): Response
+                {
+                    return $this->middleware->process($request, $this->next);
+                }
+            };
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/packages/foundation/src/Middleware/HttpPipeline.php
+++ b/packages/foundation/src/Middleware/HttpPipeline.php
@@ -14,8 +14,17 @@ final class HttpPipeline
         private readonly array $middleware = [],
     ) {}
 
+    public function withMiddleware(HttpMiddlewareInterface $middleware): self
+    {
+        return new self([...$this->middleware, $middleware]);
+    }
+
     public function handle(Request $request, HttpHandlerInterface $finalHandler): Response
     {
+        if ($this->middleware === []) {
+            return $finalHandler->handle($request);
+        }
+
         $handler = $finalHandler;
 
         foreach (array_reverse($this->middleware) as $mw) {

--- a/packages/foundation/src/Middleware/JobHandlerInterface.php
+++ b/packages/foundation/src/Middleware/JobHandlerInterface.php
@@ -6,7 +6,7 @@ namespace Waaseyaa\Foundation\Middleware;
 
 use Waaseyaa\Queue\Job;
 
-interface JobNextHandlerInterface
+interface JobHandlerInterface
 {
     public function handle(Job $job): void;
 }

--- a/packages/foundation/src/Middleware/JobMiddlewareInterface.php
+++ b/packages/foundation/src/Middleware/JobMiddlewareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+interface JobMiddlewareInterface
+{
+    public function process(Job $job, JobNextHandlerInterface $next): void;
+}

--- a/packages/foundation/src/Middleware/JobMiddlewareInterface.php
+++ b/packages/foundation/src/Middleware/JobMiddlewareInterface.php
@@ -8,5 +8,5 @@ use Waaseyaa\Queue\Job;
 
 interface JobMiddlewareInterface
 {
-    public function process(Job $job, JobNextHandlerInterface $next): void;
+    public function process(Job $job, JobHandlerInterface $next): void;
 }

--- a/packages/foundation/src/Middleware/JobNextHandlerInterface.php
+++ b/packages/foundation/src/Middleware/JobNextHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+interface JobNextHandlerInterface
+{
+    public function handle(Job $job): void;
+}

--- a/packages/foundation/src/Middleware/JobPipeline.php
+++ b/packages/foundation/src/Middleware/JobPipeline.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Waaseyaa\Queue\Job;
+
+final class JobPipeline
+{
+    /** @param JobMiddlewareInterface[] $middleware */
+    public function __construct(
+        private readonly array $middleware = [],
+    ) {}
+
+    public function handle(Job $job, JobNextHandlerInterface $finalHandler): void
+    {
+        $handler = $finalHandler;
+
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements JobNextHandlerInterface {
+                public function __construct(
+                    private readonly JobMiddlewareInterface $middleware,
+                    private readonly JobNextHandlerInterface $next,
+                ) {}
+
+                public function handle(Job $job): void
+                {
+                    $this->middleware->process($job, $this->next);
+                }
+            };
+        }
+
+        $handler->handle($job);
+    }
+}

--- a/packages/foundation/src/Middleware/JobPipeline.php
+++ b/packages/foundation/src/Middleware/JobPipeline.php
@@ -13,8 +13,18 @@ final class JobPipeline
         private readonly array $middleware = [],
     ) {}
 
+    public function withMiddleware(JobMiddlewareInterface $middleware): self
+    {
+        return new self([...$this->middleware, $middleware]);
+    }
+
     public function handle(Job $job, JobHandlerInterface $finalHandler): void
     {
+        if ($this->middleware === []) {
+            $finalHandler->handle($job);
+            return;
+        }
+
         $handler = $finalHandler;
 
         foreach (array_reverse($this->middleware) as $mw) {

--- a/packages/foundation/src/Middleware/JobPipeline.php
+++ b/packages/foundation/src/Middleware/JobPipeline.php
@@ -13,16 +13,16 @@ final class JobPipeline
         private readonly array $middleware = [],
     ) {}
 
-    public function handle(Job $job, JobNextHandlerInterface $finalHandler): void
+    public function handle(Job $job, JobHandlerInterface $finalHandler): void
     {
         $handler = $finalHandler;
 
         foreach (array_reverse($this->middleware) as $mw) {
             $next = $handler;
-            $handler = new class($mw, $next) implements JobNextHandlerInterface {
+            $handler = new class($mw, $next) implements JobHandlerInterface {
                 public function __construct(
                     private readonly JobMiddlewareInterface $middleware,
-                    private readonly JobNextHandlerInterface $next,
+                    private readonly JobHandlerInterface $next,
                 ) {}
 
                 public function handle(Job $job): void

--- a/packages/foundation/tests/Unit/Attribute/AsEntityTypeTest.php
+++ b/packages/foundation/tests/Unit/Attribute/AsEntityTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsEntityType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsEntityType::class)]
+final class AsEntityTypeTest extends TestCase
+{
+    #[Test]
+    public function stores_id_and_label(): void
+    {
+        $attr = new AsEntityType(id: 'node', label: 'Content');
+        $this->assertSame('node', $attr->id);
+        $this->assertSame('Content', $attr->label);
+    }
+
+    #[Test]
+    public function is_a_class_level_attribute(): void
+    {
+        $ref = new \ReflectionClass(AsEntityType::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+    }
+}

--- a/packages/foundation/tests/Unit/Attribute/AsFieldTypeTest.php
+++ b/packages/foundation/tests/Unit/Attribute/AsFieldTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsFieldType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsFieldType::class)]
+final class AsFieldTypeTest extends TestCase
+{
+    #[Test]
+    public function stores_id_and_label(): void
+    {
+        $attr = new AsFieldType(id: 'text', label: 'Text');
+        $this->assertSame('text', $attr->id);
+        $this->assertSame('Text', $attr->label);
+    }
+
+    #[Test]
+    public function is_a_class_level_attribute(): void
+    {
+        $ref = new \ReflectionClass(AsFieldType::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+    }
+}

--- a/packages/foundation/tests/Unit/Attribute/AsMiddlewareTest.php
+++ b/packages/foundation/tests/Unit/Attribute/AsMiddlewareTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Tests\Unit\Attribute;
+
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AsMiddleware::class)]
+final class AsMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function stores_pipeline_and_priority(): void
+    {
+        $attr = new AsMiddleware(pipeline: 'http', priority: 100);
+        $this->assertSame('http', $attr->pipeline);
+        $this->assertSame(100, $attr->priority);
+    }
+
+    #[Test]
+    public function priority_defaults_to_zero(): void
+    {
+        $attr = new AsMiddleware(pipeline: 'event');
+        $this->assertSame(0, $attr->priority);
+    }
+
+    #[Test]
+    public function is_a_class_level_attribute(): void
+    {
+        $ref = new \ReflectionClass(AsMiddleware::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+        $instance = $attrs[0]->newInstance();
+        $this->assertSame(\Attribute::TARGET_CLASS, $instance->flags);
+    }
+}

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -142,6 +142,64 @@ final class PackageManifestCompilerTest extends TestCase
         $this->assertFileExists($storagePath . '/framework/packages.php');
     }
 
+    #[Test]
+    public function load_recompiles_when_cache_is_corrupt(): void
+    {
+        $storagePath = $this->tempDir . '/storage';
+        mkdir($storagePath . '/framework', 0o755, true);
+
+        // Write a corrupt cache file
+        file_put_contents(
+            $storagePath . '/framework/packages.php',
+            '<?php throw new \RuntimeException("corrupt");',
+        );
+
+        // Write valid installed.json so recompile succeeds
+        $installed = [
+            'packages' => [
+                [
+                    'name' => 'waaseyaa/test',
+                    'extra' => [
+                        'waaseyaa' => [
+                            'providers' => ['Waaseyaa\\Test\\RecompiledProvider'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode($installed, JSON_THROW_ON_ERROR),
+        );
+
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->load();
+
+        $this->assertSame(['Waaseyaa\\Test\\RecompiledProvider'], $manifest->providers);
+    }
+
+    #[Test]
+    public function load_recompiles_when_cache_returns_non_array(): void
+    {
+        $storagePath = $this->tempDir . '/storage';
+        mkdir($storagePath . '/framework', 0o755, true);
+
+        file_put_contents(
+            $storagePath . '/framework/packages.php',
+            '<?php return "not an array";',
+        );
+
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => []], JSON_THROW_ON_ERROR),
+        );
+
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->load();
+
+        $this->assertSame([], $manifest->providers);
+    }
+
     private function removeDir(string $dir): void
     {
         if (!is_dir($dir)) {

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Tests\Unit\Discovery;
+
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PackageManifestCompiler::class)]
+final class PackageManifestCompilerTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_test_' . uniqid();
+        mkdir($this->tempDir . '/vendor/composer', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tempDir);
+    }
+
+    #[Test]
+    public function compile_reads_installed_json_manifest(): void
+    {
+        $installed = [
+            'packages' => [
+                [
+                    'name' => 'waaseyaa/node',
+                    'extra' => [
+                        'waaseyaa' => [
+                            'providers' => ['Waaseyaa\\Node\\NodeServiceProvider'],
+                            'commands' => ['Waaseyaa\\Node\\Command\\NodeCreateCommand'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode($installed, JSON_THROW_ON_ERROR),
+        );
+
+        $storagePath = $this->tempDir . '/storage';
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->compile();
+
+        $this->assertSame(['Waaseyaa\\Node\\NodeServiceProvider'], $manifest->providers);
+        $this->assertSame(['Waaseyaa\\Node\\Command\\NodeCreateCommand'], $manifest->commands);
+    }
+
+    #[Test]
+    public function compile_handles_missing_installed_json(): void
+    {
+        $storagePath = $this->tempDir . '/storage';
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->compile();
+
+        $this->assertSame([], $manifest->providers);
+        $this->assertSame([], $manifest->commands);
+    }
+
+    #[Test]
+    public function compile_and_cache_writes_php_file(): void
+    {
+        // Write empty installed.json
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => []], JSON_THROW_ON_ERROR),
+        );
+
+        $storagePath = $this->tempDir . '/storage';
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $compiler->compileAndCache();
+
+        $this->assertFileExists($storagePath . '/framework/packages.php');
+
+        $cached = require $storagePath . '/framework/packages.php';
+        $this->assertIsArray($cached);
+        $this->assertArrayHasKey('providers', $cached);
+    }
+
+    #[Test]
+    public function load_uses_cache_when_available(): void
+    {
+        $storagePath = $this->tempDir . '/storage';
+        mkdir($storagePath . '/framework', 0o755, true);
+
+        $data = [
+            'providers' => ['CachedProvider'],
+            'commands' => [],
+            'routes' => [],
+            'migrations' => [],
+            'field_types' => [],
+            'listeners' => [],
+            'middleware' => [],
+        ];
+
+        file_put_contents(
+            $storagePath . '/framework/packages.php',
+            '<?php return ' . var_export($data, true) . ';' . "\n",
+        );
+
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->load();
+
+        $this->assertSame(['CachedProvider'], $manifest->providers);
+    }
+
+    #[Test]
+    public function load_compiles_when_no_cache(): void
+    {
+        // Write installed.json with a provider
+        $installed = [
+            'packages' => [
+                [
+                    'name' => 'waaseyaa/test',
+                    'extra' => [
+                        'waaseyaa' => [
+                            'providers' => ['Waaseyaa\\Test\\TestProvider'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode($installed, JSON_THROW_ON_ERROR),
+        );
+
+        $storagePath = $this->tempDir . '/storage';
+        $compiler = new PackageManifestCompiler($this->tempDir, $storagePath);
+        $manifest = $compiler->load();
+
+        $this->assertSame(['Waaseyaa\\Test\\TestProvider'], $manifest->providers);
+        // Cache file should now exist
+        $this->assertFileExists($storagePath . '/framework/packages.php');
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestTest.php
@@ -43,10 +43,28 @@ final class PackageManifestTest extends TestCase
     }
 
     #[Test]
-    public function from_array_handles_missing_keys(): void
+    public function from_array_throws_on_missing_keys(): void
     {
-        $manifest = PackageManifest::fromArray([]);
-        $this->assertSame([], $manifest->providers);
-        $this->assertSame([], $manifest->fieldTypes);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required keys');
+
+        PackageManifest::fromArray([]);
+    }
+
+    #[Test]
+    public function from_array_throws_on_non_array_value(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be an array');
+
+        PackageManifest::fromArray([
+            'providers' => 'not-an-array',
+            'commands' => [],
+            'routes' => [],
+            'migrations' => [],
+            'field_types' => [],
+            'listeners' => [],
+            'middleware' => [],
+        ]);
     }
 }

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+namespace Waaseyaa\Foundation\Tests\Unit\Discovery;
+
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PackageManifest::class)]
+final class PackageManifestTest extends TestCase
+{
+    #[Test]
+    public function defaults_to_empty_arrays(): void
+    {
+        $manifest = new PackageManifest();
+        $this->assertSame([], $manifest->providers);
+        $this->assertSame([], $manifest->commands);
+        $this->assertSame([], $manifest->routes);
+        $this->assertSame([], $manifest->migrations);
+        $this->assertSame([], $manifest->fieldTypes);
+        $this->assertSame([], $manifest->listeners);
+        $this->assertSame([], $manifest->middleware);
+    }
+
+    #[Test]
+    public function round_trips_through_array(): void
+    {
+        $manifest = new PackageManifest(
+            providers: ['App\\Provider'],
+            commands: ['App\\Command'],
+            fieldTypes: ['text' => 'App\\TextField'],
+            middleware: ['http' => [['class' => 'App\\Mw', 'priority' => 100]]],
+        );
+
+        $array = $manifest->toArray();
+        $restored = PackageManifest::fromArray($array);
+
+        $this->assertSame($manifest->providers, $restored->providers);
+        $this->assertSame($manifest->commands, $restored->commands);
+        $this->assertSame($manifest->fieldTypes, $restored->fieldTypes);
+        $this->assertSame($manifest->middleware, $restored->middleware);
+    }
+
+    #[Test]
+    public function from_array_handles_missing_keys(): void
+    {
+        $manifest = PackageManifest::fromArray([]);
+        $this->assertSame([], $manifest->providers);
+        $this->assertSame([], $manifest->fieldTypes);
+    }
+}

--- a/packages/foundation/tests/Unit/Event/EventBusTest.php
+++ b/packages/foundation/tests/Unit/Event/EventBusTest.php
@@ -8,6 +8,9 @@ use Waaseyaa\Foundation\Event\BroadcasterInterface;
 use Waaseyaa\Foundation\Event\DomainEvent;
 use Waaseyaa\Foundation\Event\EventBus;
 use Waaseyaa\Foundation\Event\EventStoreInterface;
+use Waaseyaa\Foundation\Middleware\EventHandlerInterface;
+use Waaseyaa\Foundation\Middleware\EventMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\EventPipeline;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -132,6 +135,54 @@ final class EventBusTest extends TestCase
     private function createNullBroadcaster(): BroadcasterInterface
     {
         return $this->createMock(BroadcasterInterface::class);
+    }
+
+    #[Test]
+    public function dispatches_through_event_pipeline_when_provided(): void
+    {
+        $pipelineUsed = false;
+
+        $mw = new class($pipelineUsed) implements EventMiddlewareInterface {
+            public function __construct(private bool &$used) {}
+            public function process(DomainEvent $event, EventHandlerInterface $next): void
+            {
+                $this->used = true;
+                $next->handle($event);
+            }
+        };
+
+        $pipeline = new EventPipeline([$mw]);
+
+        $bus = new EventBus(
+            syncDispatcher: new EventDispatcher(),
+            asyncBus: $this->createNullMessageBus(),
+            broadcaster: $this->createNullBroadcaster(),
+            eventPipeline: $pipeline,
+        );
+
+        $bus->dispatch(new TestNodeSaved('node', '42', ['title']));
+        $this->assertTrue($pipelineUsed);
+    }
+
+    #[Test]
+    public function works_without_event_pipeline(): void
+    {
+        $received = null;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(TestNodeSaved::class, function (TestNodeSaved $e) use (&$received) {
+            $received = $e;
+        });
+
+        $bus = new EventBus(
+            syncDispatcher: $dispatcher,
+            asyncBus: $this->createNullMessageBus(),
+            broadcaster: $this->createNullBroadcaster(),
+            eventPipeline: null,
+        );
+
+        $event = new TestNodeSaved('node', '42', ['title']);
+        $bus->dispatch($event);
+        $this->assertSame($event, $received);
     }
 }
 

--- a/packages/foundation/tests/Unit/Middleware/EventPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/EventPipelineTest.php
@@ -97,6 +97,22 @@ final class EventPipelineTest extends TestCase
         $this->assertFalse($reached);
     }
 
+    #[Test]
+    public function with_middleware_returns_new_instance(): void
+    {
+        $original = new EventPipeline();
+
+        $mw = new class implements EventMiddlewareInterface {
+            public function process(DomainEvent $event, EventHandlerInterface $next): void
+            {
+                $next->handle($event);
+            }
+        };
+
+        $new = $original->withMiddleware($mw);
+        $this->assertNotSame($original, $new);
+    }
+
     private function createEvent(): DomainEvent
     {
         return new class('test', '1') extends DomainEvent {

--- a/packages/foundation/tests/Unit/Middleware/EventPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/EventPipelineTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Event\DomainEvent;
+use Waaseyaa\Foundation\Middleware\EventHandlerInterface;
+use Waaseyaa\Foundation\Middleware\EventMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\EventPipeline;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventPipeline::class)]
+final class EventPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_delegates_to_final_handler(): void
+    {
+        $handled = false;
+        $pipeline = new EventPipeline();
+
+        $handler = new class($handled) implements EventHandlerInterface {
+            public function __construct(private bool &$handled) {}
+            public function handle(DomainEvent $event): void
+            {
+                $this->handled = true;
+            }
+        };
+
+        $pipeline->handle($this->createEvent(), $handler);
+        $this->assertTrue($handled);
+    }
+
+    #[Test]
+    public function middleware_wraps_in_onion_order(): void
+    {
+        $log = [];
+
+        $mw1 = new class($log) implements EventMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(DomainEvent $event, EventHandlerInterface $next): void
+            {
+                $this->log[] = 'mw1-before';
+                $next->handle($event);
+                $this->log[] = 'mw1-after';
+            }
+        };
+
+        $mw2 = new class($log) implements EventMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(DomainEvent $event, EventHandlerInterface $next): void
+            {
+                $this->log[] = 'mw2-before';
+                $next->handle($event);
+                $this->log[] = 'mw2-after';
+            }
+        };
+
+        $handler = new class($log) implements EventHandlerInterface {
+            public function __construct(private array &$log) {}
+            public function handle(DomainEvent $event): void
+            {
+                $this->log[] = 'handler';
+            }
+        };
+
+        $pipeline = new EventPipeline([$mw1, $mw2]);
+        $pipeline->handle($this->createEvent(), $handler);
+
+        $this->assertSame(['mw1-before', 'mw2-before', 'handler', 'mw2-after', 'mw1-after'], $log);
+    }
+
+    #[Test]
+    public function middleware_can_suppress_event(): void
+    {
+        $reached = false;
+
+        $suppress = new class implements EventMiddlewareInterface {
+            public function process(DomainEvent $event, EventHandlerInterface $next): void
+            {
+                // Don't call next — suppress the event
+            }
+        };
+
+        $handler = new class($reached) implements EventHandlerInterface {
+            public function __construct(private bool &$reached) {}
+            public function handle(DomainEvent $event): void
+            {
+                $this->reached = true;
+            }
+        };
+
+        $pipeline = new EventPipeline([$suppress]);
+        $pipeline->handle($this->createEvent(), $handler);
+        $this->assertFalse($reached);
+    }
+
+    private function createEvent(): DomainEvent
+    {
+        return new class('test', '1') extends DomainEvent {
+            public function getPayload(): array { return []; }
+        };
+    }
+}

--- a/packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\HttpPipeline;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(HttpPipeline::class)]
+final class HttpPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_delegates_to_final_handler(): void
+    {
+        $pipeline = new HttpPipeline();
+        $request = Request::create('/test');
+
+        $handler = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('final');
+            }
+        };
+
+        $response = $pipeline->handle($request, $handler);
+        $this->assertSame('final', $response->getContent());
+    }
+
+    #[Test]
+    public function middleware_wraps_in_onion_order(): void
+    {
+        $log = [];
+
+        $mw1 = new class($log) implements HttpMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(Request $request, HttpHandlerInterface $next): Response
+            {
+                $this->log[] = 'mw1-before';
+                $response = $next->handle($request);
+                $this->log[] = 'mw1-after';
+                return $response;
+            }
+        };
+
+        $mw2 = new class($log) implements HttpMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(Request $request, HttpHandlerInterface $next): Response
+            {
+                $this->log[] = 'mw2-before';
+                $response = $next->handle($request);
+                $this->log[] = 'mw2-after';
+                return $response;
+            }
+        };
+
+        $finalHandler = new class($log) implements HttpHandlerInterface {
+            public function __construct(private array &$log) {}
+            public function handle(Request $request): Response
+            {
+                $this->log[] = 'handler';
+                return new Response('ok');
+            }
+        };
+
+        $pipeline = new HttpPipeline([$mw1, $mw2]);
+        $pipeline->handle(Request::create('/test'), $finalHandler);
+
+        $this->assertSame(['mw1-before', 'mw2-before', 'handler', 'mw2-after', 'mw1-after'], $log);
+    }
+
+    #[Test]
+    public function middleware_can_short_circuit(): void
+    {
+        $shortCircuit = new class implements HttpMiddlewareInterface {
+            public function process(Request $request, HttpHandlerInterface $next): Response
+            {
+                return new Response('blocked', 403);
+            }
+        };
+
+        $pipeline = new HttpPipeline([$shortCircuit]);
+
+        $handler = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('should not reach');
+            }
+        };
+
+        $response = $pipeline->handle(Request::create('/test'), $handler);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('blocked', $response->getContent());
+    }
+
+    #[Test]
+    public function middleware_can_modify_request(): void
+    {
+        $addHeader = new class implements HttpMiddlewareInterface {
+            public function process(Request $request, HttpHandlerInterface $next): Response
+            {
+                $request->headers->set('X-Custom', 'added');
+                return $next->handle($request);
+            }
+        };
+
+        $handler = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response($request->headers->get('X-Custom', 'missing'));
+            }
+        };
+
+        $pipeline = new HttpPipeline([$addHeader]);
+        $response = $pipeline->handle(Request::create('/test'), $handler);
+        $this->assertSame('added', $response->getContent());
+    }
+}

--- a/packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/HttpPipelineTest.php
@@ -100,6 +100,36 @@ final class HttpPipelineTest extends TestCase
     }
 
     #[Test]
+    public function with_middleware_returns_new_instance(): void
+    {
+        $original = new HttpPipeline();
+
+        $mw = new class implements HttpMiddlewareInterface {
+            public function process(Request $request, HttpHandlerInterface $next): Response
+            {
+                return $next->handle($request);
+            }
+        };
+
+        $new = $original->withMiddleware($mw);
+
+        $this->assertNotSame($original, $new);
+
+        // Original still has no middleware — delegates directly
+        $handler = new class implements HttpHandlerInterface {
+            public int $calls = 0;
+            public function handle(Request $request): Response
+            {
+                $this->calls++;
+                return new Response('ok');
+            }
+        };
+
+        $original->handle(Request::create('/test'), $handler);
+        $this->assertSame(1, $handler->calls);
+    }
+
+    #[Test]
     public function middleware_can_modify_request(): void
     {
         $addHeader = new class implements HttpMiddlewareInterface {

--- a/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
+use Waaseyaa\Queue\Job;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JobPipeline::class)]
+final class JobPipelineTest extends TestCase
+{
+    #[Test]
+    public function empty_pipeline_delegates_to_final_handler(): void
+    {
+        $handled = false;
+        $pipeline = new JobPipeline();
+
+        $handler = new class($handled) implements JobNextHandlerInterface {
+            public function __construct(private bool &$handled) {}
+            public function handle(Job $job): void
+            {
+                $this->handled = true;
+            }
+        };
+
+        $pipeline->handle($this->createJob(), $handler);
+        $this->assertTrue($handled);
+    }
+
+    #[Test]
+    public function middleware_wraps_in_onion_order(): void
+    {
+        $log = [];
+
+        $mw1 = new class($log) implements JobMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(Job $job, JobNextHandlerInterface $next): void
+            {
+                $this->log[] = 'mw1-before';
+                $next->handle($job);
+                $this->log[] = 'mw1-after';
+            }
+        };
+
+        $mw2 = new class($log) implements JobMiddlewareInterface {
+            public function __construct(private array &$log) {}
+            public function process(Job $job, JobNextHandlerInterface $next): void
+            {
+                $this->log[] = 'mw2-before';
+                $next->handle($job);
+                $this->log[] = 'mw2-after';
+            }
+        };
+
+        $handler = new class($log) implements JobNextHandlerInterface {
+            public function __construct(private array &$log) {}
+            public function handle(Job $job): void
+            {
+                $this->log[] = 'handler';
+            }
+        };
+
+        $pipeline = new JobPipeline([$mw1, $mw2]);
+        $pipeline->handle($this->createJob(), $handler);
+
+        $this->assertSame(['mw1-before', 'mw2-before', 'handler', 'mw2-after', 'mw1-after'], $log);
+    }
+
+    #[Test]
+    public function middleware_can_skip_job(): void
+    {
+        $reached = false;
+
+        $skip = new class implements JobMiddlewareInterface {
+            public function process(Job $job, JobNextHandlerInterface $next): void
+            {
+                // Don't call next — skip the job
+            }
+        };
+
+        $handler = new class($reached) implements JobNextHandlerInterface {
+            public function __construct(private bool &$reached) {}
+            public function handle(Job $job): void
+            {
+                $this->reached = true;
+            }
+        };
+
+        $pipeline = new JobPipeline([$skip]);
+        $pipeline->handle($this->createJob(), $handler);
+        $this->assertFalse($reached);
+    }
+
+    private function createJob(): Job
+    {
+        return new class extends Job {
+            public function handle(): void {}
+        };
+    }
+}

--- a/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
@@ -97,6 +97,22 @@ final class JobPipelineTest extends TestCase
         $this->assertFalse($reached);
     }
 
+    #[Test]
+    public function with_middleware_returns_new_instance(): void
+    {
+        $original = new JobPipeline();
+
+        $mw = new class implements JobMiddlewareInterface {
+            public function process(Job $job, JobHandlerInterface $next): void
+            {
+                $next->handle($job);
+            }
+        };
+
+        $new = $original->withMiddleware($mw);
+        $this->assertNotSame($original, $new);
+    }
+
     private function createJob(): Job
     {
         return new class extends Job {

--- a/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
+++ b/packages/foundation/tests/Unit/Middleware/JobPipelineTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
 
 use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
-use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobHandlerInterface;
 use Waaseyaa\Foundation\Middleware\JobPipeline;
 use Waaseyaa\Queue\Job;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,7 +21,7 @@ final class JobPipelineTest extends TestCase
         $handled = false;
         $pipeline = new JobPipeline();
 
-        $handler = new class($handled) implements JobNextHandlerInterface {
+        $handler = new class($handled) implements JobHandlerInterface {
             public function __construct(private bool &$handled) {}
             public function handle(Job $job): void
             {
@@ -40,7 +40,7 @@ final class JobPipelineTest extends TestCase
 
         $mw1 = new class($log) implements JobMiddlewareInterface {
             public function __construct(private array &$log) {}
-            public function process(Job $job, JobNextHandlerInterface $next): void
+            public function process(Job $job, JobHandlerInterface $next): void
             {
                 $this->log[] = 'mw1-before';
                 $next->handle($job);
@@ -50,7 +50,7 @@ final class JobPipelineTest extends TestCase
 
         $mw2 = new class($log) implements JobMiddlewareInterface {
             public function __construct(private array &$log) {}
-            public function process(Job $job, JobNextHandlerInterface $next): void
+            public function process(Job $job, JobHandlerInterface $next): void
             {
                 $this->log[] = 'mw2-before';
                 $next->handle($job);
@@ -58,7 +58,7 @@ final class JobPipelineTest extends TestCase
             }
         };
 
-        $handler = new class($log) implements JobNextHandlerInterface {
+        $handler = new class($log) implements JobHandlerInterface {
             public function __construct(private array &$log) {}
             public function handle(Job $job): void
             {
@@ -78,13 +78,13 @@ final class JobPipelineTest extends TestCase
         $reached = false;
 
         $skip = new class implements JobMiddlewareInterface {
-            public function process(Job $job, JobNextHandlerInterface $next): void
+            public function process(Job $job, JobHandlerInterface $next): void
             {
                 // Don't call next — skip the job
             }
         };
 
-        $handler = new class($reached) implements JobNextHandlerInterface {
+        $handler = new class($reached) implements JobHandlerInterface {
             public function __construct(private bool &$reached) {}
             public function handle(Job $job): void
             {

--- a/packages/queue/src/Handler/JobHandler.php
+++ b/packages/queue/src/Handler/JobHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Queue\Handler;
 
-use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobHandlerInterface as JobHandlerContract;
 use Waaseyaa\Foundation\Middleware\JobPipeline;
 use Waaseyaa\Queue\Job;
 
@@ -34,7 +34,7 @@ final class JobHandler implements HandlerInterface
         /** @var Job $message */
         $message->incrementAttempts();
 
-        $jobHandler = new class implements JobNextHandlerInterface {
+        $jobHandler = new class implements JobHandlerContract {
             public function handle(Job $job): void
             {
                 $job->handle();

--- a/packages/queue/src/Handler/JobHandler.php
+++ b/packages/queue/src/Handler/JobHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Queue\Handler;
 
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
 use Waaseyaa\Queue\Job;
 
 /**
@@ -12,9 +14,16 @@ use Waaseyaa\Queue\Job;
  * This default handler is automatically prepended by SyncQueue so that any
  * Job subclass dispatched without a dedicated handler adapter will have its
  * handle() method called correctly, with the attempt counter incremented.
+ *
+ * When a JobPipeline is provided, the job is executed through the middleware
+ * stack before reaching its handle() method.
  */
 final class JobHandler implements HandlerInterface
 {
+    public function __construct(
+        private readonly ?JobPipeline $pipeline = null,
+    ) {}
+
     public function supports(object $message): bool
     {
         return $message instanceof Job;
@@ -24,6 +33,18 @@ final class JobHandler implements HandlerInterface
     {
         /** @var Job $message */
         $message->incrementAttempts();
-        $message->handle();
+
+        $jobHandler = new class implements JobNextHandlerInterface {
+            public function handle(Job $job): void
+            {
+                $job->handle();
+            }
+        };
+
+        if ($this->pipeline !== null) {
+            $this->pipeline->handle($message, $jobHandler);
+        } else {
+            $jobHandler->handle($message);
+        }
     }
 }

--- a/packages/queue/tests/Unit/Handler/JobHandlerTest.php
+++ b/packages/queue/tests/Unit/Handler/JobHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Queue\Tests\Unit\Handler;
 
 use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
-use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobHandlerInterface;
 use Waaseyaa\Foundation\Middleware\JobPipeline;
 use Waaseyaa\Queue\Handler\HandlerInterface;
 use Waaseyaa\Queue\Handler\JobHandler;
@@ -96,37 +96,6 @@ final class JobHandlerTest extends TestCase
     }
 
     #[Test]
-    public function supports_job_instances(): void
-    {
-        $handler = new JobHandler();
-        $job = new class extends Job {
-            public function handle(): void {}
-        };
-
-        $this->assertTrue($handler->supports($job));
-        $this->assertFalse($handler->supports(new \stdClass()));
-    }
-
-    #[Test]
-    public function handles_job_without_pipeline(): void
-    {
-        $handled = false;
-        $job = new class($handled) extends Job {
-            public function __construct(private bool &$handled) {}
-            public function handle(): void
-            {
-                $this->handled = true;
-            }
-        };
-
-        $handler = new JobHandler();
-        $handler->handle($job);
-
-        $this->assertTrue($handled);
-        $this->assertSame(1, $job->getAttempts());
-    }
-
-    #[Test]
     public function handles_job_through_pipeline(): void
     {
         $pipelineUsed = false;
@@ -134,7 +103,7 @@ final class JobHandlerTest extends TestCase
 
         $mw = new class($pipelineUsed) implements JobMiddlewareInterface {
             public function __construct(private bool &$used) {}
-            public function process(Job $job, JobNextHandlerInterface $next): void
+            public function process(Job $job, JobHandlerInterface $next): void
             {
                 $this->used = true;
                 $next->handle($job);
@@ -166,7 +135,7 @@ final class JobHandlerTest extends TestCase
 
         $mw = new class($attemptsDuringPipeline) implements JobMiddlewareInterface {
             public function __construct(private int &$attempts) {}
-            public function process(Job $job, JobNextHandlerInterface $next): void
+            public function process(Job $job, JobHandlerInterface $next): void
             {
                 $this->attempts = $job->getAttempts();
                 $next->handle($job);

--- a/packages/queue/tests/Unit/Handler/JobHandlerTest.php
+++ b/packages/queue/tests/Unit/Handler/JobHandlerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Queue\Tests\Unit\Handler;
 
+use Waaseyaa\Foundation\Middleware\JobMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\JobNextHandlerInterface;
+use Waaseyaa\Foundation\Middleware\JobPipeline;
 use Waaseyaa\Queue\Handler\HandlerInterface;
 use Waaseyaa\Queue\Handler\JobHandler;
 use Waaseyaa\Queue\Job;
@@ -90,5 +93,94 @@ final class JobHandlerTest extends TestCase
         // incrementAttempts() runs before handle(), so the counter must be 1
         // when handle() executes.
         $this->assertSame(1, $attemptsAtHandleTime);
+    }
+
+    #[Test]
+    public function supports_job_instances(): void
+    {
+        $handler = new JobHandler();
+        $job = new class extends Job {
+            public function handle(): void {}
+        };
+
+        $this->assertTrue($handler->supports($job));
+        $this->assertFalse($handler->supports(new \stdClass()));
+    }
+
+    #[Test]
+    public function handles_job_without_pipeline(): void
+    {
+        $handled = false;
+        $job = new class($handled) extends Job {
+            public function __construct(private bool &$handled) {}
+            public function handle(): void
+            {
+                $this->handled = true;
+            }
+        };
+
+        $handler = new JobHandler();
+        $handler->handle($job);
+
+        $this->assertTrue($handled);
+        $this->assertSame(1, $job->getAttempts());
+    }
+
+    #[Test]
+    public function handles_job_through_pipeline(): void
+    {
+        $pipelineUsed = false;
+        $jobHandled = false;
+
+        $mw = new class($pipelineUsed) implements JobMiddlewareInterface {
+            public function __construct(private bool &$used) {}
+            public function process(Job $job, JobNextHandlerInterface $next): void
+            {
+                $this->used = true;
+                $next->handle($job);
+            }
+        };
+
+        $pipeline = new JobPipeline([$mw]);
+
+        $job = new class($jobHandled) extends Job {
+            public function __construct(private bool &$handled) {}
+            public function handle(): void
+            {
+                $this->handled = true;
+            }
+        };
+
+        $handler = new JobHandler(pipeline: $pipeline);
+        $handler->handle($job);
+
+        $this->assertTrue($pipelineUsed);
+        $this->assertTrue($jobHandled);
+        $this->assertSame(1, $job->getAttempts());
+    }
+
+    #[Test]
+    public function increments_attempts_before_pipeline(): void
+    {
+        $attemptsDuringPipeline = 0;
+
+        $mw = new class($attemptsDuringPipeline) implements JobMiddlewareInterface {
+            public function __construct(private int &$attempts) {}
+            public function process(Job $job, JobNextHandlerInterface $next): void
+            {
+                $this->attempts = $job->getAttempts();
+                $next->handle($job);
+            }
+        };
+
+        $pipeline = new JobPipeline([$mw]);
+        $job = new class extends Job {
+            public function handle(): void {}
+        };
+
+        $handler = new JobHandler(pipeline: $pipeline);
+        $handler->handle($job);
+
+        $this->assertSame(1, $attemptsDuringPipeline);
     }
 }


### PR DESCRIPTION
## Problem

Waaseyaa needs structured logging with channels, formatters, and routing — similar to Laravel's Log facade but using DI.

## Current State

The foundation package already has:
- `LoggerInterface` with PSR-3 compatible interface (8 severity levels)
- `LogLevel` enum with severity ranking
- `FileLogger` — writes to file with timestamp + level + context JSON
- `ErrorLogHandler` — delegates to `error_log()` with custom writer support
- `CompositeLogger` — multiplexes to multiple handlers
- `NullLogger` — discards all messages

## What's Missing

- **LogManager** — channel-based routing (e.g., `$logManager->channel('errors')`)
- **Formatter system** — pluggable formatters (JSON, text, etc.) instead of hardcoded format strings
- **Configuration layer** — config file defining channels, their handlers, and formatters
- **Log processors/middleware** — enrich context (hostname, request ID, user) across all logs
- **Level-based routing** — route ERROR→file, DEBUG→stderr conditionally