### PR TITLE
feat: skeleton should ship a Dockerfile

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "waaseyaa-specs": {
+      "command": "node",
+      "args": ["tools/spec-retrieval/server.js"],
+      "cwd": "."
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,88 @@
 - Field-level access: `FieldAccessPolicyInterface` (companion to `AccessPolicyInterface`). Classes must implement both — `EntityAccessHandler` finds field policies via `instanceof` check. Open-by-default: Neutral = accessible, only Forbidden restricts.
 - Access result semantics differ by level: entity-level uses `isAllowed()` (deny unless granted), field-level uses `!isForbidden()` (allow unless denied). This asymmetry is intentional.
 
+## Orchestration
+
+When working on files matching these patterns, load the specialist skill and retrieve the spec for deep context:
+
+| File pattern | Specialist skill | Cold memory spec |
+|---|---|---|
+| `packages/entity/*`, `packages/entity-storage/*`, `packages/field/*`, `packages/config/*` | `waaseyaa:entity-system` | `docs/specs/entity-system.md` |
+| `packages/access/*`, `packages/user/src/Middleware/*` | `waaseyaa:access-control` | `docs/specs/access-control.md`, `docs/specs/field-access.md` |
+| `packages/api/*`, `packages/routing/*` | `waaseyaa:api-layer` | `docs/specs/api-layer.md` |
+| `packages/admin/*` | `waaseyaa:admin-spa` | `docs/specs/admin-spa.md` |
+| `packages/ai-*/*` | `waaseyaa:ai-integration` | `docs/specs/ai-integration.md` |
+| `packages/foundation/*`, `packages/cache/*`, `packages/database-legacy/*`, `packages/plugin/*` | `waaseyaa:infrastructure` | `docs/specs/infrastructure.md`, `docs/specs/package-discovery.md` |
+| `packages/mcp/*` | `waaseyaa:mcp-endpoint` | `docs/specs/mcp-endpoint.md` |
+| `public/index.php`, `packages/*/src/Middleware/*` | `waaseyaa:middleware-pipeline` | `docs/specs/middleware-pipeline.md` |
+
+Use `waaseyaa_search_specs` MCP tool to find specs affected by a change when the mapping isn't obvious.
+
+**MCP tools available:**
+- `waaseyaa_list_specs` — list all subsystem specs with descriptions
+- `waaseyaa_get_spec <name>` — retrieve full spec content (e.g., `waaseyaa_get_spec entity-system`)
+- `waaseyaa_search_specs <query>` — keyword search across all specs (e.g., `waaseyaa_search_specs EntityAccessHandler`)
+
+## Layer Architecture
+
+| Layer | Name | Packages |
+|---|---|---|
+| 0 | Foundation | foundation, cache, plugin, typed-data, database-legacy, testing, i18n, queue, state, validation |
+| 1 | Core Data | entity, entity-storage, access, user, config, field |
+| 2 | Content Types | node, taxonomy, media, path, menu |
+| 3 | Services | workflows |
+| 4 | API | api, routing |
+| 5 | AI | ai-schema, ai-agent, ai-pipeline, ai-vector |
+| 6 | Interfaces | cli, admin, mcp, ssr, telescope |
+
+**Rule:** Packages can only import from their own layer or lower. Upward communication via DomainEvents.
+
+## Operation Checklists
+
+**Adding an entity type:**
+1. Define `EntityType` with id, label, entity keys, entity class
+2. Create entity class extending `EntityBase` — constructor takes `(array $values)`, hardcodes `entityTypeId` and `entityKeys`
+3. Register in `EntityTypeManager` via service provider's `register()` method
+4. Create storage schema via `SqlSchemaHandler` — define columns, `_data` blob is automatic
+5. Add `AccessPolicyInterface` (+ `FieldAccessPolicyInterface` if field-level control needed)
+6. Add API routes in `RouteBuilder`, wire controller, set route access options (`_gate` for entity access)
+7. Test: use `InMemoryEntityStorage` or `PdoDatabase::createSqlite()` for in-memory testing
+
+**Adding an access policy:**
+1. Create class implementing `AccessPolicyInterface` (add `FieldAccessPolicyInterface` if field access needed — same class, intersection type)
+2. Register via `#[PolicyAttribute('entity_type_id')]` attribute on the class
+3. Implement `access()` returning `AccessResult` — use `::allowed()`, `::neutral()`, `::forbidden()`
+4. For field access: implement `fieldAccess()` — Neutral = accessible (open-by-default), only Forbidden restricts
+5. Test with anonymous classes implementing both interfaces (PHPUnit `createMock()` can't mock intersection types)
+
+**Adding an API endpoint:**
+1. Add route in `RouteBuilder` with access options (`_public`, `_permission`, `_role`, or `_gate`)
+2. Implement controller method following `JsonApiController` CRUD patterns
+3. Wire access via route options — `AccessChecker` evaluates them from the matched route
+4. For entity endpoints: use `ResourceSerializer` with paired nullable `?EntityAccessHandler` + `?AccountInterface`
+5. Add to `SchemaPresenter` if JSON Schema output is needed — set `x-access-restricted` for view-only fields
+
+**Adding middleware:**
+1. Implement `HttpMiddlewareInterface` (or `EventMiddlewareInterface` / `JobMiddlewareInterface`)
+2. Add `#[AsMiddleware(priority: N)]` attribute — lower priority runs first (outer onion layer)
+3. Middleware is auto-discovered by `MiddlewareCompiler` via attribute scanning
+4. Follow handler naming: `{Type}HandlerInterface` for handler, `{Type}MiddlewareInterface` for middleware
+
+**Adding a service provider:**
+1. Create class extending `ServiceProvider` in the package's root namespace
+2. `register()` — bind interfaces to implementations, register entity types, set up factories
+3. `boot()` — subscribe to events, register routes, warm caches (after all providers registered)
+4. Add `extra.waaseyaa.provider` to the package's `composer.json` for auto-discovery
+
+## Codified Context
+
+This project uses three-tier codified context infrastructure ([arxiv.org/abs/2602.20478](https://arxiv.org/abs/2602.20478)):
+- **Tier 1 (Constitution):** This CLAUDE.md file — loaded every session, orchestration triggers, checklists
+- **Tier 2 (Skills):** Domain specialist skills in `skills/waaseyaa/` — loaded on demand per the orchestration table
+- **Tier 3 (Specs):** Subsystem specs in `docs/specs/` — retrieved via `waaseyaa_*` MCP tools for deep context
+
+Design docs in `docs/plans/` are session artifacts (implementation history). Specs in `docs/specs/` are enduring architectural knowledge (kept current). When refactoring a subsystem, update its spec — run `tools/drift-detector.sh` to find stale specs.
+
 ## Commands
 - `./vendor/bin/phpunit --configuration phpunit.xml.dist` — run all tests (do NOT use `-v`, PHPUnit 10.5 rejects it)
 - `./vendor/bin/phpunit --filter Phase10` — run tests for a specific phase
@@ -52,6 +134,7 @@
 - **Avoid double `$storage->create()` in access checks**: When checking field access before persisting a new entity, create once and reuse for both the access check and the save. Don't create a throwaway temp entity.
 - **Paired nullable parameters**: `ResourceSerializer::serialize()` and `SchemaPresenter::present()` accept `?EntityAccessHandler` + `?AccountInterface`. Both must be non-null or both null — only two of four states are meaningful. The guard pattern is `if ($handler !== null && $account !== null)`.
 - **SchemaPresenter `x-access-restricted`**: JSON Schema extension marking fields viewable but not editable. The admin SPA reads this to show disabled widgets instead of hiding the field. Distinct from system `readOnly` (id, uuid) which hides the field from forms entirely.
+- **Stale specs cause bad code**: When refactoring a subsystem, update the relevant `docs/specs/` file. Stale specs cause agents to generate code conflicting with recent changes. Run `tools/drift-detector.sh` to find affected specs.
 
 ## Testing
 - Integration tests in `tests/Integration/PhaseN/` — one directory per implementation phase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Structure
 - Monorepo: 29 PHP packages in `packages/`, 3 meta-packages, 1 JS admin SPA
-- 7-layer architecture (Foundation → Core Data → Services → Content Types → API → AI → Interfaces)
+- 7-layer architecture (Foundation → Core Data → Content Types → Services → API → AI → Interfaces)
 - Each package has its own `composer.json` with path repository references
 - Root `composer.json` uses `@dev` constraints for all waaseyaa/* packages
 - Authorization pipeline in `public/index.php`: SessionMiddleware → AuthorizationMiddleware. Session always sets `_account` on request; authorization reads it.
@@ -59,7 +59,7 @@ Use `waaseyaa_search_specs` MCP tool to find specs affected by a change when the
 
 **Adding an access policy:**
 1. Create class implementing `AccessPolicyInterface` (add `FieldAccessPolicyInterface` if field access needed — same class, intersection type)
-2. Register via `#[PolicyAttribute('entity_type_id')]` attribute on the class
+2. Register via `#[PolicyAttribute(entityType: 'entity_type_id')]` attribute on the class
 3. Implement `access()` returning `AccessResult` — use `::allowed()`, `::neutral()`, `::forbidden()`
 4. For field access: implement `fieldAccess()` — Neutral = accessible (open-by-default), only Forbidden restricts
 5. Test with anonymous classes implementing both interfaces (PHPUnit `createMock()` can't mock intersection types)
@@ -73,15 +73,15 @@ Use `waaseyaa_search_specs` MCP tool to find specs affected by a change when the
 
 **Adding middleware:**
 1. Implement `HttpMiddlewareInterface` (or `EventMiddlewareInterface` / `JobMiddlewareInterface`)
-2. Add `#[AsMiddleware(priority: N)]` attribute — lower priority runs first (outer onion layer)
-3. Middleware is auto-discovered by `MiddlewareCompiler` via attribute scanning
+2. Add `#[AsMiddleware(priority: N)]` attribute — higher priority runs first (outer onion layer)
+3. Middleware is auto-discovered by `PackageManifestCompiler` via attribute scanning
 4. Follow handler naming: `{Type}HandlerInterface` for handler, `{Type}MiddlewareInterface` for middleware
 
 **Adding a service provider:**
 1. Create class extending `ServiceProvider` in the package's root namespace
 2. `register()` — bind interfaces to implementations, register entity types, set up factories
 3. `boot()` — subscribe to events, register routes, warm caches (after all providers registered)
-4. Add `extra.waaseyaa.provider` to the package's `composer.json` for auto-discovery
+4. Add `extra.waaseyaa.providers` to the package's `composer.json` for auto-discovery
 
 ## Codified Context
 
@@ -116,7 +116,7 @@ Design docs in `docs/plans/` are session artifacts (implementation history). Spe
 - **_data JSON blob**: SqlSchemaHandler adds a `_data` TEXT column. SqlEntityStorage::splitForStorage() puts non-schema values into it as JSON; mapRowToEntity() merges them back on load.
 - **PascalCase conversion**: Use `str_replace('_', '', ucwords($name, '_'))` not `ucfirst()`.
 - **InMemoryEntityStorage** (`Waaseyaa\Api\Tests\Fixtures\`) — use for tests. SqlEntityStorage for real storage.
-- **EntityTypeManager** takes `(EventDispatcher, callable $storageFactory)` where factory receives `EntityType $definition`.
+- **EntityTypeManager** takes `(EventDispatcherInterface, ?\Closure $storageFactory = null)` where factory receives `EntityTypeInterface $definition`.
 - **EntityEvent uses public properties**: `$event->entity` and `$event->originalEntity` are public readonly — no getter methods. Common mistake: `$event->getEntity()`.
 - **DatabaseInterface vs PdoDatabase**: `DatabaseInterface` does NOT have `getPdo()`. If raw PDO is needed, type-hint `PdoDatabase` directly. Prefer using query builder (`select()`, `insert()`, `delete()`) over raw PDO when possible.
 - **LIKE wildcard escaping**: `PdoSelect` appends `ESCAPE '\'` for LIKE/NOT LIKE operators. When building LIKE patterns in `SqlEntityQuery`, escape `%` and `_` in user input with `str_replace(['%', '_'], ['\\%', '\\_'], $value)`.
@@ -127,7 +127,7 @@ Design docs in `docs/plans/` are session artifacts (implementation history). Spe
 - **No psr/log**: Project does not use `psr/log`. For best-effort logging (e.g., in event listeners), use `error_log()`.
 - **Middleware interface naming**: Handler interfaces follow `{Type}HandlerInterface` pattern (HttpHandlerInterface, EventHandlerInterface, JobHandlerInterface). Middleware follows `{Type}MiddlewareInterface`.
 - **Entity enforceIsNew()**: When creating entities with pre-set IDs (e.g., `new User(['uid' => 2])`), call `$entity->enforceIsNew()` before `save()`. Otherwise `isNew()` returns false, SqlEntityStorage tries UPDATE instead of INSERT, and silently affects 0 rows.
-- **Layer discipline for imports**: Foundation (layer 1) must never import from higher layers. When cross-layer attribute scanning is needed, use string constants instead of `::class` references (e.g., `private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute'`). `ReflectionClass::getAttributes()` accepts string class names.
+- **Layer discipline for imports**: Foundation (layer 0) must never import from higher layers. When cross-layer attribute scanning is needed, use string constants instead of `::class` references (e.g., `private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute'`). `ReflectionClass::getAttributes()` accepts string class names.
 - **Avoid circular package deps**: Access owns `AccountInterface`; User owns `AnonymousUser`. Access must not depend on User. Middleware needing an account should type-hint `AccountInterface`, not concrete `AnonymousUser`.
 - **php://input is single-read**: `HttpRequest::createFromGlobals()` consumes `php://input`. For subsequent body reads, use `$httpRequest->getContent()`, not `file_get_contents('php://input')`.
 - **Backward-compatible cache evolution**: When adding new properties to cached manifests/configs, make them optional in deserialization (use `$data['key'] ?? []`) to avoid breaking old cached files.

--- a/docs/plans/2026-03-02-codified-context-design.md
+++ b/docs/plans/2026-03-02-codified-context-design.md
@@ -1,0 +1,240 @@
+# Codified Context Infrastructure — Design
+
+**Date:** 2026-03-02
+**Status:** Approved
+**Source:** [Codified Context: Infrastructure for AI Agents in a Complex Codebase](https://arxiv.org/abs/2602.20478)
+
+## Summary
+
+Apply the paper's three-tier codified context architecture to Waaseyaa. The paper demonstrates that structured project knowledge (constitution + specialist agents + subsystem specs) substantially improves AI-generated code consistency across sessions in a 108K-line codebase. Waaseyaa at 74K lines is a natural fit.
+
+## Current State
+
+| Tier | Paper's architecture | Waaseyaa today |
+|------|---------------------|----------------|
+| 1. Hot memory (constitution) | ~660-line CLAUDE.md with conventions, orchestration protocols, trigger tables | 68-line CLAUDE.md — conventions + gotchas, no orchestration |
+| 2. Specialized agents | 19 domain-expert agent specs (~9,300 lines) | Generic superpowers skills, no project-specific agents |
+| 3. Cold memory (knowledge base) | 34 specs (~16,250 lines) via MCP retrieval | 18 plan docs (~19,785 lines) — session artifacts, not reusable specs |
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Approach | Full three-tier architecture | Existing plan docs provide mining material; upfront investment compounds |
+| Agent mechanism | Claude Code skills | Skills = markdown specs loaded into sessions, exactly the paper's model |
+| Retrieval | Local MCP server | Claude Code natively supports MCP; separate from remote packages/mcp/ |
+| Knowledge sourcing | Mine existing 18 plan docs + CLAUDE.md gotchas | Knowledge exists, needs restructuring, not creation |
+| Maintenance | Git-based drift detection + session discipline | Paper's #1 failure mode is stale specs |
+
+---
+
+## Tier 1: Constitution (Expanded CLAUDE.md)
+
+Expand from 68 to ~180 lines. Add three sections; keep existing content.
+
+### 1.1 Orchestration Trigger Table
+
+Maps file patterns to specialist skills and cold memory specs:
+
+```markdown
+## Orchestration
+
+| File pattern | Specialist skill | Cold memory spec |
+|---|---|---|
+| packages/entity/*, packages/entity-storage/*, packages/field/* | waaseyaa:entity-system | docs/specs/entity-system.md |
+| packages/access/*, packages/user/src/Middleware/* | waaseyaa:access-control | docs/specs/access-control.md |
+| packages/api/*, packages/routing/* | waaseyaa:api-layer | docs/specs/api-layer.md |
+| packages/admin/* | waaseyaa:admin-spa | docs/specs/admin-spa.md |
+| packages/ai-*/* | waaseyaa:ai-integration | docs/specs/ai-integration.md |
+| packages/foundation/*, packages/cache/*, packages/database-legacy/* | waaseyaa:infrastructure | docs/specs/infrastructure.md |
+| packages/mcp/* | waaseyaa:mcp-endpoint | docs/specs/mcp-endpoint.md |
+| public/index.php, packages/*/src/Middleware/* | waaseyaa:middleware-pipeline | docs/specs/middleware-pipeline.md |
+```
+
+### 1.2 Layer Architecture Reference
+
+```markdown
+## Layer Architecture
+
+Layer 0 (Foundation): foundation, cache, plugin, typed-data, database-legacy, testing, i18n, queue, state, validation
+Layer 1 (Core Data): entity, entity-storage, access, user, config, field
+Layer 2 (Content Types): node, taxonomy, media, path, menu
+Layer 3 (Services): workflows
+Layer 4 (API): api, routing
+Layer 5 (AI): ai-schema, ai-agent, ai-pipeline, ai-vector
+Layer 6 (Interfaces): cli, admin, mcp, ssr, telescope
+
+Rule: packages can only import from their own layer or lower. Upward communication via DomainEvents.
+```
+
+### 1.3 Operation Checklists
+
+Short recipes for common tasks:
+
+- **Adding an entity type** — steps: define EntityType, register in EntityTypeManager, create storage schema, add access policy, add API routes
+- **Adding an access policy** — steps: implement AccessPolicyInterface (+ FieldAccessPolicyInterface if needed), register via PolicyAttribute, test with anonymous classes
+- **Adding an API endpoint** — steps: add route in RouteBuilder, implement controller, wire access via route options, add to SchemaPresenter
+- **Adding middleware** — steps: implement HttpMiddlewareInterface, add AsMiddleware attribute, register in pipeline compiler
+
+### 1.4 Drift Warning
+
+Add to gotchas:
+> When refactoring a subsystem, update the relevant `docs/specs/` file. Stale specs cause agents to generate code conflicting with recent changes. Use `waaseyaa_search_specs` MCP tool to find affected specs.
+
+---
+
+## Tier 2: Domain Specialist Skills
+
+7 skills, each ~200-400 lines. Installed as Claude Code skills. Content is >50% domain knowledge (following the paper's finding).
+
+### Skill Structure Template
+
+```
+name: waaseyaa:<domain>
+description: <when to trigger>
+---
+# <Domain> Specialist
+
+## Scope
+Which packages and files this covers.
+
+## Key Interfaces
+The contracts an agent must understand when working in this domain.
+
+## Architecture
+How data flows through this subsystem (with code patterns).
+
+## Common Mistakes
+Domain-specific gotchas (superset of what's in CLAUDE.md).
+
+## Testing Patterns
+How to write tests for this domain (in-memory strategies, fixtures).
+
+## Related Specs
+Which docs/specs/ files to retrieve for deep context.
+```
+
+### Skill Inventory
+
+| Skill | Packages | Key knowledge encoded |
+|---|---|---|
+| `waaseyaa:entity-system` | entity, entity-storage, field, config | Constructor patterns (array $values + hardcoded type), _data JSON blob split/merge, enforceIsNew(), SqlEntityStorage reflection, entity keys mapping, UnitOfWork, EntityEvent public properties |
+| `waaseyaa:access-control` | access, user (middleware) | Asymmetric semantics (isAllowed vs !isForbidden), FieldAccessPolicyInterface, intersection types for policies, open-by-default field access, policy evaluation OR logic, Forbidden short-circuit, AccountInterface vs concrete User |
+| `waaseyaa:api-layer` | api, routing | JSON:API controller CRUD, ResourceSerializer paired nullables, SchemaPresenter x-access-restricted, QueryParser→QueryApplier→EntityQuery pipeline, post-fetch access filtering, LIKE wildcard escaping |
+| `waaseyaa:admin-spa` | admin | Nuxt 3 composables (useEntity, useSchema, useLanguage, useRealtime), SSE integration with entity events, schema-driven form generation, i18n in en.json, TypeScript patterns |
+| `waaseyaa:ai-integration` | ai-schema, ai-agent, ai-pipeline, ai-vector | EntityJsonSchemaGenerator (draft 2020-12), AgentExecutor with audit logging, Pipeline step orchestration by weight, tool safety, SchemaRegistry |
+| `waaseyaa:infrastructure` | foundation, cache, database-legacy, plugin, queue | ServiceProvider register/boot lifecycle, DomainEvent three-channel dispatch (sync/async/broadcast), query builder (NOT raw PDO), cache atomic writes, migration SchemaBuilder, attribute discovery |
+| `waaseyaa:middleware-pipeline` | foundation (middleware types), routing, public/index.php | Session→Authorization→Route chain, HttpPipeline compilation, middleware discovery via AsMiddleware attribute, route options (_public, _permission, _role, _gate), php://input single-read |
+
+---
+
+## Tier 3: Subsystem Specs + MCP Retrieval
+
+### 3.1 Subsystem Specifications
+
+10 specs in `docs/specs/`, mined from existing plan docs. Written for AI consumption: explicit file paths, code patterns, parameter names.
+
+| Spec file | Mined from | Content scope |
+|---|---|---|
+| `entity-system.md` | architecture-v2-design, cms-design | Entity types, storage drivers, _data blob, entity keys, constructor patterns, query pipeline |
+| `access-control.md` | authorization-wiring-design, field-level-access-design, field-access-wiring-design | Access result semantics, policy interfaces, Gate, AccessChecker, route options |
+| `field-access.md` | field-level-access-design, field-access-wiring-design | FieldAccessPolicyInterface, open-by-default, view/edit denial, x-access-restricted, paired nullables |
+| `api-layer.md` | admin-spa-completion, architecture-v2-design | JSON:API controller, ResourceSerializer, QueryParser, SchemaPresenter, query operators |
+| `middleware-pipeline.md` | authorization-wiring-design, laravel-integration-design | SessionMiddleware, AuthorizationMiddleware, pipeline compilation, middleware discovery |
+| `package-discovery.md` | laravel-integration-design | ServiceProvider lifecycle, composer.json manifest, three compilers, attribute discovery |
+| `infrastructure.md` | architecture-v2-design | DomainEvent channels, cache backends, database query builder, migration system |
+| `mcp-endpoint.md` | webmcp-design | McpEndpoint, auth interface, tool registry, JSON-RPC dispatch |
+| `admin-spa.md` | admin-spa-completion | Composables, schema-driven forms, SSE real-time, i18n |
+| `ai-integration.md` | architecture-v2-design | Schema generation, agent execution, pipeline orchestration |
+
+Each spec: ~200-500 lines.
+
+### 3.2 MCP Retrieval Server
+
+Lightweight local MCP server for Claude Code sessions. Separate from `packages/mcp/` (which is a remote MCP server for AI agents hitting Waaseyaa's API).
+
+**Location:** `tools/spec-retrieval/` (standalone, not a Waaseyaa package)
+
+**Tools:**
+
+| Tool | Parameters | Returns |
+|---|---|---|
+| `waaseyaa_list_specs` | none | Array of {name, description, file} for all specs |
+| `waaseyaa_get_spec` | `name: string` | Full markdown content of the named spec |
+| `waaseyaa_search_specs` | `query: string` | Matching sections across all specs (keyword substring) |
+
+**Implementation:** Node.js script using `@modelcontextprotocol/sdk`. Reads markdown files from `docs/specs/`. Keyword substring matching (the paper found this sufficient). ~200 lines.
+
+**Configuration:** Added to `.claude/settings.json` as a local MCP server:
+```json
+{
+  "mcpServers": {
+    "waaseyaa-specs": {
+      "command": "node",
+      "args": ["tools/spec-retrieval/server.js"],
+      "cwd": "."
+    }
+  }
+}
+```
+
+---
+
+## Maintenance & Drift Detection
+
+### Drift Detection Script
+
+**Location:** `tools/drift-detector.sh`
+
+Maps recent git commits (since last check) to subsystem-to-file mappings. Outputs which specs may need updating based on which files changed.
+
+```
+$ tools/drift-detector.sh
+Files changed in last 5 commits:
+  packages/api/src/Controller/SchemaController.php → docs/specs/api-layer.md
+  packages/access/src/EntityAccessHandler.php → docs/specs/access-control.md, docs/specs/field-access.md
+
+⚠ 2 specs may need review.
+```
+
+### Session Discipline
+
+After any session that changes a subsystem's behavior:
+1. Update `CLAUDE.md` if gotchas changed
+2. Update relevant `docs/specs/` file
+3. The `revise-claude-md` skill already handles step 1; extend pattern to specs
+
+### Estimated Maintenance Cost
+
+- Per-session overhead: ~5 min when specs are affected
+- Biweekly review pass: ~30 min
+- Weekly total: 1-2 hours
+
+---
+
+## Repeatable Skill
+
+After building this infrastructure, write a `codified-context` skill that applies this paper's architecture to any project:
+
+1. Audit existing codified context (CLAUDE.md, memory files, docs)
+2. Analyze codebase structure and identify domain groupings
+3. Generate constitution expansion (trigger table, layer reference, checklists)
+4. Create domain specialist skill templates
+5. Mine existing docs for subsystem spec content
+6. Scaffold MCP retrieval server
+
+---
+
+## Deliverables
+
+| Deliverable | Count | Lines (est.) |
+|---|---|---|
+| Expanded CLAUDE.md | 1 file | ~180 lines |
+| Domain specialist skills | 7 skills | ~2,100 lines |
+| Subsystem specs | 10 docs | ~3,500 lines |
+| MCP retrieval server | 1 tool | ~200 lines |
+| Drift detection script | 1 script | ~100 lines |
+| Codified-context skill | 1 skill | ~200 lines |
+| **Total** | **21 artifacts** | **~6,280 lines** |
+
+Knowledge-to-code ratio: ~8% from codified context alone. Combined with existing plan docs: ~35%.

--- a/docs/plans/2026-03-02-codified-context-implementation.md
+++ b/docs/plans/2026-03-02-codified-context-implementation.md
@@ -1,0 +1,1213 @@
+# Codified Context Infrastructure — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build three-tier codified context infrastructure (constitution + specialist skills + subsystem specs with MCP retrieval) for the Waaseyaa CMS monorepo.
+
+**Architecture:** Tier 3 specs first (knowledge base that everything references), then Tier 3 MCP retrieval server (TDD), then Tier 2 skills (reference specs), then Tier 1 constitution (references both), then maintenance tooling, then the repeatable skill.
+
+**Tech Stack:** Markdown (specs/skills), Node.js + @modelcontextprotocol/sdk (MCP server), Bash (drift detector)
+
+**Source design:** `docs/plans/2026-03-02-codified-context-design.md`
+
+---
+
+## Phase 1: Subsystem Specs (Tier 3 Content)
+
+Write 10 subsystem specs in `docs/specs/`. Each spec is written for AI consumption: explicit file paths, code patterns, interface signatures, parameter names. NOT prose for humans.
+
+### Task 1: Create specs directory and write entity-system.md
+
+**Files:**
+- Create: `docs/specs/entity-system.md`
+
+**Step 1: Create directory**
+
+```bash
+mkdir -p docs/specs
+```
+
+**Step 2: Write entity-system.md**
+
+Mine from: `docs/plans/2026-02-27-aurora-cms-design.md`, `docs/plans/2026-02-28-aurora-architecture-v2-design.md`, and source code.
+
+Structure (~300 lines):
+
+```markdown
+# Entity System
+
+## Packages
+- `packages/entity/` — EntityInterface, EntityBase, EntityType, EntityTypeManager
+- `packages/entity-storage/` — SqlEntityStorage, SqlEntityQuery, SqlSchemaHandler
+- `packages/field/` — FieldType interface, field definitions
+- `packages/config/` — ConfigEntity, ConfigManager
+
+## Key Interfaces
+
+### EntityInterface (packages/entity/src/EntityInterface.php)
+- `id(): int|string|null`
+- `uuid(): string`
+- `label(): string`
+- `getEntityTypeId(): string`
+- `bundle(): string`
+- `isNew(): bool`
+- `toArray(): array`
+- `language(): string`
+
+### EntityType (packages/entity/src/EntityType.php)
+Final readonly class. Named constructor params:
+`new EntityType(id: 'node', label: 'Content', class: Node::class, ...)`
+Keys: id, uuid, label, bundle, revision, langcode
+
+### EntityTypeManager (packages/entity/src/EntityTypeManager.php)
+Constructor: `(EventDispatcherInterface, callable $storageFactory)`
+Storage factory receives `EntityType $definition`, returns `EntityStorageInterface`.
+
+### SqlEntityStorage (packages/entity-storage/src/SqlEntityStorage.php)
+- 336 lines. Implements EntityStorageInterface.
+- Constructor: `(EntityTypeInterface, DatabaseInterface, EventDispatcherInterface)`
+- Uses reflection to detect entity constructor shape (array $values vs named params)
+- `splitForStorage()` — separates schema columns from _data JSON blob
+- `mapRowToEntity()` — merges _data JSON back into entity values on load
+
+## Architecture
+
+### Entity Construction
+Entity subclasses (User, Node) accept `(array $values)` and hardcode entityTypeId/entityKeys:
+```php
+final class User extends ContentEntityBase {
+    public function __construct(array $values) {
+        parent::__construct('user', ['uid', 'uuid', 'name', ...], $values);
+    }
+}
+```
+SqlEntityStorage uses reflection to detect this pattern.
+
+### _data JSON Blob
+SqlSchemaHandler adds a `_data` TEXT column to every entity table.
+- On save: `splitForStorage()` puts non-schema values into `_data` as JSON
+- On load: `mapRowToEntity()` merges `_data` back into the values array
+- Always use `json_encode(..., JSON_THROW_ON_ERROR)` paired with `json_decode(..., JSON_THROW_ON_ERROR)`
+
+### Entity Events
+EntityEvent uses public readonly properties: `$event->entity`, `$event->originalEntity`
+Common mistake: calling `$event->getEntity()` — no such method exists.
+
+### Entity Keys Mapping
+Each EntityType defines which fields contain standard values:
+- `id` — primary key field name (e.g., 'uid' for User, 'nid' for Node)
+- `uuid` — UUID field name
+- `label` — human-readable label field
+- `bundle` — bundle discriminator (optional)
+- `revision` — revision ID (optional)
+- `langcode` — language code (optional)
+
+## Common Mistakes
+
+1. **Forgetting `enforceIsNew()`** — When creating entities with pre-set IDs (e.g., `new User(['uid' => 2])`), call `$entity->enforceIsNew()` before `save()`. Otherwise `isNew()` returns false, SqlEntityStorage tries UPDATE, silently affects 0 rows.
+2. **Using `$event->getEntity()`** — EntityEvent has public properties, not getters.
+3. **PascalCase conversion** — Use `str_replace('_', '', ucwords($name, '_'))` not `ucfirst()`.
+4. **Asymmetric JSON** — Always pair `json_encode(JSON_THROW_ON_ERROR)` with `json_decode(JSON_THROW_ON_ERROR)`.
+5. **Dual-state bug pattern** — When data can come from two sources (attribute vs registry), use one canonical source. Found repeatedly in entity values.
+
+## Testing Patterns
+
+- Use `InMemoryEntityStorage` from `Waaseyaa\Api\Tests\Fixtures\` for unit tests
+- Use `PdoDatabase::createSqlite()` with `:memory:` for SQL-level tests
+- Final classes can't be mocked — use real instances with `sys_get_temp_dir() . '/waaseyaa_test_' . uniqid()`
+- Entity subclass constructors only accept `(array $values)` — always construct with array
+```
+
+**Step 3: Verify file references are accurate**
+
+Spot-check 3-4 file paths mentioned in the spec against the actual codebase.
+
+Run: `ls packages/entity/src/EntityInterface.php packages/entity/src/EntityType.php packages/entity-storage/src/SqlEntityStorage.php`
+Expected: all three exist
+
+---
+
+### Task 2: Write access-control.md and field-access.md
+
+**Files:**
+- Create: `docs/specs/access-control.md`
+- Create: `docs/specs/field-access.md`
+
+**Step 1: Write access-control.md (~350 lines)**
+
+Mine from: `docs/plans/2026-03-01-authorization-wiring-design.md`, `docs/plans/2026-03-01-field-level-access-design.md`.
+
+Must include:
+- AccessPolicyInterface full signature: `access(EntityInterface, string $operation, AccountInterface): AccessResult`, `createAccess(string $entityTypeId, string $bundle, AccountInterface): AccessResult`, `appliesTo(string $entityTypeId): bool`
+- AccessResult factory methods: `::allowed()`, `::neutral()`, `::forbidden()` with `isAllowed()`, `isForbidden()`, `isNeutral()`, `andIf()`, `orIf()`
+- AccessStatus enum: ALLOWED, NEUTRAL, FORBIDDEN
+- EntityAccessHandler: `check()`, `checkCreateAccess()` — OR logic, Forbidden short-circuits
+- Gate and PermissionHandler
+- Route access control: `_public`, `_permission`, `_role`, `_gate` route options
+- AccessChecker reads route options and delegates
+- Policy discovery via `#[PolicyAttribute]` (string constant, not ::class — layer discipline)
+- Open-by-default: routes without access requirements pass through
+- Entity-level semantics: deny-unless-granted via `isAllowed()`
+- AccountInterface (in access package) vs concrete User/AnonymousUser (in user package) — access must NOT depend on user package
+
+**Step 2: Write field-access.md (~250 lines)**
+
+Mine from: `docs/plans/2026-03-01-field-level-access-design.md`, `docs/plans/2026-03-01-field-access-wiring-design.md`.
+
+Must include:
+- FieldAccessPolicyInterface: `fieldAccess(EntityInterface, string $fieldName, string $operation, AccountInterface): AccessResult`
+- Policies must implement BOTH AccessPolicyInterface AND FieldAccessPolicyInterface
+- EntityAccessHandler: `checkFieldAccess()`, `filterFields()` — OR logic, Forbidden short-circuits, skips non-FieldAccess policies
+- **Critical semantics:** field-level uses `!isForbidden()` (allow-unless-denied), NOT `isAllowed()`. This asymmetry with entity-level is intentional.
+- View denial: field omitted from JSON:API response
+- Edit denial: field shown as read-only with `x-access-restricted: true` in schema
+- Paired nullable pattern: `?EntityAccessHandler` + `?AccountInterface` — both non-null or both null
+- Prototype entity for schema evaluation: `$prototype = new $class([])`
+- No new discovery — same `#[PolicyAttribute]`, `appliesTo()` scopes
+- Testing: anonymous classes implementing intersection types (PHPUnit can't mock intersections)
+
+**Step 3: Verify file references**
+
+Run: `ls packages/access/src/AccessPolicyInterface.php packages/access/src/FieldAccessPolicyInterface.php packages/access/src/EntityAccessHandler.php packages/access/src/AccessResult.php`
+
+---
+
+### Task 3: Write api-layer.md
+
+**Files:**
+- Create: `docs/specs/api-layer.md`
+
+**Step 1: Write api-layer.md (~350 lines)**
+
+Mine from: `docs/plans/2026-03-01-admin-spa-completion.md`, source code.
+
+Must include:
+- JsonApiController (packages/api/src/JsonApiController.php, 400 lines): `index()`, `show()`, `store()`, `update()`, `destroy()`
+- Constructor: `(EntityTypeManagerInterface, ResourceSerializer, ?EntityAccessHandler, ?AccountInterface)`
+- ResourceSerializer (packages/api/src/ResourceSerializer.php, 105 lines): `serialize(EntityInterface, ?EntityAccessHandler, ?AccountInterface): JsonApiResource`
+- Paired nullable pattern: both handler + account must be non-null or both null
+- QueryParser → QueryApplier → EntityQuery pipeline
+- Post-fetch access filtering: access checked after query execution, not in SQL
+- SchemaPresenter (packages/api/src/Schema/SchemaPresenter.php, 331 lines): `present(EntityTypeInterface, ?EntityAccessHandler, ?AccountInterface): array`
+- JSON Schema extensions: x-widget, x-label, x-description, x-weight, x-required, x-access-restricted
+- x-access-restricted vs system readOnly: restricted = viewable but not editable (disabled widget), readOnly = hidden from forms (id, uuid)
+- LIKE wildcard escaping: `str_replace(['%', '_'], ['\\%', '\\_'], $value)` — PdoSelect appends `ESCAPE '\'`
+- SchemaController: constructor accepts optional `?EntityAccessHandler` + `?AccountInterface`, creates prototype entity for schema evaluation
+- Query operators: CONTAINS → `%value%`, STARTS_WITH → `value%`, ENDS_WITH → `%value`
+
+**Step 2: Verify file references**
+
+Run: `ls packages/api/src/JsonApiController.php packages/api/src/ResourceSerializer.php packages/api/src/Schema/SchemaPresenter.php`
+
+---
+
+### Task 4: Write middleware-pipeline.md and package-discovery.md
+
+**Files:**
+- Create: `docs/specs/middleware-pipeline.md`
+- Create: `docs/specs/package-discovery.md`
+
+**Step 1: Write middleware-pipeline.md (~250 lines)**
+
+Mine from: `docs/plans/2026-03-01-authorization-wiring-design.md`, `docs/plans/2026-03-01-laravel-integration-layer-design.md`.
+
+Must include:
+- Three typed pipeline interfaces: Http, Event, Job — each has MiddlewareInterface + HandlerInterface
+- HttpMiddlewareInterface: `process(Request, HttpHandlerInterface): Response`
+- HttpHandlerInterface: `handle(Request): Response`
+- Same pattern for Event (DomainEvent) and Job
+- Onion pattern: middleware array reversed, each wraps next in closure
+- public/index.php pipeline: SessionMiddleware → AuthorizationMiddleware → RouteHandler
+- SessionMiddleware: `session_start()`, reads `$_SESSION['waaseyaa_uid']`, loads User, falls back to AnonymousUser, sets `_account` on request attributes
+- AuthorizationMiddleware: reads `_account`, reads matched Route, delegates to AccessChecker, returns 403 on Forbidden
+- Middleware discovery via `#[AsMiddleware(pipeline: 'http', priority: 100)]` attribute
+- MiddlewarePipelineCompiler compiles to `storage/framework/middleware.php`
+- php://input is single-read: `HttpRequest::createFromGlobals()` consumes it, use `$request->getContent()` after
+
+**Step 2: Write package-discovery.md (~300 lines)**
+
+Mine from: `docs/plans/2026-03-01-laravel-integration-layer-design.md`.
+
+Must include:
+- ServiceProvider abstract class: `register()` (pure binding, no side effects), `boot()` (post-registration, cross-layer safe)
+- Auto-discovery: `composer.json` → `extra.waaseyaa.providers`
+- Three compilers: PackageManifestCompiler, MiddlewarePipelineCompiler, ConfigCacheCompiler
+- Compilation order: manifest → middleware → config
+- Compiled artifacts in `storage/framework/`: `packages.php`, `middleware.php`, `config.php`
+- Dev: auto-compile on first use. Prod: pre-compiled via `waaseyaa optimize`
+- Attribute scanning: `#[AsFieldType]`, `#[AsListener]`, `#[AsMiddleware]`, `#[AsCommand]`, `#[AsEntityType]`
+- PackageManifest properties: providers, commands, routes, migrations, field_types, listeners, middleware, permissions, policies
+- Permission discovery: `extra.waaseyaa.permissions` in composer.json
+- Policy discovery: `#[PolicyAttribute]` → `policies` in manifest (entity type ID => FQCN)
+- Config caching: CachedConfigFactory decorator pattern, environment overrides via `WAASEYAA_CONFIG__SYSTEM_SITE__NAME`
+- CLI: `waaseyaa optimize`, `waaseyaa optimize:clear`, `waaseyaa optimize:manifest`, `waaseyaa optimize:middleware`, `waaseyaa optimize:config`
+- Backward-compatible cache evolution: use `$data['key'] ?? []` for new properties
+
+**Step 3: Verify file references**
+
+Run: `ls packages/foundation/src/ServiceProvider/ServiceProvider.php packages/foundation/src/Discovery/PackageManifestCompiler.php 2>/dev/null; ls packages/foundation/src/Middleware/HttpMiddlewareInterface.php 2>/dev/null || echo "check Middleware dir structure"`
+
+---
+
+### Task 5: Write infrastructure.md
+
+**Files:**
+- Create: `docs/specs/infrastructure.md`
+
+**Step 1: Write infrastructure.md (~300 lines)**
+
+Mine from: `docs/plans/2026-02-28-aurora-architecture-v2-design.md`, source code.
+
+Must include:
+- DomainEvent (packages/foundation/src/Event/DomainEvent.php): abstract class extending Symfony Event, properties: eventId (UUIDv7), occurredAt, aggregateType, aggregateId, tenantId, actorId. Abstract `getPayload(): array`.
+- Three dispatch channels: sync (EventDispatcher, immediate), async (Messenger, queued), broadcast (SSE, real-time UI)
+- EventBus: dispatches to all three channels. `eventStore?->append()` → eventPipeline → syncDispatcher → asyncBus → broadcaster
+- Cache system: CacheBackendInterface, MemoryBackend (testing), DatabaseBackend, RedisBackend. Tag-based invalidation.
+- Atomic file writes: write to temp file, then `rename()`. Never `file_put_contents()` directly to cache target.
+- DatabaseInterface (packages/database-legacy/src/DatabaseInterface.php): query builder abstraction. Does NOT have `getPdo()`.
+- PdoDatabase: concrete implementation. Has `getPdo()`. Only type-hint this when raw PDO is needed.
+- Query builder: `select()`, `insert()`, `update()`, `delete()` — prefer over raw PDO
+- PdoDatabase::createSqlite() for in-memory test databases
+- PDO fetch mode: FETCH_ASSOC (avoids duplicate numeric-indexed columns)
+- Plugin system: PluginInterface, attribute-based discovery
+- No psr/log: use `error_log()` for best-effort logging
+- Best-effort side effects: event listeners for non-critical ops wrap in try-catch with `error_log()`
+- Layer discipline: Foundation (layer 0) must never import from higher layers. Use string constants for cross-layer attribute scanning.
+
+**Step 2: Verify file references**
+
+Run: `ls packages/foundation/src/Event/DomainEvent.php packages/database-legacy/src/DatabaseInterface.php packages/database-legacy/src/PdoDatabase.php`
+
+---
+
+### Task 6: Write mcp-endpoint.md
+
+**Files:**
+- Create: `docs/specs/mcp-endpoint.md`
+
+**Step 1: Write mcp-endpoint.md (~200 lines)**
+
+Mine from: `docs/plans/2026-02-28-webmcp-design.md`.
+
+Must include:
+- McpEndpoint (packages/mcp/src/McpEndpoint.php): `handle(ServerRequestInterface): ResponseInterface`
+- McpAuthInterface (packages/mcp/src/Auth/McpAuthInterface.php): `authenticate(ServerRequestInterface): ?AccountInterface`
+- BearerTokenAuth: reads `Authorization: Bearer <token>`, maps tokens to AccountInterface instances
+- Bridge adapters: AuroraToolAdapter (McpToolDefinition → SDK MetadataInterface), AuroraToolExecutorAdapter (→ SDK ToolExecutorInterface)
+- Routes: `POST|GET /mcp` (auth required), `GET /.well-known/mcp.json` (public)
+- McpServerCard: name, version, endpoint, transport, capabilities, authentication
+- Request flow: HTTP → McpRouteProvider → McpEndpoint → McpAuthInterface → JsonRpcHandler → ToolListHandler/ToolCallHandler → Bridge → SchemaRegistry → McpToolExecutor → Entity Storage
+- Audit: piggybacks on AgentAuditLog via McpToolExecutor → AgentExecutor::executeTool()
+- MCP transport: Streamable HTTP (spec 2025-03-26), single endpoint, POST for requests, GET for SSE
+- Auth roadmap: MVP bearer tokens → OAuth 2.1 → scoped permissions
+
+**Step 2: Verify file references**
+
+Run: `ls packages/mcp/src/McpEndpoint.php packages/mcp/src/Auth/McpAuthInterface.php packages/mcp/src/Auth/BearerTokenAuth.php`
+
+---
+
+### Task 7: Write admin-spa.md and ai-integration.md
+
+**Files:**
+- Create: `docs/specs/admin-spa.md`
+- Create: `docs/specs/ai-integration.md`
+
+**Step 1: Write admin-spa.md (~200 lines)**
+
+Mine from: `docs/plans/2026-03-01-admin-spa-completion.md`, source files.
+
+Must include:
+- Nuxt 3 + Vue 3 + TypeScript
+- Composables in `packages/admin/app/composables/`: useEntity.ts, useSchema.ts, useLanguage.ts, useRealtime.ts
+- useEntity: reactive entity CRUD operations against JSON:API backend
+- useSchema: loads JSON Schema for entity types, `sortedProperties(editable)` filters system readOnly but keeps x-access-restricted
+- useRealtime: SSE connection to PHP backend for live entity updates
+- useLanguage: language selection and i18n
+- i18n: `packages/admin/app/i18n/en.json`
+- Schema-driven forms: SchemaForm.vue renders from JSON Schema, SchemaField.vue passes `disabled` for x-access-restricted fields
+- x-access-restricted: field is viewable but not editable — renders disabled widget. Distinct from system readOnly (id, uuid) which hides field entirely.
+- Build verification: `cd packages/admin && npm run build` — no test framework, build verifies TypeScript compilation
+
+**Step 2: Write ai-integration.md (~200 lines)**
+
+Mine from: `docs/plans/2026-02-28-aurora-architecture-v2-design.md`, source code.
+
+Must include:
+- ai-schema: EntityJsonSchemaGenerator (draft 2020-12), `generate(entityTypeId): array`, `generateAll(): array<string, array>`, SchemaRegistry
+- ai-agent: AgentInterface, AgentExecutor (`execute()`, `dryRun()`, `executeTool()`), AgentContext, AgentResult, AgentAuditLog (in-memory)
+- ai-pipeline: Pipeline (ConfigEntity, ordered steps by weight), PipelineExecutor (executes in weight order, output → next input), PipelineStepInterface, PipelineContext, PipelineDispatcher, StepResult
+- ai-vector: Vector embeddings, similarity search (planned)
+- Pipeline pattern: `addStep(name, weight)`, `removeStep()`, executor passes `StepResult.output` as next step's input
+
+**Step 3: Verify file references**
+
+Run: `ls packages/admin/app/composables/useEntity.ts packages/ai-schema/src/EntityJsonSchemaGenerator.php packages/ai-agent/src/AgentExecutor.php packages/ai-pipeline/src/Pipeline.php 2>/dev/null`
+
+---
+
+### Task 8: Commit all specs
+
+**Step 1: Review spec count**
+
+Run: `ls docs/specs/*.md | wc -l`
+Expected: 10
+
+**Step 2: Commit**
+
+```bash
+git add docs/specs/
+git commit -m "docs: add 10 subsystem specs for codified context Tier 3
+
+Mined from existing plan docs and source code. Written for AI
+consumption with explicit file paths, interface signatures, and
+code patterns.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2: MCP Retrieval Server (Tier 3 Tooling)
+
+Build a local MCP server in `tools/spec-retrieval/` that Claude Code uses to query subsystem specs.
+
+### Task 9: Scaffold MCP retrieval server
+
+**Files:**
+- Create: `tools/spec-retrieval/package.json`
+- Create: `tools/spec-retrieval/.gitignore`
+
+**Step 1: Create directory and package.json**
+
+```bash
+mkdir -p tools/spec-retrieval
+```
+
+Write `tools/spec-retrieval/package.json`:
+```json
+{
+  "name": "waaseyaa-spec-retrieval",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test test.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}
+```
+
+Write `tools/spec-retrieval/.gitignore`:
+```
+node_modules/
+```
+
+**Step 2: Install dependencies**
+
+Run: `cd tools/spec-retrieval && npm install`
+Expected: package-lock.json created, @modelcontextprotocol/sdk installed
+
+**Step 3: Add to root .gitignore if not already there**
+
+Check and add `tools/spec-retrieval/node_modules/` to root `.gitignore` if needed.
+
+---
+
+### Task 10: Write failing test for list and get tools
+
+**Files:**
+- Create: `tools/spec-retrieval/test.js`
+
+**Step 1: Write test file**
+
+Use Node.js built-in test runner (`node:test`). Test the server's tool handlers directly (unit test, no MCP transport).
+
+```javascript
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { createToolHandlers } from './server.js';
+
+describe('waaseyaa_list_specs', () => {
+  let handlers;
+
+  before(() => {
+    handlers = createToolHandlers('../../docs/specs');
+  });
+
+  it('returns all specs with name and description', async () => {
+    const result = await handlers.waaseyaa_list_specs();
+    assert.ok(Array.isArray(result));
+    assert.ok(result.length >= 10);
+    for (const spec of result) {
+      assert.ok(spec.name, 'each spec has a name');
+      assert.ok(spec.description, 'each spec has a description');
+      assert.ok(spec.file, 'each spec has a file path');
+    }
+  });
+});
+
+describe('waaseyaa_get_spec', () => {
+  let handlers;
+
+  before(() => {
+    handlers = createToolHandlers('../../docs/specs');
+  });
+
+  it('returns full content for a valid spec', async () => {
+    const result = await handlers.waaseyaa_get_spec({ name: 'entity-system' });
+    assert.ok(typeof result === 'string');
+    assert.ok(result.includes('# Entity System'));
+    assert.ok(result.length > 100);
+  });
+
+  it('returns error for unknown spec', async () => {
+    const result = await handlers.waaseyaa_get_spec({ name: 'nonexistent' });
+    assert.ok(result.includes('not found'));
+  });
+});
+
+describe('waaseyaa_search_specs', () => {
+  let handlers;
+
+  before(() => {
+    handlers = createToolHandlers('../../docs/specs');
+  });
+
+  it('returns matching sections for a query', async () => {
+    const result = await handlers.waaseyaa_search_specs({ query: 'EntityAccessHandler' });
+    assert.ok(typeof result === 'string');
+    assert.ok(result.includes('EntityAccessHandler'));
+  });
+
+  it('returns no matches message for garbage query', async () => {
+    const result = await handlers.waaseyaa_search_specs({ query: 'xyzzy_nonexistent_term' });
+    assert.ok(result.includes('No matches'));
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd tools/spec-retrieval && node --test test.js`
+Expected: FAIL — `createToolHandlers` not exported from server.js
+
+---
+
+### Task 11: Implement MCP server
+
+**Files:**
+- Create: `tools/spec-retrieval/server.js`
+
+**Step 1: Write server.js (~150 lines)**
+
+```javascript
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Create tool handler functions for the spec retrieval tools.
+ * Exported for testing. specsDir is relative to this file.
+ */
+export function createToolHandlers(specsDir) {
+  const dir = resolve(__dirname, specsDir);
+
+  async function listSpecs() {
+    const files = (await readdir(dir)).filter(f => f.endsWith('.md'));
+    const specs = [];
+    for (const file of files) {
+      const content = await readFile(join(dir, file), 'utf-8');
+      const name = file.replace('.md', '');
+      // Extract first heading as description
+      const match = content.match(/^#\s+(.+)$/m);
+      const description = match ? match[1] : name;
+      specs.push({ name, description, file: `docs/specs/${file}` });
+    }
+    return specs;
+  }
+
+  async function getSpec({ name }) {
+    const filePath = join(dir, `${name}.md`);
+    try {
+      return await readFile(filePath, 'utf-8');
+    } catch {
+      return `Spec "${name}" not found. Use waaseyaa_list_specs to see available specs.`;
+    }
+  }
+
+  async function searchSpecs({ query }) {
+    const files = (await readdir(dir)).filter(f => f.endsWith('.md'));
+    const results = [];
+    const lowerQuery = query.toLowerCase();
+
+    for (const file of files) {
+      const content = await readFile(join(dir, file), 'utf-8');
+      const lines = content.split('\n');
+      const matches = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].toLowerCase().includes(lowerQuery)) {
+          // Include 2 lines of context before and after
+          const start = Math.max(0, i - 2);
+          const end = Math.min(lines.length - 1, i + 2);
+          matches.push(lines.slice(start, end + 1).join('\n'));
+        }
+      }
+
+      if (matches.length > 0) {
+        const name = file.replace('.md', '');
+        results.push(`## ${name}\n\n${matches.join('\n\n---\n\n')}`);
+      }
+    }
+
+    if (results.length === 0) {
+      return `No matches found for "${query}".`;
+    }
+    return results.join('\n\n===\n\n');
+  }
+
+  return {
+    waaseyaa_list_specs: listSpecs,
+    waaseyaa_get_spec: getSpec,
+    waaseyaa_search_specs: searchSpecs,
+  };
+}
+
+// MCP server setup (only runs when executed directly, not when imported for tests)
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const handlers = createToolHandlers('../../docs/specs');
+
+  const server = new Server(
+    { name: 'waaseyaa-specs', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler('tools/list', async () => ({
+    tools: [
+      {
+        name: 'waaseyaa_list_specs',
+        description: 'List all available Waaseyaa subsystem specifications',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'waaseyaa_get_spec',
+        description: 'Get the full content of a named subsystem specification',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string', description: 'Spec name (e.g., "entity-system")' } },
+          required: ['name'],
+        },
+      },
+      {
+        name: 'waaseyaa_search_specs',
+        description: 'Search across all subsystem specs by keyword',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string', description: 'Search query' } },
+          required: ['query'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler('tools/call', async (request) => {
+    const { name, arguments: args } = request.params;
+    const handler = handlers[name];
+    if (!handler) {
+      return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+    }
+    const result = await handler(args || {});
+    const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    return { content: [{ type: 'text', text }] };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd tools/spec-retrieval && node --test test.js`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add tools/spec-retrieval/
+git commit -m "feat: MCP spec retrieval server for codified context Tier 3
+
+Three tools: waaseyaa_list_specs, waaseyaa_get_spec,
+waaseyaa_search_specs. Keyword substring matching over docs/specs/.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Configure MCP server in Claude Code settings
+
+**Files:**
+- Modify: `.claude/settings.local.json`
+
+**Step 1: Add MCP server configuration**
+
+Add `mcpServers` key to the existing settings file (merge with existing content):
+
+```json
+{
+  "mcpServers": {
+    "waaseyaa-specs": {
+      "command": "node",
+      "args": ["tools/spec-retrieval/server.js"],
+      "cwd": "/home/fsd42/dev/waaseyaa"
+    }
+  }
+}
+```
+
+Note: merge with existing `permissions` key, don't overwrite.
+
+**Step 2: Verify configuration is valid JSON**
+
+Run: `python3 -c "import json; json.load(open('.claude/settings.local.json'))"`
+Expected: no error
+
+**Step 3: Commit**
+
+```bash
+git add .claude/settings.local.json
+git commit -m "config: register MCP spec retrieval server in Claude Code settings
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 3: Domain Specialist Skills (Tier 2)
+
+Write 7 project-specific skills. Each skill is a markdown file installed in the Claude Code skills directory. Content is >50% domain knowledge.
+
+Skills location: determine based on the project's skill configuration. Check how existing project-specific skills are configured (if any) or create a `skills/` directory in the project root.
+
+### Task 13: Determine skill installation location
+
+**Step 1: Check how Claude Code discovers project skills**
+
+Look for skill configuration in `.claude/` directory or CLAUDE.md. Check the superpowers plugin structure for reference on how skills are registered.
+
+Run: `find .claude/ -name "*.json" -exec grep -l skill {} \; 2>/dev/null; ls skills/ 2>/dev/null || echo "no skills dir"`
+
+**Step 2: Create skills directory**
+
+```bash
+mkdir -p skills/waaseyaa
+```
+
+Skills will be markdown files: `skills/waaseyaa/<name>.md`
+
+Configure skill discovery in `.claude/settings.local.json` if needed (add skills path).
+
+---
+
+### Task 14: Write waaseyaa:entity-system skill
+
+**Files:**
+- Create: `skills/waaseyaa/entity-system.md`
+
+**Step 1: Write skill (~300 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:entity-system
+description: Use when working on entity types, entity storage, field types, config entities, or any code in packages/entity/, packages/entity-storage/, packages/field/, packages/config/
+```
+
+Sections (per design template):
+1. **Scope** — packages/entity/, packages/entity-storage/, packages/field/, packages/config/
+2. **Key Interfaces** — EntityInterface, EntityType, EntityTypeManager, EntityStorageInterface, SqlEntityStorage, FieldTypeInterface, ConfigEntity
+3. **Architecture** — Entity construction patterns, _data JSON blob split/merge, entity keys mapping, UnitOfWork, SqlSchemaHandler auto-creates tables
+4. **Common Mistakes** — enforceIsNew(), getEntity() vs public properties, PascalCase, JSON symmetry, dual-state pattern, final class mocking
+5. **Testing Patterns** — InMemoryEntityStorage, PdoDatabase::createSqlite(), real instances for final classes, entity constructor always array
+6. **Related Specs** — `waaseyaa_get_spec entity-system` via MCP
+
+Content draws from the entity-system.md spec but adds behavioral guidance (when to use which storage, how to add a new entity type step by step, etc).
+
+---
+
+### Task 15: Write waaseyaa:access-control skill
+
+**Files:**
+- Create: `skills/waaseyaa/access-control.md`
+
+**Step 1: Write skill (~350 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:access-control
+description: Use when working on access policies, permissions, entity/field access checking, authorization middleware, or any code in packages/access/, packages/user/src/Middleware/
+```
+
+Key content:
+- Asymmetric semantics (the most critical knowledge): entity uses `isAllowed()`, field uses `!isForbidden()`
+- Policy implementation checklist: implement both interfaces, use PolicyAttribute, test with anonymous intersection-type classes
+- EntityAccessHandler combining logic: OR, Forbidden short-circuits
+- AccountInterface lives in access package, concrete User/AnonymousUser in user package — never import user from access
+- Layer discipline: access uses string constants for policy attribute scanning, not `::class` references
+- Route access: `_public`, `_permission`, `_role`, `_gate` options
+- Related specs: `waaseyaa_get_spec access-control`, `waaseyaa_get_spec field-access`
+
+---
+
+### Task 16: Write waaseyaa:api-layer skill
+
+**Files:**
+- Create: `skills/waaseyaa/api-layer.md`
+
+**Step 1: Write skill (~300 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:api-layer
+description: Use when working on JSON:API endpoints, resource serialization, query parsing, schema generation, or any code in packages/api/, packages/routing/
+```
+
+Key content:
+- JsonApiController CRUD method signatures
+- ResourceSerializer paired nullable pattern
+- QueryParser → QueryApplier → EntityQuery → post-fetch filtering pipeline
+- SchemaPresenter extensions (x-widget, x-access-restricted, etc.)
+- LIKE wildcard escaping pattern
+- SchemaController prototype entity pattern
+- Related spec: `waaseyaa_get_spec api-layer`
+
+---
+
+### Task 17: Write waaseyaa:admin-spa skill
+
+**Files:**
+- Create: `skills/waaseyaa/admin-spa.md`
+
+**Step 1: Write skill (~200 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:admin-spa
+description: Use when working on the admin SPA, Vue components, composables, i18n, or any code in packages/admin/
+```
+
+Key content:
+- Nuxt 3 + Vue 3 + TypeScript stack
+- Four composables and their responsibilities
+- Schema-driven form rendering pattern
+- x-access-restricted → disabled widget (not hidden)
+- i18n in packages/admin/app/i18n/en.json
+- Build verification: `cd packages/admin && npm run build`
+- No test framework — TypeScript compilation is the verification
+- Related spec: `waaseyaa_get_spec admin-spa`
+
+---
+
+### Task 18: Write waaseyaa:ai-integration skill
+
+**Files:**
+- Create: `skills/waaseyaa/ai-integration.md`
+
+**Step 1: Write skill (~200 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:ai-integration
+description: Use when working on AI schema generation, agent execution, pipeline orchestration, vector embeddings, or any code in packages/ai-schema/, packages/ai-agent/, packages/ai-pipeline/, packages/ai-vector/
+```
+
+Key content:
+- EntityJsonSchemaGenerator: generate() and generateAll() signatures
+- AgentExecutor: execute(), dryRun(), executeTool() with audit logging
+- Pipeline: ConfigEntity with ordered steps by weight, PipelineExecutor chains output→input
+- SchemaRegistry for tool/schema lookup
+- Related spec: `waaseyaa_get_spec ai-integration`
+
+---
+
+### Task 19: Write waaseyaa:infrastructure skill
+
+**Files:**
+- Create: `skills/waaseyaa/infrastructure.md`
+
+**Step 1: Write skill (~300 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:infrastructure
+description: Use when working on foundation services, events, cache, database queries, plugins, migrations, or any code in packages/foundation/, packages/cache/, packages/database-legacy/, packages/plugin/, packages/queue/
+```
+
+Key content:
+- ServiceProvider register() vs boot() lifecycle
+- DomainEvent three-channel dispatch (sync/async/broadcast)
+- DatabaseInterface vs PdoDatabase — when to use which
+- Query builder preferred over raw PDO
+- Cache atomic writes pattern
+- No psr/log — use error_log()
+- Best-effort side effects in event listeners
+- Layer discipline: Foundation never imports from higher layers
+- Related specs: `waaseyaa_get_spec infrastructure`, `waaseyaa_get_spec package-discovery`
+
+---
+
+### Task 20: Write waaseyaa:middleware-pipeline skill
+
+**Files:**
+- Create: `skills/waaseyaa/middleware-pipeline.md`
+
+**Step 1: Write skill (~250 lines)**
+
+Front matter:
+```yaml
+name: waaseyaa:middleware-pipeline
+description: Use when working on HTTP/event/job middleware, the request pipeline, public/index.php, or any middleware in packages/*/src/Middleware/
+```
+
+Key content:
+- Three typed pipeline interfaces (Http, Event, Job)
+- Onion pattern implementation
+- public/index.php pipeline: Session → Authorization → Route
+- Middleware discovery via #[AsMiddleware] attribute
+- MiddlewarePipelineCompiler
+- php://input single-read gotcha
+- Middleware interface naming: {Type}MiddlewareInterface, {Type}HandlerInterface
+- Related spec: `waaseyaa_get_spec middleware-pipeline`
+
+---
+
+### Task 21: Commit all skills
+
+**Step 1: Review skill count**
+
+Run: `ls skills/waaseyaa/*.md | wc -l`
+Expected: 7
+
+**Step 2: Commit**
+
+```bash
+git add skills/
+git commit -m "feat: add 7 domain specialist skills for codified context Tier 2
+
+Project-specific skills encoding subsystem knowledge for entity system,
+access control, API layer, admin SPA, AI integration, infrastructure,
+and middleware pipeline.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 4: Constitution Expansion (Tier 1)
+
+### Task 22: Expand CLAUDE.md with orchestration and checklists
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add Orchestration section after Project Structure**
+
+Insert after the `## Project Structure` section (after line 11):
+
+```markdown
+## Orchestration
+
+When working on a subsystem, invoke the matching specialist skill and retrieve the cold memory spec for deep context.
+
+| File pattern | Specialist skill | Cold memory spec |
+|---|---|---|
+| packages/entity/*, packages/entity-storage/*, packages/field/* | waaseyaa:entity-system | entity-system |
+| packages/access/*, packages/user/src/Middleware/* | waaseyaa:access-control | access-control, field-access |
+| packages/api/*, packages/routing/* | waaseyaa:api-layer | api-layer |
+| packages/admin/* | waaseyaa:admin-spa | admin-spa |
+| packages/ai-*/* | waaseyaa:ai-integration | ai-integration |
+| packages/foundation/*, packages/cache/*, packages/database-legacy/* | waaseyaa:infrastructure | infrastructure, package-discovery |
+| packages/mcp/* | — | mcp-endpoint |
+| public/index.php, packages/*/src/Middleware/* | waaseyaa:middleware-pipeline | middleware-pipeline |
+
+To retrieve a spec: use the `waaseyaa_get_spec` MCP tool (e.g., `waaseyaa_get_spec entity-system`).
+To search across specs: use `waaseyaa_search_specs` MCP tool.
+```
+
+**Step 2: Add Layer Architecture section after Orchestration**
+
+```markdown
+## Layer Architecture
+
+- Layer 0 (Foundation): foundation, cache, plugin, typed-data, database-legacy, testing, i18n, queue, state, validation
+- Layer 1 (Core Data): entity, entity-storage, access, user, config, field
+- Layer 2 (Content Types): node, taxonomy, media, path, menu
+- Layer 3 (Services): workflows
+- Layer 4 (API): api, routing
+- Layer 5 (AI): ai-schema, ai-agent, ai-pipeline, ai-vector
+- Layer 6 (Interfaces): cli, admin, mcp, ssr, telescope
+
+Rule: packages can only import from their own layer or lower. Upward communication via DomainEvents.
+```
+
+**Step 3: Add Operation Checklists section before Commands**
+
+```markdown
+## Operation Checklists
+
+**Adding an entity type:**
+1. Define EntityType with named constructor params (id, label, class, keys)
+2. Create entity class extending ContentEntityBase, constructor accepts `(array $values)`, hardcodes entityTypeId and entityKeys
+3. Register in EntityTypeManager
+4. SqlSchemaHandler auto-creates table from EntityType definition
+5. Add AccessPolicyInterface implementation with `#[PolicyAttribute]`
+6. Add routes in RouteBuilder with access options (_permission, _role, etc.)
+
+**Adding an access policy:**
+1. Create class implementing AccessPolicyInterface (+ FieldAccessPolicyInterface if field-level needed)
+2. Add `#[PolicyAttribute]` attribute
+3. Implement `appliesTo(string $entityTypeId): bool` to scope
+4. Test with anonymous classes implementing intersection types (PHPUnit can't mock intersections)
+
+**Adding an API endpoint:**
+1. Add route in RouteBuilder with access options
+2. Implement controller method
+3. Wire EntityAccessHandler + AccountInterface if access-aware
+4. Update SchemaPresenter if schema changes
+
+**Adding middleware:**
+1. Implement HttpMiddlewareInterface (or Event/Job variant)
+2. Add `#[AsMiddleware(pipeline: 'http', priority: N)]` attribute
+3. Middleware discovered by MiddlewarePipelineCompiler
+```
+
+**Step 4: Add drift warning to Architecture Gotchas section**
+
+Append to the end of the Architecture Gotchas section:
+```markdown
+- **Spec drift**: When refactoring a subsystem, update the relevant `docs/specs/` file. Stale specs cause agents to generate code conflicting with recent changes. Use `waaseyaa_search_specs` MCP tool to find affected specs.
+```
+
+**Step 5: Verify CLAUDE.md is well-formed**
+
+Run: `wc -l CLAUDE.md`
+Expected: ~170-200 lines
+
+**Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: expand CLAUDE.md with orchestration, layers, and checklists
+
+Codified context Tier 1: trigger table routing file patterns to
+specialist skills and specs, 7-layer architecture reference,
+operation checklists for common tasks, drift warning.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 5: Maintenance Tooling
+
+### Task 23: Write drift detection script
+
+**Files:**
+- Create: `tools/drift-detector.sh`
+
+**Step 1: Write drift-detector.sh (~80 lines)**
+
+```bash
+#!/usr/bin/env bash
+# Drift detector: maps recent git changes to subsystem specs that may need updating.
+# Usage: tools/drift-detector.sh [N_COMMITS]
+#        Defaults to 10 commits.
+
+set -euo pipefail
+
+N=${1:-10}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# File pattern → spec mapping (matches CLAUDE.md orchestration table)
+declare -A SPEC_MAP
+SPEC_MAP["packages/entity/"]="entity-system"
+SPEC_MAP["packages/entity-storage/"]="entity-system"
+SPEC_MAP["packages/field/"]="entity-system"
+SPEC_MAP["packages/access/"]="access-control field-access"
+SPEC_MAP["packages/user/src/Middleware/"]="access-control"
+SPEC_MAP["packages/api/"]="api-layer"
+SPEC_MAP["packages/routing/"]="api-layer middleware-pipeline"
+SPEC_MAP["packages/admin/"]="admin-spa"
+SPEC_MAP["packages/ai-schema/"]="ai-integration"
+SPEC_MAP["packages/ai-agent/"]="ai-integration"
+SPEC_MAP["packages/ai-pipeline/"]="ai-integration"
+SPEC_MAP["packages/ai-vector/"]="ai-integration"
+SPEC_MAP["packages/foundation/"]="infrastructure package-discovery middleware-pipeline"
+SPEC_MAP["packages/cache/"]="infrastructure"
+SPEC_MAP["packages/database-legacy/"]="infrastructure"
+SPEC_MAP["packages/mcp/"]="mcp-endpoint"
+SPEC_MAP["public/index.php"]="middleware-pipeline"
+
+# Get changed files in last N commits
+CHANGED_FILES=$(cd "$PROJECT_DIR" && git diff --name-only HEAD~${N}..HEAD 2>/dev/null || echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No changes in last $N commits."
+  exit 0
+fi
+
+# Find affected specs
+declare -A AFFECTED_SPECS
+while IFS= read -r file; do
+  for pattern in "${!SPEC_MAP[@]}"; do
+    if [[ "$file" == "$pattern"* ]]; then
+      for spec in ${SPEC_MAP[$pattern]}; do
+        AFFECTED_SPECS[$spec]=1
+      done
+    fi
+  done
+done <<< "$CHANGED_FILES"
+
+if [ ${#AFFECTED_SPECS[@]} -eq 0 ]; then
+  echo "No specs affected by changes in last $N commits."
+  exit 0
+fi
+
+echo "Files changed in last $N commits affect these specs:"
+echo ""
+for spec in "${!AFFECTED_SPECS[@]}"; do
+  SPEC_FILE="$PROJECT_DIR/docs/specs/${spec}.md"
+  if [ -f "$SPEC_FILE" ]; then
+    SPEC_MTIME=$(stat -c %Y "$SPEC_FILE" 2>/dev/null || stat -f %m "$SPEC_FILE" 2>/dev/null)
+    LAST_COMMIT_TIME=$(cd "$PROJECT_DIR" && git log -1 --format=%ct -- "docs/specs/${spec}.md" 2>/dev/null || echo "0")
+    LATEST_CODE_CHANGE=$(cd "$PROJECT_DIR" && git log -1 --format=%ct HEAD~${N}..HEAD 2>/dev/null || echo "0")
+    if [ "$LAST_COMMIT_TIME" -lt "$LATEST_CODE_CHANGE" ]; then
+      echo "  ⚠  docs/specs/${spec}.md — may be stale (last updated before recent code changes)"
+    else
+      echo "  ✓  docs/specs/${spec}.md — recently updated"
+    fi
+  else
+    echo "  ✗  docs/specs/${spec}.md — MISSING"
+  fi
+done
+```
+
+**Step 2: Make executable**
+
+Run: `chmod +x tools/drift-detector.sh`
+
+**Step 3: Test it**
+
+Run: `tools/drift-detector.sh 5`
+Expected: Lists specs affected by recent commits with staleness indicators
+
+**Step 4: Commit**
+
+```bash
+git add tools/drift-detector.sh
+git commit -m "feat: add drift detection script for spec staleness
+
+Maps recent git changes to subsystem specs and reports which
+may need review. Usage: tools/drift-detector.sh [N_COMMITS]
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 6: Repeatable Skill
+
+### Task 24: Write codified-context skill
+
+**Files:**
+- Create: `skills/codified-context.md`
+
+**Step 1: Write skill (~200 lines)**
+
+This skill encodes the process from the paper for applying to any project. Front matter:
+
+```yaml
+name: codified-context
+description: Use when setting up or auditing a project's codified context infrastructure (CLAUDE.md constitution, domain specialist skills, subsystem specs with MCP retrieval). Based on arxiv.org/abs/2602.20478.
+```
+
+Content:
+1. **Audit existing context** — Check for CLAUDE.md, memory files, docs/plans, existing skills. Count lines of code vs knowledge.
+2. **Analyze codebase structure** — Identify packages/modules, map to layers, find natural domain groupings (5-8 groups typical).
+3. **Tier 1: Expand constitution** — Add orchestration trigger table (file patterns → skills → specs), layer reference, operation checklists, drift warning.
+4. **Tier 2: Create domain specialist skills** — One skill per domain group. Structure: scope, key interfaces, architecture, common mistakes, testing patterns, related specs. >50% domain knowledge.
+5. **Tier 3: Write subsystem specs** — Mine existing docs/plans for enduring architectural knowledge. Write for AI consumption (file paths, code patterns, interface signatures). Build MCP retrieval server (3 tools: list, get, search).
+6. **Maintenance** — Drift detection script mapping git changes to spec staleness. Session discipline: update specs when behavior changes.
+
+Include the checklist from the paper's practitioner guidelines:
+- Basic constitution yields outsized returns
+- Repeated explanation signals codification need
+- Stale specs silently mislead
+- Specialist agents resolve stuck sessions
+
+**Step 2: Commit**
+
+```bash
+git add skills/codified-context.md
+git commit -m "feat: add codified-context skill for repeatable infrastructure setup
+
+Encodes the process from arxiv.org/abs/2602.20478 for applying
+three-tier codified context to any project.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 7: Final Verification
+
+### Task 25: End-to-end verification
+
+**Step 1: Verify all artifacts exist**
+
+Run:
+```bash
+echo "=== Specs ===" && ls docs/specs/*.md | wc -l && \
+echo "=== Skills ===" && ls skills/waaseyaa/*.md skills/codified-context.md | wc -l && \
+echo "=== MCP Server ===" && ls tools/spec-retrieval/server.js tools/spec-retrieval/package.json && \
+echo "=== Drift Detector ===" && ls tools/drift-detector.sh && \
+echo "=== CLAUDE.md ===" && wc -l CLAUDE.md
+```
+
+Expected:
+- 10 specs
+- 8 skills (7 domain + 1 codified-context)
+- MCP server files present
+- Drift detector present
+- CLAUDE.md ~170-200 lines
+
+**Step 2: Run MCP server tests**
+
+Run: `cd tools/spec-retrieval && node --test test.js`
+Expected: All tests pass
+
+**Step 3: Run drift detector**
+
+Run: `tools/drift-detector.sh 5`
+Expected: Output without errors
+
+**Step 4: Run existing project tests (regression check)**
+
+Run: `./vendor/bin/phpunit --configuration phpunit.xml.dist`
+Expected: All existing tests still pass (we only added docs/tools, no PHP changes)
+
+**Step 5: Final commit log review**
+
+Run: `git log --oneline -10`
+Expected: Clean sequence of commits for each phase

--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,0 +1,454 @@
+# Access Control
+
+Waaseyaa's access control system spans three packages: `packages/access/` (core primitives), `packages/routing/` (route-level checks), and `packages/user/` (session resolution). This document covers entity-level and route-level access. For field-level access, see `docs/specs/field-access.md`.
+
+## Packages
+
+| Package | Path | Provides |
+|---------|------|----------|
+| access | `packages/access/src/` | AccessPolicyInterface, AccessResult, AccessStatus, EntityAccessHandler, AccountInterface, FieldAccessPolicyInterface, PermissionHandler, Gate, AuthorizationMiddleware |
+| routing | `packages/routing/src/` | AccessChecker (route-level access) |
+| user | `packages/user/src/Middleware/` | SessionMiddleware (account resolution) |
+
+## Core Interfaces
+
+### AccessPolicyInterface
+
+**File:** `packages/access/src/AccessPolicyInterface.php`
+**Namespace:** `Waaseyaa\Access`
+
+```php
+interface AccessPolicyInterface
+{
+    public function access(
+        EntityInterface $entity,
+        string $operation, // 'view', 'update', or 'delete'
+        AccountInterface $account,
+    ): AccessResult;
+
+    public function createAccess(
+        string $entityTypeId,
+        string $bundle,
+        AccountInterface $account,
+    ): AccessResult;
+
+    public function appliesTo(string $entityTypeId): bool;
+}
+```
+
+- `access()` checks an existing entity for a given operation.
+- `createAccess()` checks whether an entity of the given type/bundle can be created.
+- `appliesTo()` scopes which entity types this policy governs. EntityAccessHandler skips policies that return `false`.
+
+### AccountInterface
+
+**File:** `packages/access/src/AccountInterface.php`
+**Namespace:** `Waaseyaa\Access`
+
+```php
+interface AccountInterface
+{
+    public function id(): int|string;
+    public function hasPermission(string $permission): bool;
+    public function getRoles(): array; // string[]
+    public function isAuthenticated(): bool;
+}
+```
+
+**Critical:** `AccountInterface` lives in the `access` package, not `user`. The `User` entity and `AnonymousUser` live in `packages/user/`. Access must never depend on User to avoid circular package dependencies. Middleware needing an account should type-hint `AccountInterface`, not concrete `AnonymousUser`.
+
+## Access Result Semantics
+
+**File:** `packages/access/src/AccessResult.php`
+**Namespace:** `Waaseyaa\Access`
+
+AccessResult is a `final readonly class` with three states defined in the `AccessStatus` enum:
+
+```php
+enum AccessStatus: string
+{
+    case ALLOWED = 'allowed';
+    case NEUTRAL = 'neutral';
+    case FORBIDDEN = 'forbidden';
+}
+```
+
+### Factory Methods
+
+```php
+AccessResult::allowed(string $reason = ''): AccessResult
+AccessResult::neutral(string $reason = ''): AccessResult
+AccessResult::forbidden(string $reason = ''): AccessResult
+```
+
+### State Checks
+
+```php
+$result->isAllowed(): bool   // status === ALLOWED
+$result->isNeutral(): bool   // status === NEUTRAL
+$result->isForbidden(): bool // status === FORBIDDEN
+```
+
+### Combination Logic
+
+**`orIf()`** -- OR logic, used by EntityAccessHandler to combine policy results:
+
+- Forbidden wins over everything (short-circuit)
+- Either Allowed yields Allowed
+- Both Neutral yields Neutral
+
+**`andIf()`** -- AND logic, used by AccessChecker to combine route requirements:
+
+- Forbidden wins over everything (short-circuit)
+- Both must be Allowed for Allowed
+- At least one Neutral yields Neutral
+
+### Entity-Level Evaluation Pattern
+
+Entity access uses **deny-by-default** with `isAllowed()`:
+
+```php
+// EntityAccessHandler::check() starts with Neutral, combines via orIf().
+// Controller checks: $result->isAllowed()
+// Neutral means "no policy granted" = denied.
+```
+
+This is intentionally asymmetric with field-level access, which uses `!isForbidden()`. See `docs/specs/field-access.md`.
+
+## Entity Access Handler
+
+**File:** `packages/access/src/EntityAccessHandler.php`
+**Namespace:** `Waaseyaa\Access`
+
+Orchestrates policy evaluation. Not a `final class` (can be extended).
+
+```php
+class EntityAccessHandler
+{
+    public function __construct(array $policies = []) // AccessPolicyInterface[]
+    public function addPolicy(AccessPolicyInterface $policy): void
+
+    public function check(
+        EntityInterface $entity,
+        string $operation,       // 'view', 'update', 'delete'
+        AccountInterface $account,
+    ): AccessResult;
+
+    public function checkCreateAccess(
+        string $entityTypeId,
+        string $bundle,
+        AccountInterface $account,
+    ): AccessResult;
+
+    public function checkFieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation,       // 'view' or 'edit'
+        AccountInterface $account,
+    ): AccessResult;
+
+    public function filterFields(
+        EntityInterface $entity,
+        array $fieldNames,       // string[]
+        string $operation,       // 'view' or 'edit'
+        AccountInterface $account,
+    ): array; // string[] — fields not forbidden
+}
+```
+
+### Evaluation Algorithm
+
+For `check()` and `checkCreateAccess()`:
+
+1. Start with `AccessResult::neutral('No policy provided an opinion.')`.
+2. Iterate registered policies. Skip those where `appliesTo($entityTypeId)` returns false.
+3. Call `$policy->access(...)` or `$policy->createAccess(...)`.
+4. Combine results with `orIf()` (any Allowed grants access).
+5. Short-circuit on Forbidden -- nothing can override it.
+6. Return final result.
+
+For `checkFieldAccess()` and `filterFields()`, see `docs/specs/field-access.md`.
+
+### Policy Registration
+
+Policies are passed to the constructor or added via `addPolicy()`. In `public/index.php`, the handler is created with an array of policy instances:
+
+```php
+$accessHandler = new EntityAccessHandler([]);
+// Policies are manually registered; auto-discovery writes them into the manifest
+// but instantiation happens in the front controller.
+```
+
+## Gate System
+
+The Gate is a separate access mechanism from EntityAccessHandler. It resolves policies by entity type and delegates ability checks to method calls.
+
+### GateInterface
+
+**File:** `packages/access/src/Gate/GateInterface.php`
+**Namespace:** `Waaseyaa\Access\Gate`
+
+```php
+interface GateInterface
+{
+    public function allows(string $ability, mixed $subject, ?object $user = null): bool;
+    public function denies(string $ability, mixed $subject, ?object $user = null): bool;
+    public function authorize(string $ability, mixed $subject, ?object $user = null): void;
+        // throws AccessDeniedException
+}
+```
+
+### Gate (Implementation)
+
+**File:** `packages/access/src/Gate/Gate.php`
+**Namespace:** `Waaseyaa\Access\Gate`
+
+```php
+final class Gate implements GateInterface
+{
+    public function __construct(private readonly array $policies = [])
+}
+```
+
+Policy resolution strategy:
+1. Check for `#[PolicyAttribute(entityType: '...')]` on the policy class.
+2. Fall back to naming convention: `NodePolicy` maps to entity type `node` (PascalCase to snake_case).
+
+Ability delegation: `$gate->allows('update', $node)` calls `$policy->update($user, $node)`. If the method does not exist, ability is denied.
+
+### PolicyAttribute
+
+**File:** `packages/access/src/Gate/PolicyAttribute.php`
+**Namespace:** `Waaseyaa\Access\Gate`
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class PolicyAttribute
+{
+    public function __construct(
+        public readonly string $entityType,
+    ) {}
+}
+```
+
+### AccessPolicy (Plugin Discovery Attribute)
+
+**File:** `packages/access/src/Attribute/AccessPolicy.php`
+**Namespace:** `Waaseyaa\Access\Attribute`
+
+Extends `WaaseyaaPlugin`. Used for attribute-based plugin discovery (distinct from `PolicyAttribute` for the Gate).
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AccessPolicy extends WaaseyaaPlugin
+{
+    public function __construct(
+        string $id,
+        public readonly array $entityTypes = [],
+        string $label = '',
+        string $description = '',
+    ) {}
+}
+```
+
+### AccessDeniedException
+
+**File:** `packages/access/src/Gate/AccessDeniedException.php`
+
+```php
+final class AccessDeniedException extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $ability,
+        public readonly mixed $subject,
+        string $message = '',
+    ) {}
+}
+```
+
+## Route Access Control
+
+**File:** `packages/routing/src/AccessChecker.php`
+**Namespace:** `Waaseyaa\Routing`
+
+```php
+final class AccessChecker
+{
+    public function __construct(private readonly ?GateInterface $gate = null)
+
+    public function check(Route $route, AccountInterface $account): AccessResult
+
+    public static function applyGateToRoute(
+        Route $route,
+        string $ability,
+        mixed $subject = null,
+    ): void
+}
+```
+
+### Route Options
+
+Routes declare access requirements via Symfony Route options. Multiple requirements combine with AND logic (all must pass).
+
+| Option | Type | Behavior |
+|--------|------|----------|
+| `_public` | `true` | Always allow (no auth required) |
+| `_permission` | `string` | Require specific permission via `$account->hasPermission()` |
+| `_role` | `string` | Require role (comma-separated for multiple); checks `$account->getRoles()` |
+| `_gate` | `array{ability: string, subject?: mixed}` | Require gate ability check |
+
+If no access requirements are present on the route, returns `AccessResult::neutral()`. AuthorizationMiddleware treats Neutral as passthrough (open-by-default at the route level).
+
+### Evaluation
+
+1. Start with `AccessResult::allowed()`.
+2. For each requirement present, compute its result and combine via `andIf()`.
+3. If no requirements found, return `AccessResult::neutral()`.
+4. Return combined result.
+
+## Permission Handler
+
+**File:** `packages/access/src/PermissionHandler.php`
+**Namespace:** `Waaseyaa\Access`
+
+```php
+class PermissionHandler implements PermissionHandlerInterface
+{
+    public function registerPermission(string $id, string $title, string $description = ''): void
+    public function getPermissions(): array // array<string, array{title: string, description: string}>
+    public function hasPermission(string $permission): bool
+}
+```
+
+Permissions are declared in `composer.json` under `extra.waaseyaa.permissions` and collected into the package manifest by `PackageManifestCompiler`.
+
+```json
+{
+  "extra": {
+    "waaseyaa": {
+      "permissions": {
+        "access content": { "title": "Access published content" },
+        "create article": { "title": "Create Article content" }
+      }
+    }
+  }
+}
+```
+
+## Authorization Pipeline
+
+**Entry point:** `public/index.php`
+
+The authorization pipeline is a pair of HTTP middleware executed in order:
+
+```
+Request -> SessionMiddleware -> AuthorizationMiddleware -> Final Handler -> Response
+```
+
+### SessionMiddleware
+
+**File:** `packages/user/src/Middleware/SessionMiddleware.php`
+**Namespace:** `Waaseyaa\User\Middleware`
+
+```php
+final class SessionMiddleware implements HttpMiddlewareInterface
+{
+    public function __construct(
+        private readonly EntityStorageInterface $userStorage,
+    ) {}
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+}
+```
+
+Behavior:
+1. Reads `$_SESSION['waaseyaa_uid']` (via `$request->attributes->get('_session')` or `$_SESSION`).
+2. Loads User entity via `$this->userStorage->load($uid)`.
+3. Falls back to `AnonymousUser` if: no UID in session, load fails, or loaded entity is not `AccountInterface`.
+4. Sets `$request->attributes->set('_account', $account)`.
+5. Calls `$next->handle($request)`.
+
+Does not handle login/logout. Only resolves "who is making this request."
+
+Lives in the `user` package because it depends on `User`, `AnonymousUser`, and entity storage.
+
+### AuthorizationMiddleware
+
+**File:** `packages/access/src/Middleware/AuthorizationMiddleware.php`
+**Namespace:** `Waaseyaa\Access\Middleware`
+
+```php
+final class AuthorizationMiddleware implements HttpMiddlewareInterface
+{
+    public function __construct(
+        private readonly AccessChecker $accessChecker,
+    ) {}
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+}
+```
+
+Behavior:
+1. Reads matched `Route` from `$request->attributes->get('_route_object')`. If null, passes through.
+2. Reads `AccountInterface` from `$request->attributes->get('_account')`. If missing/invalid, returns 403 JSON:API error.
+3. Delegates to `$this->accessChecker->check($route, $account)`.
+4. If Forbidden: returns 403 JSON:API response with `$result->reason`.
+5. If Neutral (no requirements on route): passes through (open-by-default).
+6. If Allowed: calls `$next->handle($request)`.
+
+Requires SessionMiddleware to run first. Enforced by middleware priority ordering.
+
+### 403 Response Format
+
+```json
+{
+  "jsonapi": { "version": "1.1" },
+  "errors": [{
+    "status": "403",
+    "title": "Forbidden",
+    "detail": "The 'administer site' permission is required."
+  }]
+}
+```
+
+Content-Type: `application/vnd.api+json`.
+
+## Discovery
+
+Policies and permissions are discovered at build time via `PackageManifestCompiler`:
+
+- **Policy discovery:** `#[AccessPolicy]` attribute is scanned during class scanning. Discovered policies stored as `array<string, string>` (entity type ID => FQCN) in the manifest.
+- **Permission discovery:** `composer.json` `extra.waaseyaa.permissions` collected into `PackageManifest::$permissions`.
+
+Layer discipline: Foundation (layer 1) uses string constants for attribute class names to avoid importing from higher layers. `ReflectionClass::getAttributes()` accepts string class names.
+
+## File Reference
+
+```
+packages/access/src/
+    AccessPolicyInterface.php        - Entity access policy contract
+    FieldAccessPolicyInterface.php   - Field access policy contract (see field-access.md)
+    AccessResult.php                 - Tri-state value object (Allowed/Neutral/Forbidden)
+    AccessStatus.php                 - Enum: ALLOWED, NEUTRAL, FORBIDDEN
+    EntityAccessHandler.php          - Orchestrates policy evaluation
+    AccountInterface.php             - User account contract (id, permissions, roles)
+    PermissionHandler.php            - In-memory permission registry
+    PermissionHandlerInterface.php   - Permission registry contract
+    Attribute/
+        AccessPolicy.php             - Plugin discovery attribute
+    Gate/
+        GateInterface.php            - Gate contract (allows/denies/authorize)
+        Gate.php                     - Gate implementation with policy resolution
+        PolicyAttribute.php          - Maps policy class to entity type
+        AccessDeniedException.php    - Thrown by Gate::authorize()
+    Middleware/
+        AuthorizationMiddleware.php  - Route-level access enforcement
+
+packages/routing/src/
+    AccessChecker.php                - Route option access checks
+
+packages/user/src/Middleware/
+    SessionMiddleware.php            - Resolves AccountInterface from session
+
+public/index.php                     - Front controller; wires the pipeline
+```

--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -420,7 +420,7 @@ Policies and permissions are discovered at build time via `PackageManifestCompil
 - **Policy discovery:** `#[AccessPolicy]` attribute is scanned during class scanning. Discovered policies stored as `array<string, string>` (entity type ID => FQCN) in the manifest.
 - **Permission discovery:** `composer.json` `extra.waaseyaa.permissions` collected into `PackageManifest::$permissions`.
 
-Layer discipline: Foundation (layer 1) uses string constants for attribute class names to avoid importing from higher layers. `ReflectionClass::getAttributes()` accepts string class names.
+Layer discipline: Foundation (layer 0) uses string constants for attribute class names to avoid importing from higher layers. `ReflectionClass::getAttributes()` accepts string class names.
 
 ## File Reference
 

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,0 +1,363 @@
+# Admin SPA
+
+## Package
+
+- Path: `packages/admin/`
+- Package name: `@waaseyaa/admin` (private, version 0.1.0)
+- Entry point: `packages/admin/app/app.vue` wraps `<NuxtLayout>` + `<NuxtPage />`
+- Default layout: `packages/admin/app/layouts/default.vue` renders `<LayoutAdminShell>`
+- Source directory: `packages/admin/app/` (configured via `srcDir: 'app/'` in nuxt.config.ts)
+
+## Tech Stack
+
+| Dependency     | Version   | Purpose                         |
+|----------------|-----------|---------------------------------|
+| Nuxt           | ^3.15.0   | SSR/SPA framework, file-based routing, auto-imports |
+| Vue            | ^3.5.0    | Composition API, reactivity     |
+| vue-router     | ^4.5.0    | Client-side routing             |
+| TypeScript     | ^5.6.0    | Type checking (devDependency)   |
+| @types/node    | ^22.0.0   | Node type definitions           |
+
+No CSS framework. Styles are defined in `packages/admin/app/components/layout/AdminShell.vue` as global CSS using CSS custom properties (`--color-primary`, `--color-surface`, etc.).
+
+## API Proxy
+
+Configured in `packages/admin/nuxt.config.ts`:
+
+```ts
+nitro: {
+  devProxy: {
+    '/api': { target: 'http://localhost:8081/api', changeOrigin: true },
+  },
+},
+routeRules: {
+  '/api/**': { proxy: 'http://localhost:8081/api/**' },
+},
+```
+
+All `/api/*` requests proxy to the PHP backend at `http://localhost:8081`. The PHP backend is served by the built-in PHP server with `public/index.php` as the front controller.
+
+## Composables
+
+All composables are in `packages/admin/app/composables/`. Nuxt auto-imports them.
+
+### useEntity (`packages/admin/app/composables/useEntity.ts`)
+
+CRUD operations against the JSON:API backend. Returns plain functions (not reactive state).
+
+```ts
+function useEntity(): {
+  list(type: string, query?: { page?: { offset: number; limit: number }; sort?: string }):
+    Promise<{ data: JsonApiResource[]; meta: Record<string, any>; links: Record<string, string> }>
+  get(type: string, id: string): Promise<JsonApiResource>
+  create(type: string, attributes: Record<string, any>): Promise<JsonApiResource>
+  update(type: string, id: string, attributes: Record<string, any>): Promise<JsonApiResource>
+  remove(type: string, id: string): Promise<void>
+  search(type: string, labelField: string, query: string, limit?: number): Promise<JsonApiResource[]>
+}
+```
+
+Key types:
+```ts
+interface JsonApiResource {
+  type: string; id: string; attributes: Record<string, any>
+  relationships?: Record<string, any>; links?: Record<string, string>; meta?: Record<string, any>
+}
+interface JsonApiDocument {
+  jsonapi: { version: string }; data: JsonApiResource | JsonApiResource[] | null
+  errors?: Array<{ status: string; title: string; detail?: string }>
+  meta?: Record<string, any>; links?: Record<string, string>
+}
+```
+
+- `list()` uses offset-based pagination: `page[offset]`, `page[limit]`
+- `search()` uses `filter[{labelField}][operator]=STARTS_WITH` with 250ms debounce on the widget side. Minimum 2 characters required.
+- All methods use Nuxt `$fetch` (not `useFetch`) for imperative data fetching.
+
+### useSchema (`packages/admin/app/composables/useSchema.ts`)
+
+Fetches and caches JSON Schema for an entity type. Drives all form rendering.
+
+```ts
+function useSchema(entityType: string): {
+  schema: Ref<EntitySchema | null>; loading: Ref<boolean>; error: Ref<string | null>
+  fetch(): Promise<void>; invalidate(): void
+  sortedProperties(editable?: boolean): [string, SchemaProperty][]
+}
+```
+
+Key types:
+```ts
+interface SchemaProperty {
+  type: string; description?: string; format?: string; readOnly?: boolean
+  enum?: string[]; minimum?: number; maximum?: number; maxLength?: number
+  'x-widget'?: string; 'x-label'?: string; 'x-description'?: string
+  'x-weight'?: number; 'x-required'?: boolean; 'x-enum-labels'?: Record<string, string>
+  'x-target-type'?: string; 'x-access-restricted'?: boolean
+}
+interface EntitySchema {
+  $schema: string; title: string; description: string; type: string
+  'x-entity-type': string; 'x-translatable': boolean; 'x-revisionable': boolean
+  properties: Record<string, SchemaProperty>; required?: string[]
+}
+```
+
+- Endpoint: `GET /api/schema/{entityType}` returns `{ meta: { schema: EntitySchema } }`
+- Module-level `Map<string, EntitySchema>` cache. Call `invalidate()` to clear a single type.
+- `sortedProperties(true)` filters out system `readOnly` fields (id, uuid) and hidden widgets, but keeps `x-access-restricted` fields (rendered as disabled inputs). Sorted by `x-weight` ascending.
+- `sortedProperties(false)` returns all properties sorted by weight.
+
+### useLanguage (`packages/admin/app/composables/useLanguage.ts`)
+
+Simple i18n with token replacement.
+
+```ts
+function useLanguage(): {
+  t(key: string, replacements?: Record<string, string>): string
+  locale: ComputedRef<string>; setLocale(locale: string): void
+}
+```
+
+- Translation file: `packages/admin/app/i18n/en.json`
+- Replacement syntax: `{token}` in translation strings
+- Module-level `currentLocale` ref shared across all callers
+- Falls back to the key itself when no translation is found
+
+### useRealtime (`packages/admin/app/composables/useRealtime.ts`)
+
+Server-Sent Events connection for real-time entity updates.
+
+```ts
+function useRealtime(channels?: string[]): {
+  messages: Ref<BroadcastMessage[]>; connected: Ref<boolean>; error: Ref<string | null>
+  disconnect(): void; reconnect(): void
+}
+interface BroadcastMessage {
+  channel: string; event: string; data: Record<string, unknown>; timestamp: number
+}
+```
+
+- Endpoint: `GET /api/broadcast?channels={comma-separated}` (SSE)
+- Default channel: `['admin']`
+- Auto-connects on instantiation; auto-disconnects on `onUnmounted`
+- Exponential backoff reconnect: delay = `min(3000 * 2^(retryCount-1), 30000)`, max 10 retries
+- Message buffer: last 100 messages (ring buffer via `slice(-99)`)
+- Event types: `entity.saved`, `entity.deleted` (used by SchemaList for auto-refresh)
+
+## Schema-Driven Forms
+
+The form rendering pipeline:
+
+1. `SchemaForm` calls `useSchema(entityType).fetch()` to get the JSON Schema
+2. `sortedProperties(true)` returns editable fields sorted by `x-weight`
+3. For each field, `SchemaField` resolves the widget component from `x-widget`
+4. Each widget receives `modelValue`, `label`, `description`, `required`, `disabled`, `schema`
+
+### Widget Resolution (`packages/admin/app/components/schema/SchemaField.vue`)
+
+`x-widget` value maps to a component via `widgetMap`:
+
+| x-widget             | Component                  | HTML element         |
+|----------------------|----------------------------|----------------------|
+| `text` (default)     | `WidgetsTextInput`         | `<input type="text">` |
+| `email`              | `WidgetsTextInput`         | `<input type="email">` |
+| `url`                | `WidgetsTextInput`         | `<input type="url">` |
+| `password`           | `WidgetsTextInput`         | `<input type="text">` |
+| `textarea`           | `WidgetsTextArea`          | `<textarea>`         |
+| `richtext`           | `WidgetsRichText`          | `<div contenteditable>` |
+| `number`             | `WidgetsNumberInput`       | `<input type="number">` |
+| `boolean`            | `WidgetsToggle`            | `<input type="checkbox">` |
+| `select`             | `WidgetsSelect`            | `<select>`           |
+| `datetime`           | `WidgetsDateTimeInput`     | `<input type="datetime-local">` |
+| `entity_autocomplete`| `WidgetsEntityAutocomplete`| `<input type="text">` + dropdown |
+| `hidden`             | `WidgetsHiddenField`       | (renders nothing)    |
+| `image`, `file`      | `WidgetsTextInput`         | `<input type="text">` |
+
+### Access-Restricted Fields
+
+When the PHP `SchemaPresenter` marks a field with `readOnly: true` + `x-access-restricted: true`:
+- `sortedProperties(true)` keeps the field (unlike system readOnly which is excluded)
+- `SchemaForm` passes `:disabled="!!fieldSchema['x-access-restricted']"`
+- The `@update:model-value` handler guards: `if (!fieldSchema['x-access-restricted']) formData[fieldName] = val`
+- Result: field is visible but not editable in the UI
+
+### RichText Sanitization
+
+`WidgetsRichText` (`packages/admin/app/components/widgets/RichText.vue`) sanitizes HTML client-side using DOMParser. Allowed tags: `P, BR, B, I, U, STRONG, EM, A, UL, OL, LI, H1-H6, BLOCKQUOTE, PRE, CODE, SUB, SUP, HR`. Links restricted to `http://`, `https://`, or `/` prefixes.
+
+### EntityAutocomplete Widget
+
+`WidgetsEntityAutocomplete` (`packages/admin/app/components/widgets/EntityAutocomplete.vue`):
+- Uses `x-target-type` from schema to determine which entity type to search
+- Calls `useEntity().search(targetType, 'title', query)` with 250ms debounce
+- Keyboard navigation: ArrowUp/ArrowDown/Enter/Escape
+- ARIA: `role="combobox"`, `aria-expanded`, `aria-autocomplete="list"`, dropdown has `role="listbox"`, items have `role="option"`
+
+## SSE Integration
+
+### Frontend Flow
+
+1. `SchemaList` instantiates `useRealtime(['admin'])` on mount
+2. `useRealtime` opens `EventSource` to `GET /api/broadcast?channels=admin`
+3. Incoming messages are parsed as JSON and appended to `messages` ref
+4. `SchemaList` watches `messages` and auto-refreshes entity list when:
+   - `latest.event === 'entity.saved'` or `'entity.deleted'`
+   - `latest.data?.entityType === props.entityType`
+
+### Connection Status
+
+- Green pulsing dot indicator in pagination bar when connected
+- Error message with reconnect button when connection lost after max retries
+- CSS animation: `@keyframes pulse` on `.sse-status`
+
+## i18n
+
+Translation file: `packages/admin/app/i18n/en.json`
+
+Key categories:
+- UI chrome: `app_name`, `dashboard`, `content`, `sidebar_nav`
+- CRUD actions: `save`, `create`, `create_new`, `edit`, `delete`, `back_to_list`
+- States: `loading`, `saving`
+- Feedback: `entity_created`, `entity_saved`, `confirm_delete`
+- Pagination: `showing`, `of`, `previous`, `next`, `no_items`
+- Errors: `error_generic`, `error_not_found`, `error_loading_schema`, `error_loading_types`, `error_loading_entities`, `error_deleting`, `error_nav`
+- Autocomplete: `autocomplete_placeholder`, `autocomplete_no_results`, `autocomplete_loading`
+- Realtime: `realtime_connected`
+
+Token replacement pattern: `t('key', { token: 'value' })` replaces `{token}` in the string.
+
+## Component Patterns
+
+### Directory Structure
+
+```
+packages/admin/app/
+  app.vue                          # Root: <NuxtLayout> + <NuxtPage />
+  layouts/
+    default.vue                    # Wraps content in <LayoutAdminShell>
+  components/
+    layout/
+      AdminShell.vue               # Top bar + sidebar + content area + global styles
+      NavBuilder.vue               # Dynamic sidebar nav from /api/entity-types
+    schema/
+      SchemaForm.vue               # Entity create/edit form driven by JSON Schema
+      SchemaField.vue              # Single field: resolves x-widget to widget component
+      SchemaList.vue               # Entity list table with sort, pagination, SSE auto-refresh
+    widgets/
+      TextInput.vue                # text/email/url/password/image/file
+      TextArea.vue                 # textarea
+      RichText.vue                 # contenteditable with HTML sanitization
+      NumberInput.vue              # number with min/max
+      Toggle.vue                   # checkbox for booleans
+      Select.vue                   # dropdown from enum + x-enum-labels
+      DateTimeInput.vue            # datetime-local
+      EntityAutocomplete.vue       # Typeahead search for entity references
+      HiddenField.vue              # Renders nothing (excluded from editable forms)
+  composables/
+    useEntity.ts                   # JSON:API CRUD + search
+    useSchema.ts                   # Schema fetch/cache/sort
+    useLanguage.ts                 # i18n
+    useRealtime.ts                 # SSE connection
+  pages/
+    index.vue                      # Dashboard: entity type cards
+    [entityType]/
+      index.vue                    # Entity list (delegates to SchemaList)
+      create.vue                   # Entity create form (delegates to SchemaForm)
+      [id].vue                     # Entity edit form (delegates to SchemaForm with entityId)
+  i18n/
+    en.json                        # English translations
+```
+
+### Naming Conventions
+
+- Components use PascalCase in Nuxt auto-import paths: `LayoutAdminShell`, `SchemaForm`, `WidgetsTextInput`
+- Composables follow Vue convention: `use{Name}` returning an object of refs and functions
+- Pages use Nuxt file-based routing with `[param]` dynamic segments
+
+### Widget Interface Contract
+
+Every widget component must accept these props:
+```ts
+{
+  modelValue: any       // Current field value
+  label?: string        // Human label from x-label or field name
+  description?: string  // Help text from x-description or description
+  required?: boolean    // From x-required
+  disabled?: boolean    // True when x-access-restricted
+  schema?: SchemaProperty  // Full schema property for widget-specific behavior
+}
+```
+And emit: `'update:modelValue'` with the new value.
+
+## Routing
+
+File-based routing via Nuxt 3:
+
+| Route                    | Page File                                | Purpose              |
+|--------------------------|------------------------------------------|----------------------|
+| `/`                      | `pages/index.vue`                        | Dashboard            |
+| `/:entityType`           | `pages/[entityType]/index.vue`           | Entity list          |
+| `/:entityType/create`    | `pages/[entityType]/create.vue`          | Create form          |
+| `/:entityType/:id`       | `pages/[entityType]/[id].vue`            | Edit form            |
+
+## Accessibility
+
+- Skip-to-content link: `<a href="#main-content" class="skip-link">`
+- ARIA landmarks: `role="banner"` (topbar), `role="navigation"` (sidebar), `role="main"` (content)
+- Sidebar label: `aria-label` bound to `t('sidebar_nav')`
+- Autocomplete: full `combobox` pattern with `listbox`/`option` roles
+- Delete buttons include entity label in `aria-label`
+- Live region: `<div role="status" aria-live="polite">` announces pagination changes
+- Screen-reader-only class: `.sr-only` for visually hidden announcements
+- Responsive: sidebar collapses to off-canvas drawer below 768px with overlay
+
+## Build & Testing
+
+### Build
+
+```bash
+cd packages/admin && npm run build
+```
+
+No dedicated test framework. The build step verifies TypeScript compilation and Nuxt module resolution. Build scripts from `packages/admin/package.json`:
+- `dev`: `nuxt dev` (development server with HMR)
+- `build`: `nuxt build` (production build)
+- `generate`: `nuxt generate` (static site generation)
+- `preview`: `nuxt preview` (preview production build)
+- `postinstall`: `nuxt prepare` (generate `.nuxt` types)
+
+### Backend Testing
+
+Backend JSON:API and schema endpoints are tested via PHPUnit integration tests in `tests/Integration/PhaseN/`. The admin SPA relies on these endpoints being correct.
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `packages/admin/package.json` | NPM package definition |
+| `packages/admin/nuxt.config.ts` | Nuxt configuration, API proxy |
+| `packages/admin/app/app.vue` | Root component |
+| `packages/admin/app/layouts/default.vue` | Default layout (AdminShell wrapper) |
+| `packages/admin/app/composables/useEntity.ts` | JSON:API CRUD composable |
+| `packages/admin/app/composables/useSchema.ts` | Schema fetching and caching |
+| `packages/admin/app/composables/useLanguage.ts` | i18n composable |
+| `packages/admin/app/composables/useRealtime.ts` | SSE connection composable |
+| `packages/admin/app/components/layout/AdminShell.vue` | Shell layout + global CSS |
+| `packages/admin/app/components/layout/NavBuilder.vue` | Dynamic sidebar navigation |
+| `packages/admin/app/components/schema/SchemaForm.vue` | Schema-driven entity form |
+| `packages/admin/app/components/schema/SchemaField.vue` | Widget resolver for a single field |
+| `packages/admin/app/components/schema/SchemaList.vue` | Entity list with sort/pagination/SSE |
+| `packages/admin/app/components/widgets/TextInput.vue` | Text/email/url input widget |
+| `packages/admin/app/components/widgets/TextArea.vue` | Textarea widget |
+| `packages/admin/app/components/widgets/RichText.vue` | Contenteditable rich text widget |
+| `packages/admin/app/components/widgets/NumberInput.vue` | Number input widget |
+| `packages/admin/app/components/widgets/Toggle.vue` | Checkbox toggle widget |
+| `packages/admin/app/components/widgets/Select.vue` | Dropdown select widget |
+| `packages/admin/app/components/widgets/DateTimeInput.vue` | Datetime-local input widget |
+| `packages/admin/app/components/widgets/EntityAutocomplete.vue` | Typeahead entity reference widget |
+| `packages/admin/app/components/widgets/HiddenField.vue` | Hidden field (renders nothing) |
+| `packages/admin/app/pages/index.vue` | Dashboard page |
+| `packages/admin/app/pages/[entityType]/index.vue` | Entity list page |
+| `packages/admin/app/pages/[entityType]/create.vue` | Entity create page |
+| `packages/admin/app/pages/[entityType]/[id].vue` | Entity edit page |
+| `packages/admin/app/i18n/en.json` | English translation strings |

--- a/docs/specs/ai-integration.md
+++ b/docs/specs/ai-integration.md
@@ -1,0 +1,510 @@
+# AI Integration
+
+Waaseyaa's AI layer (architecture layer 6) provides four packages that enable AI agents to introspect, mutate, and search CMS content. All four packages sit in the `packages/` directory and follow the standard `Waaseyaa\AI\*` namespace pattern.
+
+## Packages
+
+| Package | Namespace | Path | Purpose |
+|---------|-----------|------|---------|
+| ai-schema | `Waaseyaa\AI\Schema\` | `packages/ai-schema/src/` | JSON Schema generation, MCP tool definitions, tool execution |
+| ai-agent | `Waaseyaa\AI\Agent\` | `packages/ai-agent/src/` | Agent executor, audit logging, MCP server adapter |
+| ai-pipeline | `Waaseyaa\AI\Pipeline\` | `packages/ai-pipeline/src/` | Processing pipelines, step orchestration, async dispatch |
+| ai-vector | `Waaseyaa\AI\Vector\` | `packages/ai-vector/src/` | Vector embeddings, similarity search, distance metrics |
+
+### Package Dependencies
+
+```
+ai-schema   -> entity
+ai-agent    -> ai-schema, access
+ai-pipeline -> entity, queue
+ai-vector   -> entity
+```
+
+`ai-agent` depends on `ai-schema` for `McpToolExecutor` and on `access` for `AccountInterface`. `ai-pipeline` depends on `queue` for async dispatch via `QueueInterface`. `ai-vector` and `ai-schema` depend only on `entity`.
+
+## Schema Generation
+
+**File:** `packages/ai-schema/src/EntityJsonSchemaGenerator.php`
+**Class:** `Waaseyaa\AI\Schema\EntityJsonSchemaGenerator`
+
+Generates JSON Schema (draft 2020-12) from registered entity types. Takes an `EntityTypeManagerInterface` and inspects entity type definitions to produce a schema array.
+
+### Constructor
+
+```php
+public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+)
+```
+
+### Key Methods
+
+- `generate(string $entityTypeId): array` -- Produces a single JSON Schema for one entity type.
+- `generateAll(): array` -- Returns schemas for all registered entity types, keyed by entity type ID.
+
+### Schema Shape
+
+The generated schema maps entity keys to JSON Schema properties:
+
+| Entity Key | JSON Schema Type | Required |
+|------------|-----------------|----------|
+| id | `['integer', 'string']` | Yes |
+| uuid | `string` (format: uuid) | Yes |
+| label | `string` | Yes |
+| bundle | `string` | Yes |
+| langcode | `string` | No |
+| revision | `integer` (only if revisionable) | No |
+
+The output always includes `'$schema' => 'https://json-schema.org/draft/2020-12/schema'` and sets `'additionalProperties' => true` to allow non-key fields.
+
+## MCP Tool System
+
+### McpToolDefinition
+
+**File:** `packages/ai-schema/src/Mcp/McpToolDefinition.php`
+**Class:** `Waaseyaa\AI\Schema\Mcp\McpToolDefinition`
+
+Readonly value object matching the MCP tool registration format:
+
+```php
+final readonly class McpToolDefinition
+{
+    public function __construct(
+        public string $name,        // snake_case, e.g. "create_node"
+        public string $description, // human-readable
+        public array $inputSchema,  // JSON Schema for input params
+    ) {}
+
+    public function toArray(): array; // MCP-compliant serialization
+}
+```
+
+### McpToolGenerator
+
+**File:** `packages/ai-schema/src/Mcp/McpToolGenerator.php`
+**Class:** `Waaseyaa\AI\Schema\Mcp\McpToolGenerator`
+
+For each registered entity type, generates five CRUD+query tools:
+
+| Tool Pattern | Operation | Required Arguments |
+|-------------|-----------|-------------------|
+| `create_{type}` | Create entity | `attributes` |
+| `read_{type}` | Read by ID | `id` |
+| `update_{type}` | Update entity | `id`, `attributes` |
+| `delete_{type}` | Delete by ID | `id` |
+| `query_{type}` | Query with filters | (all optional) |
+
+All tools accept optional `langcode` and `fallback` parameters for multilingual operations. The query tool supports `filters` (array of `{field, value, operator}`), `sort` (prefix `-` for descending), `limit` (default 50), and `offset` (default 0).
+
+### TranslationToolGenerator
+
+**File:** `packages/ai-schema/src/Mcp/TranslationToolGenerator.php`
+**Class:** `Waaseyaa\AI\Schema\Mcp\TranslationToolGenerator`
+
+Generates four translation-specific tools per entity type:
+
+| Tool Pattern | Required Arguments |
+|-------------|-------------------|
+| `{type}_translations_list` | `id` |
+| `{type}_translation_create` | `id`, `langcode`, `attributes` |
+| `{type}_translation_update` | `id`, `langcode`, `attributes` |
+| `{type}_translation_delete` | `id`, `langcode` |
+
+### McpToolExecutor
+
+**File:** `packages/ai-schema/src/Mcp/McpToolExecutor.php`
+**Class:** `Waaseyaa\AI\Schema\Mcp\McpToolExecutor`
+
+Executes MCP tool calls against the entity system. Parses tool names by iterating known operations (`create`, `read`, `update`, `delete`, `query`) and extracting the entity type ID from the suffix.
+
+```php
+public function execute(string $toolName, array $arguments): array
+```
+
+Returns MCP-compliant result arrays: `{content: [{type: 'text', text: JSON}]}` on success, with `isError: true` on failure. All JSON encoding uses `JSON_THROW_ON_ERROR`.
+
+**Important:** The query operation calls `$query->accessCheck(false)` because MCP tool calls run in an AI agent context where access is managed at the agent level, not the query level.
+
+**Important:** The update operation checks `$entity instanceof FieldableInterface` before calling `set()`. Non-fieldable entities return an error.
+
+## SchemaRegistry
+
+**File:** `packages/ai-schema/src/SchemaRegistry.php`
+**Class:** `Waaseyaa\AI\Schema\SchemaRegistry`
+
+Central facade combining JSON Schema and MCP tool outputs. Provides a unified API for AI agents to discover the full CMS surface area.
+
+```php
+final class SchemaRegistry
+{
+    public function __construct(
+        private readonly EntityJsonSchemaGenerator $schemaGenerator,
+        private readonly McpToolGenerator $toolGenerator,
+    ) {}
+
+    public function getSchema(string $entityTypeId): array;
+    public function getAllSchemas(): array;
+    public function getTools(): array;          // cached via null coalescing
+    public function getTool(string $name): ?McpToolDefinition;
+}
+```
+
+Tool definitions are cached in-memory via `$this->toolCache ??= $this->toolGenerator->generateAll()`. The cache lives for the request lifetime only.
+
+## Agent Execution
+
+### AgentInterface
+
+**File:** `packages/ai-agent/src/AgentInterface.php`
+**Class:** `Waaseyaa\AI\Agent\AgentInterface`
+
+```php
+interface AgentInterface
+{
+    public function execute(AgentContext $context): AgentResult;
+    public function dryRun(AgentContext $context): AgentResult;
+    public function describe(): string;
+}
+```
+
+All agents must support both `execute()` (real mutations) and `dryRun()` (preview without changes). The `describe()` method returns a human-readable summary of the agent's purpose.
+
+### AgentContext
+
+**File:** `packages/ai-agent/src/AgentContext.php`
+**Class:** `Waaseyaa\AI\Agent\AgentContext`
+
+```php
+final readonly class AgentContext
+{
+    public function __construct(
+        public AccountInterface $account,   // user the agent acts as
+        public array $parameters = [],      // agent-specific params
+        public bool $dryRun = false,
+    ) {}
+}
+```
+
+Agents always operate as a specific user via `AccountInterface`. The `$parameters` array carries agent-specific input data.
+
+### AgentResult and AgentAction
+
+**File:** `packages/ai-agent/src/AgentResult.php`
+
+```php
+final readonly class AgentResult
+{
+    public bool $success;
+    public string $message;
+    public array $data;
+    public array $actions;   // AgentAction[]
+
+    public static function success(string $message, array $data = [], array $actions = []): self;
+    public static function failure(string $message, array $data = []): self;
+}
+```
+
+**File:** `packages/ai-agent/src/AgentAction.php`
+
+```php
+final readonly class AgentAction
+{
+    public string $type;         // 'create', 'update', 'delete', 'tool_call'
+    public string $description;  // human-readable
+    public array $data;          // structured action data
+}
+```
+
+### AgentExecutor
+
+**File:** `packages/ai-agent/src/AgentExecutor.php`
+**Class:** `Waaseyaa\AI\Agent\AgentExecutor`
+
+Wraps agent execution with safety guarantees and audit logging. Three execution paths:
+
+1. `execute(AgentInterface, AgentContext): AgentResult` -- Full execution with try/catch.
+2. `dryRun(AgentInterface, AgentContext): AgentResult` -- Preview mode with try/catch.
+3. `executeTool(string $toolName, array $arguments, AgentContext): array` -- MCP tool call on behalf of an agent.
+
+All three paths log to an in-memory audit log. Exceptions are caught and converted to failure results, never propagated. The `executeTool()` method delegates to `McpToolExecutor::execute()`.
+
+### Audit Logging
+
+**File:** `packages/ai-agent/src/AgentAuditLog.php`
+
+```php
+final readonly class AgentAuditLog
+{
+    public string $agentId;    // agent FQCN or 'tool'
+    public int $accountId;     // user ID the agent acted as
+    public string $action;     // 'execute', 'dry_run', or 'tool_call'
+    public bool $success;
+    public string $message;
+    public array $data;
+    public int $timestamp;     // Unix timestamp
+}
+```
+
+The audit log is in-memory (`AgentExecutor::$auditLog`), retrieved via `getAuditLog()`, and accumulates across multiple executions within the same executor instance.
+
+### McpServer
+
+**File:** `packages/ai-agent/src/McpServer.php`
+**Class:** `Waaseyaa\AI\Agent\McpServer`
+
+Lightweight adapter exposing `tools/list` and `tools/call` from the MCP protocol. Not a full protocol server (no transport layer).
+
+```php
+public function listTools(): array;                         // {tools: [...]}
+public function callTool(string $name, array $arguments): array; // MCP result
+```
+
+## Pipeline System
+
+### Pipeline (Config Entity)
+
+**File:** `packages/ai-pipeline/src/Pipeline.php`
+**Class:** `Waaseyaa\AI\Pipeline\Pipeline`
+
+Config entity (extends `ConfigEntityBase`) with entity type ID `'pipeline'` and keys `{id, label}`. Contains an ordered list of `PipelineStepConfig` objects.
+
+Constructor accepts `array $values` with optional `description` (string) and `steps` (array of step data or `PipelineStepConfig` objects).
+
+**Critical:** The Pipeline class uses `syncStepsToValues()` to prevent the dual-state bug pattern documented in CLAUDE.md. Step data is always kept in sync between the `$this->steps` array and `$this->values['steps']`. Any mutation (`addStep()`, `removeStep()`) calls `syncStepsToValues()` immediately.
+
+### PipelineStepConfig
+
+**File:** `packages/ai-pipeline/src/PipelineStepConfig.php`
+
+```php
+final readonly class PipelineStepConfig
+{
+    public string $id;            // step ID within the pipeline
+    public string $pluginId;      // plugin ID of the step implementation
+    public string $label;
+    public int $weight;           // execution order (lower = first)
+    public array $configuration;  // step-specific config
+}
+```
+
+### PipelineStepInterface
+
+**File:** `packages/ai-pipeline/src/PipelineStepInterface.php`
+
+```php
+interface PipelineStepInterface
+{
+    public function process(array $input, PipelineContext $context): StepResult;
+    public function describe(): string;
+}
+```
+
+Steps receive input from the previous step (or the pipeline trigger) and return a `StepResult`. The `PipelineContext` carries shared state across all steps.
+
+### StepResult
+
+**File:** `packages/ai-pipeline/src/StepResult.php`
+
+Three factory methods control pipeline flow:
+
+- `StepResult::success(array $output, string $message)` -- Continue to next step.
+- `StepResult::failure(string $message, array $output)` -- Stop pipeline, mark as failed.
+- `StepResult::halt(string $message, array $output)` -- Stop pipeline, mark as succeeded.
+
+The `$stopPipeline` flag (set by `halt()`) triggers early exit without failure.
+
+### PipelineExecutor
+
+**File:** `packages/ai-pipeline/src/PipelineExecutor.php`
+**Class:** `Waaseyaa\AI\Pipeline\PipelineExecutor`
+
+Synchronous executor. Takes a map of `PipelineStepInterface` implementations keyed by plugin ID.
+
+```php
+public function __construct(private readonly array $stepPlugins = [])
+public function execute(Pipeline $pipeline, array $input = []): PipelineResult
+```
+
+Execution flow:
+1. Gets steps from the pipeline (sorted by weight).
+2. Creates a `PipelineContext` with the pipeline ID and start timestamp.
+3. Iterates steps in weight order. Each step's `$output` becomes the next step's `$input`.
+4. Before each step, sets `_step_configuration` in the context.
+5. Stops on: step failure, step halt, or missing plugin ID.
+6. Returns `PipelineResult` with timing info (`hrtime(true)` for nanosecond precision).
+
+### PipelineDispatcher (Async)
+
+**File:** `packages/ai-pipeline/src/PipelineDispatcher.php`
+
+Fire-and-forget async dispatch via `QueueInterface`:
+
+```php
+public function dispatch(Pipeline $pipeline, array $input = []): PipelineQueueMessage
+```
+
+Creates a `PipelineQueueMessage` with the pipeline ID, input data, and creation timestamp, then pushes it to the queue.
+
+### PipelineResult
+
+**File:** `packages/ai-pipeline/src/PipelineResult.php`
+
+```php
+final readonly class PipelineResult
+{
+    public bool $success;
+    public array $stepResults;    // StepResult[]
+    public array $finalOutput;    // output from last successful step
+    public string $message;
+    public float $durationMs;     // total execution time
+}
+```
+
+## Vector Storage and Embeddings
+
+### EmbeddingInterface
+
+**File:** `packages/ai-vector/src/EmbeddingInterface.php`
+
+```php
+interface EmbeddingInterface
+{
+    public function embed(string $text): array;          // float[]
+    public function embedBatch(array $texts): array;     // float[][]
+    public function getDimensions(): int;
+}
+```
+
+Implementations connect to embedding providers (OpenAI, local models, etc.). The `getDimensions()` method returns the vector dimensionality.
+
+### VectorStoreInterface
+
+**File:** `packages/ai-vector/src/VectorStoreInterface.php`
+
+```php
+interface VectorStoreInterface
+{
+    public function store(EntityEmbedding $embedding): void;
+    public function delete(string $entityTypeId, int|string $entityId): void;
+    public function search(
+        array $queryVector,
+        int $limit = 10,
+        ?string $entityTypeId = null,
+        ?string $langcode = null,
+        array $fallbackLangcodes = [],
+    ): array;  // SimilarityResult[]
+    public function get(string $entityTypeId, int|string $entityId): ?EntityEmbedding;
+    public function has(string $entityTypeId, int|string $entityId): bool;
+}
+```
+
+The `search()` method supports language-aware retrieval: filter by `$langcode`, and if no results are found, try each `$fallbackLangcodes` in order.
+
+### EntityEmbedding
+
+**File:** `packages/ai-vector/src/EntityEmbedding.php`
+
+```php
+final readonly class EntityEmbedding
+{
+    public string $entityTypeId;
+    public int|string $entityId;
+    public array $vector;           // float[]
+    public string $langcode;        // '' means language-neutral
+    public array $metadata;         // e.g. {label, bundle}
+    public int $createdAt;
+}
+```
+
+### EntityEmbedder
+
+**File:** `packages/ai-vector/src/EntityEmbedder.php`
+
+High-level service that composes `EmbeddingInterface` and `VectorStoreInterface`:
+
+```php
+public function embedEntity(EntityInterface $entity): EntityEmbedding;
+public function searchSimilar(string $query, int $limit = 10, ?string $entityTypeId = null): array;
+public function removeEntity(string $entityTypeId, int|string $entityId): void;
+```
+
+`embedEntity()` builds text from `$entity->label() . ' ' . json_encode($entity->toArray(), JSON_THROW_ON_ERROR)`, generates a vector, stores it with metadata `{label, bundle}`, and returns the embedding.
+
+### InMemoryVectorStore
+
+**File:** `packages/ai-vector/src/InMemoryVectorStore.php`
+
+In-memory implementation for testing. Uses cosine similarity. Stores embeddings keyed by `"{entityTypeId}:{entityId}:{langcode}"`. The `delete()` method removes all langcode variants for an entity.
+
+### DistanceMetric
+
+**File:** `packages/ai-vector/src/DistanceMetric.php`
+
+```php
+enum DistanceMetric: string
+{
+    case COSINE = 'cosine';
+    case EUCLIDEAN = 'euclidean';
+    case DOT_PRODUCT = 'dot_product';
+}
+```
+
+### FakeEmbeddingProvider (Testing)
+
+**File:** `packages/ai-vector/src/Testing/FakeEmbeddingProvider.php`
+
+Deterministic embedding provider for tests. Generates vectors by SHA-256 hashing the input text with HMAC iterations, then normalizing to unit magnitude. Same text always produces the same vector. Default dimensionality is 128.
+
+## Tool Safety
+
+MCP tool execution has the following safety properties:
+
+1. **Exception isolation:** `AgentExecutor` wraps all execution paths in try/catch. Exceptions never propagate to the caller; they are converted to failure results and logged.
+2. **Audit trail:** Every agent execution, dry-run, and tool call is recorded in `AgentAuditLog` with the agent ID, account ID, action type, success status, message, and timestamp.
+3. **User context:** Agents always execute as a specific `AccountInterface`. The account ID is logged in every audit entry.
+4. **Dry-run support:** All agents must implement `dryRun()` to preview changes without mutations.
+5. **Query access bypass:** `McpToolExecutor` sets `accessCheck(false)` on entity queries. Access control for MCP tool calls is expected to be enforced at the agent/endpoint level, not the individual query level.
+6. **FieldableInterface check:** Updates verify the entity implements `FieldableInterface` before calling `set()`.
+
+## Dual-State Bug Pattern
+
+The Pipeline class explicitly guards against the dual-state bug pattern documented in CLAUDE.md. When entity data can exist in two locations (typed properties and the `$values` array), mutations must update both or use one canonical source.
+
+Pipeline uses `syncStepsToValues()` to maintain a single source of truth. Called after every mutation (`addStep()`, `removeStep()`, and in the constructor). The `toConfig()` method reads from the `$this->steps` array (the canonical source) and serializes step configs inline.
+
+**Rule:** When working on Pipeline or similar config entities with typed properties, always call the sync method after mutations. Do not read from `$this->values['steps']` directly; use `$this->getSteps()`.
+
+## File Reference
+
+| File | Class | Role |
+|------|-------|------|
+| `packages/ai-schema/src/EntityJsonSchemaGenerator.php` | `EntityJsonSchemaGenerator` | JSON Schema draft 2020-12 from entity types |
+| `packages/ai-schema/src/SchemaRegistry.php` | `SchemaRegistry` | Unified schema + tool facade |
+| `packages/ai-schema/src/Mcp/McpToolDefinition.php` | `McpToolDefinition` | MCP tool value object |
+| `packages/ai-schema/src/Mcp/McpToolGenerator.php` | `McpToolGenerator` | CRUD tool generation per entity type |
+| `packages/ai-schema/src/Mcp/McpToolExecutor.php` | `McpToolExecutor` | Tool call execution against entity system |
+| `packages/ai-schema/src/Mcp/TranslationToolGenerator.php` | `TranslationToolGenerator` | Translation-specific tool generation |
+| `packages/ai-agent/src/AgentInterface.php` | `AgentInterface` | Agent contract: execute, dryRun, describe |
+| `packages/ai-agent/src/AgentExecutor.php` | `AgentExecutor` | Safety wrapper + audit logging |
+| `packages/ai-agent/src/AgentContext.php` | `AgentContext` | Execution context with account + params |
+| `packages/ai-agent/src/AgentResult.php` | `AgentResult` | Execution result with actions |
+| `packages/ai-agent/src/AgentAction.php` | `AgentAction` | Single action value object |
+| `packages/ai-agent/src/AgentAuditLog.php` | `AgentAuditLog` | Audit log entry |
+| `packages/ai-agent/src/McpServer.php` | `McpServer` | MCP protocol adapter (tools/list, tools/call) |
+| `packages/ai-pipeline/src/Pipeline.php` | `Pipeline` | Config entity for processing pipelines |
+| `packages/ai-pipeline/src/PipelineStepInterface.php` | `PipelineStepInterface` | Step plugin contract |
+| `packages/ai-pipeline/src/PipelineStepConfig.php` | `PipelineStepConfig` | Step configuration value object |
+| `packages/ai-pipeline/src/PipelineContext.php` | `PipelineContext` | Shared execution state |
+| `packages/ai-pipeline/src/StepResult.php` | `StepResult` | Step result (success/failure/halt) |
+| `packages/ai-pipeline/src/PipelineResult.php` | `PipelineResult` | Full pipeline execution result |
+| `packages/ai-pipeline/src/PipelineExecutor.php` | `PipelineExecutor` | Synchronous pipeline runner |
+| `packages/ai-pipeline/src/PipelineDispatcher.php` | `PipelineDispatcher` | Async queue dispatch |
+| `packages/ai-pipeline/src/PipelineQueueMessage.php` | `PipelineQueueMessage` | Queue message value object |
+| `packages/ai-vector/src/EmbeddingInterface.php` | `EmbeddingInterface` | Embedding provider contract |
+| `packages/ai-vector/src/VectorStoreInterface.php` | `VectorStoreInterface` | Vector storage contract |
+| `packages/ai-vector/src/EntityEmbedding.php` | `EntityEmbedding` | Embedding value object |
+| `packages/ai-vector/src/SimilarityResult.php` | `SimilarityResult` | Search result with score |
+| `packages/ai-vector/src/EntityEmbedder.php` | `EntityEmbedder` | High-level embed + search service |
+| `packages/ai-vector/src/InMemoryVectorStore.php` | `InMemoryVectorStore` | In-memory store (cosine similarity) |
+| `packages/ai-vector/src/DistanceMetric.php` | `DistanceMetric` | Distance metric enum |
+| `packages/ai-vector/src/Testing/FakeEmbeddingProvider.php` | `FakeEmbeddingProvider` | Deterministic test embeddings |

--- a/docs/specs/ai-integration.md
+++ b/docs/specs/ai-integration.md
@@ -1,6 +1,6 @@
 # AI Integration
 
-Waaseyaa's AI layer (architecture layer 6) provides four packages that enable AI agents to introspect, mutate, and search CMS content. All four packages sit in the `packages/` directory and follow the standard `Waaseyaa\AI\*` namespace pattern.
+Waaseyaa's AI layer (architecture layer 5) provides four packages that enable AI agents to introspect, mutate, and search CMS content. All four packages sit in the `packages/` directory and follow the standard `Waaseyaa\AI\*` namespace pattern.
 
 ## Packages
 

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,0 +1,704 @@
+# API Layer
+
+Technical specification for the Waaseyaa JSON:API layer and routing system. This document covers the `packages/api/` and `packages/routing/` packages, which together provide RESTful CRUD endpoints, resource serialization, query parsing, JSON Schema presentation, route building, and access checking.
+
+## Packages
+
+### packages/api/
+
+| File | Namespace | Purpose |
+|------|-----------|---------|
+| `src/JsonApiController.php` | `Waaseyaa\Api` | CRUD operations on entities (index, show, store, update, destroy) |
+| `src/ResourceSerializer.php` | `Waaseyaa\Api` | Entity-to-JsonApiResource conversion with field access filtering |
+| `src/JsonApiDocument.php` | `Waaseyaa\Api` | JSON:API document value object (data, errors, meta, links, included) |
+| `src/JsonApiResource.php` | `Waaseyaa\Api` | JSON:API resource value object (type, id, attributes, relationships) |
+| `src/JsonApiError.php` | `Waaseyaa\Api` | JSON:API error value object with static factory methods |
+| `src/JsonApiRouteProvider.php` | `Waaseyaa\Api` | Auto-registers five CRUD routes per entity type |
+| `src/Query/QueryParser.php` | `Waaseyaa\Api\Query` | Parses `$_GET` into ParsedQuery (filters, sorts, pagination, sparse fieldsets) |
+| `src/Query/QueryApplier.php` | `Waaseyaa\Api\Query` | Applies ParsedQuery to EntityQueryInterface |
+| `src/Query/QueryFilter.php` | `Waaseyaa\Api\Query` | Value object for a single filter condition |
+| `src/Query/QuerySort.php` | `Waaseyaa\Api\Query` | Value object for a single sort directive |
+| `src/Query/ParsedQuery.php` | `Waaseyaa\Api\Query` | Value object holding all parsed query components |
+| `src/Query/PaginationLinks.php` | `Waaseyaa\Api\Query` | Generates self/first/prev/next pagination URLs |
+| `src/Schema/SchemaPresenter.php` | `Waaseyaa\Api\Schema` | Converts EntityType definitions to JSON Schema with widget hints |
+| `src/Controller/SchemaController.php` | `Waaseyaa\Api\Controller` | `GET /api/schema/{entity_type}` endpoint |
+| `src/Controller/TranslationController.php` | `Waaseyaa\Api\Controller` | Translation sub-resource CRUD endpoints |
+| `src/Controller/BroadcastController.php` | `Waaseyaa\Api\Controller` | SSE real-time broadcast endpoint |
+| `src/Controller/BroadcastStorage.php` | `Waaseyaa\Api\Controller` | PDO-backed message queue for SSE broadcasting |
+| `src/Cache/ApiCacheMiddleware.php` | `Waaseyaa\Api\Cache` | ETag, If-None-Match, Cache-Control header generation |
+| `src/OpenApi/OpenApiGenerator.php` | `Waaseyaa\Api\OpenApi` | Generates OpenAPI 3.1 spec from entity type definitions |
+| `src/OpenApi/SchemaBuilder.php` | `Waaseyaa\Api\OpenApi` | Builds component schemas for OpenAPI spec |
+| `src/MutableTranslatableInterface.php` | `Waaseyaa\Api` | Extension of TranslatableInterface with `addTranslation()` |
+
+### packages/routing/
+
+| File | Namespace | Purpose |
+|------|-----------|---------|
+| `src/WaaseyaaRouter.php` | `Waaseyaa\Routing` | Wraps Symfony UrlMatcher + UrlGenerator |
+| `src/RouteBuilder.php` | `Waaseyaa\Routing` | Fluent API for building Symfony Route objects |
+| `src/RouteMatch.php` | `Waaseyaa\Routing` | Value object for matched route (name, route, parameters) |
+| `src/AccessChecker.php` | `Waaseyaa\Routing` | Route-level access checking via route options |
+| `src/Attribute/GateAttribute.php` | `Waaseyaa\Routing\Attribute` | PHP attribute for gate-based access control on controller methods |
+| `src/ParamConverter/EntityParamConverter.php` | `Waaseyaa\Routing\ParamConverter` | Converts route parameter IDs to loaded entity objects |
+| `src/Language/LanguageNegotiatorInterface.php` | `Waaseyaa\Routing\Language` | Interface for language negotiation |
+| `src/Language/AcceptHeaderNegotiator.php` | `Waaseyaa\Routing\Language` | Language negotiation from Accept-Language header |
+| `src/Language/UrlPrefixNegotiator.php` | `Waaseyaa\Routing\Language` | Language negotiation from URL prefix |
+
+## Core Value Objects
+
+### JsonApiDocument
+
+```php
+// packages/api/src/JsonApiDocument.php
+final readonly class JsonApiDocument
+{
+    public function __construct(
+        public JsonApiResource|array|null $data = null,
+        public array $errors = [],
+        public array $meta = [],
+        public array $links = [],
+        public array $included = [],
+        public int $statusCode = 200,
+    ) {}
+
+    public function toArray(): array;
+
+    // Static factories:
+    public static function fromResource(JsonApiResource $resource, array $links = [], array $meta = [], int $statusCode = 200): self;
+    public static function fromCollection(array $resources, array $links = [], array $meta = []): self;
+    public static function fromErrors(array $errors, array $meta = [], int $statusCode = 400): self;
+    public static function empty(array $meta = [], int $statusCode = 200): self;
+}
+```
+
+`toArray()` always includes `jsonapi.version = "1.1"`. The `data` and `errors` members are mutually exclusive per the JSON:API spec. When `$data` is `null` (e.g., after DELETE), `toArray()` emits `"data": null`.
+
+### JsonApiResource
+
+```php
+// packages/api/src/JsonApiResource.php
+final readonly class JsonApiResource
+{
+    public function __construct(
+        public string $type,       // entity type ID
+        public string $id,         // UUID (preferred) or numeric ID as string
+        public array $attributes = [],
+        public array $relationships = [],
+        public array $links = [],
+        public array $meta = [],
+    ) {}
+
+    public function toArray(): array;
+}
+```
+
+### JsonApiError
+
+```php
+// packages/api/src/JsonApiError.php
+final readonly class JsonApiError
+{
+    public function __construct(
+        public string $status,
+        public string $title,
+        public string $detail = '',
+        public array $source = [],
+    ) {}
+
+    public function toArray(): array;
+
+    // Static factories:
+    public static function notFound(string $detail = ''): self;      // 404
+    public static function forbidden(string $detail = ''): self;     // 403
+    public static function unprocessable(string $detail = '', array $source = []): self;  // 422
+    public static function badRequest(string $detail = ''): self;    // 400
+    public static function conflict(string $detail = ''): self;      // 409
+    public static function internalError(string $detail = ''): self; // 500
+}
+```
+
+## JSON:API Controller
+
+`JsonApiController` is a framework-agnostic PHP class. It receives parsed parameters and returns `JsonApiDocument` objects. The front controller in `public/index.php` handles HTTP concerns (headers, body parsing, status codes).
+
+### Constructor
+
+```php
+// packages/api/src/JsonApiController.php
+final class JsonApiController
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly ResourceSerializer $serializer,
+        private readonly ?EntityAccessHandler $accessHandler = null,
+        private readonly ?AccountInterface $account = null,
+    ) {}
+}
+```
+
+The `$accessHandler` and `$account` follow the **paired nullable** pattern: both must be non-null or both null. When both are null, no access checking is performed.
+
+### CRUD Operations
+
+**`index(string $entityTypeId, array $query = []): JsonApiDocument`**
+
+1. Validates entity type exists via `$entityTypeManager->hasDefinition()`.
+2. Creates a `QueryParser` and parses `$query` into `ParsedQuery`.
+3. Runs a **count query** with filters only (no sorts/pagination) to get total.
+4. Runs the **main query** with filters, sorts, and pagination via `QueryApplier`.
+5. Loads entities via `$storage->loadMultiple($ids)`.
+6. **Post-fetch access filter**: if access handler is available, filters entities where `$accessHandler->check($entity, 'view', $account)->isAllowed()` is false.
+7. Serializes via `$serializer->serializeCollection()`.
+8. Applies sparse fieldsets if `fields[type]` is in the query.
+9. Generates pagination links and meta (`total`, `offset`, `limit`).
+10. Returns `JsonApiDocument::fromCollection()`.
+
+**`show(string $entityTypeId, int|string $id): JsonApiDocument`**
+
+1. Loads entity by ID or UUID via `loadByIdOrUuid()`.
+2. Checks view access. Returns 403 if denied.
+3. Serializes and returns `JsonApiDocument::fromResource()`.
+
+**`store(string $entityTypeId, array $data): JsonApiDocument`**
+
+1. Validates `data.type` matches `$entityTypeId`.
+2. Creates entity via `$storage->create($attributes)`.
+3. Checks create access via `$accessHandler->checkCreateAccess()`.
+4. Checks **field edit access** for each submitted attribute via `$accessHandler->checkFieldAccess($entity, $fieldName, 'edit', $account)`. Uses `isForbidden()` (field-level semantics).
+5. Saves entity and returns document with `statusCode: 201` and `meta.created = true`.
+
+**`update(string $entityTypeId, int|string $id, array $data): JsonApiDocument`**
+
+1. Loads entity, validates `data.type` and optional `data.id` (409 Conflict if UUID mismatch).
+2. Checks update access at entity level.
+3. Checks field edit access for each submitted attribute.
+4. Applies updates via `$entity->set($field, $value)` (requires `FieldableInterface`).
+5. Saves and returns updated resource.
+
+**`destroy(string $entityTypeId, int|string $id): JsonApiDocument`**
+
+1. Loads entity, checks delete access.
+2. Deletes via `$storage->delete([$entity])`.
+3. Returns `JsonApiDocument::empty(meta: ['deleted' => true], statusCode: 204)`.
+
+### ID Resolution
+
+`loadByIdOrUuid()` accepts `int|string`. If the entity type has a UUID key and the value matches UUID regex (`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i`), it queries by UUID. Otherwise it loads by primary key.
+
+## Resource Serialization
+
+```php
+// packages/api/src/ResourceSerializer.php
+final class ResourceSerializer
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly string $basePath = '/api',
+    ) {}
+
+    public function serialize(
+        EntityInterface $entity,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): JsonApiResource;
+
+    public function serializeCollection(
+        array $entities,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): array;
+}
+```
+
+### Serialization Logic
+
+1. Uses UUID as resource ID if available, otherwise falls back to numeric ID.
+2. Calls `$entity->toArray()` for all values.
+3. Excludes entity keys (`id`, `uuid`) from attributes -- they become top-level `type`/`id`.
+4. When access handler + account are provided, calls `$accessHandler->filterFields($entity, array_keys($attributes), 'view', $account)` to remove view-denied fields.
+5. Generates a `self` link: `{basePath}/{entityTypeId}/{resourceId}`.
+
+### Paired Nullable Pattern
+
+`$accessHandler` and `$account` must both be non-null or both null. The guard pattern is:
+
+```php
+if ($accessHandler !== null && $account !== null) {
+    $allowedFields = $accessHandler->filterFields($entity, array_keys($attributes), 'view', $account);
+    $attributes = array_intersect_key($attributes, array_flip($allowedFields));
+}
+```
+
+Only two of the four possible states (both-null, both-non-null) are meaningful. Passing one without the other silently skips access filtering.
+
+## Schema Presenter
+
+```php
+// packages/api/src/Schema/SchemaPresenter.php
+final class SchemaPresenter
+{
+    public function present(
+        EntityTypeInterface $entityType,
+        array $fieldDefinitions = [],
+        ?EntityInterface $entity = null,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): array;
+}
+```
+
+### JSON Schema Output Format
+
+Follows JSON Schema draft-07 with custom extensions:
+
+```json
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Content",
+    "description": "Schema for Content entities.",
+    "type": "object",
+    "x-entity-type": "node",
+    "x-translatable": false,
+    "x-revisionable": false,
+    "properties": { ... },
+    "required": [ ... ]
+}
+```
+
+### Custom Extensions
+
+| Extension | Type | Purpose |
+|-----------|------|---------|
+| `x-widget` | string | Widget type hint for admin SPA (text, textarea, richtext, select, boolean, number, email, url, datetime, entity_autocomplete, image, file, password, hidden) |
+| `x-label` | string | Human-readable field label |
+| `x-description` | string | Field help text |
+| `x-weight` | int | Display order weight |
+| `x-required` | bool | Whether field is required in forms |
+| `x-access-restricted` | bool | Field is viewable but not editable by current account |
+| `x-entity-type` | string | Entity type ID (top-level) |
+| `x-translatable` | bool | Whether entity type supports translations (top-level) |
+| `x-revisionable` | bool | Whether entity type supports revisions (top-level) |
+| `x-target-type` | string | Target entity type for entity_reference fields |
+| `x-enum-labels` | object | Human-readable labels for enum values |
+
+### readOnly vs x-access-restricted
+
+These serve different purposes in the admin SPA:
+
+- **`readOnly: true`** (without `x-access-restricted`): System fields like `id`, `uuid`. The admin SPA **hides** these from forms entirely.
+- **`readOnly: true` + `x-access-restricted: true`**: The user can **view** the field but cannot **edit** it. The admin SPA shows a disabled widget.
+
+### Field Access Integration
+
+When `$entity`, `$accessHandler`, and `$account` are all non-null:
+
+1. For each non-system field, checks `checkFieldAccess($entity, $fieldName, 'view', $account)`.
+2. If `isForbidden()` for view: **removes** the property from the schema entirely.
+3. If not forbidden for view, checks `checkFieldAccess($entity, $fieldName, 'edit', $account)`.
+4. If `isForbidden()` for edit: marks the property with `readOnly: true` and `x-access-restricted: true`.
+
+System keys (id, uuid, label, bundle, langcode) are always shown as-is.
+
+### Type and Widget Mappings
+
+Field type to JSON Schema type: `string->string`, `text->string`, `boolean->boolean`, `integer->integer`, `float->number`, `decimal->number`, `email->string`, `uri->string`, `timestamp->string`, `entity_reference->string`.
+
+Field type to widget: `string->text`, `text->textarea`, `text_long->richtext`, `boolean->boolean`, `integer->number`, `email->email`, `uri->url`, `timestamp->datetime`, `entity_reference->entity_autocomplete`, `list_string->select`.
+
+Format mappings: `email->email`, `uri->uri`, `timestamp->date-time`, `datetime->date-time`.
+
+### SchemaController
+
+```php
+// packages/api/src/Controller/SchemaController.php
+final class SchemaController
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly SchemaPresenter $schemaPresenter,
+        private readonly ?EntityAccessHandler $accessHandler = null,
+        private readonly ?AccountInterface $account = null,
+    ) {}
+
+    public function show(string $entityTypeId): JsonApiDocument;
+}
+```
+
+Creates a prototype entity (`new $class([])`) for field access checking. Wraps in try-catch and logs failures via `error_log()`. Returns the schema in `meta.schema` of a `JsonApiDocument`.
+
+## Query Pipeline
+
+### QueryParser
+
+Parses `$_GET`-style arrays into a `ParsedQuery` value object.
+
+**Supported query parameters:**
+
+| Parameter | Format | Example |
+|-----------|--------|---------|
+| `filter[field]=value` | Simple equality | `filter[status]=published` |
+| `filter[field][operator]=op&filter[field][value]=val` | Operator filter | `filter[title][operator]=CONTAINS&filter[title][value]=hello` |
+| `sort=field,-field2` | Comma-separated, `-` prefix for DESC | `sort=-created,title` |
+| `page[offset]=N` | Offset-based pagination | `page[offset]=20` |
+| `page[limit]=N` | Page size | `page[limit]=10` |
+| `fields[type]=field1,field2` | Sparse fieldsets | `fields[node]=title,body` |
+
+### QueryFilter
+
+```php
+// packages/api/src/Query/QueryFilter.php
+final readonly class QueryFilter
+{
+    private const VALID_OPERATORS = ['=', '!=', '>', '<', '>=', '<=', 'CONTAINS', 'STARTS_WITH'];
+
+    public function __construct(
+        public string $field,
+        public mixed $value,
+        public string $operator = '=',
+    ) {}
+}
+```
+
+Throws `InvalidArgumentException` for unsupported operators.
+
+### QuerySort
+
+```php
+// packages/api/src/Query/QuerySort.php
+final readonly class QuerySort
+{
+    public function __construct(
+        public string $field,
+        public string $direction = 'ASC',  // 'ASC' or 'DESC'
+    ) {}
+}
+```
+
+### ParsedQuery
+
+```php
+// packages/api/src/Query/ParsedQuery.php
+final readonly class ParsedQuery
+{
+    public function __construct(
+        public array $filters = [],           // QueryFilter[]
+        public array $sorts = [],             // QuerySort[]
+        public ?int $offset = null,
+        public ?int $limit = null,
+        public array $sparseFieldsets = [],    // array<string, list<string>>
+    ) {}
+}
+```
+
+### QueryApplier
+
+```php
+// packages/api/src/Query/QueryApplier.php
+final class QueryApplier
+{
+    private int $defaultLimit = 50;
+    private int $maxLimit = 100;
+
+    public function apply(ParsedQuery $query, EntityQueryInterface $entityQuery): EntityQueryInterface;
+    public function getEffectiveLimit(ParsedQuery $query): int;
+    public function getEffectiveOffset(ParsedQuery $query): int;
+    public function getDefaultLimit(): int;
+    public function getMaxLimit(): int;
+}
+```
+
+`apply()` translates each `QueryFilter` to `$entityQuery->condition()`, each `QuerySort` to `$entityQuery->sort()`, and applies `$entityQuery->range($offset, $limit)`. The limit is clamped to `min($requestedLimit, $maxLimit)` with a default of 50.
+
+### PaginationLinks
+
+```php
+// packages/api/src/Query/PaginationLinks.php
+final class PaginationLinks
+{
+    public static function generate(string $basePath, int $offset, int $limit, int $total): array;
+}
+```
+
+Returns `self`, `first`, and optionally `prev` and `next` links. Format: `{basePath}?page[offset]={N}&page[limit]={M}`.
+
+## Post-Fetch Access Filtering
+
+Entity-level access is applied **after** query execution in `JsonApiController::index()`:
+
+```php
+if ($this->accessHandler !== null && $this->account !== null) {
+    $entities = array_filter(
+        $entities,
+        fn($entity) => $this->accessHandler->check($entity, 'view', $this->account)->isAllowed(),
+    );
+}
+```
+
+This means:
+- The SQL query runs with `accessCheck(false)` -- no access checks in the database layer.
+- Entities are loaded, then filtered by view access in PHP.
+- The `total` count in pagination meta reflects the **unfiltered** count (from the count query, also with `accessCheck(false)`). This means `total` may be higher than the number of resources returned.
+
+Access result semantics differ by level:
+- **Entity level**: uses `isAllowed()` -- deny unless explicitly granted.
+- **Field level**: uses `!isForbidden()` -- allow unless explicitly denied (open by default).
+
+## LIKE Wildcard Escaping
+
+The `CONTAINS` and `STARTS_WITH` filter operators are translated to SQL `LIKE` patterns by `SqlEntityQuery` (in `packages/entity-storage/`). There are two important details:
+
+1. **PdoSelect appends `ESCAPE '\'`** for all LIKE/NOT LIKE operators. This means the backslash character is the escape character in LIKE patterns.
+
+2. **User input must be escaped** before embedding in LIKE patterns:
+
+```php
+$escapedValue = str_replace(['%', '_'], ['\\%', '\\_'], $value);
+// CONTAINS: "%{$escapedValue}%"
+// STARTS_WITH: "{$escapedValue}%"
+```
+
+Without this escaping, a user submitting `100%` as a filter value would match unintended rows because `%` is a LIKE wildcard.
+
+## Route Building
+
+### WaaseyaaRouter
+
+```php
+// packages/routing/src/WaaseyaaRouter.php
+final class WaaseyaaRouter
+{
+    public function __construct(?RequestContext $context = null);
+
+    public function addRoute(string $name, Route $route): void;
+    public function match(string $pathinfo): array;
+    public function generate(string $name, array $parameters = []): string;
+    public function getRouteCollection(): RouteCollection;
+}
+```
+
+Wraps Symfony `UrlMatcher` and `UrlGenerator`. Lazy-initializes matchers/generators and resets them when routes change.
+
+### RouteBuilder
+
+Fluent API for building Symfony Route objects:
+
+```php
+// packages/routing/src/RouteBuilder.php
+$route = RouteBuilder::create('/node/{node}')
+    ->controller('App\Controller\NodeController::view')
+    ->entityParameter('node', 'node')
+    ->requirePermission('access content')
+    ->methods('GET')
+    ->build();
+```
+
+| Method | Route Option | Purpose |
+|--------|-------------|---------|
+| `controller(string\|callable)` | `_controller` | Sets the controller |
+| `methods(string ...)` | (route methods) | Allowed HTTP methods |
+| `entityParameter(string $name, string $entityType)` | `parameters[$name] = ['type' => 'entity:{entityType}']` | Entity param upcasting |
+| `requirePermission(string $permission)` | `_permission` | Require specific permission |
+| `requireRole(string $role)` | `_role` | Require specific role |
+| `allowAll()` | `_public = true` | Public route, no auth required |
+| `requirement(string $key, string $regex)` | (route requirements) | Regex requirement for parameter |
+| `default(string $key, mixed $value)` | (route defaults) | Default parameter value |
+| `build()` | -- | Returns configured Symfony Route |
+
+### Route Access Options
+
+Routes declare access requirements via Symfony Route options. These are checked by `AccessChecker`:
+
+| Option | Type | Meaning |
+|--------|------|---------|
+| `_public` | `true` | Always allow access (no authentication required) |
+| `_permission` | `string` | Account must have the named permission |
+| `_role` | `string` | Account must have the named role (comma-separated for multiple) |
+| `_gate` | `array{ability: string, subject?: mixed}` | Gate ability check |
+
+Multiple requirements are combined with **AND** logic (all must pass). If no access requirements are present, `AccessChecker::check()` returns `AccessResult::neutral()`.
+
+### AccessChecker
+
+```php
+// packages/routing/src/AccessChecker.php
+final class AccessChecker
+{
+    public function __construct(
+        private readonly ?GateInterface $gate = null,
+    ) {}
+
+    public function check(Route $route, AccountInterface $account): AccessResult;
+    public static function applyGateToRoute(Route $route, string $ability, mixed $subject = null): void;
+}
+```
+
+### GateAttribute
+
+PHP attribute for declarative gate checks on controller methods:
+
+```php
+// packages/routing/src/Attribute/GateAttribute.php
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class GateAttribute
+{
+    public function __construct(
+        public readonly string $ability,   // e.g., 'config.export'
+        public readonly mixed $subject = null,
+    ) {}
+}
+```
+
+### EntityParamConverter
+
+```php
+// packages/routing/src/ParamConverter/EntityParamConverter.php
+final class EntityParamConverter
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+
+    public function convert(array $parameters, Route $route): array;
+}
+```
+
+Reads the route `parameters` option for entries with `type => 'entity:{entityTypeId}'`. Loads the entity from storage and replaces the raw ID in the parameter array. Throws `ResourceNotFoundException` if entity not found.
+
+### JsonApiRouteProvider
+
+```php
+// packages/api/src/JsonApiRouteProvider.php
+final class JsonApiRouteProvider
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly string $basePath = '/api',
+    ) {}
+
+    public function registerRoutes(WaaseyaaRouter $router): void;
+}
+```
+
+Registers five routes per entity type:
+
+| Route Name | Method | Path | Controller Method |
+|-----------|--------|------|-------------------|
+| `api.{type}.index` | GET | `/api/{type}` | `index` |
+| `api.{type}.show` | GET | `/api/{type}/{id}` | `show` |
+| `api.{type}.store` | POST | `/api/{type}` | `store` |
+| `api.{type}.update` | PATCH | `/api/{type}/{id}` | `update` |
+| `api.{type}.destroy` | DELETE | `/api/{type}/{id}` | `destroy` |
+
+Each route sets `_entity_type` as a default parameter.
+
+## Translation Sub-Resource
+
+```php
+// packages/api/src/Controller/TranslationController.php
+final class TranslationController
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly ResourceSerializer $serializer,
+    ) {}
+}
+```
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `index(entityTypeId, id)` | `GET /api/{type}/{id}/translations` | List translations |
+| `show(entityTypeId, id, langcode)` | `GET /api/{type}/{id}/translations/{langcode}` | Get translation |
+| `store(entityTypeId, id, langcode, data)` | `POST /api/{type}/{id}/translations/{langcode}` | Create translation |
+| `update(entityTypeId, id, langcode, data)` | `PATCH /api/{type}/{id}/translations/{langcode}` | Update translation |
+| `destroy(entityTypeId, id, langcode)` | `DELETE /api/{type}/{id}/translations/{langcode}` | Delete translation |
+
+Creating a translation requires `MutableTranslatableInterface`. Deleting the original language returns 422.
+
+## API Cache Middleware
+
+```php
+// packages/api/src/Cache/ApiCacheMiddleware.php
+final class ApiCacheMiddleware
+{
+    public function __construct(
+        private readonly ?int $entityMaxAge = null,     // default: 0
+        private readonly ?int $collectionMaxAge = null,  // default: 0
+        private readonly ?int $schemaMaxAge = null,      // default: 3600
+        private readonly bool $isPrivate = true,
+    ) {}
+
+    public function generateETag(JsonApiDocument $document): string;
+    public function isNotModified(string $ifNoneMatch, string $etag): bool;
+    public function buildHeaders(JsonApiDocument $document, string $responseType = 'entity'): array;
+    public function process(JsonApiDocument $document, string $responseType = 'entity', string $ifNoneMatch = ''): array;
+}
+```
+
+ETags use `W/"..."` (weak validator) with SHA-256 hash of the serialized response. Supports wildcard and multi-value `If-None-Match`. Returns `Vary: Accept, Accept-Language, Authorization`.
+
+## OpenAPI Generation
+
+```php
+// packages/api/src/OpenApi/OpenApiGenerator.php
+final class OpenApiGenerator
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private string $basePath = '/api',
+        private string $title = 'Waaseyaa API',
+        private string $version = '0.1.0',
+    ) {}
+
+    public function generate(): array;
+}
+```
+
+Generates OpenAPI 3.1.0 spec. For each entity type, creates four component schemas (`{Type}Resource`, `{Type}Attributes`, `{Type}CreateRequest`, `{Type}UpdateRequest`) and five path operations. Includes shared schemas for `JsonApiDocument`, `JsonApiErrorDocument`, `JsonApiError`, `JsonApiVersion`, and `JsonApiLinks`.
+
+## File Reference
+
+```
+packages/api/
+  src/
+    Cache/
+      ApiCacheMiddleware.php
+    Controller/
+      BroadcastController.php
+      BroadcastStorage.php
+      SchemaController.php
+      TranslationController.php
+    OpenApi/
+      OpenApiGenerator.php
+      SchemaBuilder.php
+    Query/
+      PaginationLinks.php
+      ParsedQuery.php
+      QueryApplier.php
+      QueryFilter.php
+      QueryParser.php
+      QuerySort.php
+    Schema/
+      SchemaPresenter.php
+    JsonApiController.php
+    JsonApiDocument.php
+    JsonApiError.php
+    JsonApiResource.php
+    JsonApiRouteProvider.php
+    MutableTranslatableInterface.php
+    ResourceSerializer.php
+
+packages/routing/
+  src/
+    Attribute/
+      GateAttribute.php
+    Language/
+      AcceptHeaderNegotiator.php
+      LanguageNegotiatorInterface.php
+      UrlPrefixNegotiator.php
+    ParamConverter/
+      EntityParamConverter.php
+    AccessChecker.php
+    RouteBuilder.php
+    RouteMatch.php
+    WaaseyaaRouter.php
+```

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -1,0 +1,836 @@
+# Entity System
+
+Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
+
+## Packages
+
+| Package | Path | Namespace | Purpose |
+|---------|------|-----------|---------|
+| entity | `packages/entity/` | `Waaseyaa\Entity\` | Interfaces, base classes, entity type definitions, events. No storage. |
+| entity-storage | `packages/entity-storage/` | `Waaseyaa\EntityStorage\` | SQL storage, schema handler, query builder, repository, unit of work. |
+| field | `packages/field/` | `Waaseyaa\Field\` | Field type plugins, field definitions, field item lists. |
+| config | `packages/config/` | `Waaseyaa\Config\` | Config objects, config factory, import/export, storage backends. |
+
+## Core Interfaces (packages/entity/src/)
+
+### EntityInterface
+
+File: `packages/entity/src/EntityInterface.php`
+
+```php
+interface EntityInterface
+{
+    public function id(): int|string|null;
+    public function uuid(): string;
+    public function label(): string;
+    public function getEntityTypeId(): string;
+    public function bundle(): string;
+    public function isNew(): bool;
+    public function toArray(): array;
+    public function language(): string;
+}
+```
+
+### FieldableInterface
+
+File: `packages/entity/src/FieldableInterface.php`
+
+```php
+interface FieldableInterface
+{
+    public function hasField(string $name): bool;
+    public function get(string $name): mixed;
+    public function set(string $name, mixed $value): static;
+    public function getFieldDefinitions(): array; // array<string, mixed>
+}
+```
+
+### ContentEntityInterface
+
+File: `packages/entity/src/ContentEntityInterface.php`
+
+Extends `EntityInterface` and `FieldableInterface`. No additional methods.
+
+### ConfigEntityInterface
+
+File: `packages/entity/src/ConfigEntityInterface.php`
+
+```php
+interface ConfigEntityInterface extends EntityInterface
+{
+    public function status(): bool;
+    public function enable(): static;
+    public function disable(): static;
+    public function getDependencies(): array; // array<string, string[]>
+    public function toConfig(): array;
+}
+```
+
+### EntityTypeInterface
+
+File: `packages/entity/src/EntityTypeInterface.php`
+
+```php
+interface EntityTypeInterface
+{
+    public function id(): string;
+    public function getLabel(): string;
+    public function getClass(): string;                     // class-string<EntityInterface>
+    public function getStorageClass(): string;              // class-string<EntityStorageInterface>
+    public function getKeys(): array;                       // array<string, string>
+    public function isRevisionable(): bool;
+    public function isTranslatable(): bool;
+    public function getBundleEntityType(): ?string;
+    public function getConstraints(): array;                // array<string, mixed>
+}
+```
+
+### EntityTypeManagerInterface
+
+File: `packages/entity/src/EntityTypeManagerInterface.php`
+
+```php
+interface EntityTypeManagerInterface
+{
+    public function getDefinition(string $entityTypeId): EntityTypeInterface;
+    public function getDefinitions(): array;        // array<string, EntityTypeInterface>
+    public function hasDefinition(string $entityTypeId): bool;
+    public function getStorage(string $entityTypeId): EntityStorageInterface;
+}
+```
+
+### EntityStorageInterface
+
+File: `packages/entity/src/Storage/EntityStorageInterface.php`
+
+```php
+interface EntityStorageInterface
+{
+    public function create(array $values = []): EntityInterface;
+    public function load(int|string $id): ?EntityInterface;
+    public function loadMultiple(array $ids = []): array;   // array<int|string, EntityInterface>
+    public function save(EntityInterface $entity): int;     // SAVED_NEW (1) or SAVED_UPDATED (2)
+    public function delete(array $entities): void;          // EntityInterface[]
+    public function getQuery(): EntityQueryInterface;
+    public function getEntityTypeId(): string;
+}
+```
+
+### EntityQueryInterface
+
+File: `packages/entity/src/Storage/EntityQueryInterface.php`
+
+```php
+interface EntityQueryInterface
+{
+    public function condition(string $field, mixed $value, string $operator = '='): static;
+    public function exists(string $field): static;
+    public function notExists(string $field): static;
+    public function sort(string $field, string $direction = 'ASC'): static;
+    public function range(int $offset, int $limit): static;
+    public function count(): static;
+    public function accessCheck(bool $check = true): static;
+    public function execute(): array;  // array<int|string>
+}
+```
+
+### RevisionableStorageInterface
+
+File: `packages/entity/src/Storage/RevisionableStorageInterface.php`
+
+Extends `EntityStorageInterface`. Adds:
+
+```php
+public function loadRevision(int|string $revisionId): ?EntityInterface;
+public function loadMultipleRevisions(array $ids): array;
+public function deleteRevision(int|string $revisionId): void;
+public function getLatestRevisionId(int|string $entityId): int|string|null;
+```
+
+### EntityRepositoryInterface
+
+File: `packages/entity/src/Repository/EntityRepositoryInterface.php`
+
+Higher-level API with language fallback:
+
+```php
+interface EntityRepositoryInterface
+{
+    public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface;
+    public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array;
+    public function save(EntityInterface $entity): int;
+    public function delete(EntityInterface $entity): void;
+    public function exists(string $id): bool;
+    public function count(array $criteria = []): int;
+}
+```
+
+### EntityConstants
+
+File: `packages/entity/src/EntityConstants.php`
+
+```php
+final class EntityConstants
+{
+    public const SAVED_NEW = 1;
+    public const SAVED_UPDATED = 2;
+}
+```
+
+## EntityType Definition
+
+File: `packages/entity/src/EntityType.php`
+
+`EntityType` is a `final readonly class` implementing `EntityTypeInterface`. Constructed with named parameters:
+
+```php
+new EntityType(
+    id: 'node',
+    label: 'Content',
+    class: Node::class,
+    storageClass: SqlEntityStorage::class,
+    keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+    revisionable: false,
+    translatable: false,
+    bundleEntityType: 'node_type',
+    constraints: [],
+);
+```
+
+Entity types are registered explicitly with `EntityTypeManager::registerEntityType()`. The manager throws `\InvalidArgumentException` if a type ID is already registered.
+
+### EntityTypeAttribute (future plugin discovery)
+
+File: `packages/entity/src/Attribute/EntityTypeAttribute.php`
+
+PHP attribute `#[EntityTypeAttribute(...)]` for class-level discovery. Extends `WaaseyaaPlugin`. Not currently used for registration (types are registered manually) but wired for future plugin-based discovery.
+
+## Entity Lifecycle
+
+### Create
+
+1. Call `$storage->create(['title' => 'Hello'])` or `new Node(['title' => 'Hello'])`
+2. `EntityBase::__construct()` auto-generates UUID via `Uuid::v4()->toRfc4122()` if not provided
+3. Entity starts with `isNew() === true` (id is null)
+
+### Save (new entity)
+
+1. `SqlEntityStorage::save()` detects `isNew() === true`
+2. Calls `splitForStorage()` to separate schema columns from `_data` JSON blob
+3. Dispatches `EntityEvents::PRE_SAVE` event
+4. Runs `INSERT` via `$database->insert()`, omitting null id key (auto-increment)
+5. Sets the generated ID on entity via `$entity->set($idKey, (int)$id)`
+6. Calls `$entity->enforceIsNew(false)`
+7. Dispatches `EntityEvents::POST_SAVE` event
+8. Returns `EntityConstants::SAVED_NEW` (1)
+
+### Save (existing entity)
+
+1. `SqlEntityStorage::save()` detects `isNew() === false`
+2. Calls `splitForStorage()` to separate schema columns from `_data` JSON blob
+3. Dispatches `EntityEvents::PRE_SAVE` event
+4. Runs `UPDATE` via `$database->update()`, excluding the ID from update fields
+5. Dispatches `EntityEvents::POST_SAVE` event
+6. Returns `EntityConstants::SAVED_UPDATED` (2)
+
+### Load
+
+1. `SqlEntityStorage::load($id)` executes `SELECT` on entity table
+2. `mapRowToEntity()` casts numeric IDs to `int`
+3. Merges `_data` JSON blob back into the values array
+4. Instantiates entity via `instantiateEntity()` (adapts to constructor signature)
+5. Calls `$entity->enforceIsNew(false)` on loaded entities
+
+### Delete
+
+1. Dispatches `EntityEvents::PRE_DELETE` for each entity
+2. Collects IDs, runs `DELETE ... WHERE id IN (...)`
+3. Dispatches `EntityEvents::POST_DELETE` for each entity
+
+## Storage Layer
+
+### SqlEntityStorage
+
+File: `packages/entity-storage/src/SqlEntityStorage.php`
+Namespace: `Waaseyaa\EntityStorage`
+Class: `final class SqlEntityStorage implements EntityStorageInterface`
+
+Constructor:
+```php
+public function __construct(
+    private readonly EntityTypeInterface $entityType,
+    private readonly DatabaseInterface $database,
+    private readonly EventDispatcherInterface $eventDispatcher,
+)
+```
+
+Table name derived from `$entityType->id()` (e.g., entity type `'node'` maps to table `node`).
+
+### _data JSON Blob
+
+`SqlSchemaHandler::buildTableSpec()` adds a `_data TEXT NOT NULL DEFAULT '{}'` column to every entity table.
+
+`SqlEntityStorage::splitForStorage()`:
+- For each value key, checks if a matching column exists in the table (via `SchemaInterface::fieldExists()`, results cached in `$columnCache`)
+- Values matching real columns go into `$dbValues`
+- All other values go into `$extraData`, which is JSON-encoded into `_data`
+
+`SqlEntityStorage::mapRowToEntity()`:
+- If `$row['_data']` exists, `json_decode()` it and merge back into `$row`
+- Remove the `_data` key from the row before entity creation
+
+### SqlSchemaHandler
+
+File: `packages/entity-storage/src/SqlSchemaHandler.php`
+Class: `final class SqlSchemaHandler`
+
+Constructor: `(EntityTypeInterface $entityType, DatabaseInterface $database)`
+
+Key methods:
+- `ensureTable(): void` -- creates entity table if it does not exist
+- `ensureTranslationTable(array $translatableFieldSchemas = []): void` -- creates `{type}_translations` table
+- `addFieldColumns(array $fieldSchemas): void` -- adds columns to existing entity table
+- `addTranslationFieldColumns(array $fieldSchemas): void` -- adds columns to translation table
+- `getTableName(): string` -- returns entity type id
+- `getTranslationTableName(): string` -- returns `{type}_translations`
+
+Default table schema (from `buildTableSpec()`):
+- `{idKey}` -- `serial NOT NULL` (auto-increment primary key)
+- `{uuidKey}` -- `varchar(128) NOT NULL DEFAULT ''`
+- `{bundleKey}` -- `varchar(128) NOT NULL DEFAULT ''`
+- `{labelKey}` -- `varchar(255) NOT NULL DEFAULT ''`
+- `{langcodeKey}` -- `varchar(12) NOT NULL DEFAULT 'en'`
+- `_data` -- `text NOT NULL DEFAULT '{}'`
+- Primary key on `{idKey}`, unique index on UUID, index on bundle
+
+### EntityStorageFactory
+
+File: `packages/entity-storage/src/EntityStorageFactory.php`
+Class: `final class EntityStorageFactory`
+
+Constructor: `(DatabaseInterface $database, EventDispatcherInterface $eventDispatcher)`
+
+`getStorage(EntityTypeInterface $entityType): SqlEntityStorage` -- creates and caches SqlEntityStorage instances by entity type ID.
+
+### EntityRepository
+
+File: `packages/entity-storage/src/EntityRepository.php`
+Class: `final class EntityRepository implements EntityRepositoryInterface`
+
+Constructor: `(EntityTypeInterface $entityType, EntityStorageDriverInterface $driver, EventDispatcherInterface $eventDispatcher)`
+
+Higher-level layer that handles:
+- Entity hydration (`hydrate()` method with `_data` merge and constructor adaptation)
+- Language fallback via `setFallbackChain(string[] $chain)` (default: `['en']`)
+- Event dispatch (PRE_SAVE, POST_SAVE, PRE_DELETE, POST_DELETE)
+
+### UnitOfWork
+
+File: `packages/entity-storage/src/UnitOfWork.php`
+Class: `final class UnitOfWork`
+
+Constructor: `(DatabaseInterface $database, EventDispatcherInterface $eventDispatcher)`
+
+`transaction(\Closure $callback): mixed` -- wraps callback in DB transaction, buffers events during transaction, dispatches after commit. On failure, discards events and rolls back.
+
+`bufferEvent(Event $event, string $eventName): void` -- buffers events inside transaction, dispatches immediately outside.
+
+### Storage Drivers
+
+#### EntityStorageDriverInterface
+
+File: `packages/entity-storage/src/Driver/EntityStorageDriverInterface.php`
+
+Low-level I/O SPI without entity hydration or events:
+
+```php
+public function read(string $entityType, string $id, ?string $langcode = null): ?array;
+public function write(string $entityType, string $id, array $values): void;
+public function remove(string $entityType, string $id): void;
+public function exists(string $entityType, string $id): bool;
+public function count(string $entityType, array $criteria = []): int;
+public function findBy(string $entityType, array $criteria = [], ?array $orderBy = null, ?int $limit = null): array;
+```
+
+#### SqlStorageDriver
+
+File: `packages/entity-storage/src/Driver/SqlStorageDriver.php`
+Constructor: `(ConnectionResolverInterface $connectionResolver, string $idKey = 'id')`
+
+Handles raw SQL I/O. Supports translation tables: if `{entityType}_translations` table exists, `read()` merges translation data over base values.
+
+#### InMemoryStorageDriver
+
+File: `packages/entity-storage/src/Driver/InMemoryStorageDriver.php`
+
+In-memory storage for testing. Additional methods beyond the interface:
+- `writeTranslation(string $entityType, string $id, string $langcode, array $values): void`
+- `deleteTranslation(string $entityType, string $id, string $langcode): void`
+- `getAvailableLanguages(string $entityType, string $id): string[]`
+- `clear(): void`
+
+### Connection Resolution
+
+#### ConnectionResolverInterface
+
+File: `packages/entity-storage/src/Connection/ConnectionResolverInterface.php`
+
+```php
+public function connection(?string $name = null): DatabaseInterface;
+public function getDefaultConnectionName(): string;
+```
+
+Multi-tenancy seam. `SingleConnectionResolver` always returns the same connection.
+
+## Constructor Patterns
+
+### Base class constructor (EntityBase)
+
+```php
+public function __construct(array $values = [], string $entityTypeId = '', array $entityKeys = [])
+```
+
+Accepts `$entityTypeId` and `$entityKeys` parameters. Used when storage instantiates generic entities.
+
+### Subclass constructor (User, Node)
+
+Subclasses hardcode their entity type ID and keys. Only accept `(array $values)`:
+
+```php
+// User: packages/user/src/User.php
+final class User extends ContentEntityBase implements AccountInterface
+{
+    private const ENTITY_TYPE_ID = 'user';
+    private const ENTITY_KEYS = ['id' => 'uid', 'uuid' => 'uuid', 'label' => 'name'];
+
+    public function __construct(array $values = [])
+    {
+        parent::__construct($values, self::ENTITY_TYPE_ID, self::ENTITY_KEYS);
+    }
+}
+
+// Node: packages/node/src/Node.php
+final class Node extends ContentEntityBase
+{
+    protected string $entityTypeId = 'node';
+    protected array $entityKeys = ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'];
+
+    public function __construct(array $values = [])
+    {
+        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+    }
+}
+```
+
+### SqlEntityStorage constructor detection
+
+`SqlEntityStorage::instantiateEntity()` uses reflection to detect the constructor shape:
+1. Reflects the entity class constructor
+2. Checks if a parameter named `'entityTypeId'` exists
+3. If yes, passes `(values: $values, entityTypeId: ..., entityKeys: ...)`
+4. If no, passes `(values: $values)` only
+
+This is critical: entity subclasses like User and Node only accept `(array $values)` and hardcode their type/keys.
+
+### enforceIsNew()
+
+`EntityBase::enforceIsNew(bool $value = true): static`
+
+When creating entities with pre-set IDs (e.g., `new User(['uid' => 2])`), call `$entity->enforceIsNew()` before `save()`. Without this, `isNew()` returns false (because `id()` is not null), and SqlEntityStorage performs UPDATE instead of INSERT, silently affecting 0 rows.
+
+`isNew()` returns `$this->enforceIsNew || $this->id() === null`.
+
+## Entity Keys
+
+Entity keys map logical names to actual column/property names. Defined in `EntityType::$keys`:
+
+| Key | Purpose | Default fallback |
+|-----|---------|-----------------|
+| `id` | Primary key column | `'id'` |
+| `uuid` | UUID column | `'uuid'` |
+| `label` | Human-readable label | `'label'` |
+| `bundle` | Bundle/type discriminator | `'bundle'` |
+| `langcode` | Language code | `'langcode'` |
+| `revision` | Revision ID (revisionable types) | -- |
+
+Examples:
+- Node: `['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type']`
+- User: `['id' => 'uid', 'uuid' => 'uuid', 'label' => 'name']`
+
+`EntityBase` resolves values via keys: `$this->values[$this->entityKeys['id'] ?? 'id']`.
+Bundle defaults to `$this->entityTypeId` when no bundle value exists.
+
+## Query Pipeline
+
+### SqlEntityQuery
+
+File: `packages/entity-storage/src/SqlEntityQuery.php`
+Class: `final class SqlEntityQuery implements EntityQueryInterface`
+
+Constructor: `(EntityTypeInterface $entityType, DatabaseInterface $database)`
+
+Table and ID key derived from entity type. Fluent API builds conditions, sorts, and ranges.
+
+Supported operators:
+- Standard SQL: `=`, `<>`, `<`, `>`, `<=`, `>=`, `IN`, `NOT IN`, `LIKE`, `NOT LIKE`
+- `IS NULL` / `IS NOT NULL` -- via `exists()` and `notExists()`
+- `CONTAINS` -- translated to `LIKE '%escaped_value%'`
+- `STARTS_WITH` -- translated to `LIKE 'escaped_value%'`
+
+LIKE wildcard escaping: `str_replace(['%', '_'], ['\\%', '\\_'], $value)` before wrapping with `%`.
+
+Count mode: `count()` switches `execute()` to return `[(int) $count]` instead of IDs.
+
+`accessCheck()` is a no-op in v0.1.0.
+
+Usage pattern:
+```php
+$ids = $storage->getQuery()
+    ->condition('status', 1)
+    ->condition('type', 'article')
+    ->sort('created', 'DESC')
+    ->range(0, 10)
+    ->execute();
+
+$entities = $storage->loadMultiple($ids);
+```
+
+## Events
+
+### EntityEvent
+
+File: `packages/entity/src/Event/EntityEvent.php`
+
+```php
+class EntityEvent extends Event
+{
+    public function __construct(
+        public readonly EntityInterface $entity,
+        public readonly ?EntityInterface $originalEntity = null,
+    ) {}
+}
+```
+
+Properties are **public readonly**. Access as `$event->entity` and `$event->originalEntity`. There are NO getter methods. Common mistake: `$event->getEntity()` does not exist.
+
+### EntityEvents (enum)
+
+File: `packages/entity/src/Event/EntityEvents.php`
+
+```php
+enum EntityEvents: string
+{
+    case PRE_SAVE = 'waaseyaa.entity.pre_save';
+    case POST_SAVE = 'waaseyaa.entity.post_save';
+    case PRE_DELETE = 'waaseyaa.entity.pre_delete';
+    case POST_DELETE = 'waaseyaa.entity.post_delete';
+    case POST_LOAD = 'waaseyaa.entity.post_load';
+    case PRE_CREATE = 'waaseyaa.entity.pre_create';
+}
+```
+
+Dispatched with `$eventDispatcher->dispatch(new EntityEvent($entity), EntityEvents::PRE_SAVE->value)`.
+Note: use `->value` to get the string from the enum.
+
+### Domain Events (EntitySaved, EntityDeleted)
+
+File: `packages/entity/src/Event/EntitySaved.php` -- extends `DomainEvent`, contains `$changedFields`, `$isNew`
+File: `packages/entity/src/Event/EntityDeleted.php` -- extends `DomainEvent`
+
+These are separate from `EntityEvent`. They carry aggregate metadata (`aggregateType`, `aggregateId`, `tenantId`, `actorId`).
+
+## Configuration Entities
+
+### ConfigEntityBase
+
+File: `packages/entity/src/ConfigEntityBase.php`
+Class: `abstract class ConfigEntityBase extends EntityBase implements ConfigEntityInterface`
+
+Config entities differ from content entities:
+- Stored as YAML via config system, not in SQL tables
+- Have `status()` (enabled/disabled) and `getDependencies()`
+- `toConfig()` returns array suitable for YAML serialization
+- Dependencies keyed by type: `['package' => [...], 'config' => [...], 'content' => [...]]`
+
+## Config System (packages/config/src/)
+
+### ConfigInterface
+
+File: `packages/config/src/ConfigInterface.php`
+
+```php
+interface ConfigInterface
+{
+    public function getName(): string;
+    public function get(string $key = ''): mixed;      // dot-notation traversal
+    public function set(string $key, mixed $value): static;
+    public function clear(string $key): static;
+    public function delete(): static;
+    public function save(): static;
+    public function isNew(): bool;
+    public function getRawData(): array;
+}
+```
+
+### Config
+
+File: `packages/config/src/Config.php`
+Class: `final class Config implements ConfigInterface`
+
+Supports dot-notation for nested values: `$config->get('page.front')`.
+Mutable vs immutable: constructor accepts `bool $immutable`. Immutable configs throw `ImmutableConfigException` on any write operation.
+
+### ConfigFactoryInterface
+
+File: `packages/config/src/ConfigFactoryInterface.php`
+
+```php
+interface ConfigFactoryInterface
+{
+    public function get(string $name): ConfigInterface;           // returns immutable
+    public function getEditable(string $name): ConfigInterface;   // returns mutable
+    public function loadMultiple(array $names): array;
+    public function rename(string $oldName, string $newName): static;
+    public function listAll(string $prefix = ''): array;
+}
+```
+
+`get()` returns cached immutable Config. `getEditable()` always creates a new mutable Config wrapped in EventAwareStorage.
+
+### ConfigManagerInterface
+
+File: `packages/config/src/ConfigManagerInterface.php`
+
+```php
+interface ConfigManagerInterface
+{
+    public function getActiveStorage(): StorageInterface;
+    public function getSyncStorage(): StorageInterface;
+    public function import(): ConfigImportResult;
+    public function export(): void;
+    public function diff(string $configName): array;
+}
+```
+
+`import()` compares sync to active storage, creates/updates/deletes as needed, returns `ConfigImportResult`.
+`export()` clears sync storage, copies all active configs.
+
+### Config StorageInterface
+
+File: `packages/config/src/StorageInterface.php`
+
+```php
+interface StorageInterface
+{
+    public function exists(string $name): bool;
+    public function read(string $name): array|false;
+    public function readMultiple(array $names): array;
+    public function write(string $name, array $data): bool;
+    public function delete(string $name): bool;
+    public function rename(string $name, string $newName): bool;
+    public function listAll(string $prefix = ''): array;
+    public function deleteAll(string $prefix = ''): bool;
+    public function createCollection(string $collection): static;
+    public function getCollectionName(): string;
+    public function getAllCollectionNames(): array;
+}
+```
+
+Implementations: `Storage\MemoryStorage`, `Storage\FileStorage`.
+
+### Config Events
+
+File: `packages/config/src/Event/ConfigEvents.php`
+
+```php
+enum ConfigEvents: string
+{
+    case PRE_SAVE = 'waaseyaa.config.pre_save';
+    case POST_SAVE = 'waaseyaa.config.post_save';
+    case PRE_DELETE = 'waaseyaa.config.pre_delete';
+    case POST_DELETE = 'waaseyaa.config.post_delete';
+    case IMPORT = 'waaseyaa.config.import';
+}
+```
+
+## Field System (packages/field/src/)
+
+### FieldTypeInterface
+
+File: `packages/field/src/FieldTypeInterface.php`
+
+```php
+interface FieldTypeInterface extends PluginInspectionInterface
+{
+    public static function schema(): array;           // array<string, array{type: string, ...}>
+    public static function defaultSettings(): array;
+    public static function defaultValue(): mixed;
+    public static function jsonSchema(): array;
+}
+```
+
+### FieldDefinition
+
+File: `packages/field/src/FieldDefinition.php`
+Class: `final readonly class FieldDefinition implements FieldDefinitionInterface`
+
+```php
+public function __construct(
+    private string $name,
+    private string $type,
+    private int $cardinality = 1,
+    private array $settings = [],
+    private string $targetEntityTypeId = '',
+    private ?string $targetBundle = null,
+    private bool $translatable = false,
+    private bool $revisionable = false,
+    private mixed $defaultValue = null,
+    private string $label = '',
+    private string $description = '',
+    private bool $required = false,
+    private bool $readOnly = false,
+    private array $constraints = [],    // Constraint[]
+)
+```
+
+`toJsonSchema()` maps types: `string` -> `{'type': 'string'}`, `integer` -> `{'type': 'integer'}`, `boolean` -> `{'type': 'boolean'}`, `float` -> `{'type': 'number'}`, `text` -> object with `value`/`format`, `entity_reference` -> object with `target_id`/`target_type`. Wraps in `{'type': 'array', 'items': ...}` when `isMultiple()`.
+
+### FieldItemBase
+
+File: `packages/field/src/FieldItemBase.php`
+Class: `abstract class FieldItemBase extends PluginBase implements FieldItemInterface, FieldTypeInterface`
+
+Subclasses must implement:
+- `static function propertyDefinitions(): array` -- e.g., `['value' => 'string']`
+- `static function mainPropertyName(): string` -- e.g., `'value'`
+- `static function schema(): array` -- SQL column definitions
+- `static function jsonSchema(): array` -- JSON Schema representation
+
+### Built-in Field Items
+
+| Class | Path | ID | Properties | Main Property |
+|-------|------|----|------------|---------------|
+| `StringItem` | `packages/field/src/Item/StringItem.php` | `string` | `value: string` | `value` |
+| `TextItem` | `packages/field/src/Item/TextItem.php` | `text` | `value: string, format: string` | `value` |
+| `IntegerItem` | `packages/field/src/Item/IntegerItem.php` | `integer` | `value: integer` | `value` |
+| `FloatItem` | `packages/field/src/Item/FloatItem.php` | `float` | `value: float` | `value` |
+| `BooleanItem` | `packages/field/src/Item/BooleanItem.php` | `boolean` | `value: boolean` | `value` |
+| `EntityReferenceItem` | `packages/field/src/Item/EntityReferenceItem.php` | `entity_reference` | `target_id: integer, target_type: string` | `target_id` |
+
+### FieldItemList
+
+File: `packages/field/src/FieldItemList.php`
+Class: `class FieldItemList implements FieldItemListInterface, \IteratorAggregate, \Countable`
+
+Contains `FieldItemInterface[]` items. Supports `__get($name)` to access first item's property value (e.g., `$list->value`).
+
+### FieldTypeManager
+
+File: `packages/field/src/FieldTypeManager.php`
+Class: `class FieldTypeManager extends DefaultPluginManager implements FieldTypeManagerInterface`
+
+Constructor: `(array $directories = [], ?CacheBackendInterface $cache = null)`
+
+Uses `AttributeDiscovery` with `FieldType::class` attribute. Plugin discovery scans directories for `#[FieldType(...)]` attributes.
+
+Additional methods:
+- `getDefaultSettings(string $fieldType): array`
+- `getColumns(string $fieldType): array` -- returns `schema()` from the field type class
+
+### FieldType Attribute
+
+File: `packages/field/src/Attribute/FieldType.php`
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class FieldType extends WaaseyaaPlugin
+{
+    public function __construct(
+        string $id,
+        string $label = '',
+        string $description = '',
+        string $package = '',
+        public readonly string $category = 'general',
+        public readonly int $defaultCardinality = 1,
+        public readonly string $defaultWidget = '',
+        public readonly string $defaultFormatter = '',
+    )
+}
+```
+
+## File Reference
+
+### packages/entity/src/
+- `EntityInterface.php` -- core entity contract
+- `EntityBase.php` -- abstract base with values array, UUID generation, enforceIsNew
+- `ContentEntityInterface.php` -- extends EntityInterface + FieldableInterface
+- `ContentEntityBase.php` -- abstract base for content entities (fieldable)
+- `ConfigEntityInterface.php` -- config entity contract with status/dependencies
+- `ConfigEntityBase.php` -- abstract base for config entities
+- `FieldableInterface.php` -- hasField, get, set, getFieldDefinitions
+- `EntityType.php` -- final readonly value object for entity type definitions
+- `EntityTypeInterface.php` -- entity type definition contract
+- `EntityTypeManager.php` -- registry with storage factory support
+- `EntityTypeManagerInterface.php` -- manager contract
+- `EntityConstants.php` -- SAVED_NEW (1), SAVED_UPDATED (2)
+- `TranslatableInterface.php` -- translation contract
+- `RevisionableInterface.php` -- revision contract
+- `Attribute/EntityTypeAttribute.php` -- PHP attribute for entity type discovery
+- `Event/EntityEvent.php` -- event with public readonly entity + originalEntity
+- `Event/EntityEvents.php` -- string-backed enum of event names
+- `Event/EntitySaved.php` -- domain event for entity save
+- `Event/EntityDeleted.php` -- domain event for entity delete
+- `Storage/EntityStorageInterface.php` -- storage CRUD contract
+- `Storage/EntityQueryInterface.php` -- query builder contract
+- `Storage/RevisionableStorageInterface.php` -- revision storage contract
+- `Repository/EntityRepositoryInterface.php` -- high-level repository contract
+
+### packages/entity-storage/src/
+- `SqlEntityStorage.php` -- SQL storage with _data blob split/merge
+- `SqlEntityQuery.php` -- SQL query builder with CONTAINS/STARTS_WITH operators
+- `SqlSchemaHandler.php` -- table creation and schema management
+- `EntityStorageFactory.php` -- factory that creates/caches SqlEntityStorage
+- `EntityRepository.php` -- high-level repository with language fallback
+- `UnitOfWork.php` -- transaction wrapper with event buffering
+- `Driver/EntityStorageDriverInterface.php` -- low-level I/O SPI
+- `Driver/SqlStorageDriver.php` -- SQL driver with translation table support
+- `Driver/InMemoryStorageDriver.php` -- in-memory driver for testing
+- `Connection/ConnectionResolverInterface.php` -- multi-tenancy seam
+- `Connection/SingleConnectionResolver.php` -- single-tenant default
+
+### packages/field/src/
+- `FieldTypeInterface.php` -- field type plugin contract
+- `FieldDefinitionInterface.php` -- field definition contract
+- `FieldDefinition.php` -- final readonly field definition value object
+- `FieldItemInterface.php` -- field item contract
+- `FieldItemBase.php` -- abstract base for field items
+- `FieldItemList.php` -- list of field items with IteratorAggregate
+- `FieldItemListInterface.php` -- field item list contract
+- `PropertyValue.php` -- typed data wrapper for property values
+- `FieldTypeManager.php` -- plugin manager for field types
+- `FieldTypeManagerInterface.php` -- field type manager contract
+- `Attribute/FieldType.php` -- PHP attribute for field type discovery
+- `Item/StringItem.php` -- string field type plugin
+- `Item/TextItem.php` -- formatted text field type plugin
+- `Item/IntegerItem.php` -- integer field type plugin
+- `Item/FloatItem.php` -- float field type plugin
+- `Item/BooleanItem.php` -- boolean field type plugin
+- `Item/EntityReferenceItem.php` -- entity reference field type plugin
+
+### packages/config/src/
+- `ConfigInterface.php` -- config object contract with dot-notation access
+- `Config.php` -- mutable/immutable config with nested value support
+- `ConfigFactoryInterface.php` -- factory contract (get immutable, getEditable mutable)
+- `ConfigFactory.php` -- factory with in-memory cache for immutable configs
+- `ConfigManagerInterface.php` -- import/export manager contract
+- `ConfigManager.php` -- sync/active storage comparison and import/export
+- `StorageInterface.php` -- config storage contract (read/write/delete/list)
+- `ConfigImportResult.php` -- import result value object (created/updated/deleted/errors)
+- `EventAwareStorage.php` -- storage wrapper that dispatches config events
+- `Event/ConfigEvent.php` -- config change event
+- `Event/ConfigEvents.php` -- string-backed enum of config event names
+- `Storage/MemoryStorage.php` -- in-memory config storage for testing
+- `Storage/FileStorage.php` -- filesystem YAML config storage
+
+### Test fixtures
+- `packages/api/tests/Fixtures/InMemoryEntityStorage.php` -- implements EntityStorageInterface for tests

--- a/docs/specs/field-access.md
+++ b/docs/specs/field-access.md
@@ -1,0 +1,317 @@
+# Field-Level Access
+
+Field-level access control allows policies to restrict which fields a user can view or edit on entities. It is a companion to entity-level access, sharing the same handler and discovery infrastructure but with intentionally different semantics.
+
+## Overview
+
+- **Interface:** `FieldAccessPolicyInterface` in `packages/access/src/`
+- **Handler:** `EntityAccessHandler` in `packages/access/src/` (same class that handles entity access)
+- **Companion:** Classes implement both `AccessPolicyInterface` AND `FieldAccessPolicyInterface`
+- **Discovery:** Same `#[AccessPolicy]` attribute; no separate discovery pipeline
+- **Default:** Open-by-default. No field policies = all fields accessible.
+
+## Asymmetric Semantics
+
+Access result interpretation differs between entity-level and field-level checks. This asymmetry is intentional.
+
+| Level | Check | Default | Meaning |
+|-------|-------|---------|---------|
+| Entity | `$result->isAllowed()` | Deny unless granted | Neutral = no policy granted = denied |
+| Field | `!$result->isForbidden()` | Allow unless denied | Neutral = no policy denied = accessible |
+
+Entity-level is deny-by-default: a policy must explicitly return `Allowed` for access to be granted. Field-level is open-by-default: access is granted unless a policy explicitly returns `Forbidden`.
+
+```php
+// Entity access check (deny-by-default):
+$result = $handler->check($entity, 'view', $account);
+if ($result->isAllowed()) { /* grant */ }
+
+// Field access check (open-by-default):
+$result = $handler->checkFieldAccess($entity, 'title', 'view', $account);
+if (!$result->isForbidden()) { /* grant */ }
+```
+
+## FieldAccessPolicyInterface
+
+**File:** `packages/access/src/FieldAccessPolicyInterface.php`
+**Namespace:** `Waaseyaa\Access`
+
+```php
+interface FieldAccessPolicyInterface
+{
+    /**
+     * @param EntityInterface  $entity    The entity being accessed.
+     * @param string           $fieldName The field name being checked.
+     * @param string           $operation 'view' or 'edit'
+     * @param AccountInterface $account   The account requesting access.
+     */
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation, // 'view' or 'edit'
+        AccountInterface $account,
+    ): AccessResult;
+}
+```
+
+### Operations
+
+| Operation | Meaning | Denial Effect |
+|-----------|---------|---------------|
+| `'view'` | Can the account see this field value? | Field omitted from JSON:API response |
+| `'edit'` | Can the account modify this field? | 403 error if submitted in POST/PATCH; shown as disabled in admin form |
+
+## Open-by-Default Design
+
+When `EntityAccessHandler::checkFieldAccess()` runs:
+
+1. Starts with `AccessResult::neutral('No field access policy provided an opinion.')`.
+2. Iterates policies. Skips those where `appliesTo()` returns false.
+3. Skips policies that do not implement `FieldAccessPolicyInterface` (uses `instanceof`).
+4. Calls `$policy->fieldAccess(...)` on qualifying policies.
+5. Combines with `orIf()`. Forbidden short-circuits.
+6. Returns result.
+
+When no policy implements `FieldAccessPolicyInterface` for the entity type, the result is Neutral. Neutral is not Forbidden, so all fields pass through. This ensures zero behavioral change when no field policies exist.
+
+```php
+// EntityAccessHandler::checkFieldAccess() excerpt:
+$result = AccessResult::neutral('No field access policy provided an opinion.');
+foreach ($this->policies as $policy) {
+    if (!$policy->appliesTo($entityTypeId)) { continue; }
+    if (!$policy instanceof FieldAccessPolicyInterface) { continue; }
+    $policyResult = $policy->fieldAccess($entity, $fieldName, $operation, $account);
+    $result = $result->orIf($policyResult);
+    if ($result->isForbidden()) { return $result; }
+}
+return $result;
+```
+
+### Bulk Filtering
+
+`EntityAccessHandler::filterFields()` is a convenience method:
+
+```php
+public function filterFields(
+    EntityInterface $entity,
+    array $fieldNames,   // string[]
+    string $operation,   // 'view' or 'edit'
+    AccountInterface $account,
+): array // string[] -- fields not forbidden
+```
+
+Implementation: filters via `!$this->checkFieldAccess(...)->isForbidden()`.
+
+## Intersection Types for Policies
+
+Policy classes must implement both interfaces to participate in field access checks. A class that only implements `AccessPolicyInterface` is skipped for field checks. A class that only implements `FieldAccessPolicyInterface` would never be registered (policies are typed as `AccessPolicyInterface[]`).
+
+```php
+#[AccessPolicy(id: 'node_access', entityTypes: ['node'])]
+final class NodeAccessPolicy implements AccessPolicyInterface, FieldAccessPolicyInterface
+{
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        // entity-level logic
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        // create-level logic
+    }
+
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'node';
+    }
+
+    public function fieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult
+    {
+        // field-level logic
+        if ($fieldName === 'status' && !$account->hasPermission('administer nodes')) {
+            return AccessResult::forbidden('Only administrators can edit the status field.');
+        }
+        return AccessResult::neutral();
+    }
+}
+```
+
+The `appliesTo()` method from `AccessPolicyInterface` scopes both entity-level and field-level access to the same entity types.
+
+## View vs Edit Denial
+
+### JSON:API Serialization (ResourceSerializer)
+
+**File:** `packages/api/src/ResourceSerializer.php`
+
+When access context is provided, `serialize()` omits view-denied fields from the attributes object:
+
+```php
+public function serialize(
+    EntityInterface $entity,
+    ?EntityAccessHandler $accessHandler = null,
+    ?AccountInterface $account = null,
+): array
+```
+
+- View-denied field: omitted entirely from response attributes.
+- Edit-denied field: still included in view response (edit denial only affects mutation).
+
+### Schema Generation (SchemaPresenter)
+
+**File:** `packages/api/src/Schema/SchemaPresenter.php`
+
+When access context is provided, `present()` annotates the JSON Schema:
+
+```php
+public function present(
+    EntityTypeInterface $entityType,
+    array $fieldDefinitions = [],
+    ?EntityInterface $entity = null,
+    ?EntityAccessHandler $accessHandler = null,
+    ?AccountInterface $account = null,
+): array
+```
+
+- View-denied fields: removed from schema entirely (frontend never sees them).
+- Edit-denied fields: marked `readOnly: true` with `x-access-restricted: true`.
+
+### `x-access-restricted` Extension
+
+`x-access-restricted: true` is a JSON Schema extension that signals the admin SPA to show the field as a disabled widget. This is distinct from system `readOnly` (used for `id`, `uuid`) which hides the field from forms entirely.
+
+```json
+{
+  "properties": {
+    "status": {
+      "type": "boolean",
+      "readOnly": true,
+      "x-access-restricted": true
+    }
+  }
+}
+```
+
+Frontend behavior:
+- System `readOnly` without `x-access-restricted`: field hidden from edit forms.
+- `readOnly` with `x-access-restricted`: field shown as disabled widget (user can see value but not change it).
+
+### JSON:API Controller (JsonApiController)
+
+**File:** `packages/api/src/JsonApiController.php`
+
+- GET (index/show): passes access context to serializer; view-denied fields omitted.
+- POST (store) / PATCH (update): checks edit access for each submitted field before applying. Returns 403 JSON:API error if any submitted field is edit-denied.
+
+## Paired Nullable Parameters
+
+`ResourceSerializer::serialize()` and `SchemaPresenter::present()` accept `?EntityAccessHandler` + `?AccountInterface`. Both must be non-null or both null -- only two of four states are meaningful.
+
+```php
+// Correct guard pattern:
+if ($accessHandler !== null && $account !== null) {
+    $viewableFields = $accessHandler->filterFields($entity, $fieldNames, 'view', $account);
+}
+```
+
+When both are null, no field filtering occurs and the full entity/schema is returned.
+
+## Wiring
+
+**File:** `public/index.php`
+
+The front controller creates the access handler and passes it through the call chain:
+
+```php
+$account = $httpRequest->attributes->get('_account');
+$accessHandler = new EntityAccessHandler([]);
+// Pass to JsonApiController constructor (already accepts optional params)
+// Pass to SchemaController constructor (accepts optional params)
+```
+
+For `SchemaController`, a prototype entity is created for policy evaluation:
+
+```php
+$class = $entityType->getEntityClass();
+$prototypeEntity = new $class([]); // User/Node accept (array $values)
+$schema = $schemaPresenter->present($entityType, $fields, $prototypeEntity, $accessHandler, $account);
+```
+
+With no policies registered, `EntityAccessHandler` returns Neutral for all fields. Field-level semantics (`!isForbidden()`) means all fields pass through unchanged.
+
+## Testing Field Access
+
+### Anonymous Classes for Intersection Types
+
+PHPUnit `createMock()` cannot mock intersection types. Use real anonymous classes:
+
+```php
+$policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        return AccessResult::allowed();
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        return AccessResult::neutral();
+    }
+
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'node';
+    }
+
+    public function fieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($fieldName === 'secret_field' && $operation === 'view') {
+            return AccessResult::forbidden('Restricted.');
+        }
+        return AccessResult::neutral();
+    }
+};
+
+$handler = new EntityAccessHandler([$policy]);
+```
+
+### Testing Patterns
+
+- Test that Neutral from `checkFieldAccess()` passes `!isForbidden()` (open-by-default).
+- Test that Forbidden from any policy short-circuits.
+- Test that policies not implementing `FieldAccessPolicyInterface` are skipped.
+- Test `filterFields()` with mixed access results.
+- Avoid double `$storage->create()` in access checks: when checking field access before persisting a new entity, create once and reuse for both the access check and the save.
+
+### Unit Test Locations
+
+```
+packages/access/tests/Unit/FieldAccessPolicyTest.php
+packages/access/tests/Unit/EntityAccessHandlerFieldAccessTest.php
+packages/api/tests/Unit/ResourceSerializerFieldAccessTest.php
+packages/api/tests/Unit/JsonApiControllerFieldAccessTest.php
+packages/api/tests/Unit/Schema/SchemaPresenterFieldAccessTest.php
+tests/Integration/Phase6/FieldAccessIntegrationTest.php
+```
+
+## File Reference
+
+```
+packages/access/src/
+    FieldAccessPolicyInterface.php   - Field access policy contract
+    AccessPolicyInterface.php        - Entity access policy contract (companion)
+    AccessResult.php                 - Tri-state value object
+    EntityAccessHandler.php          - checkFieldAccess(), filterFields()
+
+packages/api/src/
+    ResourceSerializer.php           - Omits view-denied fields
+    JsonApiController.php            - Checks edit access on mutations
+    Schema/
+        SchemaPresenter.php          - x-access-restricted annotation
+
+packages/admin/app/
+    composables/useSchema.ts         - Reads x-access-restricted
+    components/schema/SchemaForm.vue - Disabled prop for restricted fields
+    components/schema/SchemaField.vue - Passes disabled to widgets
+
+public/index.php                     - Wires access context into controllers
+```

--- a/docs/specs/field-access.md
+++ b/docs/specs/field-access.md
@@ -232,7 +232,7 @@ $accessHandler = new EntityAccessHandler([]);
 For `SchemaController`, a prototype entity is created for policy evaluation:
 
 ```php
-$class = $entityType->getEntityClass();
+$class = $entityType->getClass();
 $prototypeEntity = new $class([]); // User/Node accept (array $values)
 $schema = $schemaPresenter->present($entityType, $fields, $prototypeEntity, $accessHandler, $account);
 ```

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,0 +1,609 @@
+# Infrastructure
+
+Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, and migration system.
+
+## Packages
+
+| Package | Namespace | Layer | Purpose |
+|---------|-----------|-------|---------|
+| `packages/foundation/` | `Waaseyaa\Foundation\` | 1 (Foundation) | DomainEvent, ServiceProvider, middleware interfaces, migration system, attribute discovery |
+| `packages/cache/` | `Waaseyaa\Cache\` | 1 (Foundation) | CacheBackendInterface, MemoryBackend, DatabaseBackend, NullBackend, tag invalidation |
+| `packages/database-legacy/` | `Waaseyaa\Database\` | 1 (Foundation) | DatabaseInterface, PdoDatabase, query builder (select/insert/update/delete), schema, transactions |
+| `packages/plugin/` | `Waaseyaa\Plugin\` | 2 (Core Data) | PluginManager, attribute-based plugin discovery, plugin factory |
+
+## Domain Events
+
+### DomainEvent base class
+
+File: `packages/foundation/src/Event/DomainEvent.php`
+
+```php
+namespace Waaseyaa\Foundation\Event;
+
+abstract class DomainEvent extends Event
+{
+    public readonly string $eventId;          // UUIDv7, auto-generated
+    public readonly \DateTimeImmutable $occurredAt;  // auto-set to now
+
+    public function __construct(
+        public readonly string $aggregateType,   // e.g., 'node', 'user', 'config'
+        public readonly string $aggregateId,     // entity ID or config name
+        public readonly ?string $tenantId = null,
+        public readonly ?string $actorId = null,
+    );
+
+    abstract public function getPayload(): array;
+}
+```
+
+All properties are `public readonly`. There are no getter methods.
+
+### Three-channel dispatch
+
+EventBus dispatches every DomainEvent through three channels in order:
+
+```
+DomainEvent dispatched
+    |
+    1. EventStore::append()        -- optional, for event sourcing
+    |
+    2. Sync listeners              -- Symfony EventDispatcher, wrapped by EventPipeline middleware
+    |                                 Cache invalidation, access index updates, validation side-effects
+    |                                 Must complete before response.
+    |
+    3. Async listeners             -- Symfony Messenger ($asyncBus->dispatch())
+    |                                 AI re-embedding, search re-indexing, webhook delivery
+    |
+    4. Broadcast listeners         -- BroadcasterInterface ($broadcaster->broadcast())
+                                     Admin SPA real-time updates via SSE
+```
+
+File: `packages/foundation/src/Event/EventBus.php`
+
+```php
+namespace Waaseyaa\Foundation\Event;
+
+final class EventBus
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $syncDispatcher,
+        private readonly MessageBusInterface $asyncBus,
+        private readonly BroadcasterInterface $broadcaster,
+        private readonly ?EventStoreInterface $eventStore = null,
+        private readonly ?EventPipeline $eventPipeline = null,
+    ) {}
+
+    public function dispatch(DomainEvent $event): void;
+}
+```
+
+When `$eventPipeline` is non-null, sync dispatch is wrapped in the event middleware pipeline. When null, sync dispatch calls the dispatcher directly.
+
+### Event attributes
+
+| Attribute | Target | File | Purpose |
+|-----------|--------|------|---------|
+| `#[Listener(priority: 0)]` | CLASS | `packages/foundation/src/Event/Attribute/Listener.php` | Mark class as event listener; event type inferred from `__invoke()` parameter |
+| `#[Async]` | METHOD | `packages/foundation/src/Event/Attribute/Async.php` | Route listener through Messenger async bus |
+| `#[Broadcast(channel: '...')]` | CLASS | `packages/foundation/src/Event/Attribute/Broadcast.php` | Route listener through SSE broadcaster |
+
+### Supporting interfaces
+
+| Interface | File | Method |
+|-----------|------|--------|
+| `EventStoreInterface` | `packages/foundation/src/Event/EventStoreInterface.php` | `append(DomainEvent $event): void` |
+| `BroadcasterInterface` | `packages/foundation/src/Event/BroadcasterInterface.php` | `broadcast(DomainEvent $event): void` |
+
+### Best-effort side effects
+
+Event listeners for non-critical operations (broadcasting, logging, cache invalidation) must wrap in try-catch and log via `error_log()` to avoid crashing the primary request. The project does not use `psr/log`.
+
+## Cache System
+
+### CacheBackendInterface
+
+File: `packages/cache/src/CacheBackendInterface.php`
+
+```php
+namespace Waaseyaa\Cache;
+
+interface CacheBackendInterface
+{
+    public const PERMANENT = -1;
+
+    public function get(string $cid): CacheItem|false;
+    public function getMultiple(array &$cids): array;   // pass-by-reference; $cids narrowed to misses
+    public function set(string $cid, mixed $data, int $expire = self::PERMANENT, array $tags = []): void;
+    public function delete(string $cid): void;
+    public function deleteMultiple(array $cids): void;
+    public function deleteAll(): void;
+    public function invalidate(string $cid): void;       // marks invalid but does not delete
+    public function invalidateMultiple(array $cids): void;
+    public function invalidateAll(): void;
+    public function removeBin(): void;                   // drops the entire bin
+}
+```
+
+### CacheItem
+
+File: `packages/cache/src/CacheItem.php`
+
+```php
+final readonly class CacheItem
+{
+    public function __construct(
+        public string $cid,
+        public mixed $data,
+        public int $created,
+        public int $expire = CacheBackendInterface::PERMANENT,
+        public array $tags = [],
+        public bool $valid = true,
+    ) {}
+}
+```
+
+### TagAwareCacheInterface
+
+File: `packages/cache/src/TagAwareCacheInterface.php`
+
+Extends `CacheBackendInterface` with:
+
+```php
+interface TagAwareCacheInterface extends CacheBackendInterface
+{
+    /** @param string[] $tags */
+    public function invalidateByTags(array $tags): void;
+}
+```
+
+### Backend implementations
+
+| Backend | File | Tag-aware | Notes |
+|---------|------|-----------|-------|
+| `MemoryBackend` | `packages/cache/src/Backend/MemoryBackend.php` | Yes | In-memory array; use for tests. Implements `TagAwareCacheInterface`. |
+| `DatabaseBackend` | `packages/cache/src/Backend/DatabaseBackend.php` | Yes | PDO-backed; auto-creates table on first use. `INSERT OR REPLACE`. Tags stored comma-separated. |
+| `NullBackend` | `packages/cache/src/Backend/NullBackend.php` | No | All gets return false; all writes are no-ops. Use for disabled bins. |
+
+### CacheFactory and CacheConfiguration
+
+File: `packages/cache/src/CacheFactory.php`, `packages/cache/src/CacheConfiguration.php`
+
+```php
+interface CacheFactoryInterface
+{
+    public function get(string $bin): CacheBackendInterface;
+}
+```
+
+`CacheFactory` creates backends per bin. `CacheConfiguration` maps bin names to backend classes or factory callables. Factory callables take precedence over class names for backends that need constructor arguments (e.g., DatabaseBackend needs a `\PDO`).
+
+```php
+$config = new CacheConfiguration(
+    defaultBackend: MemoryBackend::class,
+    binFactories: [
+        'cache_entity' => fn() => new DatabaseBackend($pdo, 'cache_entity'),
+    ],
+);
+$factory = new CacheFactory($config);
+$cache = $factory->get('cache_entity');  // returns DatabaseBackend
+$cache = $factory->get('cache_other');   // returns MemoryBackend
+```
+
+### Tag invalidation
+
+File: `packages/cache/src/CacheTagsInvalidator.php`
+
+`CacheTagsInvalidator` holds references to all registered cache bins and delegates `invalidateTags()` to those that implement `TagAwareCacheInterface`.
+
+### Cache event listeners
+
+| Listener | File | Listens to | Tags invalidated |
+|----------|------|-----------|------------------|
+| `EntityCacheInvalidator` | `packages/cache/src/Listener/EntityCacheInvalidator.php` | `EntityEvent` (post-save, post-delete) | `entity:{type}`, `entity:{type}:{id}` |
+| `ConfigCacheInvalidator` | `packages/cache/src/Listener/ConfigCacheInvalidator.php` | `ConfigEvent` (post-save, post-delete) | `config`, `config:{name}` |
+| `TranslationCacheInvalidator` | `packages/cache/src/Listener/TranslationCacheInvalidator.php` | Translation events | Translation-specific tags |
+
+### Atomic file writes pattern
+
+Cache files and compiled artifacts must use write-to-temp-then-rename to prevent serving partial writes:
+
+```php
+$tmpPath = $cachePath . '.tmp.' . getmypid();
+file_put_contents($tmpPath, $content);
+rename($tmpPath, $cachePath);
+```
+
+This pattern is used in `PackageManifestCompiler::compileAndCache()` and must be used anywhere the cache system writes PHP files to disk.
+
+## Database Layer
+
+### DatabaseInterface
+
+File: `packages/database-legacy/src/DatabaseInterface.php`
+
+```php
+namespace Waaseyaa\Database;
+
+interface DatabaseInterface
+{
+    public function select(string $table, string $alias = ''): SelectInterface;
+    public function insert(string $table): InsertInterface;
+    public function update(string $table): UpdateInterface;
+    public function delete(string $table): DeleteInterface;
+    public function schema(): SchemaInterface;
+    public function transaction(string $name = ''): TransactionInterface;
+    public function query(string $sql, array $args = []): \Traversable;
+}
+```
+
+**CRITICAL**: `DatabaseInterface` does NOT have `getPdo()`. If raw PDO is needed, type-hint `PdoDatabase` directly. Prefer using the query builder (`select()`, `insert()`, `update()`, `delete()`) over raw PDO.
+
+### PdoDatabase
+
+File: `packages/database-legacy/src/PdoDatabase.php`
+
+```php
+final class PdoDatabase implements DatabaseInterface
+{
+    public function __construct(private readonly \PDO $pdo);
+    public static function createSqlite(string $path = ':memory:'): self;
+    public function getPdo(): \PDO;   // ONLY on PdoDatabase, NOT on DatabaseInterface
+}
+```
+
+PdoDatabase sets two PDO attributes on construction:
+- `ATTR_ERRMODE` = `ERRMODE_EXCEPTION`
+- `ATTR_DEFAULT_FETCH_MODE` = `FETCH_ASSOC` (avoids duplicate numeric-indexed columns)
+
+### TransactionInterface
+
+File: `packages/database-legacy/src/TransactionInterface.php`
+
+```php
+interface TransactionInterface
+{
+    public function commit(): void;
+    public function rollBack(): void;
+}
+```
+
+`PdoTransaction` begins the transaction in its constructor. Calling `commit()` or `rollBack()` after the transaction is no longer active throws `\RuntimeException`.
+
+## Query Builder
+
+### SelectInterface
+
+File: `packages/database-legacy/src/SelectInterface.php`
+
+```php
+interface SelectInterface
+{
+    public function fields(string $tableAlias, array $fields = []): static;
+    public function addField(string $tableAlias, string $field, string $alias = ''): static;
+    public function condition(string $field, mixed $value, string $operator = '='): static;
+    public function isNull(string $field): static;
+    public function isNotNull(string $field): static;
+    public function orderBy(string $field, string $direction = 'ASC'): static;
+    public function range(int $offset, int $limit): static;
+    public function join(string $table, string $alias, string $condition): static;
+    public function leftJoin(string $table, string $alias, string $condition): static;
+    public function countQuery(): static;  // clones + wraps in COUNT(*)
+    public function execute(): \Traversable;
+}
+```
+
+### PdoSelect condition operators
+
+File: `packages/database-legacy/src/Query/PdoSelect.php`
+
+Supported operators in `condition()`:
+- `=`, `!=`, `<`, `>`, `<=`, `>=` -- standard comparison, single `?` placeholder
+- `IN`, `NOT IN` -- value must be array, generates `(?, ?, ...)` placeholders
+- `BETWEEN` -- value must be array of exactly 2
+- `LIKE`, `NOT LIKE` -- appends `ESCAPE '\'` automatically
+- `IS NULL`, `IS NOT NULL` -- use `isNull()`/`isNotNull()` methods instead
+
+**LIKE wildcard escaping**: When building LIKE patterns in application code (e.g., `SqlEntityQuery`), escape `%` and `_` in user input:
+```php
+$escaped = str_replace(['%', '_'], ['\\%', '\\_'], $userInput);
+$query->condition('title', '%' . $escaped . '%', 'LIKE');
+```
+
+All conditions are ANDed together. No OR support at this level.
+
+### InsertInterface
+
+File: `packages/database-legacy/src/InsertInterface.php`
+
+```php
+interface InsertInterface
+{
+    public function fields(array $fields): static;      // column names
+    public function values(array $values): static;      // can be called multiple times for batch
+    public function execute(): int|string;              // returns lastInsertId
+}
+```
+
+If `fields()` is not called, field names are inferred from the first `values()` call's array keys. Indexed arrays require prior `fields()` call.
+
+### UpdateInterface
+
+File: `packages/database-legacy/src/UpdateInterface.php`
+
+```php
+interface UpdateInterface
+{
+    public function fields(array $fields): static;      // ['column' => value]
+    public function condition(string $field, mixed $value, string $operator = '='): static;
+    public function execute(): int;                     // returns affected row count
+}
+```
+
+### DeleteInterface
+
+File: `packages/database-legacy/src/DeleteInterface.php`
+
+```php
+interface DeleteInterface
+{
+    public function condition(string $field, mixed $value, string $operator = '='): static;
+    public function execute(): int;                     // returns affected row count
+}
+```
+
+### Usage examples
+
+```php
+// Select with join
+$results = $db->select('node', 'n')
+    ->fields('n', ['nid', 'title'])
+    ->leftJoin('node_field_data', 'nfd', 'n.nid = nfd.nid')
+    ->condition('n.type', 'article')
+    ->orderBy('n.created', 'DESC')
+    ->range(0, 10)
+    ->execute();
+
+// Insert
+$db->insert('users')
+    ->values(['uid' => 1, 'name' => 'admin', 'mail' => 'admin@example.com'])
+    ->execute();
+
+// Update
+$affected = $db->update('users')
+    ->fields(['name' => 'superadmin'])
+    ->condition('uid', 1)
+    ->execute();
+
+// Delete
+$affected = $db->delete('sessions')
+    ->condition('expire', time(), '<')
+    ->execute();
+
+// Transaction
+$txn = $db->transaction();
+try {
+    $db->insert('audit_log')->values([...])->execute();
+    $txn->commit();
+} catch (\Throwable $e) {
+    $txn->rollBack();
+    throw $e;
+}
+```
+
+## Schema System
+
+### SchemaInterface (legacy)
+
+File: `packages/database-legacy/src/SchemaInterface.php`
+
+```php
+interface SchemaInterface
+{
+    public function tableExists(string $table): bool;
+    public function fieldExists(string $table, string $field): bool;
+    public function createTable(string $name, array $spec): void;
+    public function dropTable(string $table): void;
+    public function addField(string $table, string $field, array $spec): void;
+    public function dropField(string $table, string $field): void;
+    public function addIndex(string $table, string $name, array $fields): void;
+    public function dropIndex(string $table, string $name): void;
+    public function addUniqueKey(string $table, string $name, array $fields): void;
+    public function addPrimaryKey(string $table, array $fields): void;
+}
+```
+
+`PdoSchema` uses SQLite-specific SQL. Type mapping: `serial` -> INTEGER AUTOINCREMENT, `varchar` -> TEXT, `int`/`integer` -> INTEGER, `text` -> TEXT, `float`/`numeric`/`decimal` -> REAL, `blob` -> BLOB.
+
+Note: SQLite cannot add a primary key to an existing table. `addPrimaryKey()` throws `\RuntimeException`.
+
+## Migration System
+
+The migration system uses Doctrine DBAL (not the legacy PdoDatabase). It lives in `packages/foundation/src/Migration/`.
+
+### Migration base class
+
+File: `packages/foundation/src/Migration/Migration.php`
+
+```php
+abstract class Migration
+{
+    public array $after = [];  // package names this migration must run after
+
+    abstract public function up(SchemaBuilder $schema): void;
+    public function down(SchemaBuilder $schema): void {}  // optional rollback
+}
+```
+
+### SchemaBuilder
+
+File: `packages/foundation/src/Migration/SchemaBuilder.php`
+
+Uses Doctrine DBAL `Connection` + `Schema`. Creates tables via `TableBuilder` closure pattern:
+
+```php
+$schema->create('nodes', function (TableBuilder $table) {
+    $table->id();                           // string('id', 128)
+    $table->string('type', 64);
+    $table->text('title');
+    $table->json('_data')->nullable();
+    $table->timestamps();                   // created + changed timestamps
+    $table->primary(['id']);
+    $table->index(['type']);
+});
+```
+
+Other `SchemaBuilder` methods: `drop()`, `dropIfExists()`, `hasTable()`, `hasColumn()`.
+
+### TableBuilder column types
+
+File: `packages/foundation/src/Migration/TableBuilder.php`
+
+| Method | Column Type | Doctrine Type |
+|--------|------------|---------------|
+| `id(name)` | `string(name, 128)` | STRING |
+| `string(name, length)` | varchar | STRING |
+| `text(name)` | text | TEXT |
+| `integer(name)` | integer | INTEGER |
+| `boolean(name)` | boolean | BOOLEAN |
+| `float(name)` | float | FLOAT |
+| `json(name)` | json | JSON |
+| `timestamp(name)` | datetime_immutable | DATETIME_IMMUTABLE |
+
+Convenience methods: `timestamps()` (creates `created` + `changed`), `entityBase()` (id + entity_type + bundle + _data + timestamps), `translationColumns()` (langcode + default_langcode + translation_source), `revisionColumns()` (revision_id + revision_created + revision_log).
+
+### ColumnDefinition
+
+File: `packages/foundation/src/Migration/ColumnDefinition.php`
+
+Fluent modifiers: `->nullable()`, `->default(value)`, `->unique()`.
+
+### Migrator
+
+File: `packages/foundation/src/Migration/Migrator.php`
+
+```php
+final class Migrator
+{
+    public function __construct(Connection $connection, MigrationRepository $repository);
+
+    /** @param array<string, array<string, Migration>> $migrations  package => [name => Migration] */
+    public function run(array $migrations): MigrationResult;
+    public function rollback(array $migrations): MigrationResult;
+    public function status(array $migrations): array;  // ['pending' => [...], 'completed' => [...]]
+}
+```
+
+Migrations are topologically sorted by `Migration::$after` dependencies. Each batch gets an incrementing batch number. Rollback undoes the last batch in reverse order.
+
+### MigrationRepository
+
+File: `packages/foundation/src/Migration/MigrationRepository.php`
+
+Tracks executed migrations in the `waaseyaa_migrations` table:
+- `id` INTEGER PRIMARY KEY AUTOINCREMENT
+- `migration` VARCHAR(255) -- migration name
+- `package` VARCHAR(128) -- originating package
+- `batch` INTEGER -- batch number
+- `ran_at` TIMESTAMP
+
+### MigrationResult
+
+File: `packages/foundation/src/Migration/MigrationResult.php`
+
+```php
+final readonly class MigrationResult
+{
+    public function __construct(
+        public int $count,
+        public array $migrations = [],
+    ) {}
+}
+```
+
+## File Reference
+
+### packages/foundation/src/
+
+```
+Event/
+    DomainEvent.php              -- abstract base for all domain events
+    EventBus.php                 -- three-channel dispatcher (sync/async/broadcast)
+    EventStoreInterface.php      -- append-only event store
+    BroadcasterInterface.php     -- SSE/real-time broadcast
+    Attribute/
+        Listener.php             -- #[Listener(priority: 0)]
+        Async.php                -- #[Async] on method
+        Broadcast.php            -- #[Broadcast(channel: '...')]
+Middleware/
+    HttpMiddlewareInterface.php  -- process(Request, HttpHandlerInterface): Response
+    HttpHandlerInterface.php     -- handle(Request): Response
+    HttpPipeline.php             -- onion-pattern HTTP middleware stack
+    EventMiddlewareInterface.php -- process(DomainEvent, EventHandlerInterface): void
+    EventHandlerInterface.php    -- handle(DomainEvent): void
+    EventPipeline.php            -- onion-pattern event middleware stack
+    JobMiddlewareInterface.php   -- process(Job, JobHandlerInterface): void
+    JobHandlerInterface.php      -- handle(Job): void
+    JobPipeline.php              -- onion-pattern job middleware stack
+Migration/
+    Migration.php                -- abstract base, up()/down() + $after deps
+    SchemaBuilder.php            -- Doctrine DBAL table creation
+    TableBuilder.php             -- fluent column definition DSL
+    ColumnDefinition.php         -- nullable/default/unique modifiers
+    Migrator.php                 -- topological sort + batch execution
+    MigrationRepository.php      -- tracks completed migrations in DB
+    MigrationResult.php          -- count + list of ran migrations
+ServiceProvider/
+    ServiceProviderInterface.php -- register()/boot()/provides()/isDeferred()
+    ServiceProvider.php          -- abstract base with singleton/bind/tag helpers
+    ProviderDiscovery.php        -- reads composer installed.json extra.waaseyaa
+    ContainerCompiler.php        -- register phase -> boot phase -> Symfony DI container
+Discovery/
+    PackageManifest.php          -- typed DTO for cached manifest data
+    PackageManifestCompiler.php  -- reads composer metadata + scans PHP attributes -> packages.php
+Attribute/
+    AsFieldType.php              -- #[AsFieldType(id: '...', label: '...')]
+    AsEntityType.php             -- #[AsEntityType(id: '...', label: '...')]
+    AsMiddleware.php             -- #[AsMiddleware(pipeline: '...', priority: 0)]
+```
+
+### packages/cache/src/
+
+```
+CacheBackendInterface.php        -- get/set/delete/invalidate contract
+CacheItem.php                    -- readonly DTO: cid, data, created, expire, tags, valid
+CacheFactoryInterface.php        -- get(bin): CacheBackendInterface
+CacheFactory.php                 -- bin resolution via CacheConfiguration
+CacheConfiguration.php           -- bin->backend mapping, factory callables
+TagAwareCacheInterface.php       -- extends CacheBackendInterface + invalidateByTags()
+CacheTagsInvalidatorInterface.php -- invalidateTags(tags)
+CacheTagsInvalidator.php         -- delegates to all registered TagAwareCacheInterface bins
+Backend/
+    MemoryBackend.php            -- in-memory, tag-aware (use for tests)
+    DatabaseBackend.php          -- PDO-backed, auto-creates table, tag-aware
+    NullBackend.php              -- no-op backend
+Listener/
+    EntityCacheInvalidator.php   -- entity:{type}, entity:{type}:{id}
+    ConfigCacheInvalidator.php   -- config, config:{name}
+    TranslationCacheInvalidator.php
+```
+
+### packages/database-legacy/src/
+
+```
+DatabaseInterface.php            -- select/insert/update/delete/schema/transaction/query
+PdoDatabase.php                  -- implements DatabaseInterface, has getPdo()
+SelectInterface.php              -- fluent select builder
+InsertInterface.php              -- fluent insert builder
+UpdateInterface.php              -- fluent update builder
+DeleteInterface.php              -- fluent delete builder
+SchemaInterface.php              -- DDL operations (createTable, addField, etc.)
+TransactionInterface.php         -- commit/rollBack
+PdoTransaction.php               -- PDO transaction wrapper
+Query/
+    PdoSelect.php                -- SELECT with joins, conditions, ordering, pagination
+    PdoInsert.php                -- INSERT with field inference from values
+    PdoUpdate.php                -- UPDATE with conditions
+    PdoDelete.php                -- DELETE with conditions
+Schema/
+    PdoSchema.php                -- SQLite DDL implementation
+```

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -6,10 +6,10 @@ Specification for the foundational infrastructure layer of Waaseyaa CMS: domain 
 
 | Package | Namespace | Layer | Purpose |
 |---------|-----------|-------|---------|
-| `packages/foundation/` | `Waaseyaa\Foundation\` | 1 (Foundation) | DomainEvent, ServiceProvider, middleware interfaces, migration system, attribute discovery |
-| `packages/cache/` | `Waaseyaa\Cache\` | 1 (Foundation) | CacheBackendInterface, MemoryBackend, DatabaseBackend, NullBackend, tag invalidation |
-| `packages/database-legacy/` | `Waaseyaa\Database\` | 1 (Foundation) | DatabaseInterface, PdoDatabase, query builder (select/insert/update/delete), schema, transactions |
-| `packages/plugin/` | `Waaseyaa\Plugin\` | 2 (Core Data) | PluginManager, attribute-based plugin discovery, plugin factory |
+| `packages/foundation/` | `Waaseyaa\Foundation\` | 0 (Foundation) | DomainEvent, ServiceProvider, middleware interfaces, migration system, attribute discovery |
+| `packages/cache/` | `Waaseyaa\Cache\` | 0 (Foundation) | CacheBackendInterface, MemoryBackend, DatabaseBackend, NullBackend, tag invalidation |
+| `packages/database-legacy/` | `Waaseyaa\Database\` | 0 (Foundation) | DatabaseInterface, PdoDatabase, query builder (select/insert/update/delete), schema, transactions |
+| `packages/plugin/` | `Waaseyaa\Plugin\` | 0 (Foundation) | PluginManager, attribute-based plugin discovery, plugin factory |
 
 ## Domain Events
 

--- a/docs/specs/mcp-endpoint.md
+++ b/docs/specs/mcp-endpoint.md
@@ -1,0 +1,299 @@
+# MCP Endpoint
+
+## Overview
+
+The `waaseyaa/mcp` package exposes Waaseyaa's entity system as a remote MCP (Model Context Protocol) server over Streamable HTTP. External AI assistants (Claude Desktop, Cursor, etc.) and custom AI agents connect to a single `/mcp` endpoint to discover and invoke CRUD tools for all registered entity types. The package sits in Layer 6 (Interfaces) alongside CLI, SSR, and Admin.
+
+## Package
+
+- **Location:** `packages/mcp/`
+- **Namespace:** `Waaseyaa\Mcp\`
+- **Dependencies:** `waaseyaa/ai-schema`, `waaseyaa/ai-agent`, `waaseyaa/routing`, `waaseyaa/access`
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/McpEndpoint.php` | Main HTTP handler: auth, JSON-RPC dispatch, tool list/call |
+| `src/McpResponse.php` | Value object wrapping response body, status code, content type |
+| `src/McpRouteProvider.php` | Registers `/mcp` and `/.well-known/mcp.json` routes |
+| `src/McpServerCard.php` | Generates the `/.well-known/mcp.json` server card |
+| `src/Auth/McpAuthInterface.php` | Pluggable authentication contract |
+| `src/Auth/BearerTokenAuth.php` | MVP auth: opaque bearer token to account mapping |
+| `src/Bridge/ToolRegistryInterface.php` | Interface for accessing MCP tool definitions |
+| `src/Bridge/ToolExecutorInterface.php` | Interface for executing MCP tool calls |
+
+## McpEndpoint Class
+
+`McpEndpoint` is the main HTTP handler. It is a `final readonly class` that receives three dependencies via constructor injection:
+
+- `McpAuthInterface $auth` -- authenticates the request.
+- `ToolRegistryInterface $registry` -- provides tool definitions.
+- `ToolExecutorInterface $executor` -- executes tool calls.
+
+### handle() Method
+
+```php
+public function handle(
+    string $method,
+    string $body,
+    ?string $authorizationHeader,
+): McpResponse
+```
+
+The method processes requests in this order:
+
+1. **Authenticate** -- calls `$this->auth->authenticate($authorizationHeader)`. If null is returned, responds with HTTP 401 and a JSON-RPC error (code `-32001`, message "Unauthorized").
+2. **Parse JSON-RPC** -- decodes the body with `json_decode()`. On `JsonException`, returns parse error (code `-32700`). On missing `method` field, returns invalid request (code `-32600`).
+3. **Dispatch** -- matches the JSON-RPC method to an internal handler:
+   - `initialize` -- returns protocol version (`2025-03-26`), capabilities, and server info.
+   - `ping` -- returns an empty result.
+   - `tools/list` -- iterates `$registry->getTools()` and returns tool definitions.
+   - `tools/call` -- validates `params.name`, looks up the tool, and delegates to `$executor->execute()`.
+   - Any other method returns a "Method not found" error (code `-32601`).
+
+### McpResponse
+
+A `final readonly class` value object:
+
+```php
+final readonly class McpResponse
+{
+    public function __construct(
+        public string $body,
+        public int $statusCode = 200,
+        public string $contentType = 'application/json',
+    ) {}
+}
+```
+
+All endpoint responses are wrapped in `McpResponse`. The front controller converts this to a proper HTTP response.
+
+## Authentication
+
+### McpAuthInterface
+
+```php
+interface McpAuthInterface
+{
+    public function authenticate(?string $authorizationHeader): ?AccountInterface;
+}
+```
+
+Takes the raw `Authorization` header value. Returns the authenticated `AccountInterface` or `null` on failure. The interface is deliberately minimal so implementations can be swapped without changing the endpoint.
+
+### BearerTokenAuth
+
+MVP implementation that maps opaque bearer tokens to user accounts:
+
+```php
+final readonly class BearerTokenAuth implements McpAuthInterface
+{
+    /** @param array<string, AccountInterface> $tokens */
+    public function __construct(private array $tokens) {}
+}
+```
+
+Behavior:
+- Returns `null` if the header is missing or empty.
+- Returns `null` if the header does not start with `Bearer ` (case-insensitive check).
+- Extracts the token (characters after `Bearer `) and looks it up in the `$tokens` map.
+- Each token maps to a specific user account, so MCP tool calls respect entity access control.
+- No token expiry in MVP. OAuth 2.1 adapter replaces this later.
+
+### Authentication Roadmap
+
+| Phase | Implementation | Notes |
+|-------|---------------|-------|
+| MVP (v0.1.0) | `BearerTokenAuth` | Opaque tokens, no expiry |
+| v0.2.0 | OAuth 2.1 adapter | PKCE, resource indicators, RFC 9728 |
+| v0.3.0+ | Scoped permissions | Per-tool authorization, rate limiting |
+
+## Tool Registry
+
+### ToolRegistryInterface
+
+```php
+interface ToolRegistryInterface
+{
+    /** @return McpToolDefinition[] */
+    public function getTools(): array;
+
+    public function getTool(string $name): ?McpToolDefinition;
+}
+```
+
+Abstracts the `SchemaRegistry` so the MCP endpoint can be tested independently. Each `McpToolDefinition` (from `waaseyaa/ai-schema`) provides a name, description, and JSON Schema input definition. Tool definitions are auto-discovered from all registered entity types -- each entity type gets 5 CRUD tools (create, read, update, delete, list).
+
+### Tool Discovery Flow
+
+```
+EntityType registration
+    -> SchemaRegistry builds McpToolDefinition[]
+    -> ToolRegistryInterface exposes them
+    -> McpEndpoint::handleToolsList() serializes via toArray()
+```
+
+## Bridge Adapters
+
+The `Bridge/` namespace contains interfaces that decouple the MCP endpoint from concrete AI-layer classes.
+
+### ToolRegistryInterface
+
+Bridges `SchemaRegistry::getTools()` to the endpoint. See Tool Registry section above.
+
+### ToolExecutorInterface
+
+```php
+interface ToolExecutorInterface
+{
+    /**
+     * @param string $toolName e.g. "create_node", "read_user"
+     * @param array<string, mixed> $arguments Tool input arguments.
+     * @return array{content: array<int, array{type: string, text: string}>, isError?: bool}
+     */
+    public function execute(string $toolName, array $arguments): array;
+}
+```
+
+Delegates to `McpToolExecutor` which routes through `AgentExecutor::executeTool()` into entity storage. The return format follows the MCP tool result specification: an array of content blocks, each with a `type` (typically `"text"`) and `text` value.
+
+### Execution Flow
+
+```
+McpEndpoint::handleToolsCall()
+    -> ToolExecutorInterface::execute($toolName, $arguments)
+    -> McpToolExecutor -> AgentExecutor::executeTool()
+    -> Entity Storage (CRUD)
+    -> Result as {content: [{type: "text", text: "..."}]}
+```
+
+## JSON-RPC Protocol
+
+All communication uses JSON-RPC 2.0 over HTTP.
+
+### Supported Methods
+
+| Method | Description |
+|--------|-------------|
+| `initialize` | Returns protocol version, capabilities, server info |
+| `ping` | Health check, returns empty result |
+| `tools/list` | Returns all registered tool definitions |
+| `tools/call` | Executes a tool by name with arguments |
+
+### Request Format
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "params": {
+        "name": "create_node",
+        "arguments": {"title": "Hello", "body": "World"}
+    },
+    "id": 1
+}
+```
+
+### Success Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "content": [{"type": "text", "text": "{\"id\": 42}"}]
+    }
+}
+```
+
+### Error Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "error": {"code": -32601, "message": "Method not found: resources/list"},
+    "id": 1
+}
+```
+
+### Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `-32700` | Parse error (invalid JSON) |
+| `-32600` | Invalid request (missing `method` field) |
+| `-32601` | Method not found |
+| `-32602` | Invalid params (missing tool name, unknown tool) |
+| `-32001` | Unauthorized (auth failure) |
+
+### Transport
+
+The MCP spec (protocol version 2025-03-26) defines Streamable HTTP as the remote transport:
+
+- Single endpoint at `/mcp` accepts POST and GET.
+- POST sends JSON-RPC messages. Server responds with `application/json`.
+- GET opens SSE stream for server-initiated messages (future).
+- Sessions use `Mcp-Session-Id` header.
+
+## Routes
+
+`McpRouteProvider` registers two routes:
+
+| Route Name | Path | Methods | Auth |
+|------------|------|---------|------|
+| `mcp.endpoint` | `/mcp` | POST, GET | Required |
+| `mcp.server_card` | `/.well-known/mcp.json` | GET | Public (`allowAll()`) |
+
+### Server Card
+
+`McpServerCard` generates the `/.well-known/mcp.json` response:
+
+```json
+{
+    "name": "Waaseyaa",
+    "version": "0.1.0",
+    "description": "AI-native content management system",
+    "endpoint": "/mcp",
+    "transport": "streamable-http",
+    "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+    },
+    "authentication": {
+        "type": "bearer"
+    }
+}
+```
+
+## MCP Feature Scope
+
+| Feature | MVP | Future |
+|---------|-----|--------|
+| `tools/list` | Yes | -- |
+| `tools/call` | Yes | -- |
+| `resources/list` | No | v0.2.0+ |
+| `resources/read` | No | v0.2.0+ |
+| `prompts/list` | No | v0.3.0+ |
+| Server card | Yes | Evolves with spec |
+| SSE streaming | No | Via SDK |
+| Session management | No | Via SDK |
+
+## File Reference
+
+```
+packages/mcp/
+  src/
+    McpEndpoint.php
+    McpResponse.php
+    McpRouteProvider.php
+    McpServerCard.php
+    Auth/
+      McpAuthInterface.php
+      BearerTokenAuth.php
+    Bridge/
+      ToolRegistryInterface.php
+      ToolExecutorInterface.php
+  composer.json
+```

--- a/docs/specs/middleware-pipeline.md
+++ b/docs/specs/middleware-pipeline.md
@@ -1,0 +1,370 @@
+# Middleware Pipeline
+
+Waaseyaa implements typed middleware pipelines for three execution contexts: HTTP requests, domain events, and background jobs. Each pipeline uses the onion pattern with separate, type-safe interface pairs. Middleware is discovered via PHP 8 attributes and compiled into sorted stacks.
+
+## Packages
+
+| Package | Role | Key files |
+|---------|------|-----------|
+| `packages/foundation/` | Interfaces, pipeline classes, `AsMiddleware` attribute, `PackageManifestCompiler` | `src/Middleware/`, `src/Attribute/AsMiddleware.php`, `src/Discovery/` |
+| `packages/routing/` | `AccessChecker`, `RouteBuilder` (route option helpers) | `src/AccessChecker.php`, `src/RouteBuilder.php` |
+| `packages/user/` | `SessionMiddleware` (resolves `_account` from PHP session) | `src/Middleware/SessionMiddleware.php` |
+| `packages/access/` | `AuthorizationMiddleware` (enforces route-level access) | `src/Middleware/AuthorizationMiddleware.php` |
+
+## Three Typed Pipeline Interfaces
+
+Each pipeline context has a paired middleware interface and handler interface. They are structurally identical but type-safe to prevent cross-pipeline wiring.
+
+### HTTP
+
+```
+packages/foundation/src/Middleware/HttpMiddlewareInterface.php
+packages/foundation/src/Middleware/HttpHandlerInterface.php
+packages/foundation/src/Middleware/HttpPipeline.php
+```
+
+```php
+// Namespace: Waaseyaa\Foundation\Middleware
+interface HttpMiddlewareInterface {
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}
+interface HttpHandlerInterface {
+    public function handle(Request $request): Response;
+}
+```
+
+- `Request` = `Symfony\Component\HttpFoundation\Request`
+- `Response` = `Symfony\Component\HttpFoundation\Response`
+- Returns a `Response` -- the HTTP pipeline produces a value.
+
+### Event
+
+```
+packages/foundation/src/Middleware/EventMiddlewareInterface.php
+packages/foundation/src/Middleware/EventHandlerInterface.php
+packages/foundation/src/Middleware/EventPipeline.php
+```
+
+```php
+// Namespace: Waaseyaa\Foundation\Middleware
+interface EventMiddlewareInterface {
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}
+interface EventHandlerInterface {
+    public function handle(DomainEvent $event): void;
+}
+```
+
+- `DomainEvent` = `Waaseyaa\Foundation\Event\DomainEvent` (abstract, extends Symfony `Event`)
+- Returns `void` -- event dispatch is side-effect-only.
+
+### Job
+
+```
+packages/foundation/src/Middleware/JobMiddlewareInterface.php
+packages/foundation/src/Middleware/JobHandlerInterface.php
+packages/foundation/src/Middleware/JobPipeline.php
+```
+
+```php
+// Namespace: Waaseyaa\Foundation\Middleware
+interface JobMiddlewareInterface {
+    public function process(Job $job, JobHandlerInterface $next): void;
+}
+interface JobHandlerInterface {
+    public function handle(Job $job): void;
+}
+```
+
+- `Job` = `Waaseyaa\Queue\Job`
+- Returns `void` -- job execution is side-effect-only.
+
+## Handler Interface Naming Convention
+
+Handler interfaces follow `{Type}HandlerInterface`. Middleware interfaces follow `{Type}MiddlewareInterface`.
+
+| Pipeline | Handler interface | Middleware interface |
+|----------|-------------------|---------------------|
+| HTTP | `HttpHandlerInterface` | `HttpMiddlewareInterface` |
+| Event | `EventHandlerInterface` | `EventMiddlewareInterface` |
+| Job | `JobHandlerInterface` | `JobMiddlewareInterface` |
+
+All six interfaces live in `Waaseyaa\Foundation\Middleware` namespace. The design document references `JobNextHandlerInterface` but the implemented interface is `JobHandlerInterface` -- use the actual name from the codebase.
+
+## Onion Pattern
+
+Each pipeline class (`HttpPipeline`, `EventPipeline`, `JobPipeline`) wraps a stack of middleware around a final handler. Execution order is outer-to-inner going in, inner-to-outer coming back.
+
+### How it works
+
+1. The pipeline receives an ordered array of middleware and a final handler.
+2. It iterates in **reverse** over the middleware array.
+3. Each middleware is wrapped in an anonymous class implementing the handler interface, creating a chain.
+4. The outermost wrapper is called first; it calls `$next->handle()` to proceed inward.
+
+### HttpPipeline implementation (canonical reference)
+
+```php
+// File: packages/foundation/src/Middleware/HttpPipeline.php
+final class HttpPipeline
+{
+    /** @param HttpMiddlewareInterface[] $middleware */
+    public function __construct(private readonly array $middleware = []) {}
+
+    public function withMiddleware(HttpMiddlewareInterface $middleware): self
+    {
+        return new self([...$this->middleware, $middleware]);
+    }
+
+    public function handle(Request $request, HttpHandlerInterface $finalHandler): Response
+    {
+        if ($this->middleware === []) {
+            return $finalHandler->handle($request);
+        }
+        $handler = $finalHandler;
+        foreach (array_reverse($this->middleware) as $mw) {
+            $next = $handler;
+            $handler = new class($mw, $next) implements HttpHandlerInterface {
+                public function __construct(
+                    private readonly HttpMiddlewareInterface $middleware,
+                    private readonly HttpHandlerInterface $next,
+                ) {}
+                public function handle(Request $request): Response {
+                    return $this->middleware->process($request, $this->next);
+                }
+            };
+        }
+        return $handler->handle($request);
+    }
+}
+```
+
+Key details:
+- `HttpPipeline` is immutable. `withMiddleware()` returns a new instance.
+- Empty middleware array short-circuits directly to the final handler.
+- `EventPipeline` and `JobPipeline` follow the same pattern but return `void`.
+
+### Execution order example
+
+Given middleware `[A, B]` added in order, execution proceeds:
+
+```
+A::process() enters
+  B::process() enters
+    finalHandler::handle() executes
+  B::process() exits
+A::process() exits
+```
+
+A middleware can short-circuit by returning a response without calling `$next->handle()`.
+
+## HTTP Pipeline Chain
+
+The production HTTP pipeline in `public/index.php` wires two middleware in this order:
+
+```
+SessionMiddleware -> AuthorizationMiddleware -> final handler
+```
+
+### Wiring code (from public/index.php)
+
+```php
+$pipeline = (new HttpPipeline())
+    ->withMiddleware(new SessionMiddleware($userStorage))
+    ->withMiddleware(new AuthorizationMiddleware($accessChecker));
+
+$authResponse = $pipeline->handle(
+    $httpRequest,
+    new class implements HttpHandlerInterface {
+        public function handle(HttpRequest $request): HttpResponse {
+            return new HttpResponse('', 200);
+        }
+    },
+);
+```
+
+### SessionMiddleware
+
+**File:** `packages/user/src/Middleware/SessionMiddleware.php`
+**Namespace:** `Waaseyaa\User\Middleware`
+**Implements:** `HttpMiddlewareInterface`
+
+Behavior:
+1. Reads `$_SESSION['waaseyaa_uid']` (or `$request->attributes->get('_session')` for testability).
+2. Loads `User` entity via `EntityStorageInterface::load($uid)`.
+3. Falls back to `AnonymousUser` if uid is null, user not found, or storage throws.
+4. Sets `AccountInterface` instance on `$request->attributes->set('_account', $account)`.
+5. Calls `$next->handle($request)`.
+
+This middleware always calls the next handler. It never short-circuits.
+
+### AuthorizationMiddleware
+
+**File:** `packages/access/src/Middleware/AuthorizationMiddleware.php`
+**Namespace:** `Waaseyaa\Access\Middleware`
+**Implements:** `HttpMiddlewareInterface`
+
+Behavior:
+1. Reads `Route` from `$request->attributes->get('_route_object')`. If null, passes through.
+2. Reads `AccountInterface` from `$request->attributes->get('_account')`. If missing/invalid, returns 403.
+3. Delegates to `AccessChecker::check($route, $account)`.
+4. If `$result->isForbidden()`, returns 403 JSON:API response.
+5. Otherwise (allowed or neutral), calls `$next->handle($request)`.
+
+This middleware can short-circuit with a 403 response.
+
+### Pre-pipeline steps in index.php
+
+CORS handling and route matching happen **before** the pipeline runs. The matched `Route` object is set on `$request->attributes->set('_route_object', $matchedRoute)` before the pipeline starts. This is required because `AuthorizationMiddleware` reads it from the request.
+
+## Middleware Discovery
+
+### AsMiddleware attribute
+
+**File:** `packages/foundation/src/Attribute/AsMiddleware.php`
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMiddleware
+{
+    public function __construct(
+        public readonly string $pipeline,   // 'http', 'event', or 'job'
+        public readonly int $priority = 0,  // Higher = runs first
+    ) {}
+}
+```
+
+Usage on a middleware class:
+
+```php
+#[AsMiddleware(pipeline: 'http', priority: 100)]
+final class TenantResolverMiddleware implements HttpMiddlewareInterface { ... }
+```
+
+### PackageManifestCompiler
+
+**File:** `packages/foundation/src/Discovery/PackageManifestCompiler.php`
+
+The compiler scans all `Waaseyaa\\*` classes in the Composer classmap for `AsMiddleware` attributes. Discovered middleware is stored in the `PackageManifest::$middleware` property, keyed by pipeline name:
+
+```php
+// PackageManifest::$middleware type
+array<string, list<array{class: string, priority: int}>>
+```
+
+Example compiled manifest entry:
+
+```php
+'middleware' => [
+    'http' => [
+        ['class' => 'Waaseyaa\\...\\TenantResolverMiddleware', 'priority' => 100],
+        ['class' => 'Waaseyaa\\...\\LanguageNegotiatorMiddleware', 'priority' => 90],
+    ],
+    'event' => [
+        ['class' => 'Waaseyaa\\...\\TenantScopeMiddleware', 'priority' => 100],
+    ],
+],
+```
+
+Middleware stacks are sorted by priority descending (`$b['priority'] <=> $a['priority']`). Higher priority runs first (outermost in the onion).
+
+### Cached artifact
+
+Written to `storage/framework/packages.php` by `PackageManifestCompiler::compileAndCache()`. Uses atomic write-to-temp-then-rename pattern to prevent partial reads.
+
+## Route Options for Access Control
+
+Routes declare access requirements via Symfony Route options. `AccessChecker` reads these at runtime.
+
+| Option | Type | Meaning |
+|--------|------|---------|
+| `_public` | `bool` | If `true`, skip all access checks. Anyone can access. |
+| `_permission` | `string` | Require `$account->hasPermission($permission)` to return `true`. |
+| `_role` | `string` | Comma-separated role list. Account must have at least one. |
+| `_gate` | `array{ability: string, subject?: mixed}` | Delegates to `GateInterface::allows()`. |
+
+**Combination logic:** Multiple options are combined with AND. All must pass.
+
+**No requirements:** If no options are set, `AccessChecker` returns `AccessResult::neutral()`. The `AuthorizationMiddleware` treats neutral as "pass through" (open-by-default).
+
+### RouteBuilder helpers
+
+```php
+// File: packages/routing/src/RouteBuilder.php
+RouteBuilder::create('/api/nodes')
+    ->requirePermission('access content')  // sets _permission option
+    ->requireRole('editor')                // sets _role option
+    ->allowAll()                           // sets _public = true
+    ->build();
+```
+
+## php://input Single-Read Constraint
+
+`HttpRequest::createFromGlobals()` consumes `php://input`. The stream cannot be read again.
+
+**Rule:** After creating the Symfony `Request` object, always use `$httpRequest->getContent()` to read the request body. Never call `file_get_contents('php://input')` afterward.
+
+This is visible in `public/index.php`:
+
+```php
+$httpRequest = HttpRequest::createFromGlobals();
+// ... later, in the dispatch section:
+$raw = $httpRequest->getContent();  // Correct: reads from the Request object
+```
+
+## File Reference
+
+### Interfaces (packages/foundation/src/Middleware/)
+
+| File | Interface |
+|------|-----------|
+| `HttpMiddlewareInterface.php` | `process(Request, HttpHandlerInterface): Response` |
+| `HttpHandlerInterface.php` | `handle(Request): Response` |
+| `EventMiddlewareInterface.php` | `process(DomainEvent, EventHandlerInterface): void` |
+| `EventHandlerInterface.php` | `handle(DomainEvent): void` |
+| `JobMiddlewareInterface.php` | `process(Job, JobHandlerInterface): void` |
+| `JobHandlerInterface.php` | `handle(Job): void` |
+
+### Pipeline classes (packages/foundation/src/Middleware/)
+
+| File | Class |
+|------|-------|
+| `HttpPipeline.php` | `HttpPipeline` -- immutable, `withMiddleware()` returns new instance |
+| `EventPipeline.php` | `EventPipeline` -- same pattern, returns `void` |
+| `JobPipeline.php` | `JobPipeline` -- same pattern, returns `void` |
+
+### Discovery (packages/foundation/)
+
+| File | Class |
+|------|-------|
+| `src/Attribute/AsMiddleware.php` | `AsMiddleware` -- `#[Attribute]` with `pipeline` and `priority` |
+| `src/Discovery/PackageManifestCompiler.php` | `PackageManifestCompiler` -- scans classes, compiles manifest |
+| `src/Discovery/PackageManifest.php` | `PackageManifest` -- typed DTO with `$middleware` property |
+
+### Concrete middleware
+
+| File | Class | Pipeline |
+|------|-------|----------|
+| `packages/user/src/Middleware/SessionMiddleware.php` | `SessionMiddleware` | HTTP |
+| `packages/access/src/Middleware/AuthorizationMiddleware.php` | `AuthorizationMiddleware` | HTTP |
+
+### Access checking (packages/routing/)
+
+| File | Class |
+|------|-------|
+| `src/AccessChecker.php` | `AccessChecker` -- reads `_public`, `_permission`, `_role`, `_gate` from Route options |
+| `src/RouteBuilder.php` | `RouteBuilder` -- fluent API with `requirePermission()`, `requireRole()`, `allowAll()` |
+
+### Front controller
+
+| File | Role |
+|------|------|
+| `public/index.php` | Wires CORS, route matching, `HttpPipeline` (Session + Auth), dispatch |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php` | SessionMiddleware unit tests |
+| `packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php` | AuthorizationMiddleware unit tests |
+| `tests/Integration/Phase11/AuthorizationPipelineTest.php` | Full pipeline integration (Session + Auth + final handler) |

--- a/docs/specs/package-discovery.md
+++ b/docs/specs/package-discovery.md
@@ -1,0 +1,569 @@
+# Package Discovery
+
+Specification for how Waaseyaa packages are discovered, registered, booted, and compiled into optimized artifacts.
+
+## Overview
+
+Waaseyaa uses a two-phase discovery system:
+
+1. **Coarse-grained**: Composer `extra.waaseyaa` in each package's `composer.json` declares providers, commands, routes, migrations, and permissions.
+2. **Fine-grained**: PHP 8 attributes on classes (`#[AsFieldType]`, `#[Listener]`, `#[AsMiddleware]`, `PolicyAttribute`) are scanned at compile time from Composer's autoload classmap.
+
+Both are unified by `PackageManifestCompiler` into a single cached artifact at `storage/framework/packages.php`.
+
+## ServiceProvider Lifecycle
+
+### Interface
+
+File: `packages/foundation/src/ServiceProvider/ServiceProviderInterface.php`
+
+```php
+namespace Waaseyaa\Foundation\ServiceProvider;
+
+interface ServiceProviderInterface
+{
+    public function register(): void;
+    public function boot(): void;
+    public function provides(): array;
+    public function isDeferred(): bool;
+}
+```
+
+### Abstract base class
+
+File: `packages/foundation/src/ServiceProvider/ServiceProvider.php`
+
+```php
+abstract class ServiceProvider implements ServiceProviderInterface
+{
+    abstract public function register(): void;
+    public function boot(): void {}
+
+    public function provides(): array { return []; }
+    public function isDeferred(): bool { return $this->provides() !== []; }
+
+    // Binding helpers
+    protected function singleton(string $abstract, string|callable $concrete): void;
+    protected function bind(string $abstract, string|callable $concrete): void;
+    protected function tag(string $abstract, string $tag): void;
+
+    // Introspection (used by ContainerCompiler)
+    public function getBindings(): array;   // ['abstract' => ['concrete' => ..., 'shared' => bool]]
+    public function getTags(): array;       // ['tag' => ['service1', 'service2']]
+}
+```
+
+### Two-phase lifecycle
+
+**Phase 1 -- register()**: Pure binding. No side effects. No resolving other services. All packages call `register()` before any `boot()` runs.
+
+```php
+public function register(): void
+{
+    $this->singleton(EntityStorageInterface::class, SqlEntityStorage::class);
+    $this->singleton(EntityTypeManagerInterface::class, EntityTypeManager::class);
+    $this->tag(SqlEntityStorage::class, 'storage');
+}
+```
+
+**Phase 2 -- boot()**: All bindings are available from all packages. Safe to resolve cross-package dependencies, register event listeners, configure services.
+
+```php
+public function boot(): void
+{
+    // All packages are registered; cross-package resolution is safe here
+}
+```
+
+### Deferred providers
+
+A provider is deferred if `provides()` returns a non-empty array. Deferred providers are only loaded when one of their declared interfaces is first resolved. This keeps cold boot fast.
+
+```php
+public function provides(): array
+{
+    return [AiEmbedderInterface::class, AiCompletionInterface::class];
+}
+```
+
+### ContainerCompiler
+
+File: `packages/foundation/src/ServiceProvider/ContainerCompiler.php`
+
+Orchestrates the two-phase lifecycle and wires bindings into Symfony's `ContainerBuilder`:
+
+```php
+final class ContainerCompiler
+{
+    public function compile(array $providers, ContainerBuilder $container): void
+    {
+        // Phase 1: register all bindings
+        foreach ($providers as $provider) {
+            $provider->register();
+            // Map getBindings() -> ContainerBuilder definitions
+            // Map getTags() -> ContainerBuilder tags
+        }
+
+        // Phase 2: boot all providers
+        foreach ($providers as $provider) {
+            $provider->boot();
+        }
+    }
+}
+```
+
+Binding properties:
+- `shared: true` (from `singleton()`) -> `Definition::setShared(true)`
+- `shared: false` (from `bind()`) -> `Definition::setShared(false)`
+- Callable concrete values -> `Definition::setFactory($concrete)`
+- All definitions are set to `public: true`
+
+## Composer Manifest
+
+### Package composer.json format
+
+Each package declares its registration metadata in `extra.waaseyaa`:
+
+```json
+{
+    "name": "waaseyaa/node",
+    "extra": {
+        "waaseyaa": {
+            "providers": ["Waaseyaa\\Node\\NodeServiceProvider"],
+            "commands": ["Waaseyaa\\Node\\Command\\NodeCreateCommand"],
+            "routes": ["Waaseyaa\\Node\\NodeRouteProvider"],
+            "migrations": "migrations/",
+            "config": "config/",
+            "permissions": {
+                "create node content": {
+                    "title": "Create node content",
+                    "description": "Allows creating new nodes"
+                }
+            }
+        }
+    }
+}
+```
+
+Supported keys:
+| Key | Type | Purpose |
+|-----|------|---------|
+| `providers` | `string[]` | ServiceProvider FQCNs |
+| `commands` | `string[]` | CLI command FQCNs |
+| `routes` | `string[]` | Route provider FQCNs |
+| `migrations` | `string` | Path to migrations directory (relative to package) |
+| `config` | `string` | Path to default config directory |
+| `permissions` | `object` | Permission definitions with title and optional description |
+
+### Root composer.json conventions
+
+The monorepo root uses `@dev` constraints for all `waaseyaa/*` packages and path repository references:
+
+```json
+{
+    "repositories": [
+        { "type": "path", "url": "packages/*" }
+    ],
+    "require": {
+        "waaseyaa/foundation": "@dev",
+        "waaseyaa/entity": "@dev"
+    }
+}
+```
+
+### ProviderDiscovery
+
+File: `packages/foundation/src/ServiceProvider/ProviderDiscovery.php`
+
+Reads `vendor/composer/installed.json` and collects all `extra.waaseyaa.providers` entries:
+
+```php
+final class ProviderDiscovery
+{
+    public function discoverFromArray(array $installed): array;
+    public function discoverFromVendor(string $vendorPath): array;
+}
+```
+
+Returns `list<class-string<ServiceProviderInterface>>`.
+
+## PackageManifest
+
+### PackageManifest DTO
+
+File: `packages/foundation/src/Discovery/PackageManifest.php`
+
+```php
+final class PackageManifest
+{
+    public function __construct(
+        public readonly array $providers = [],      // string[]
+        public readonly array $commands = [],       // string[]
+        public readonly array $routes = [],         // string[]
+        public readonly array $migrations = [],     // [packageName => path]
+        public readonly array $fieldTypes = [],     // [id => className]
+        public readonly array $listeners = [],      // [eventClass => [{class, priority}]]
+        public readonly array $middleware = [],      // [pipeline => [{class, priority}]]
+        public readonly array $permissions = [],    // [id => {title, description?}]
+        public readonly array $policies = [],       // [entityType => className]
+    ) {}
+
+    public static function fromArray(array $data): self;
+    public function toArray(): array;
+}
+```
+
+When deserializing from cache, `permissions` and `policies` are optional keys (`$data['permissions'] ?? []`). This supports backward-compatible cache evolution -- old cache files missing new keys will not break.
+
+Required cache keys: `providers`, `commands`, `routes`, `migrations`, `field_types`, `listeners`, `middleware`.
+
+### PackageManifestCompiler
+
+File: `packages/foundation/src/Discovery/PackageManifestCompiler.php`
+
+```php
+final class PackageManifestCompiler
+{
+    public function __construct(
+        private readonly string $basePath,      // project root
+        private readonly string $storagePath,   // storage/ directory
+    );
+
+    public function compile(): PackageManifest;
+    public function compileAndCache(): PackageManifest;
+    public function load(): PackageManifest;           // cache-first, compile on miss
+}
+```
+
+**Compile pipeline:**
+
+1. Read `vendor/composer/installed.json` for coarse-grained manifest data (providers, commands, routes, migrations, permissions)
+2. Read `vendor/composer/autoload_classmap.php` for all Waaseyaa-namespaced classes
+3. Reflect each class, checking for discovery attributes
+4. Sort middleware and listeners by priority (descending -- highest priority first)
+5. Produce `PackageManifest` instance
+
+**Attribute scanning details:**
+
+The compiler scans classes that start with `Waaseyaa\` from the classmap. For each concrete (non-abstract, non-interface, non-trait) class:
+
+| Attribute | What it discovers | How |
+|-----------|------------------|-----|
+| `AsFieldType` | Field type plugins | `$instance->id` => class name |
+| `Listener` | Event listeners | Reads `__invoke()` parameter type to determine event class; `$instance->priority` for ordering |
+| `AsMiddleware` | Middleware | `$instance->pipeline` (http/event/job) + `$instance->priority` |
+| `AsEntityType` | Entity types | Currently tracked via providers (no-op in compiler) |
+| `PolicyAttribute` | Access policies | `$instance->entityType` => class name |
+
+**Cache output**: `storage/framework/packages.php`
+
+```php
+<?php return [
+    'providers' => ['Waaseyaa\\Node\\NodeServiceProvider', ...],
+    'commands' => [...],
+    'routes' => [...],
+    'migrations' => ['waaseyaa/node' => '/path/to/migrations/', ...],
+    'field_types' => ['text' => 'Waaseyaa\\Field\\Plugin\\TextField', ...],
+    'listeners' => [
+        'Waaseyaa\\Entity\\Event\\EntitySaved' => [
+            ['class' => '...', 'priority' => 100],
+            ['class' => '...', 'priority' => 0],
+        ],
+    ],
+    'middleware' => [
+        'http' => [['class' => '...', 'priority' => 100], ...],
+        'event' => [...],
+        'job' => [...],
+    ],
+    'permissions' => [...],
+    'policies' => [...],
+];
+```
+
+**Dev vs. prod behavior:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Dev, no cache | `load()` compiles and writes cache |
+| Dev, cache exists | `load()` reads from cache; corrupt cache triggers recompile |
+| Prod | `waaseyaa optimize` pre-compiles; `load()` reads cache only |
+
+**Atomic file write**: Cache is written via temp file + `rename()` to prevent serving partial writes. See `compileAndCache()`.
+
+## Three Compilers
+
+The system has three independent compilers, orchestrated by `waaseyaa optimize`:
+
+| Compiler | Artifact | File |
+|----------|----------|------|
+| `PackageManifestCompiler` | `storage/framework/packages.php` | `packages/foundation/src/Discovery/PackageManifestCompiler.php` |
+| `MiddlewarePipelineCompiler` | `storage/framework/middleware.php` | `packages/foundation/src/Middleware/MiddlewarePipelineCompiler.php` |
+| `ConfigCacheCompiler` | `storage/framework/config.php` | `packages/config/src/Cache/ConfigCacheCompiler.php` |
+
+**Compilation order**: Manifest first (middleware and config compilers may need it):
+
+```
+optimize:manifest -> optimize:middleware -> optimize:config
+```
+
+### CLI commands
+
+| Command | Purpose |
+|---------|---------|
+| `waaseyaa optimize` | Run all compilers in order |
+| `waaseyaa optimize:clear` | Delete all cached artifacts |
+| `waaseyaa optimize:manifest` | Compile package manifest only |
+| `waaseyaa optimize:middleware` | Compile middleware pipelines only |
+| `waaseyaa optimize:config` | Compile config cache only |
+
+## Attribute Discovery
+
+### Discovery attributes defined in Foundation
+
+All discovery attributes live in `packages/foundation/src/Attribute/` and `packages/foundation/src/Event/Attribute/`:
+
+```php
+// packages/foundation/src/Attribute/AsFieldType.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsFieldType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}
+
+// packages/foundation/src/Attribute/AsEntityType.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsEntityType
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+}
+
+// packages/foundation/src/Attribute/AsMiddleware.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMiddleware
+{
+    public function __construct(
+        public readonly string $pipeline,   // 'http', 'event', 'job'
+        public readonly int $priority = 0,
+    ) {}
+}
+
+// packages/foundation/src/Event/Attribute/Listener.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class Listener
+{
+    public function __construct(
+        public readonly int $priority = 0,
+    ) {}
+}
+```
+
+### Plugin system attribute discovery
+
+The `packages/plugin/` package provides a separate attribute-based discovery system for extensible plugin types:
+
+```php
+// packages/plugin/src/Attribute/WaaseyaaPlugin.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class WaaseyaaPlugin
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $label = '',
+        public readonly string $description = '',
+        public readonly string $package = '',
+    ) {}
+}
+```
+
+`AttributeDiscovery` scans directories for classes with a given attribute (configurable per plugin type), extracts `PluginDefinition` objects, and caches them via `DefaultPluginManager`.
+
+```php
+// Discovery setup
+$discovery = new AttributeDiscovery(
+    directories: ['/path/to/packages/field/src/Plugin'],
+    attributeClass: AsFieldType::class,
+);
+$manager = new DefaultPluginManager($discovery, cache: $cacheBackend);
+$definitions = $manager->getDefinitions();
+$instance = $manager->createInstance('text');
+```
+
+### Cross-layer attribute scanning
+
+File: `packages/foundation/src/Discovery/PackageManifestCompiler.php`
+
+Foundation (layer 1) must never import from higher layers. When the compiler needs to scan for attributes defined in higher-layer packages (e.g., `PolicyAttribute` from the Access package), it uses string constants instead of `::class` references:
+
+```php
+private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
+
+// In scanning code:
+foreach ($ref->getAttributes(self::POLICY_ATTRIBUTE) as $attr) {
+    $instance = $attr->newInstance();
+    $policies[$instance->entityType] = $class;
+}
+```
+
+`ReflectionClass::getAttributes()` accepts string class names, so no import is needed. This preserves strict layer discipline.
+
+## Layer Discipline
+
+### Import rules
+
+Foundation (layer 1) must never import from higher layers. This is enforced by convention and code review:
+
+- Layer 1 (Foundation, Cache, Database) -> imports only PHP core and Symfony components
+- Layer 2 (Core Data: Entity, Config, Plugin) -> may import from layer 1
+- Layer 3 (Services: Access, Field, I18n) -> may import from layers 1-2
+- Higher layers follow the same upward-only pattern
+
+### Avoiding circular package dependencies
+
+Key ownership boundaries:
+- `packages/access/` owns `AccountInterface`
+- `packages/user/` owns `User`, `AnonymousUser`
+- `packages/access/` must NOT depend on `packages/user/`
+
+Middleware needing an account type-hints `AccountInterface`, never concrete `AnonymousUser`.
+
+### String constants for cross-layer attribute names
+
+When layer 1 code needs to reference attribute classes from higher layers:
+
+```php
+// WRONG -- creates import dependency on higher layer
+use Waaseyaa\Access\Gate\PolicyAttribute;
+
+// CORRECT -- string constant, no import
+private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
+```
+
+## Plugin System
+
+### Core interfaces
+
+File: `packages/plugin/src/PluginManagerInterface.php`
+
+```php
+interface PluginManagerInterface
+{
+    public function getDefinition(string $pluginId): PluginDefinition;
+    public function getDefinitions(): array;
+    public function hasDefinition(string $pluginId): bool;
+    public function createInstance(string $pluginId, array $configuration = []): PluginInspectionInterface;
+}
+```
+
+### PluginDefinition
+
+File: `packages/plugin/src/Definition/PluginDefinition.php`
+
+```php
+final readonly class PluginDefinition
+{
+    public function __construct(
+        public string $id,
+        public string $label,
+        public string $class,
+        public string $description = '',
+        public string $package = '',
+        public array $metadata = [],
+    ) {}
+}
+```
+
+### DefaultPluginManager
+
+File: `packages/plugin/src/DefaultPluginManager.php`
+
+Caches plugin definitions via `CacheBackendInterface`. On cache miss, delegates to `PluginDiscoveryInterface` to scan. Uses `ContainerFactory` to instantiate plugin instances.
+
+```php
+class DefaultPluginManager implements PluginManagerInterface
+{
+    public function __construct(
+        PluginDiscoveryInterface $discovery,
+        ?CacheBackendInterface $cache = null,
+        string $cacheKey = 'plugin_definitions',
+        ?PluginFactoryInterface $factory = null,
+    );
+
+    public function clearCachedDefinitions(): void;
+}
+```
+
+### Plugin base class
+
+File: `packages/plugin/src/PluginBase.php`
+
+```php
+abstract class PluginBase implements PluginInspectionInterface
+{
+    public function __construct(
+        protected readonly string $pluginId,
+        protected readonly PluginDefinition $pluginDefinition,
+        protected readonly array $configuration = [],
+    );
+}
+```
+
+Plugin classes extend `PluginBase` and receive their ID, definition, and configuration at construction time via `ContainerFactory`.
+
+## File Reference
+
+### packages/foundation/src/ServiceProvider/
+
+```
+ServiceProviderInterface.php    -- register/boot/provides/isDeferred contract
+ServiceProvider.php             -- abstract base with singleton/bind/tag + getBindings/getTags
+ProviderDiscovery.php           -- reads extra.waaseyaa.providers from installed.json
+ContainerCompiler.php           -- two-phase compile into Symfony ContainerBuilder
+```
+
+### packages/foundation/src/Discovery/
+
+```
+PackageManifest.php             -- typed DTO: fromArray/toArray with backward-compatible optional keys
+PackageManifestCompiler.php     -- compile from composer metadata + attributes; atomic cache write
+```
+
+### packages/foundation/src/Attribute/
+
+```
+AsFieldType.php                 -- #[AsFieldType(id, label)]
+AsEntityType.php                -- #[AsEntityType(id, label)]
+AsMiddleware.php                -- #[AsMiddleware(pipeline, priority)]
+```
+
+### packages/foundation/src/Event/Attribute/
+
+```
+Listener.php                    -- #[Listener(priority)]
+Async.php                       -- #[Async] marks method for async dispatch
+Broadcast.php                   -- #[Broadcast(channel)] marks for SSE broadcast
+```
+
+### packages/plugin/src/
+
+```
+PluginManagerInterface.php      -- getDefinition/getDefinitions/hasDefinition/createInstance
+DefaultPluginManager.php        -- cached discovery + factory instantiation
+PluginInspectionInterface.php   -- getPluginId/getPluginDefinition
+PluginBase.php                  -- abstract base (pluginId, definition, configuration)
+Attribute/
+    WaaseyaaPlugin.php          -- #[WaaseyaaPlugin(id, label, description, package)]
+Discovery/
+    PluginDiscoveryInterface.php -- getDefinitions(): array<string, PluginDefinition>
+    AttributeDiscovery.php       -- recursive directory scan + ReflectionClass attribute extraction
+Definition/
+    PluginDefinition.php         -- readonly DTO (id, label, class, description, package, metadata)
+Factory/
+    PluginFactoryInterface.php   -- createInstance(pluginId, configuration)
+    ContainerFactory.php         -- instantiates via new $class($pluginId, $definition, $configuration)
+```

--- a/docs/specs/package-discovery.md
+++ b/docs/specs/package-discovery.md
@@ -290,20 +290,21 @@ The compiler scans classes that start with `Waaseyaa\` from the classmap. For ea
 
 **Atomic file write**: Cache is written via temp file + `rename()` to prevent serving partial writes. See `compileAndCache()`.
 
-## Three Compilers
+## Two Compilers
 
-The system has three independent compilers, orchestrated by `waaseyaa optimize`:
+The system has two independent compilers, orchestrated by `waaseyaa optimize`:
 
 | Compiler | Artifact | File |
 |----------|----------|------|
 | `PackageManifestCompiler` | `storage/framework/packages.php` | `packages/foundation/src/Discovery/PackageManifestCompiler.php` |
-| `MiddlewarePipelineCompiler` | `storage/framework/middleware.php` | `packages/foundation/src/Middleware/MiddlewarePipelineCompiler.php` |
 | `ConfigCacheCompiler` | `storage/framework/config.php` | `packages/config/src/Cache/ConfigCacheCompiler.php` |
 
-**Compilation order**: Manifest first (middleware and config compilers may need it):
+`PackageManifestCompiler` handles middleware discovery via `#[AsMiddleware]` attribute scanning — middleware order is stored in the `middleware` key of `packages.php`. There is no separate middleware compiler.
+
+**Compilation order**: Manifest first (config compiler may need it):
 
 ```
-optimize:manifest -> optimize:middleware -> optimize:config
+optimize:manifest -> optimize:config
 ```
 
 ### CLI commands
@@ -398,7 +399,7 @@ $instance = $manager->createInstance('text');
 
 File: `packages/foundation/src/Discovery/PackageManifestCompiler.php`
 
-Foundation (layer 1) must never import from higher layers. When the compiler needs to scan for attributes defined in higher-layer packages (e.g., `PolicyAttribute` from the Access package), it uses string constants instead of `::class` references:
+Foundation (layer 0) must never import from higher layers. When the compiler needs to scan for attributes defined in higher-layer packages (e.g., `PolicyAttribute` from the Access package), it uses string constants instead of `::class` references:
 
 ```php
 private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
@@ -416,11 +417,11 @@ foreach ($ref->getAttributes(self::POLICY_ATTRIBUTE) as $attr) {
 
 ### Import rules
 
-Foundation (layer 1) must never import from higher layers. This is enforced by convention and code review:
+Foundation (layer 0) must never import from higher layers. This is enforced by convention and code review:
 
-- Layer 1 (Foundation, Cache, Database) -> imports only PHP core and Symfony components
-- Layer 2 (Core Data: Entity, Config, Plugin) -> may import from layer 1
-- Layer 3 (Services: Access, Field, I18n) -> may import from layers 1-2
+- Layer 0 (Foundation, Cache, Database) -> imports only PHP core and Symfony components
+- Layer 1 (Core Data: Entity, Access, User, Config, Field) -> may import from layer 0
+- Layer 2 (Content Types: Node, Taxonomy, Media) -> may import from layers 0-1
 - Higher layers follow the same upward-only pattern
 
 ### Avoiding circular package dependencies
@@ -434,7 +435,7 @@ Middleware needing an account type-hints `AccountInterface`, never concrete `Ano
 
 ### String constants for cross-layer attribute names
 
-When layer 1 code needs to reference attribute classes from higher layers:
+When layer 0 code needs to reference attribute classes from higher layers:
 
 ```php
 // WRONG -- creates import dependency on higher layer

--- a/skills/codified-context/SKILL.md
+++ b/skills/codified-context/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: codified-context
+description: Apply three-tier codified context architecture (constitution + specialist skills + subsystem specs with MCP retrieval) to any codebase. Based on arxiv.org/abs/2602.20478.
+---
+
+# Codified Context Infrastructure
+
+## When to Use
+When setting up or auditing AI-assisted development infrastructure for a codebase. Applies the three-tier architecture from "Codified Context: Infrastructure for AI Agents in a Complex Codebase" (arxiv.org/abs/2602.20478).
+
+The paper demonstrates that structured project knowledge -- constitution, specialist agents, and subsystem specs -- substantially improves AI-generated code consistency across sessions. The approach works for any codebase above ~20K lines where multiple AI sessions touch the same code.
+
+## The Three Tiers
+
+### Tier 1: Constitution (CLAUDE.md / project instructions)
+Hot memory loaded every session. Must stay under ~200 lines. Contains:
+- **Orchestration trigger table**: file pattern -> skill -> spec mapping
+- **Layer/architecture reference**: dependency hierarchy and rules
+- **Operation checklists**: common task recipes (3-5 steps each)
+- **Critical gotchas**: mistakes that recur across sessions
+
+The constitution answers "where do I look?" -- not "how does it work?"
+
+### Tier 2: Specialist Skills
+Domain expert agents loaded on demand via slash commands or automatic triggers. Each covers one logical subsystem. Key ratio: >50% domain knowledge, <50% behavioral instructions.
+
+Structure for each skill:
+1. **Scope** -- which packages/files this covers
+2. **Key Interfaces** -- methods, parameters, return types
+3. **Architecture** -- data flow with code patterns
+4. **Common Mistakes** -- domain-specific gotchas (superset of constitution)
+5. **Testing Patterns** -- in-memory strategies, fixtures, what to assert
+6. **Related Specs** -- which cold-memory specs to retrieve for deep context
+
+### Tier 3: Subsystem Specs + MCP Retrieval
+Cold memory retrieved via MCP tools when agents need deep context. Each spec covers one subsystem.
+- Written for AI consumption: explicit file paths, code patterns, interface signatures
+- NOT prose for humans -- structured data an agent can act on
+- Retrieved via keyword search (the paper found simple substring matching sufficient)
+
+## Process
+
+### Step 1: Audit Existing Context
+Read the current state of codified knowledge.
+
+**Actions:**
+- Read CLAUDE.md / project instructions and measure line count
+- Inventory existing docs/, plans/, design decisions
+- List any existing skills or agent configurations
+- Count: how many lines of codified context vs lines of source code?
+
+**Output:** A table like:
+
+| Tier | Current state | Gap |
+|------|--------------|-----|
+| 1. Constitution | X-line CLAUDE.md, no orchestration | Need trigger table, checklists |
+| 2. Skills | N generic skills, no domain skills | Need M domain skills |
+| 3. Specs | N plan docs (session artifacts) | Need reusable specs + retrieval |
+
+### Step 2: Analyze Codebase Structure
+Identify the natural domain boundaries that will become skills and specs.
+
+**Actions:**
+- Map the package/module directory structure
+- Identify layer hierarchy and dependency rules (which modules can import which)
+- Group packages into logical subsystems (typically 5-10 domains)
+- Count lines of code per subsystem to gauge complexity
+
+**Heuristics for grouping:**
+- Packages that share interfaces or data types belong together
+- Packages that are always modified together belong together
+- A subsystem should be large enough to justify a skill (~1K+ lines) but small enough to fit in one spec (~500 lines of documentation)
+
+### Step 3: Identify Knowledge to Codify
+Mine existing documentation for enduring architectural knowledge.
+
+**Actions:**
+- Read each existing design doc / plan / ADR
+- Separate session artifacts (one-time implementation plans) from reusable knowledge (interface contracts, data flow patterns, gotchas)
+- Catalog recurring mistakes from git history, bug reports, or existing gotcha lists
+- Identify testing patterns: what in-memory substitutes exist, what fixtures are standard
+
+**Key distinction:** Plans describe what was done and why. Specs describe how the system works now. Mine the former to create the latter.
+
+### Step 4: Expand Constitution (Tier 1)
+Grow the project instructions to serve as an orchestration hub.
+
+**Add these sections:**
+
+**4a. Orchestration Trigger Table**
+Map file patterns to skills and specs so any session knows where to find domain knowledge:
+```markdown
+## Orchestration
+| File pattern | Specialist skill | Cold memory spec |
+|---|---|---|
+| src/auth/*, src/middleware/auth* | project:auth | docs/specs/authentication.md |
+| src/api/*, src/routes/* | project:api | docs/specs/api-layer.md |
+```
+
+**4b. Architecture / Layer Reference**
+One-line-per-layer summary with dependency rules:
+```markdown
+## Layers
+Layer 0 (Foundation): core, utils, types
+Layer 1 (Data): models, storage, cache
+Layer 2 (Services): auth, payments, notifications
+Layer 3 (API): routes, controllers, serializers
+Rule: packages import only from their layer or lower.
+```
+
+**4c. Operation Checklists**
+3-5 step recipes for tasks that recur across sessions:
+```markdown
+## Common Operations
+- **Adding a model**: define schema, create migration, add storage class, register in container, add API routes
+- **Adding middleware**: implement interface, add discovery attribute, register in pipeline
+```
+
+**4d. Drift Warning**
+Add to gotchas section:
+```markdown
+- When refactoring a subsystem, update the relevant docs/specs/ file. Stale specs cause agents to generate code conflicting with recent changes.
+```
+
+**Target:** ~150-200 lines total. If over 250, move content down to skills.
+
+### Step 5: Create Domain Skills (Tier 2)
+Write one skill per identified subsystem.
+
+**For each subsystem, create `skills/<domain>/SKILL.md` with:**
+
+```markdown
+---
+name: project:<domain>
+description: <one sentence: when this skill triggers>
+---
+# <Domain> Specialist
+
+## Scope
+Packages: <list>
+Key files: <list of entry points>
+
+## Key Interfaces
+<Interface/class name>
+- <method signature with parameter types and return type>
+- <behavioral contract: what callers must know>
+
+## Architecture
+<Data flow description with inline code patterns>
+Example: "Request -> Middleware -> Controller -> Serializer. The controller
+calls $storage->load($id) which returns Entity|null. Null triggers 404."
+
+## Common Mistakes
+- <Mistake>: <why it happens> -> <correct pattern>
+- <Mistake>: <why it happens> -> <correct pattern>
+
+## Testing Patterns
+- <In-memory substitute>: use <class> instead of <real class>
+- <Fixture pattern>: <how to set up test data>
+- <What to assert>: <key assertions for this domain>
+
+## Related Specs
+- docs/specs/<spec>.md -- <what it covers>
+```
+
+**Quality check:** Read each skill and verify >50% of its lines are domain knowledge (interface signatures, code patterns, data flow) rather than instructions ("you should", "make sure to").
+
+### Step 6: Write Subsystem Specs (Tier 3)
+Write specs that encode deep implementation knowledge for MCP retrieval.
+
+**For each subsystem, create `docs/specs/<subsystem>.md` with:**
+
+```markdown
+# <Subsystem> Specification
+
+## File Map
+| File | Purpose |
+|------|---------|
+| src/path/to/File.php | <one-line purpose> |
+
+## Interface Signatures
+<Full method signatures with types, grouped by interface>
+
+## Data Flow
+<Step-by-step flow for primary operations: create, read, update, delete>
+<Include actual code patterns, not pseudocode>
+
+## Storage / Schema
+<Database tables, JSON structures, file formats>
+
+## Configuration
+<Config keys, environment variables, defaults>
+
+## Edge Cases
+<Boundary conditions, error handling, race conditions>
+```
+
+**Mining process:** For each existing design doc:
+1. Extract interface signatures (these rarely change)
+2. Extract data flow descriptions (update to match current implementation)
+3. Extract gotchas and edge cases
+4. Discard implementation timelines, phase breakdowns, task lists
+
+### Step 7: Build MCP Retrieval Server
+Scaffold a lightweight MCP server that exposes specs as searchable cold memory.
+
+**Location:** `tools/spec-retrieval/` (standalone, not part of the main application)
+
+**Three tools to implement:**
+
+| Tool | Parameters | Returns |
+|------|-----------|---------|
+| `list_specs` | none | Array of {name, description, file} |
+| `get_spec` | `name: string` | Full markdown content |
+| `search_specs` | `query: string` | Matching sections (keyword substring) |
+
+**Implementation:** ~200 lines in Node.js using `@modelcontextprotocol/sdk` with stdio transport. Reads markdown files from `docs/specs/`. Keyword substring matching is sufficient -- the paper found this outperformed more complex retrieval for structured specs.
+
+**Configuration:** Add to `.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "project-specs": {
+      "command": "node",
+      "args": ["tools/spec-retrieval/server.js"],
+      "cwd": "."
+    }
+  }
+}
+```
+
+### Step 8: Set Up Maintenance
+Prevent the #1 failure mode: stale specs.
+
+**8a. Drift Detection Script**
+Create `tools/drift-detector.sh` that maps recent file changes to affected specs:
+```
+$ tools/drift-detector.sh
+Files changed in last 5 commits:
+  src/api/controllers/UserController.ts -> docs/specs/api-layer.md
+  src/auth/middleware.ts -> docs/specs/authentication.md
+Warning: 2 specs may need review.
+```
+
+Build a mapping from file path patterns to spec files (same patterns as the orchestration trigger table).
+
+**8b. Session Discipline**
+After any session that changes a subsystem's behavior:
+1. Update constitution if gotchas changed
+2. Update relevant `docs/specs/` file if interfaces or data flow changed
+3. Run drift detector to catch anything missed
+
+**8c. Maintenance Cadence**
+- Per-session: update affected specs (~5 min when needed)
+- Biweekly: run drift detector, review flagged specs (~30 min)
+- Quarterly: audit coverage -- are new subsystems missing specs?
+
+## Quality Checklist
+- [ ] Constitution is under 200 lines (fits comfortably in hot memory)
+- [ ] Orchestration table covers all active packages/modules
+- [ ] Every skill has >50% domain knowledge content (not just instructions)
+- [ ] Every spec has explicit file paths, not vague descriptions
+- [ ] Every spec has full interface signatures with types
+- [ ] MCP retrieval returns useful results for common domain queries
+- [ ] Drift detector maps all active packages to specs
+- [ ] No circular references between tiers (constitution -> skills -> specs)
+- [ ] Operation checklists cover the 4-5 most common tasks
+
+## Anti-Patterns to Avoid
+- **Bloated constitution**: Over 300 lines defeats the hot-memory purpose. Move detail to skills.
+- **Instruction-heavy skills**: Skills that are mostly "you should" with little domain knowledge. Flip the ratio.
+- **Intent-based specs**: Specs that describe what the system should do instead of how it works now. Include code patterns, not aspirations.
+- **Volatile specs**: Specs for subsystems changing daily. Wait until interfaces stabilize.
+- **Complex retrieval**: MCP server with embeddings, vector DBs, or external dependencies. Keyword substring search on structured specs works.
+- **Orphan specs**: Specs not referenced by any skill or trigger table entry. Every spec must be reachable.
+
+## Metrics
+- **Knowledge-to-code ratio**: (lines of codified context / lines of source code). Target >5%.
+- **Spec coverage**: percentage of packages/modules covered by at least one spec.
+- **Spec staleness**: run drift detector weekly. Flag specs not updated in 30+ days if their packages changed.
+- **Session quality**: agents should find correct interfaces without exploring source files. Test by starting a fresh session and asking about a subsystem.

--- a/skills/waaseyaa/access-control/SKILL.md
+++ b/skills/waaseyaa/access-control/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: waaseyaa:access-control
+description: Use when working with access policies, field access, authorization middleware, gates, route access control, AccessResult semantics, permission handlers, or files in packages/access/, packages/routing/src/AccessChecker.php, packages/user/src/Middleware/. Covers entity-level access (deny-by-default via isAllowed), field-level access (open-by-default via !isForbidden), the Gate system, route options (_public, _permission, _role, _gate), and the SessionMiddleware/AuthorizationMiddleware pipeline in public/index.php.
+---
+
+# Access Control Specialist
+
+## Scope
+
+This skill covers the Waaseyaa access control system:
+
+- Entity-level access: `AccessPolicyInterface`, `EntityAccessHandler`, `AccessResult`
+- Field-level access: `FieldAccessPolicyInterface`, `checkFieldAccess()`, `filterFields()`
+- Route-level access: `AccessChecker`, route options, `AuthorizationMiddleware`
+- Gate system: `Gate`, `GateInterface`, `PolicyAttribute`, `AccessDeniedException`
+- Session resolution: `SessionMiddleware`, `AccountInterface`
+- Permission registry: `PermissionHandler`, `PermissionHandlerInterface`
+- API integration: `ResourceSerializer` field filtering, `SchemaPresenter` access annotations
+- Discovery: `#[AccessPolicy]` attribute, manifest compilation
+
+## Key Interfaces
+
+### AccessPolicyInterface
+
+**File:** `packages/access/src/AccessPolicyInterface.php`
+
+```php
+interface AccessPolicyInterface
+{
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult;
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult;
+    public function appliesTo(string $entityTypeId): bool;
+}
+```
+
+Operations for `access()`: `'view'`, `'update'`, `'delete'`.
+
+### FieldAccessPolicyInterface
+
+**File:** `packages/access/src/FieldAccessPolicyInterface.php`
+
+```php
+interface FieldAccessPolicyInterface
+{
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation, // 'view' or 'edit'
+        AccountInterface $account,
+    ): AccessResult;
+}
+```
+
+Must be implemented alongside `AccessPolicyInterface`. EntityAccessHandler finds field policies via `instanceof FieldAccessPolicyInterface`.
+
+### AccountInterface
+
+**File:** `packages/access/src/AccountInterface.php`
+
+```php
+interface AccountInterface
+{
+    public function id(): int|string;
+    public function hasPermission(string $permission): bool;
+    public function getRoles(): array; // string[]
+    public function isAuthenticated(): bool;
+}
+```
+
+### AccessResult
+
+**File:** `packages/access/src/AccessResult.php`
+
+Three states: `AccessResult::allowed()`, `AccessResult::neutral()`, `AccessResult::forbidden()`.
+
+Combination operators:
+- `orIf()`: Forbidden wins, either Allowed yields Allowed. Used by EntityAccessHandler.
+- `andIf()`: Forbidden wins, both must be Allowed. Used by AccessChecker for route requirements.
+
+### EntityAccessHandler
+
+**File:** `packages/access/src/EntityAccessHandler.php`
+
+```php
+class EntityAccessHandler
+{
+    public function __construct(array $policies = []);
+    public function addPolicy(AccessPolicyInterface $policy): void;
+    public function check(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult;
+    public function checkCreateAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult;
+    public function checkFieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult;
+    public function filterFields(EntityInterface $entity, array $fieldNames, string $operation, AccountInterface $account): array;
+}
+```
+
+### GateInterface
+
+**File:** `packages/access/src/Gate/GateInterface.php`
+
+```php
+interface GateInterface
+{
+    public function allows(string $ability, mixed $subject, ?object $user = null): bool;
+    public function denies(string $ability, mixed $subject, ?object $user = null): bool;
+    public function authorize(string $ability, mixed $subject, ?object $user = null): void;
+}
+```
+
+### AccessChecker
+
+**File:** `packages/routing/src/AccessChecker.php`
+
+```php
+final class AccessChecker
+{
+    public function __construct(private readonly ?GateInterface $gate = null);
+    public function check(Route $route, AccountInterface $account): AccessResult;
+    public static function applyGateToRoute(Route $route, string $ability, mixed $subject = null): void;
+}
+```
+
+Route options: `_public` (bool), `_permission` (string), `_role` (string, comma-separated), `_gate` (array).
+
+## Architecture
+
+### Authorization Pipeline
+
+```
+Request -> SessionMiddleware -> AuthorizationMiddleware -> Final Handler -> Response
+```
+
+- `SessionMiddleware` (`packages/user/src/Middleware/SessionMiddleware.php`): reads `$_SESSION['waaseyaa_uid']`, loads User entity, falls back to `AnonymousUser`, sets `_account` on request attributes.
+- `AuthorizationMiddleware` (`packages/access/src/Middleware/AuthorizationMiddleware.php`): reads `_account` and `_route_object` from request, delegates to `AccessChecker::check()`, returns 403 JSON:API response on Forbidden.
+
+### Asymmetric Access Semantics
+
+This is the most critical architectural detail:
+
+| Level | Check Method | Default Stance | Interpretation |
+|-------|-------------|----------------|----------------|
+| Entity | `$result->isAllowed()` | Deny unless granted | Neutral = denied |
+| Field | `!$result->isForbidden()` | Allow unless denied | Neutral = accessible |
+
+Entity access: deny-by-default. A policy must return `Allowed`.
+Field access: open-by-default. Only explicit `Forbidden` restricts.
+
+### Package Dependencies
+
+```
+access (layer 3) -- owns AccountInterface, AccessPolicyInterface, FieldAccessPolicyInterface, EntityAccessHandler
+    |
+    +-- Does NOT depend on user package
+    |
+user (layer 3) -- owns User, AnonymousUser, SessionMiddleware
+    |
+    +-- Depends on access (for AccountInterface)
+    |
+routing (layer 5) -- owns AccessChecker
+    |
+    +-- Depends on access (for AccessResult, AccountInterface, GateInterface)
+```
+
+`AccountInterface` lives in `access`, not `user`. This prevents circular dependencies. Always type-hint `AccountInterface`, not `AnonymousUser`.
+
+### Paired Nullable Parameters
+
+`ResourceSerializer::serialize()` and `SchemaPresenter::present()` accept `?EntityAccessHandler` + `?AccountInterface`. Both must be non-null or both null.
+
+```php
+if ($handler !== null && $account !== null) {
+    // Apply field filtering
+}
+```
+
+### x-access-restricted
+
+JSON Schema extension marking fields viewable but not editable. The admin SPA reads this to show disabled widgets. Distinct from system `readOnly` (id, uuid) which hides the field entirely.
+
+```json
+{
+  "status": {
+    "type": "boolean",
+    "readOnly": true,
+    "x-access-restricted": true
+  }
+}
+```
+
+## Common Mistakes
+
+### Wrong access check method for the level
+
+```php
+// WRONG: using isAllowed() for field check
+if ($handler->checkFieldAccess($entity, 'title', 'view', $account)->isAllowed()) { ... }
+
+// CORRECT: field access uses !isForbidden()
+if (!$handler->checkFieldAccess($entity, 'title', 'view', $account)->isForbidden()) { ... }
+```
+
+### Circular dependency: access depending on user
+
+```php
+// WRONG: importing from user package into access package
+use Waaseyaa\User\AnonymousUser;
+
+// CORRECT: type-hint the interface from access package
+use Waaseyaa\Access\AccountInterface;
+```
+
+### Trying to mock final classes or intersection types
+
+```php
+// WRONG: PHPUnit can't mock final class or intersection types
+$policy = $this->createMock(AccessPolicyInterface::class); // may fail if final
+$policy = $this->createMock(AccessPolicyInterface::class & FieldAccessPolicyInterface::class); // fails
+
+// CORRECT: use anonymous class
+$policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult {
+        return AccessResult::allowed();
+    }
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult {
+        return AccessResult::neutral();
+    }
+    public function appliesTo(string $entityTypeId): bool {
+        return true;
+    }
+    public function fieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult {
+        return AccessResult::neutral();
+    }
+};
+```
+
+### Forgetting that only FieldAccessPolicyInterface implementations participate
+
+EntityAccessHandler skips policies that do not implement `FieldAccessPolicyInterface` during field access checks. An `AccessPolicyInterface`-only class will never have `fieldAccess()` called.
+
+### Double entity creation in access checks
+
+When checking field access before persisting a new entity, create the entity once and reuse it for both the access check and the save. Do not create a throwaway temp entity for the access check.
+
+### Missing paired nullable parameters
+
+Passing `EntityAccessHandler` without `AccountInterface` (or vice versa) results in no filtering. Both must be provided.
+
+### Layer discipline for discovery
+
+Foundation (layer 1) must never import from access (layer 3). Policy attribute scanning in `PackageManifestCompiler` uses string constants:
+
+```php
+private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
+// NOT: use Waaseyaa\Access\Gate\PolicyAttribute;
+```
+
+### Gate naming convention mismatch
+
+Gate resolves `NodePolicy` to entity type `node` via PascalCase-to-snake_case conversion. Use `str_replace('_', '', ucwords($name, '_'))` for the reverse (snake_case to PascalCase), not `ucfirst()`.
+
+## Testing Patterns
+
+### Unit Tests
+
+Use real instances, not mocks, for `EntityAccessHandler` (not a final class but policies often are):
+
+```php
+$handler = new EntityAccessHandler([$policy1, $policy2]);
+$result = $handler->check($entity, 'view', $account);
+self::assertTrue($result->isAllowed());
+```
+
+### Anonymous Classes for Policies
+
+```php
+$policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
+    // ... implement all methods with inline logic
+};
+```
+
+### In-Memory Infrastructure
+
+```php
+$db = PdoDatabase::createSqlite(); // :memory: SQLite
+$storage = new InMemoryEntityStorage(); // from Waaseyaa\Api\Tests\Fixtures
+```
+
+### Integration Test Location
+
+```
+tests/Integration/Phase6/FieldAccessIntegrationTest.php
+tests/Integration/Phase11/AuthorizationPipelineTest.php
+```
+
+### PHPUnit Attributes
+
+```php
+#[Test]
+#[CoversClass(EntityAccessHandler::class)]
+public function checkFieldAccessReturnsForbiddenForRestrictedField(): void
+```
+
+Use `#[CoversNothing]` for integration tests.
+
+## Related Specs
+
+- `docs/specs/access-control.md` -- Entity-level access, route access, Gate system, authorization pipeline
+- `docs/specs/field-access.md` -- Field-level access, asymmetric semantics, x-access-restricted, testing patterns
+
+## Key Files
+
+```
+packages/access/src/AccessPolicyInterface.php
+packages/access/src/FieldAccessPolicyInterface.php
+packages/access/src/AccessResult.php
+packages/access/src/AccessStatus.php
+packages/access/src/EntityAccessHandler.php
+packages/access/src/AccountInterface.php
+packages/access/src/PermissionHandler.php
+packages/access/src/PermissionHandlerInterface.php
+packages/access/src/Attribute/AccessPolicy.php
+packages/access/src/Gate/Gate.php
+packages/access/src/Gate/GateInterface.php
+packages/access/src/Gate/PolicyAttribute.php
+packages/access/src/Gate/AccessDeniedException.php
+packages/access/src/Middleware/AuthorizationMiddleware.php
+packages/routing/src/AccessChecker.php
+packages/user/src/Middleware/SessionMiddleware.php
+packages/api/src/ResourceSerializer.php
+packages/api/src/JsonApiController.php
+packages/api/src/Schema/SchemaPresenter.php
+public/index.php
+```

--- a/skills/waaseyaa/access-control/SKILL.md
+++ b/skills/waaseyaa/access-control/SKILL.md
@@ -147,15 +147,15 @@ Field access: open-by-default. Only explicit `Forbidden` restricts.
 ### Package Dependencies
 
 ```
-access (layer 3) -- owns AccountInterface, AccessPolicyInterface, FieldAccessPolicyInterface, EntityAccessHandler
+access (layer 1) -- owns AccountInterface, AccessPolicyInterface, FieldAccessPolicyInterface, EntityAccessHandler
     |
     +-- Does NOT depend on user package
     |
-user (layer 3) -- owns User, AnonymousUser, SessionMiddleware
+user (layer 1) -- owns User, AnonymousUser, SessionMiddleware
     |
     +-- Depends on access (for AccountInterface)
     |
-routing (layer 5) -- owns AccessChecker
+routing (layer 4) -- owns AccessChecker
     |
     +-- Depends on access (for AccessResult, AccountInterface, GateInterface)
 ```
@@ -246,7 +246,7 @@ Passing `EntityAccessHandler` without `AccountInterface` (or vice versa) results
 
 ### Layer discipline for discovery
 
-Foundation (layer 1) must never import from access (layer 3). Policy attribute scanning in `PackageManifestCompiler` uses string constants:
+Foundation (layer 0) must never import from access (layer 1). Policy attribute scanning in `PackageManifestCompiler` uses string constants:
 
 ```php
 private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';

--- a/skills/waaseyaa/admin-spa/SKILL.md
+++ b/skills/waaseyaa/admin-spa/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: waaseyaa:admin-spa
+description: Use when working with the admin interface, Vue composables, schema-driven forms, SSE integration, i18n translations, or files in packages/admin/
+---
+
+# Admin SPA Specialist
+
+## Scope
+
+This skill covers the Nuxt 3 admin SPA at `packages/admin/`. Use it when:
+- Adding or modifying Vue components in `packages/admin/app/components/`
+- Working with composables in `packages/admin/app/composables/`
+- Adding pages to `packages/admin/app/pages/`
+- Modifying i18n translations in `packages/admin/app/i18n/en.json`
+- Working on schema-driven form rendering
+- Integrating SSE real-time updates
+- Adding or modifying field widgets
+- Debugging API proxy or JSON:API communication issues
+
+Out of scope: PHP backend code, entity storage, access policies (see project-level CLAUDE.md for those).
+
+## Key Interfaces
+
+### JsonApiResource / JsonApiDocument (`packages/admin/app/composables/useEntity.ts`)
+
+```ts
+interface JsonApiResource {
+  type: string; id: string; attributes: Record<string, any>
+  relationships?: Record<string, any>; links?: Record<string, string>; meta?: Record<string, any>
+}
+interface JsonApiDocument {
+  jsonapi: { version: string }; data: JsonApiResource | JsonApiResource[] | null
+  errors?: Array<{ status: string; title: string; detail?: string }>
+}
+```
+
+### SchemaProperty / EntitySchema (`packages/admin/app/composables/useSchema.ts`)
+
+```ts
+interface SchemaProperty {
+  type: string; description?: string; format?: string; readOnly?: boolean
+  enum?: string[]; minimum?: number; maximum?: number; maxLength?: number
+  'x-widget'?: string; 'x-label'?: string; 'x-description'?: string
+  'x-weight'?: number; 'x-required'?: boolean; 'x-enum-labels'?: Record<string, string>
+  'x-target-type'?: string; 'x-access-restricted'?: boolean
+}
+interface EntitySchema {
+  $schema: string; title: string; description: string; type: string
+  'x-entity-type': string; 'x-translatable': boolean; 'x-revisionable': boolean
+  properties: Record<string, SchemaProperty>; required?: string[]
+}
+```
+
+### BroadcastMessage (`packages/admin/app/composables/useRealtime.ts`)
+
+```ts
+interface BroadcastMessage {
+  channel: string; event: string; data: Record<string, unknown>; timestamp: number
+}
+```
+
+### Widget Component Props Contract
+
+Every widget in `packages/admin/app/components/widgets/` must accept:
+
+```ts
+defineProps<{
+  modelValue: any
+  label?: string
+  description?: string
+  required?: boolean
+  disabled?: boolean
+  schema?: SchemaProperty
+}>()
+defineEmits<{ 'update:modelValue': [value: any] }>()
+```
+
+## Architecture
+
+### Data Flow
+
+1. **Routing**: Nuxt file-based routing. Pages at `packages/admin/app/pages/`. Dynamic segments use `[param]` syntax.
+2. **Layout**: `app.vue` -> `layouts/default.vue` -> `LayoutAdminShell` (topbar + sidebar + main content area).
+3. **Navigation**: `NavBuilder` fetches entity types from `GET /api/entity-types` and renders sidebar links.
+4. **Schema loading**: `useSchema(entityType).fetch()` calls `GET /api/schema/{entityType}`, caches in module-level `Map`.
+5. **Form rendering**: `SchemaForm` iterates `sortedProperties(true)` -> `SchemaField` resolves widget from `x-widget` -> widget component renders the input.
+6. **CRUD**: `useEntity()` provides `list`, `get`, `create`, `update`, `remove`, `search` against `GET/POST/PATCH/DELETE /api/{type}[/{id}]`.
+7. **Real-time**: `useRealtime(['admin'])` opens SSE to `GET /api/broadcast?channels=admin`. `SchemaList` watches messages and auto-refreshes on `entity.saved` / `entity.deleted` events.
+
+### API Proxy
+
+All `/api/*` requests are proxied to `http://localhost:8081/api` via Nuxt config. This is configured in `packages/admin/nuxt.config.ts` under both `nitro.devProxy` (dev) and `routeRules` (production).
+
+### Widget Resolution
+
+`SchemaField` (`packages/admin/app/components/schema/SchemaField.vue`) maps `x-widget` to components:
+
+| x-widget             | Component resolved via                   |
+|----------------------|------------------------------------------|
+| `text` (default)     | `resolveComponent('WidgetsTextInput')`   |
+| `email`, `url`, `password`, `image`, `file` | `WidgetsTextInput` |
+| `textarea`           | `WidgetsTextArea`                        |
+| `richtext`           | `WidgetsRichText`                        |
+| `number`             | `WidgetsNumberInput`                     |
+| `boolean`            | `WidgetsToggle`                          |
+| `select`             | `WidgetsSelect`                          |
+| `datetime`           | `WidgetsDateTimeInput`                   |
+| `entity_autocomplete`| `WidgetsEntityAutocomplete`              |
+| `hidden`             | `WidgetsHiddenField`                     |
+
+Fallback for unknown widgets: `WidgetsTextInput`.
+
+### Access-Restricted vs ReadOnly
+
+Two distinct concepts in schema properties:
+- **System readOnly** (`readOnly: true`, no `x-access-restricted`): Fields like `id`, `uuid`. Excluded from forms entirely by `sortedProperties(true)`.
+- **Access-restricted** (`readOnly: true` + `x-access-restricted: true`): Fields the user can view but not edit. Rendered as disabled inputs. `SchemaForm` guards the `@update:model-value` handler to prevent writes.
+
+### SSE Reconnection Strategy
+
+`useRealtime` (`packages/admin/app/composables/useRealtime.ts`):
+- Max retries: 10
+- Backoff formula: `Math.min(3000 * Math.pow(2, retryCount - 1), 30000)`
+- Retry counter resets on successful connection
+- Auto-disconnects on component unmount via `onUnmounted`
+- `reconnect()` resets error state and retry counter, then reconnects
+
+## Common Mistakes
+
+### Using `useFetch` instead of `$fetch`
+
+All composables use `$fetch` (imperative) not `useFetch` (SSR-aware). The admin SPA fetches data in `onMounted` callbacks and event handlers, not during SSR. Using `useFetch` would cause hydration issues and unwanted caching behavior.
+
+### Forgetting `x-access-restricted` guard in form handlers
+
+When adding new form submission logic, always check `x-access-restricted` before writing to `formData`. The pattern in `SchemaForm`:
+```ts
+@update:model-value="(val: any) => { if (!fieldSchema['x-access-restricted']) formData[fieldName] = val }"
+```
+Omitting this guard allows users to modify access-restricted fields via browser devtools.
+
+### Widget component naming
+
+Nuxt auto-import resolves components by directory path in PascalCase. A widget at `components/widgets/TextInput.vue` is referenced as `WidgetsTextInput` (not `TextInput`). When adding widgets to `widgetMap` in `SchemaField.vue`, use `resolveComponent('Widgets{Name}')`.
+
+### Schema cache invalidation
+
+`useSchema` uses a module-level `Map` for caching. If you modify schema data on the backend and the frontend still shows stale data, call `invalidate()` on the relevant `useSchema` instance. The cache is never automatically invalidated.
+
+### Mutating the messages array directly
+
+`useRealtime` replaces the array reference on each message (`messages.value = [...messages.value.slice(-99), msg]`). Do not push to `messages.value` directly -- Vue reactivity tracks the ref assignment, not array mutations.
+
+### Adding translations without updating en.json
+
+All user-facing strings must go through `useLanguage().t('key')`. When adding new UI text, add the key to `packages/admin/app/i18n/en.json` first. The `t()` function falls back to the key string itself if no translation exists, which can mask missing translations.
+
+### RichText sanitization bypass
+
+The `RichText` widget emits raw `innerHTML` from the contenteditable div. The sanitization runs on render (via `computed`), not on emit. Server-side sanitization is required. Do not trust client-side sanitization for security.
+
+### EntityAutocomplete hardcoded label field
+
+`EntityAutocomplete` currently hardcodes `labelField` to `'title'`. For entity types where the label field is not `title`, this must be updated. The schema's `x-target-type` is used but there is no `x-label-field` extension yet.
+
+### SSE endpoint dependency
+
+`useRealtime` connects to `GET /api/broadcast?channels=admin`. This endpoint must be wired in `public/index.php`. If the endpoint is not available, the composable will retry 10 times with exponential backoff and then show an error. The frontend works without SSE (graceful degradation).
+
+## Testing Patterns
+
+### Build Verification
+
+No frontend test framework is configured. TypeScript correctness is verified via build:
+
+```bash
+cd packages/admin && npm run build
+```
+
+This catches type errors, missing imports, and component resolution failures.
+
+### Manual Testing Workflow
+
+1. Start PHP backend: `php -S localhost:8081 public/index.php`
+2. Start Nuxt dev server: `cd packages/admin && npm run dev`
+3. Access admin at `http://localhost:3000/`
+4. Verify: dashboard loads entity types, list views show data, forms render widgets, autocomplete searches, SSE connection indicator appears
+
+### Adding a New Widget
+
+1. Create `packages/admin/app/components/widgets/{Name}.vue` implementing the widget props contract
+2. Add entry to `widgetMap` in `packages/admin/app/components/schema/SchemaField.vue`
+3. Ensure the PHP `SchemaPresenter` sets the corresponding `x-widget` value on fields
+4. Run `cd packages/admin && npm run build` to verify compilation
+
+### Adding a New Composable
+
+1. Create `packages/admin/app/composables/use{Name}.ts`
+2. Export a function named `use{Name}` returning reactive refs and functions
+3. Nuxt auto-imports from `composables/` -- no explicit import needed in components
+4. Run `cd packages/admin && npm run build` to verify
+
+### Adding a New Page
+
+1. Create file under `packages/admin/app/pages/` following Nuxt file-based routing conventions
+2. Use `[param]` for dynamic route segments
+3. Import composables as needed (auto-imported by Nuxt)
+4. Wrap content in the default layout (automatic via `layouts/default.vue`)
+5. Add navigation link in `NavBuilder` if the page should appear in the sidebar
+
+### Adding i18n Keys
+
+1. Add the key-value pair to `packages/admin/app/i18n/en.json`
+2. Use `const { t } = useLanguage()` in the component
+3. Reference with `t('your_key')` or `t('your_key', { param: 'value' })` for replacements
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `packages/admin/nuxt.config.ts` | Nuxt config, API proxy setup |
+| `packages/admin/app/composables/useEntity.ts` | JSON:API CRUD + search |
+| `packages/admin/app/composables/useSchema.ts` | Schema fetching, caching, field sorting |
+| `packages/admin/app/composables/useLanguage.ts` | i18n with token replacement |
+| `packages/admin/app/composables/useRealtime.ts` | SSE connection management |
+| `packages/admin/app/components/schema/SchemaForm.vue` | Schema-driven entity form |
+| `packages/admin/app/components/schema/SchemaField.vue` | Widget resolver (x-widget -> component) |
+| `packages/admin/app/components/schema/SchemaList.vue` | Entity list with SSE auto-refresh |
+| `packages/admin/app/components/widgets/EntityAutocomplete.vue` | Typeahead entity reference widget |
+| `packages/admin/app/components/layout/AdminShell.vue` | Layout shell + global CSS |
+| `packages/admin/app/components/layout/NavBuilder.vue` | Dynamic sidebar navigation |
+| `packages/admin/app/i18n/en.json` | English translations |
+
+## Related Specs
+
+- `docs/specs/admin-spa.md` -- Full specification with all interfaces, widget mapping, and component details

--- a/skills/waaseyaa/ai-integration/SKILL.md
+++ b/skills/waaseyaa/ai-integration/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: waaseyaa:ai-integration
+description: Use when working with AI schema generation, agent execution, pipeline orchestration, vector storage, or files in packages/ai-schema/, packages/ai-agent/, packages/ai-pipeline/, packages/ai-vector/
+---
+
+# AI Integration Specialist
+
+## Scope
+
+This skill covers the four AI packages in layer 6 of the Waaseyaa architecture:
+
+- `packages/ai-schema/` -- JSON Schema generation from entity types, MCP tool definitions and execution
+- `packages/ai-agent/` -- Agent executor with audit logging, MCP server adapter
+- `packages/ai-pipeline/` -- Config-entity-based processing pipelines with sync and async execution
+- `packages/ai-vector/` -- Vector embedding storage, similarity search, distance metrics
+
+Use this skill when:
+- Modifying or extending any file in `packages/ai-schema/src/`, `packages/ai-agent/src/`, `packages/ai-pipeline/src/`, or `packages/ai-vector/src/`
+- Writing tests in `packages/ai-schema/tests/`, `packages/ai-agent/tests/`, `packages/ai-pipeline/tests/`, or `packages/ai-vector/tests/`
+- Adding new MCP tools, agent implementations, pipeline steps, or embedding providers
+- Debugging schema generation, tool execution, pipeline flow, or vector search
+
+## Key Interfaces
+
+### AgentInterface (`packages/ai-agent/src/AgentInterface.php`)
+
+```php
+namespace Waaseyaa\AI\Agent;
+
+interface AgentInterface
+{
+    public function execute(AgentContext $context): AgentResult;
+    public function dryRun(AgentContext $context): AgentResult;
+    public function describe(): string;
+}
+```
+
+Every agent must implement both `execute()` and `dryRun()`. The `AgentContext` carries an `AccountInterface $account`, `array $parameters`, and `bool $dryRun`.
+
+### PipelineStepInterface (`packages/ai-pipeline/src/PipelineStepInterface.php`)
+
+```php
+namespace Waaseyaa\AI\Pipeline;
+
+interface PipelineStepInterface
+{
+    public function process(array $input, PipelineContext $context): StepResult;
+    public function describe(): string;
+}
+```
+
+Steps receive input data and a shared context. Return `StepResult::success()`, `StepResult::failure()`, or `StepResult::halt()`.
+
+### EmbeddingInterface (`packages/ai-vector/src/EmbeddingInterface.php`)
+
+```php
+namespace Waaseyaa\AI\Vector;
+
+interface EmbeddingInterface
+{
+    public function embed(string $text): array;       // float[]
+    public function embedBatch(array $texts): array;  // float[][]
+    public function getDimensions(): int;
+}
+```
+
+### VectorStoreInterface (`packages/ai-vector/src/VectorStoreInterface.php`)
+
+```php
+namespace Waaseyaa\AI\Vector;
+
+interface VectorStoreInterface
+{
+    public function store(EntityEmbedding $embedding): void;
+    public function delete(string $entityTypeId, int|string $entityId): void;
+    public function search(array $queryVector, int $limit = 10, ?string $entityTypeId = null, ?string $langcode = null, array $fallbackLangcodes = []): array;
+    public function get(string $entityTypeId, int|string $entityId): ?EntityEmbedding;
+    public function has(string $entityTypeId, int|string $entityId): bool;
+}
+```
+
+## Architecture
+
+### Package Dependency Chain
+
+```
+ai-schema   depends on: entity
+ai-agent    depends on: ai-schema, access
+ai-pipeline depends on: entity, queue
+ai-vector   depends on: entity
+```
+
+Layer discipline: all four packages are in layer 6 (AI). They depend downward on layer 2 (entity) and layer 3 (access, queue). They must never import from layer 7 (interfaces) or from each other except `ai-agent -> ai-schema`.
+
+### Namespace Conventions
+
+- `Waaseyaa\AI\Schema\` -- ai-schema package
+- `Waaseyaa\AI\Schema\Mcp\` -- MCP-specific classes within ai-schema
+- `Waaseyaa\AI\Agent\` -- ai-agent package
+- `Waaseyaa\AI\Pipeline\` -- ai-pipeline package
+- `Waaseyaa\AI\Vector\` -- ai-vector package
+- `Waaseyaa\AI\Vector\Testing\` -- test fixtures within ai-vector
+
+### Schema Generation Flow
+
+1. `EntityJsonSchemaGenerator` reads entity type definitions from `EntityTypeManagerInterface`
+2. Maps entity keys (id, uuid, label, bundle, langcode, revision) to JSON Schema properties
+3. Produces JSON Schema draft 2020-12 with `additionalProperties: true`
+4. `SchemaRegistry` caches tool definitions in memory via `$this->toolCache ??= $this->toolGenerator->generateAll()`
+
+### MCP Tool Execution Flow
+
+1. `McpServer::callTool()` looks up the tool in `SchemaRegistry::getTool()`
+2. Delegates to `McpToolExecutor::execute()`
+3. `McpToolExecutor` parses tool name: iterates `['create', 'read', 'update', 'delete', 'query']`, matches prefix, extracts entity type ID
+4. Dispatches to `executeCreate/Read/Update/Delete/Query` methods
+5. Returns MCP-compliant array: `{content: [{type: 'text', text: JSON}]}`, with `isError: true` on failure
+
+### Agent Execution Flow
+
+1. Caller creates `AgentContext` with `AccountInterface`, parameters, and dryRun flag
+2. `AgentExecutor::execute()` or `dryRun()` wraps the agent call in try/catch
+3. Result (success or exception-wrapped failure) is logged to `AgentAuditLog`
+4. Tool calls via `AgentExecutor::executeTool()` delegate to `McpToolExecutor` with audit logging
+
+### Pipeline Execution Flow
+
+1. `PipelineExecutor::execute()` gets steps from the `Pipeline` config entity, sorted by weight (lower first)
+2. Creates a `PipelineContext` with pipeline ID and start timestamp
+3. For each step: looks up plugin by `pluginId`, sets `_step_configuration` in context, calls `process()`
+4. Output of each step becomes input for the next
+5. Stops on: `StepResult::failure()`, `StepResult::halt()`, or missing plugin
+6. Returns `PipelineResult` with nanosecond-precision timing via `hrtime(true)`
+
+### Vector Search Flow
+
+1. `EntityEmbedder::embedEntity()` builds text as `label + ' ' + json_encode(toArray())`
+2. Passes text to `EmbeddingInterface::embed()` to get a float vector
+3. Stores `EntityEmbedding` via `VectorStoreInterface::store()`
+4. Search: `EntityEmbedder::searchSimilar()` embeds the query string, then calls `VectorStoreInterface::search()`
+5. `InMemoryVectorStore::search()` computes cosine similarity, supports langcode filtering with fallbacks
+
+## Common Mistakes
+
+### Dual-state bug in Pipeline
+
+The Pipeline class stores steps in both `$this->steps` (typed array) and `$this->values['steps']` (entity values array). Every mutation must call `syncStepsToValues()`. If you add a method that modifies `$this->steps`, call `$this->syncStepsToValues()` at the end. Never read from `$this->values['steps']` directly; use `$this->getSteps()`.
+
+### JSON symmetry
+
+`McpToolExecutor` and `EntityEmbedder` both use `json_encode(..., JSON_THROW_ON_ERROR)`. Always pair with `json_decode(..., JSON_THROW_ON_ERROR)`. Asymmetric usage causes silent null on corrupt data.
+
+### Final classes cannot be mocked
+
+All concrete classes in the AI packages are `final class`. PHPUnit's `createMock()` will fail on them. In tests:
+- Mock interfaces (`AgentInterface`, `PipelineStepInterface`, `EmbeddingInterface`, `VectorStoreInterface`, `EntityTypeManagerInterface`, `AccountInterface`)
+- Use real instances for value objects (`AgentResult`, `StepResult`, `EntityEmbedding`, `McpToolDefinition`)
+- Use `FakeEmbeddingProvider` for deterministic test embeddings
+- Use `InMemoryVectorStore` for vector storage in tests
+- For `AgentExecutor` tests, create a concrete `TestAgent` class (see `packages/ai-agent/tests/Unit/TestAgent.php`)
+
+### Pipeline step plugins must be anonymous classes in tests
+
+The `PipelineStepInterface` is not `final`, so it can be mocked. But for integration-style unit tests, use anonymous classes:
+
+```php
+$step = new class implements PipelineStepInterface {
+    public function process(array $input, PipelineContext $context): StepResult
+    {
+        return StepResult::success(['text' => strtoupper($input['text'])]);
+    }
+    public function describe(): string { return 'Uppercase'; }
+};
+```
+
+### MCP tool name parsing is prefix-based
+
+`McpToolExecutor::parseToolName()` iterates known operations and checks `str_starts_with()`. A tool named `create_` (empty entity type) throws `InvalidArgumentException`. A tool named `totally_invalid` (no matching prefix) also throws. The executor catches these and returns MCP error results.
+
+### Query tool disables access checking
+
+`McpToolExecutor::executeQuery()` calls `$query->accessCheck(false)`. Access control for MCP operations is enforced at the agent/endpoint level. Do not add access checks inside individual tool execution methods.
+
+### AccountInterface::id() returns int|string
+
+`AgentExecutor` casts `$context->account->id()` to `(int)` for the audit log's `accountId` field. If account IDs are strings (e.g., UUIDs), this cast will produce 0. Be aware of this when reviewing audit logs.
+
+### EntityEmbedder text building
+
+`EntityEmbedder::buildEntityText()` concatenates `label() . ' ' . json_encode(toArray())`. If you need to customize what text gets embedded, you must modify `buildEntityText()` or create a new embedder. There is no text extraction hook.
+
+### InMemoryVectorStore key format
+
+Keys are `"{entityTypeId}:{entityId}:{langcode}"`. The `delete()` method removes all langcode variants by matching the prefix `"{entityTypeId}:{entityId}:"`. The `get()` method returns the first match for any langcode.
+
+## Testing Patterns
+
+### Unit test locations
+
+- `packages/ai-schema/tests/Unit/` -- EntityJsonSchemaGenerator, SchemaRegistry
+- `packages/ai-schema/tests/Unit/Mcp/` -- McpToolGenerator, McpToolDefinition, McpToolExecutor, TranslationToolGenerator
+- `packages/ai-agent/tests/Unit/` -- AgentExecutor, AgentResult, AgentAction, AgentContext, AgentAuditLog, McpServer
+- `packages/ai-pipeline/tests/Unit/` -- Pipeline, PipelineExecutor, PipelineContext, PipelineStepConfig, PipelineDispatcher, StepResult, PipelineResult, PipelineQueueMessage
+- `packages/ai-vector/tests/Unit/` -- InMemoryVectorStore, EntityEmbedder, EntityEmbedding, SimilarityResult, FakeEmbeddingProvider, DistanceMetric, LanguageAwareVectorTest
+
+### Running tests
+
+```bash
+# All AI package tests
+./vendor/bin/phpunit --filter 'Waaseyaa\\AI'
+
+# Single package
+./vendor/bin/phpunit packages/ai-schema/tests/
+./vendor/bin/phpunit packages/ai-agent/tests/
+./vendor/bin/phpunit packages/ai-pipeline/tests/
+./vendor/bin/phpunit packages/ai-vector/tests/
+```
+
+Do NOT use `-v` flag -- PHPUnit 10.5 rejects it.
+
+### Test fixtures
+
+- `FakeEmbeddingProvider` (`packages/ai-vector/src/Testing/FakeEmbeddingProvider.php`) -- Deterministic, hash-based vectors. Default 128 dimensions. Use for all tests needing embeddings.
+- `InMemoryVectorStore` (`packages/ai-vector/src/InMemoryVectorStore.php`) -- Cosine similarity, no external dependencies. Use for all vector storage tests.
+- `TestAgent` (`packages/ai-agent/tests/Unit/TestAgent.php`) -- Configurable test agent with settable results and exceptions.
+
+### Pattern: Testing AgentExecutor
+
+```php
+$entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+$toolExecutor = new McpToolExecutor($entityTypeManager);
+$executor = new AgentExecutor($toolExecutor);
+
+$account = $this->createMock(AccountInterface::class);
+$account->method('id')->willReturn(1);
+$context = new AgentContext(account: $account, parameters: ['key' => 'value']);
+
+$result = $executor->execute($agent, $context);
+$log = $executor->getAuditLog();
+```
+
+### Pattern: Testing PipelineExecutor
+
+```php
+$step = new class implements PipelineStepInterface {
+    public function process(array $input, PipelineContext $context): StepResult {
+        return StepResult::success(['result' => $input['text'] . '_processed']);
+    }
+    public function describe(): string { return 'Test step'; }
+};
+
+$executor = new PipelineExecutor(['my_step' => $step]);
+$pipeline = new Pipeline([
+    'id' => 'test_pipeline',
+    'label' => 'Test',
+    'steps' => [
+        ['id' => 'step_1', 'plugin_id' => 'my_step', 'weight' => 0],
+    ],
+]);
+$result = $executor->execute($pipeline, ['text' => 'hello']);
+```
+
+### Pattern: Testing vector search
+
+```php
+$provider = new FakeEmbeddingProvider(dimensions: 128);
+$store = new InMemoryVectorStore();
+$embedder = new EntityEmbedder($provider, $store);
+
+$embedding = $embedder->embedEntity($entity);
+$results = $embedder->searchSimilar('search query', limit: 5, entityTypeId: 'node');
+```
+
+## Related Specs
+
+- `docs/specs/ai-integration.md` -- Full specification with interface signatures and architecture details
+- `docs/plans/2026-02-28-aurora-architecture-v2-design.md` -- Architecture v2 design (context for AI layer positioning)
+- `CLAUDE.md` -- Project-wide gotchas including dual-state bug pattern, JSON symmetry, final class mocking

--- a/skills/waaseyaa/ai-integration/SKILL.md
+++ b/skills/waaseyaa/ai-integration/SKILL.md
@@ -90,7 +90,7 @@ ai-pipeline depends on: entity, queue
 ai-vector   depends on: entity
 ```
 
-Layer discipline: all four packages are in layer 6 (AI). They depend downward on layer 2 (entity) and layer 3 (access, queue). They must never import from layer 7 (interfaces) or from each other except `ai-agent -> ai-schema`.
+Layer discipline: all four packages are in layer 5 (AI). They depend downward on layer 1 (entity, access) and layer 0 (queue). They must never import from layer 6 (interfaces) or from each other except `ai-agent -> ai-schema`.
 
 ### Namespace Conventions
 

--- a/skills/waaseyaa/api-layer/SKILL.md
+++ b/skills/waaseyaa/api-layer/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: waaseyaa:api-layer
+description: Use when working with JSON:API endpoints, resource serialization, query parsing, schema presentation, route building, or files in packages/api/, packages/routing/
+---
+
+# API Layer Specialist
+
+## Scope
+
+This skill covers the JSON:API and routing packages:
+
+- `packages/api/src/` -- JsonApiController, ResourceSerializer, QueryParser, QueryApplier, SchemaPresenter, SchemaController, TranslationController, BroadcastController, ApiCacheMiddleware, OpenApiGenerator
+- `packages/routing/src/` -- WaaseyaaRouter, RouteBuilder, AccessChecker, GateAttribute, EntityParamConverter, RouteMatch
+- Front controller wiring in `public/index.php`
+
+Use this skill when:
+- Adding or modifying JSON:API endpoints
+- Changing resource serialization or field access filtering
+- Working with query parsing, filtering, sorting, or pagination
+- Modifying JSON Schema presentation or widget hints
+- Building or modifying routes and route access control
+- Working with SSE broadcasting or API caching
+- Generating OpenAPI specs
+
+## Key Interfaces
+
+### JsonApiController (packages/api/src/JsonApiController.php)
+
+```php
+final class JsonApiController
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly ResourceSerializer $serializer,
+        private readonly ?EntityAccessHandler $accessHandler = null,
+        private readonly ?AccountInterface $account = null,
+    ) {}
+
+    public function index(string $entityTypeId, array $query = []): JsonApiDocument;
+    public function show(string $entityTypeId, int|string $id): JsonApiDocument;
+    public function store(string $entityTypeId, array $data): JsonApiDocument;
+    public function update(string $entityTypeId, int|string $id, array $data): JsonApiDocument;
+    public function destroy(string $entityTypeId, int|string $id): JsonApiDocument;
+}
+```
+
+Framework-agnostic. Returns `JsonApiDocument` objects. The front controller converts to HTTP responses.
+
+### ResourceSerializer (packages/api/src/ResourceSerializer.php)
+
+```php
+final class ResourceSerializer
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly string $basePath = '/api',
+    ) {}
+
+    public function serialize(
+        EntityInterface $entity,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): JsonApiResource;
+
+    public function serializeCollection(
+        array $entities,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): array;
+}
+```
+
+Excludes entity keys (id, uuid) from attributes. Uses UUID as resource ID when available.
+
+### SchemaPresenter (packages/api/src/Schema/SchemaPresenter.php)
+
+```php
+final class SchemaPresenter
+{
+    public function present(
+        EntityTypeInterface $entityType,
+        array $fieldDefinitions = [],
+        ?EntityInterface $entity = null,
+        ?EntityAccessHandler $accessHandler = null,
+        ?AccountInterface $account = null,
+    ): array;
+}
+```
+
+Outputs JSON Schema draft-07 with custom `x-widget`, `x-label`, `x-access-restricted` extensions.
+
+### Query Pipeline (packages/api/src/Query/)
+
+```php
+// QueryParser parses $_GET into ParsedQuery
+$parser = new QueryParser();
+$parsedQuery = $parser->parse($query);
+
+// QueryApplier translates ParsedQuery to EntityQuery calls
+$applier = new QueryApplier();
+$applier->apply($parsedQuery, $entityQuery);
+```
+
+Supported filter operators: `=`, `!=`, `>`, `<`, `>=`, `<=`, `CONTAINS`, `STARTS_WITH`.
+
+Default pagination: offset 0, limit 50, max limit 100.
+
+### RouteBuilder (packages/routing/src/RouteBuilder.php)
+
+```php
+$route = RouteBuilder::create('/node/{node}')
+    ->controller('App\Controller\NodeController::view')
+    ->entityParameter('node', 'node')
+    ->requirePermission('access content')
+    ->methods('GET')
+    ->build();
+```
+
+### AccessChecker (packages/routing/src/AccessChecker.php)
+
+```php
+final class AccessChecker
+{
+    public function __construct(private readonly ?GateInterface $gate = null) {}
+    public function check(Route $route, AccountInterface $account): AccessResult;
+}
+```
+
+Route access options: `_public`, `_permission`, `_role`, `_gate`. Combined with AND logic.
+
+## Architecture
+
+### Request Flow
+
+1. `public/index.php` receives HTTP request.
+2. `SessionMiddleware` sets `_account` on request.
+3. `AuthorizationMiddleware` reads `_account` for access checks.
+4. `WaaseyaaRouter::match()` resolves path to route + parameters.
+5. `AccessChecker::check()` verifies route-level access.
+6. `EntityParamConverter::convert()` upcasts entity IDs to loaded entities.
+7. Controller method executes, returns `JsonApiDocument`.
+8. Front controller sends HTTP response (status code, headers, JSON body).
+
+### Access Checking Layers
+
+Two distinct access layers with different semantics:
+
+1. **Entity level** (`EntityAccessHandler::check()`): Uses `isAllowed()` -- deny unless granted.
+2. **Field level** (`EntityAccessHandler::checkFieldAccess()`): Uses `!isForbidden()` -- allow unless denied.
+
+This asymmetry is intentional. Field access is open-by-default: `Neutral = accessible`, only `Forbidden` restricts.
+
+### Paired Nullable Pattern
+
+`ResourceSerializer::serialize()`, `SchemaPresenter::present()`, and `JsonApiController` constructor all accept `?EntityAccessHandler` + `?AccountInterface`. Both must be non-null or both null. The guard pattern:
+
+```php
+if ($accessHandler !== null && $account !== null) {
+    // perform access filtering
+}
+```
+
+### readOnly vs x-access-restricted in SchemaPresenter
+
+- `readOnly: true` alone (no `x-access-restricted`): System fields (id, uuid). Admin SPA hides from forms.
+- `readOnly: true` + `x-access-restricted: true`: User can view but not edit. Admin SPA shows disabled widget.
+
+### Post-Fetch Access Filtering
+
+`JsonApiController::index()` runs queries with `accessCheck(false)`, then filters results in PHP:
+
+```php
+$entities = array_filter(
+    $entities,
+    fn($entity) => $this->accessHandler->check($entity, 'view', $this->account)->isAllowed(),
+);
+```
+
+The `total` count in pagination meta reflects the unfiltered count.
+
+### Query Parameter Formats
+
+| Parameter | Format | Example |
+|-----------|--------|---------|
+| `filter[field]` | Simple equality | `filter[status]=published` |
+| `filter[field][operator]` + `filter[field][value]` | Operator filter | `filter[title][operator]=CONTAINS&filter[title][value]=hello` |
+| `sort` | Comma-separated, `-` prefix for DESC | `sort=-created,title` |
+| `page[offset]` + `page[limit]` | Offset pagination | `page[offset]=20&page[limit]=10` |
+| `fields[type]` | Sparse fieldsets | `fields[node]=title,body` |
+
+## Common Mistakes
+
+### Paired nullables -- passing one without the other
+
+```php
+// WRONG: accessHandler without account silently skips access filtering
+new JsonApiController($etm, $serializer, accessHandler: $handler);
+
+// CORRECT: both must be provided
+new JsonApiController($etm, $serializer, accessHandler: $handler, account: $account);
+```
+
+### LIKE wildcard escaping
+
+When building `CONTAINS`/`STARTS_WITH` patterns for SQL, user input must be escaped:
+
+```php
+// WRONG: user input "100%" matches everything
+$pattern = "%{$value}%";
+
+// CORRECT: escape LIKE wildcards in user input
+$escapedValue = str_replace(['%', '_'], ['\\%', '\\_'], $value);
+$pattern = "%{$escapedValue}%";
+```
+
+`PdoSelect` appends `ESCAPE '\'` automatically for LIKE/NOT LIKE operators.
+
+### Entity-level vs field-level access semantics
+
+```php
+// Entity level: deny unless granted
+$result = $accessHandler->check($entity, 'view', $account);
+if (!$result->isAllowed()) { /* deny */ }
+
+// Field level: allow unless denied
+$result = $accessHandler->checkFieldAccess($entity, $field, 'edit', $account);
+if ($result->isForbidden()) { /* deny */ }
+```
+
+Using `isAllowed()` for field access or `isForbidden()` for entity access inverts the logic.
+
+### Avoid double storage create
+
+When checking field access before persisting a new entity, create once and reuse:
+
+```php
+// WRONG: creates a throwaway entity, then creates another for save
+$temp = $storage->create($attributes);
+checkFieldAccess($temp, ...);
+$entity = $storage->create($attributes);
+$storage->save($entity);
+
+// CORRECT: create once, reuse for both access check and save
+$entity = $storage->create($attributes);
+checkFieldAccess($entity, ...);
+$storage->save($entity);
+```
+
+### php://input is single-read
+
+`HttpRequest::createFromGlobals()` consumes `php://input`. For subsequent body reads, use `$httpRequest->getContent()`, not `file_get_contents('php://input')`.
+
+### JSON symmetry
+
+Always pair `json_encode(..., JSON_THROW_ON_ERROR)` with `json_decode(..., JSON_THROW_ON_ERROR)`. Asymmetric usage causes silent `null` on corrupt data.
+
+### Final classes cannot be mocked
+
+All concrete classes in the API layer are `final class`. PHPUnit `createMock()` will fail. Use real instances:
+
+```php
+// WRONG:
+$serializer = $this->createMock(ResourceSerializer::class);
+
+// CORRECT: use real instances with in-memory storage
+$etm = new EntityTypeManager($dispatcher, $storageFactory);
+$serializer = new ResourceSerializer($etm);
+```
+
+### SchemaController prototype entity
+
+`SchemaController::show()` creates a prototype entity via `new $class([])` for field access checking. This requires the entity subclass constructor to accept `(array $values)`. If the constructor has a different signature, the try-catch logs the error and proceeds without field access annotations.
+
+## Testing Patterns
+
+### In-Memory Storage for API Tests
+
+```php
+use Waaseyaa\Api\Tests\Fixtures\InMemoryEntityStorage;
+use Waaseyaa\Database\PdoDatabase;
+
+// For entity operations
+$storage = new InMemoryEntityStorage($entityType);
+
+// For SQL-backed operations (cache, broadcast)
+$db = PdoDatabase::createSqlite();  // :memory: database
+```
+
+### Testing JsonApiController
+
+```php
+$etm = new EntityTypeManager($dispatcher, fn($def) => $storage);
+$serializer = new ResourceSerializer($etm);
+$controller = new JsonApiController($etm, $serializer);
+
+$doc = $controller->index('node', ['filter' => ['status' => 'published']]);
+assert($doc->statusCode === 200);
+assert(is_array($doc->data));
+```
+
+### Testing Access Filtering
+
+Use anonymous classes implementing intersection types since `createMock()` cannot handle them:
+
+```php
+$policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
+    public function checkAccess(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult {
+        return AccessResult::allowed();
+    }
+    public function checkFieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult {
+        if ($fieldName === 'secret') {
+            return AccessResult::forbidden('No access');
+        }
+        return AccessResult::neutral();
+    }
+};
+```
+
+### Testing Query Pipeline
+
+```php
+$parser = new QueryParser();
+$parsed = $parser->parse([
+    'filter' => ['status' => 'published'],
+    'sort' => '-created,title',
+    'page' => ['offset' => '10', 'limit' => '25'],
+]);
+
+assert(count($parsed->filters) === 1);
+assert($parsed->filters[0]->field === 'status');
+assert($parsed->sorts[0]->direction === 'DESC');
+assert($parsed->offset === 10);
+assert($parsed->limit === 25);
+```
+
+### Testing RouteBuilder
+
+```php
+$route = RouteBuilder::create('/api/node')
+    ->controller('Waaseyaa\Api\JsonApiController::index')
+    ->methods('GET')
+    ->requirePermission('access content')
+    ->build();
+
+assert($route->getOption('_permission') === 'access content');
+assert($route->getMethods() === ['GET']);
+```
+
+### Testing ApiCacheMiddleware
+
+```php
+$cache = new ApiCacheMiddleware(schemaMaxAge: 3600);
+$doc = JsonApiDocument::fromResource($resource);
+$result = $cache->process($doc, 'schema', 'W/"abc123"');
+assert(isset($result['headers']['ETag']));
+assert(is_bool($result['notModified']));
+```
+
+## Related Specs
+
+- `docs/specs/api-layer.md` -- Full API layer specification with interface signatures, value objects, and detailed behavior documentation
+- `CLAUDE.md` -- Project-wide gotchas including paired nullables, LIKE escaping, access result semantics, and JSON symmetry
+- `docs/plans/2026-03-01-admin-spa-completion.md` -- Admin SPA completion plan including autocomplete search (CONTAINS/STARTS_WITH) and SSE broadcasting
+- `docs/plans/2026-02-28-aurora-architecture-v2-design.md` -- Architecture v2 design with API evolution plans

--- a/skills/waaseyaa/entity-system/SKILL.md
+++ b/skills/waaseyaa/entity-system/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: waaseyaa:entity-system
+description: "Use when working with entity types, entity storage, entity queries, field definitions, field type plugins, config entities, config import/export, or files in packages/entity/, packages/entity-storage/, packages/field/, packages/config/. Covers EntityInterface, EntityBase, EntityType, EntityTypeManager, SqlEntityStorage, SqlEntityQuery, SqlSchemaHandler, EntityRepository, UnitOfWork, FieldDefinition, FieldTypeManager, FieldItemBase, ConfigFactory, ConfigManager. Also applies when touching User (packages/user/) or Node (packages/node/) entity subclasses."
+---
+
+# Entity System Specialist
+
+## Scope
+
+This skill covers four packages and their collaborators:
+
+| Package | Path | Namespace |
+|---------|------|-----------|
+| entity | `packages/entity/` | `Waaseyaa\Entity\` |
+| entity-storage | `packages/entity-storage/` | `Waaseyaa\EntityStorage\` |
+| field | `packages/field/` | `Waaseyaa\Field\` |
+| config | `packages/config/` | `Waaseyaa\Config\` |
+
+Also covers entity subclasses in:
+- `packages/user/src/User.php` (`Waaseyaa\User\User`)
+- `packages/node/src/Node.php` (`Waaseyaa\Node\Node`)
+- `packages/api/tests/Fixtures/InMemoryEntityStorage.php` (test fixture)
+
+## Key Interfaces
+
+### Entity Layer (`packages/entity/src/`)
+
+**EntityInterface** -- core contract for all entities:
+```php
+public function id(): int|string|null;
+public function uuid(): string;
+public function label(): string;
+public function getEntityTypeId(): string;
+public function bundle(): string;
+public function isNew(): bool;
+public function toArray(): array;
+public function language(): string;
+```
+
+**FieldableInterface** -- dynamic field access:
+```php
+public function hasField(string $name): bool;
+public function get(string $name): mixed;
+public function set(string $name, mixed $value): static;
+public function getFieldDefinitions(): array;
+```
+
+**ContentEntityInterface** -- extends EntityInterface + FieldableInterface (no added methods).
+
+**ConfigEntityInterface** -- extends EntityInterface with config concerns:
+```php
+public function status(): bool;
+public function enable(): static;
+public function disable(): static;
+public function getDependencies(): array;   // array<string, string[]>
+public function toConfig(): array;
+```
+
+**EntityStorageInterface** -- CRUD + query:
+```php
+public function create(array $values = []): EntityInterface;
+public function load(int|string $id): ?EntityInterface;
+public function loadMultiple(array $ids = []): array;
+public function save(EntityInterface $entity): int;     // returns SAVED_NEW (1) or SAVED_UPDATED (2)
+public function delete(array $entities): void;
+public function getQuery(): EntityQueryInterface;
+public function getEntityTypeId(): string;
+```
+
+**EntityQueryInterface** -- fluent query builder:
+```php
+public function condition(string $field, mixed $value, string $operator = '='): static;
+public function exists(string $field): static;
+public function notExists(string $field): static;
+public function sort(string $field, string $direction = 'ASC'): static;
+public function range(int $offset, int $limit): static;
+public function count(): static;
+public function accessCheck(bool $check = true): static;
+public function execute(): array;  // returns entity IDs
+```
+
+**EntityTypeInterface** -- entity type definition:
+```php
+public function id(): string;
+public function getLabel(): string;
+public function getClass(): string;
+public function getStorageClass(): string;
+public function getKeys(): array;           // ['id' => 'nid', 'uuid' => 'uuid', ...]
+public function isRevisionable(): bool;
+public function isTranslatable(): bool;
+public function getBundleEntityType(): ?string;
+public function getConstraints(): array;
+```
+
+**EntityTypeManagerInterface** -- registry + storage access:
+```php
+public function getDefinition(string $entityTypeId): EntityTypeInterface;
+public function getDefinitions(): array;
+public function hasDefinition(string $entityTypeId): bool;
+public function getStorage(string $entityTypeId): EntityStorageInterface;
+```
+
+**EntityRepositoryInterface** -- higher-level API with language fallback:
+```php
+public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface;
+public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array;
+public function save(EntityInterface $entity): int;
+public function delete(EntityInterface $entity): void;
+public function exists(string $id): bool;
+public function count(array $criteria = []): int;
+```
+
+### Field Layer (`packages/field/src/`)
+
+**FieldTypeInterface** -- plugin contract for field types:
+```php
+public static function schema(): array;
+public static function defaultSettings(): array;
+public static function defaultValue(): mixed;
+public static function jsonSchema(): array;
+```
+
+**FieldDefinitionInterface** -- field metadata:
+```php
+public function getName(): string;
+public function getType(): string;
+public function getCardinality(): int;
+public function isMultiple(): bool;
+public function getSettings(): array;
+public function isTranslatable(): bool;
+public function isRevisionable(): bool;
+public function getDefaultValue(): mixed;
+public function toJsonSchema(): array;
+```
+
+### Config Layer (`packages/config/src/`)
+
+**ConfigInterface** -- dot-notation config access:
+```php
+public function getName(): string;
+public function get(string $key = ''): mixed;
+public function set(string $key, mixed $value): static;
+public function save(): static;
+public function isNew(): bool;
+```
+
+**ConfigFactoryInterface** -- immutable vs mutable access:
+```php
+public function get(string $name): ConfigInterface;         // immutable
+public function getEditable(string $name): ConfigInterface; // mutable
+```
+
+## Architecture
+
+### Data Flow: Entity Create-Save-Load
+
+```
+Client Code
+    |
+    v
+EntityTypeManager::getStorage('node')
+    |  returns SqlEntityStorage (cached by entity type ID)
+    v
+SqlEntityStorage::create(['title' => 'Hello', 'type' => 'article'])
+    |  instantiateEntity() via reflection
+    |  (detects constructor shape: $values-only vs $values+$entityTypeId+$entityKeys)
+    v
+Node(['title' => 'Hello', 'type' => 'article'])
+    |  EntityBase auto-generates UUID
+    |  isNew() === true (id is null)
+    v
+SqlEntityStorage::save($node)
+    |  splitForStorage(): schema columns -> direct, others -> _data JSON
+    |  dispatches PRE_SAVE event
+    |  INSERT into database
+    |  sets generated ID on entity
+    |  enforceIsNew(false)
+    |  dispatches POST_SAVE event
+    |  returns EntityConstants::SAVED_NEW (1)
+    v
+SqlEntityStorage::load($id)
+    |  SELECT from database
+    |  mapRowToEntity(): merges _data JSON back into values
+    |  instantiateEntity() via reflection
+    |  enforceIsNew(false)
+    v
+Node with all values restored
+```
+
+### EntityTypeManager wiring pattern
+
+```php
+$eventDispatcher = new EventDispatcher();
+$database = PdoDatabase::createSqlite(':memory:');
+
+$storageFactory = new EntityStorageFactory($database, $eventDispatcher);
+
+$entityTypeManager = new EntityTypeManager(
+    $eventDispatcher,
+    fn (EntityTypeInterface $def) => $storageFactory->getStorage($def),
+);
+
+$entityTypeManager->registerEntityType(new EntityType(
+    id: 'node',
+    label: 'Content',
+    class: Node::class,
+    keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+));
+
+$storage = $entityTypeManager->getStorage('node');
+```
+
+### Entity query pattern
+
+```php
+$storage = $entityTypeManager->getStorage('node');
+
+// Find published articles, newest first, limit 10
+$ids = $storage->getQuery()
+    ->condition('status', 1)
+    ->condition('type', 'article')
+    ->sort('created', 'DESC')
+    ->range(0, 10)
+    ->execute();
+
+$entities = $storage->loadMultiple($ids);
+
+// Count published nodes
+$count = $storage->getQuery()
+    ->condition('status', 1)
+    ->count()
+    ->execute();
+// $count === [42]  (single-element array with the count)
+
+// Contains search (LIKE '%term%')
+$ids = $storage->getQuery()
+    ->condition('title', 'search term', 'CONTAINS')
+    ->execute();
+
+// Starts-with search (LIKE 'prefix%')
+$ids = $storage->getQuery()
+    ->condition('title', 'Hello', 'STARTS_WITH')
+    ->execute();
+```
+
+### _data JSON blob pattern
+
+SqlSchemaHandler creates every entity table with a `_data TEXT DEFAULT '{}'` column.
+
+On save, `SqlEntityStorage::splitForStorage()`:
+1. For each value, checks if a column exists in the table (cached)
+2. Schema columns go to `$dbValues`
+3. Other values go to `$extraData`, JSON-encoded into `_data`
+
+On load, `SqlEntityStorage::mapRowToEntity()`:
+1. `json_decode($row['_data'])` to get extras
+2. `unset($row['_data'])`
+3. `array_merge($row, $extras)` to restore full values
+
+This means **any arbitrary key-value pair** set on an entity will survive a save-load cycle, even without a dedicated column.
+
+### Config pattern
+
+```php
+// Read config (immutable by default)
+$config = $configFactory->get('system.site');
+$siteName = $config->get('name');              // top-level key
+$frontPage = $config->get('page.front');       // dot-notation
+
+// Edit config (must use getEditable)
+$config = $configFactory->getEditable('system.site');
+$config->set('name', 'My Site');
+$config->set('page.front', '/home');
+$config->save();
+
+// Import/export via ConfigManager
+$result = $configManager->import();
+// $result->created, $result->updated, $result->deleted, $result->errors
+```
+
+### EntityRepository with language fallback
+
+```php
+$driver = new InMemoryStorageDriver();
+$repo = new EntityRepository($entityType, $driver, $eventDispatcher);
+$repo->setFallbackChain(['fr', 'en']);
+
+// Tries 'de' first, then 'fr', then 'en', then without language
+$entity = $repo->find('42', langcode: 'de', fallback: true);
+```
+
+### UnitOfWork transaction pattern
+
+```php
+$unitOfWork = new UnitOfWork($database, $eventDispatcher);
+
+$result = $unitOfWork->transaction(function () use ($storage, $node1, $node2) {
+    $storage->save($node1);
+    $storage->save($node2);
+    return 'done';
+});
+// Events dispatched only after successful commit
+// On exception: rollback + events discarded
+```
+
+### Field definition pattern
+
+```php
+$field = new FieldDefinition(
+    name: 'body',
+    type: 'text',
+    cardinality: 1,
+    label: 'Body',
+    description: 'The main content body.',
+    required: true,
+    translatable: true,
+);
+
+$jsonSchema = $field->toJsonSchema();
+// {'type': 'object', 'properties': {'value': {'type': 'string'}, 'format': {'type': 'string'}}}
+```
+
+## Common Mistakes
+
+### Entity subclass constructors
+User, Node, and similar subclasses only accept `(array $values)` and hardcode entityTypeId and entityKeys. SqlEntityStorage uses reflection to detect the constructor shape. If you add a new entity subclass, either:
+- Accept only `(array $values)` and hardcode type/keys (like User/Node)
+- Accept the full `(array $values, string $entityTypeId, array $entityKeys)` signature (like EntityBase)
+
+Do NOT mix patterns (e.g., adding `$entityTypeId` to a subclass that already hardcodes it).
+
+### enforceIsNew() is required for pre-set IDs
+When creating entities with pre-set IDs (`new User(['uid' => 2])`), call `$entity->enforceIsNew()` before `save()`. Otherwise `isNew()` returns false, SqlEntityStorage performs UPDATE instead of INSERT, and silently affects 0 rows.
+
+### EntityEvent uses public properties, not getters
+`$event->entity` and `$event->originalEntity` are public readonly. There is no `$event->getEntity()` method. Using a getter will cause a fatal error.
+
+### Event name requires ->value
+`EntityEvents::PRE_SAVE` is an enum case, not a string. Use `EntityEvents::PRE_SAVE->value` to get the string `'waaseyaa.entity.pre_save'` for dispatch.
+
+### JSON symmetry
+Always pair `json_encode(..., JSON_THROW_ON_ERROR)` with `json_decode(..., JSON_THROW_ON_ERROR)`. The `_data` column uses `JSON_THROW_ON_ERROR` on encode but not on decode (uses `?: []` fallback). Be aware of this asymmetry if modifying the storage layer.
+
+### LIKE wildcard escaping in SqlEntityQuery
+CONTAINS and STARTS_WITH operators escape `%` and `_` in user input before wrapping with wildcards. If building custom LIKE patterns elsewhere, use: `str_replace(['%', '_'], ['\\%', '\\_'], $value)`.
+
+### DatabaseInterface does NOT have getPdo()
+Type-hint `PdoDatabase` directly if raw PDO is needed. `DatabaseInterface` only exposes `select()`, `insert()`, `update()`, `delete()`, `schema()`, `transaction()`.
+
+### final class entities cannot be mocked
+PHPUnit `createMock()` fails on `final class`. Node, User, SqlEntityStorage, SqlEntityQuery are all `final`. Use real instances in tests with `PdoDatabase::createSqlite(':memory:')` or `InMemoryEntityStorage`.
+
+### Config get() vs getEditable()
+`ConfigFactory::get()` returns immutable. Calling `set()` or `save()` on it throws `ImmutableConfigException`. Use `getEditable()` for writes.
+
+### Avoid double $storage->create() in access checks
+When checking field access before persisting a new entity, create once and reuse for both the access check and the save. Do not create a throwaway temp entity.
+
+### count() returns single-element array
+`SqlEntityQuery::count()->execute()` returns `[(int) $count]`, not a bare integer. Access with `$result[0]`.
+
+### Table name = entity type ID
+SqlEntityStorage and SqlSchemaHandler derive the table name directly from `$entityType->id()`. Entity type `'node'` maps to table `node`. Translation table is `node_translations`.
+
+## Testing Patterns
+
+### In-memory entity storage (no database needed)
+
+```php
+use Waaseyaa\Api\Tests\Fixtures\InMemoryEntityStorage;
+
+$storage = new InMemoryEntityStorage(entityTypeId: 'article');
+$entity = $storage->create(['title' => 'Test']);
+$storage->save($entity);
+$loaded = $storage->load($entity->id());
+```
+
+### SQL storage with in-memory SQLite
+
+```php
+use Waaseyaa\Database\PdoDatabase;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+
+$database = PdoDatabase::createSqlite(':memory:');
+$eventDispatcher = new EventDispatcher();
+
+$entityType = new EntityType(
+    id: 'node',
+    label: 'Content',
+    class: Node::class,
+    keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+);
+
+// Create the table first
+$schemaHandler = new SqlSchemaHandler($entityType, $database);
+$schemaHandler->ensureTable();
+
+// Then create storage
+$storage = new SqlEntityStorage($entityType, $database, $eventDispatcher);
+
+$node = new Node(['title' => 'Test', 'type' => 'article']);
+$storage->save($node);
+```
+
+### InMemoryStorageDriver for EntityRepository tests
+
+```php
+use Waaseyaa\EntityStorage\Driver\InMemoryStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+$driver = new InMemoryStorageDriver();
+$repo = new EntityRepository($entityType, $driver, $eventDispatcher);
+
+$entity = $repo->find('1');
+```
+
+### Config testing with MemoryStorage
+
+```php
+use Waaseyaa\Config\Storage\MemoryStorage;
+use Waaseyaa\Config\ConfigFactory;
+use Waaseyaa\Config\ConfigManager;
+
+$activeStorage = new MemoryStorage();
+$syncStorage = new MemoryStorage();
+$configManager = new ConfigManager($activeStorage, $syncStorage, $eventDispatcher);
+
+$configFactory = new ConfigFactory($activeStorage, $eventDispatcher);
+$config = $configFactory->getEditable('system.site');
+$config->set('name', 'Test Site');
+$config->save();
+```
+
+### PHPUnit conventions
+
+- Use `#[Test]`, `#[CoversClass(...)]`, `#[CoversNothing]` attributes
+- Integration tests: `tests/Integration/PhaseN/` with `Waaseyaa\Tests\Integration\PhaseN\` namespace
+- Unit tests: `packages/*/tests/Unit/` with `Waaseyaa\PackageName\Tests\Unit\` namespace
+- Use temp directories for file-based tests: `sys_get_temp_dir() . '/waaseyaa_test_' . uniqid()`
+- Do NOT pass `-v` to PHPUnit (PHPUnit 10.5 rejects it)
+
+## Related Specs
+
+- `docs/specs/entity-system.md` -- full subsystem specification with all interface signatures
+- `CLAUDE.md` -- project-wide gotchas and conventions
+- `docs/plans/2026-02-27-aurora-cms-design.md` -- original CMS design with entity/storage architecture
+- `docs/plans/2026-02-28-aurora-architecture-v2-design.md` -- architecture v2 with 17 pillars

--- a/skills/waaseyaa/infrastructure/SKILL.md
+++ b/skills/waaseyaa/infrastructure/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: waaseyaa:infrastructure
+description: Use when working with service providers, domain events, cache backends, database queries, migrations, package discovery, attribute scanning, or files in packages/foundation/, packages/cache/, packages/database-legacy/, packages/plugin/
+---
+
+# Infrastructure Specialist
+
+## Scope
+
+This skill covers the foundational infrastructure layer of Waaseyaa CMS:
+
+- **Domain Events**: `DomainEvent`, `EventBus`, three-channel dispatch (sync/async/broadcast)
+- **Service Providers**: `ServiceProvider`, `register()`/`boot()` lifecycle, `ContainerCompiler`
+- **Package Discovery**: `PackageManifestCompiler`, attribute scanning, `ProviderDiscovery`
+- **Cache System**: `CacheBackendInterface`, `MemoryBackend`, `DatabaseBackend`, tag invalidation
+- **Database Abstraction**: `DatabaseInterface`, `PdoDatabase`, query builder (select/insert/update/delete)
+- **Schema & Migrations**: `SchemaBuilder`, `TableBuilder`, `Migrator`, `MigrationRepository`
+- **Plugin System**: `PluginManagerInterface`, `AttributeDiscovery`, `DefaultPluginManager`
+- **Middleware Pipelines**: `HttpPipeline`, `EventPipeline`, `JobPipeline`
+
+Relevant packages: `packages/foundation/`, `packages/cache/`, `packages/database-legacy/`, `packages/plugin/`.
+
+## Key Interfaces
+
+### DatabaseInterface (packages/database-legacy/src/DatabaseInterface.php)
+
+```php
+interface DatabaseInterface
+{
+    public function select(string $table, string $alias = ''): SelectInterface;
+    public function insert(string $table): InsertInterface;
+    public function update(string $table): UpdateInterface;
+    public function delete(string $table): DeleteInterface;
+    public function schema(): SchemaInterface;
+    public function transaction(string $name = ''): TransactionInterface;
+    public function query(string $sql, array $args = []): \Traversable;
+}
+```
+
+Does NOT have `getPdo()`. Only `PdoDatabase` has that method. Type-hint `PdoDatabase` directly when raw PDO is needed.
+
+### CacheBackendInterface (packages/cache/src/CacheBackendInterface.php)
+
+```php
+interface CacheBackendInterface
+{
+    public const PERMANENT = -1;
+    public function get(string $cid): CacheItem|false;
+    public function getMultiple(array &$cids): array;
+    public function set(string $cid, mixed $data, int $expire = self::PERMANENT, array $tags = []): void;
+    public function delete(string $cid): void;
+    public function deleteMultiple(array $cids): void;
+    public function deleteAll(): void;
+    public function invalidate(string $cid): void;
+    public function invalidateMultiple(array $cids): void;
+    public function invalidateAll(): void;
+    public function removeBin(): void;
+}
+```
+
+### ServiceProviderInterface (packages/foundation/src/ServiceProvider/ServiceProviderInterface.php)
+
+```php
+interface ServiceProviderInterface
+{
+    public function register(): void;   // pure binding, no side effects
+    public function boot(): void;       // runs after ALL register() calls
+    public function provides(): array;  // deferred provider interfaces
+    public function isDeferred(): bool; // true if provides() is non-empty
+}
+```
+
+### DomainEvent (packages/foundation/src/Event/DomainEvent.php)
+
+```php
+abstract class DomainEvent extends Event
+{
+    public readonly string $eventId;
+    public readonly \DateTimeImmutable $occurredAt;
+
+    public function __construct(
+        public readonly string $aggregateType,
+        public readonly string $aggregateId,
+        public readonly ?string $tenantId = null,
+        public readonly ?string $actorId = null,
+    );
+
+    abstract public function getPayload(): array;
+}
+```
+
+### EventBus (packages/foundation/src/Event/EventBus.php)
+
+```php
+final class EventBus
+{
+    public function __construct(
+        EventDispatcherInterface $syncDispatcher,
+        MessageBusInterface $asyncBus,
+        BroadcasterInterface $broadcaster,
+        ?EventStoreInterface $eventStore = null,
+        ?EventPipeline $eventPipeline = null,
+    );
+    public function dispatch(DomainEvent $event): void;
+}
+```
+
+### Middleware pipeline interfaces
+
+Three typed pipeline variants, all using the onion pattern:
+
+```php
+// HTTP
+interface HttpMiddlewareInterface {
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}
+interface HttpHandlerInterface {
+    public function handle(Request $request): Response;
+}
+
+// Events
+interface EventMiddlewareInterface {
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}
+interface EventHandlerInterface {
+    public function handle(DomainEvent $event): void;
+}
+
+// Jobs
+interface JobMiddlewareInterface {
+    public function process(Job $job, JobHandlerInterface $next): void;
+}
+interface JobHandlerInterface {
+    public function handle(Job $job): void;
+}
+```
+
+### SelectInterface query builder (packages/database-legacy/src/SelectInterface.php)
+
+```php
+interface SelectInterface
+{
+    public function fields(string $tableAlias, array $fields = []): static;
+    public function addField(string $tableAlias, string $field, string $alias = ''): static;
+    public function condition(string $field, mixed $value, string $operator = '='): static;
+    public function isNull(string $field): static;
+    public function isNotNull(string $field): static;
+    public function orderBy(string $field, string $direction = 'ASC'): static;
+    public function range(int $offset, int $limit): static;
+    public function join(string $table, string $alias, string $condition): static;
+    public function leftJoin(string $table, string $alias, string $condition): static;
+    public function countQuery(): static;
+    public function execute(): \Traversable;
+}
+```
+
+### PackageManifestCompiler (packages/foundation/src/Discovery/PackageManifestCompiler.php)
+
+```php
+final class PackageManifestCompiler
+{
+    public function __construct(string $basePath, string $storagePath);
+    public function compile(): PackageManifest;
+    public function compileAndCache(): PackageManifest;
+    public function load(): PackageManifest;
+}
+```
+
+### Migration (packages/foundation/src/Migration/Migration.php)
+
+```php
+abstract class Migration
+{
+    public array $after = [];
+    abstract public function up(SchemaBuilder $schema): void;
+    public function down(SchemaBuilder $schema): void {}
+}
+```
+
+## Architecture
+
+### Event dispatch flow
+
+```
+EventBus::dispatch(DomainEvent)
+    1. $eventStore?->append($event)
+    2. If EventPipeline exists: pipeline wraps sync dispatch
+       Else: direct sync dispatch via Symfony EventDispatcher
+    3. $asyncBus->dispatch($event) -- Symfony Messenger
+    4. $broadcaster->broadcast($event) -- SSE
+```
+
+### Service provider lifecycle
+
+```
+ContainerCompiler::compile(providers, container)
+    Phase 1: foreach provider -> register()
+        - Collects bindings via getBindings()
+        - Collects tags via getTags()
+        - Wires into Symfony ContainerBuilder
+    Phase 2: foreach provider -> boot()
+        - All bindings available from all packages
+```
+
+### Package manifest compilation
+
+```
+PackageManifestCompiler::compile()
+    1. Read vendor/composer/installed.json -> extract extra.waaseyaa keys
+    2. Read vendor/composer/autoload_classmap.php -> filter Waaseyaa\\ classes
+    3. Reflect each class -> check for AsFieldType, Listener, AsMiddleware, PolicyAttribute
+    4. Sort middleware + listeners by priority (descending)
+    5. Return PackageManifest
+
+PackageManifestCompiler::compileAndCache()
+    1. compile()
+    2. Write to storage/framework/packages.php (atomic: tmp file + rename)
+```
+
+### Cache factory resolution
+
+```
+CacheFactory::get(bin)
+    1. Check CacheConfiguration::getFactoryForBin(bin)
+       - bin-specific factory? -> call it
+       - default factory? -> call it
+    2. Fall back to CacheConfiguration::getBackendForBin(bin)
+       - bin-specific class? -> new $class()
+       - default class -> new $defaultBackend()
+```
+
+### Migration execution
+
+```
+Migrator::run(migrations)
+    1. Topologically sort packages by Migration::$after dependencies
+    2. Get next batch number
+    3. For each migration in order:
+       - Skip if already run (MigrationRepository::hasRun)
+       - Create SchemaBuilder -> call migration->up($schema)
+       - Record in waaseyaa_migrations table
+    4. Return MigrationResult with count + names
+```
+
+## Common Mistakes
+
+### DatabaseInterface vs PdoDatabase
+
+`DatabaseInterface` does NOT have `getPdo()`. This is the most common mistake. If you need raw PDO access, type-hint `PdoDatabase` directly. Prefer using the query builder over raw PDO.
+
+```php
+// WRONG
+public function __construct(private DatabaseInterface $db) {
+    $pdo = $db->getPdo();  // Method does not exist on interface
+}
+
+// CORRECT
+public function __construct(private PdoDatabase $db) {
+    $pdo = $db->getPdo();
+}
+
+// PREFERRED -- use query builder instead of raw PDO
+$db->select('users', 'u')->condition('u.uid', $uid)->execute();
+```
+
+### LIKE wildcard escaping
+
+`PdoSelect` appends `ESCAPE '\'` for LIKE/NOT LIKE operators automatically. You must escape `%` and `_` in user input yourself:
+
+```php
+$escaped = str_replace(['%', '_'], ['\\%', '\\_'], $userInput);
+$query->condition('title', '%' . $escaped . '%', 'LIKE');
+```
+
+### Atomic file writes
+
+Cache files and compiled artifacts must use write-to-temp-then-rename:
+
+```php
+$tmpPath = $cachePath . '.tmp.' . getmypid();
+file_put_contents($tmpPath, $content);
+rename($tmpPath, $cachePath);
+```
+
+Never write directly to the target path. Partial writes cause corrupt cache.
+
+### JSON symmetry
+
+Always pair `json_encode(..., JSON_THROW_ON_ERROR)` with `json_decode(..., JSON_THROW_ON_ERROR)`. Asymmetric usage causes silent `null` on corrupt data.
+
+### Layer discipline for imports
+
+Foundation (layer 1) must never import from higher layers. When cross-layer attribute scanning is needed, use string constants:
+
+```php
+// WRONG -- imports from layer 3
+use Waaseyaa\Access\Gate\PolicyAttribute;
+
+// CORRECT -- string constant, no import
+private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
+```
+
+`ReflectionClass::getAttributes()` accepts string class names.
+
+### Best-effort side effects in event listeners
+
+Event listeners for non-critical operations must wrap in try-catch:
+
+```php
+public function onPostSave(EntityEvent $event): void
+{
+    try {
+        $this->cacheTagsInvalidator->invalidateTags([...]);
+    } catch (\Throwable $e) {
+        error_log('Cache invalidation failed: ' . $e->getMessage());
+    }
+}
+```
+
+The project does not use `psr/log`. Use `error_log()` for logging.
+
+### Final classes cannot be mocked
+
+PHPUnit `createMock()` fails on `final class`. Use real instances with temp directories:
+
+```php
+$dir = sys_get_temp_dir() . '/waaseyaa_test_' . uniqid();
+$db = PdoDatabase::createSqlite();  // in-memory
+$cache = new MemoryBackend();
+```
+
+### Backward-compatible cache evolution
+
+When adding new properties to cached manifests, make them optional:
+
+```php
+// In PackageManifest::fromArray()
+permissions: $data['permissions'] ?? [],
+policies: $data['policies'] ?? [],
+```
+
+Old cache files missing new keys will not break.
+
+### PDO fetch mode
+
+`PdoDatabase` sets `FETCH_ASSOC` to avoid duplicate numeric-indexed columns. Do not override this.
+
+### register() vs boot() in ServiceProvider
+
+`register()` is pure binding only. Never resolve other services or cause side effects in `register()`. Use `boot()` for anything that depends on other packages being registered.
+
+## Testing Patterns
+
+### In-memory database
+
+```php
+$db = PdoDatabase::createSqlite();  // SQLite :memory:
+```
+
+### In-memory cache
+
+```php
+$cache = new MemoryBackend();
+$cache->set('key', $data, tags: ['entity:node']);
+$cache->invalidateByTags(['entity:node']);
+```
+
+### Cache factory with configuration
+
+```php
+$config = new CacheConfiguration(
+    defaultBackend: MemoryBackend::class,
+    binFactories: [
+        'cache_entity' => fn() => new DatabaseBackend($pdo, 'cache_entity'),
+    ],
+);
+$factory = new CacheFactory($config);
+```
+
+### Testing corrupt cache recovery
+
+```php
+// Write corrupt cache file
+file_put_contents($cachePath, '<?php throw new \\RuntimeException("corrupt");');
+$manifest = $compiler->load();  // should recompile instead of crashing
+
+// Wrong return type
+file_put_contents($cachePath, '<?php return "not an array";');
+$manifest = $compiler->load();  // should recompile
+```
+
+### Testing migrations
+
+```php
+$connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+$repository = new MigrationRepository($connection);
+$repository->createTable();
+$migrator = new Migrator($connection, $repository);
+
+$result = $migrator->run([
+    'waaseyaa/node' => [
+        '001_create_nodes' => new CreateNodesTable(),
+    ],
+]);
+assert($result->count === 1);
+```
+
+### Testing event bus
+
+```php
+$dispatcher = new EventDispatcher();
+$asyncBus = /* Symfony Messenger test bus */;
+$broadcaster = new class implements BroadcasterInterface {
+    public function broadcast(DomainEvent $event): void {}
+};
+$bus = new EventBus($dispatcher, $asyncBus, $broadcaster);
+$bus->dispatch($event);
+```
+
+### Testing query builder
+
+```php
+$db = PdoDatabase::createSqlite();
+$db->schema()->createTable('users', [
+    'fields' => [
+        'uid' => ['type' => 'serial'],
+        'name' => ['type' => 'varchar', 'not null' => true],
+    ],
+    'primary key' => ['uid'],
+]);
+
+$db->insert('users')->values(['name' => 'admin'])->execute();
+$result = $db->select('users')->condition('name', 'admin')->execute();
+```
+
+## Related Specs
+
+- `docs/specs/infrastructure.md` -- full infrastructure specification (domain events, cache, database, migrations)
+- `docs/specs/package-discovery.md` -- full package discovery specification (service providers, manifest compilation, attribute scanning, plugin system)
+- `docs/plans/2026-03-01-laravel-integration-layer-design.md` -- design document for package auto-discovery, middleware pipelines, config caching
+- `docs/plans/2026-02-28-aurora-architecture-v2-design.md` -- full architecture v2 design with all 17 pillars

--- a/skills/waaseyaa/infrastructure/SKILL.md
+++ b/skills/waaseyaa/infrastructure/SKILL.md
@@ -290,10 +290,10 @@ Always pair `json_encode(..., JSON_THROW_ON_ERROR)` with `json_decode(..., JSON_
 
 ### Layer discipline for imports
 
-Foundation (layer 1) must never import from higher layers. When cross-layer attribute scanning is needed, use string constants:
+Foundation (layer 0) must never import from higher layers. When cross-layer attribute scanning is needed, use string constants:
 
 ```php
-// WRONG -- imports from layer 3
+// WRONG -- imports from layer 1
 use Waaseyaa\Access\Gate\PolicyAttribute;
 
 // CORRECT -- string constant, no import

--- a/skills/waaseyaa/mcp-endpoint/SKILL.md
+++ b/skills/waaseyaa/mcp-endpoint/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: waaseyaa:mcp-endpoint
+description: Use when working with the MCP server endpoint, JSON-RPC handling, tool registry, authentication, or files in packages/mcp/
+---
+
+# MCP Endpoint Specialist
+
+## Scope
+
+This skill covers the MCP (Model Context Protocol) package:
+
+- `packages/mcp/src/` -- McpEndpoint, McpResponse, McpRouteProvider, McpServerCard
+- `packages/mcp/src/Auth/` -- McpAuthInterface, BearerTokenAuth
+- `packages/mcp/src/Bridge/` -- ToolRegistryInterface, ToolExecutorInterface
+
+Use this skill when:
+- Adding or modifying the MCP HTTP endpoint
+- Working with JSON-RPC protocol handling
+- Changing MCP authentication
+- Adding new JSON-RPC methods or tool capabilities
+- Wiring MCP routes into the front controller
+- Working with the tool registry or executor bridge
+
+## Key Interfaces
+
+### McpEndpoint (packages/mcp/src/McpEndpoint.php)
+
+```php
+final readonly class McpEndpoint
+{
+    public function __construct(
+        private McpAuthInterface $auth,
+        private ToolRegistryInterface $registry,
+        private ToolExecutorInterface $executor,
+    ) {}
+
+    public function handle(
+        string $method,
+        string $body,
+        ?string $authorizationHeader,
+    ): McpResponse;
+}
+```
+
+Single entry point for all MCP traffic. Authenticates, parses JSON-RPC, dispatches to internal handlers.
+
+### McpResponse (packages/mcp/src/McpResponse.php)
+
+```php
+final readonly class McpResponse
+{
+    public function __construct(
+        public string $body,
+        public int $statusCode = 200,
+        public string $contentType = 'application/json',
+    ) {}
+}
+```
+
+### McpAuthInterface (packages/mcp/src/Auth/McpAuthInterface.php)
+
+```php
+interface McpAuthInterface
+{
+    public function authenticate(?string $authorizationHeader): ?AccountInterface;
+}
+```
+
+Returns `AccountInterface` on success, `null` on failure. `BearerTokenAuth` is the MVP implementation mapping opaque tokens to accounts.
+
+### ToolRegistryInterface (packages/mcp/src/Bridge/ToolRegistryInterface.php)
+
+```php
+interface ToolRegistryInterface
+{
+    /** @return McpToolDefinition[] */
+    public function getTools(): array;
+    public function getTool(string $name): ?McpToolDefinition;
+}
+```
+
+### ToolExecutorInterface (packages/mcp/src/Bridge/ToolExecutorInterface.php)
+
+```php
+interface ToolExecutorInterface
+{
+    public function execute(string $toolName, array $arguments): array;
+}
+```
+
+Returns MCP tool result format: `{content: [{type: "text", text: "..."}], isError?: bool}`.
+
+## Architecture
+
+### JSON-RPC Dispatch Flow
+
+```
+POST /mcp
+  -> McpEndpoint::handle()
+    -> authenticate($authorizationHeader) -> AccountInterface | null (401)
+    -> json_decode($body) -> parse error (-32700) | invalid request (-32600)
+    -> match $request['method']:
+        'initialize' -> protocol version, capabilities, server info
+        'ping'       -> empty result
+        'tools/list' -> ToolRegistryInterface::getTools() -> toArray()
+        'tools/call' -> ToolExecutorInterface::execute($name, $arguments)
+        default      -> method not found (-32601)
+```
+
+### JSON-RPC Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `-32700` | Parse error (invalid JSON) |
+| `-32600` | Invalid request (missing `method` field) |
+| `-32601` | Method not found |
+| `-32602` | Invalid params (missing tool name, unknown tool) |
+| `-32001` | Unauthorized (auth failure) |
+
+### Routes
+
+`McpRouteProvider` registers two routes:
+
+| Route | Path | Methods | Auth |
+|-------|------|---------|------|
+| `mcp.endpoint` | `/mcp` | POST, GET | Required (bearer token) |
+| `mcp.server_card` | `/.well-known/mcp.json` | GET | Public |
+
+**Note:** Routes are defined in `McpRouteProvider` but not yet wired into `public/index.php`. This is a known gap.
+
+### Package Dependencies
+
+- **Layer 6** (Interfaces) -- can import from layers 0-5
+- Depends on: `waaseyaa/ai-schema` (McpToolDefinition), `waaseyaa/ai-agent` (AgentExecutor), `waaseyaa/routing`, `waaseyaa/access` (AccountInterface)
+
+## Common Mistakes
+
+### JSON symmetry
+
+Always pair `json_encode(..., JSON_THROW_ON_ERROR)` with `json_decode(..., JSON_THROW_ON_ERROR)`. The endpoint already does this correctly -- maintain it.
+
+### AccountInterface, not concrete User
+
+The auth interface returns `?AccountInterface` (from `waaseyaa/access`), not a concrete `User` class (from `waaseyaa/user`). The MCP package must not depend on `waaseyaa/user`.
+
+### Tool result format
+
+Tool executor must return `{content: [{type: "text", text: "..."}]}`. The `isError` key is optional (defaults to false). Don't return raw strings or arrays -- wrap in the content block format.
+
+### php://input is single-read
+
+`HttpRequest::createFromGlobals()` consumes `php://input`. The front controller must pass the body via `$httpRequest->getContent()`, not re-read `php://input`.
+
+### Final classes cannot be mocked
+
+All concrete classes are `final readonly class`. Use real instances in tests:
+
+```php
+// Auth: use BearerTokenAuth with known tokens
+$auth = new BearerTokenAuth(['test-token' => $account]);
+
+// Registry/Executor: use anonymous classes implementing the interfaces
+$registry = new class implements ToolRegistryInterface { ... };
+$executor = new class implements ToolExecutorInterface { ... };
+
+$endpoint = new McpEndpoint($auth, $registry, $executor);
+$response = $endpoint->handle('POST', $body, 'Bearer test-token');
+```
+
+## Testing Patterns
+
+### Unit Testing McpEndpoint
+
+```php
+$auth = new BearerTokenAuth(['tok' => $account]);
+$registry = new class implements ToolRegistryInterface {
+    public function getTools(): array { return []; }
+    public function getTool(string $name): ?McpToolDefinition { return null; }
+};
+$executor = new class implements ToolExecutorInterface {
+    public function execute(string $toolName, array $arguments): array {
+        return ['content' => [['type' => 'text', 'text' => 'ok']]];
+    }
+};
+
+$endpoint = new McpEndpoint($auth, $registry, $executor);
+
+// Test auth failure
+$response = $endpoint->handle('POST', '{}', null);
+assert($response->statusCode === 401);
+
+// Test ping
+$body = json_encode(['jsonrpc' => '2.0', 'method' => 'ping', 'id' => 1]);
+$response = $endpoint->handle('POST', $body, 'Bearer tok');
+assert($response->statusCode === 200);
+```
+
+### Testing BearerTokenAuth
+
+```php
+$auth = new BearerTokenAuth(['secret' => $account]);
+
+assert($auth->authenticate(null) === null);
+assert($auth->authenticate('Bearer wrong') === null);
+assert($auth->authenticate('Bearer secret') === $account);
+assert($auth->authenticate('bearer secret') === $account); // case-insensitive
+```
+
+### Testing McpServerCard
+
+```php
+$card = new McpServerCard(name: 'Test', version: '1.0.0', endpoint: '/mcp');
+$json = $card->toJson();
+$decoded = json_decode($json, true);
+assert($decoded['endpoint'] === '/mcp');
+assert($decoded['transport'] === 'streamable-http');
+```
+
+## Related Specs
+
+- `docs/specs/mcp-endpoint.md` -- Full MCP endpoint specification
+- `docs/specs/ai-integration.md` -- AI layer that provides McpToolDefinition and AgentExecutor
+- `CLAUDE.md` -- Project-wide gotchas including JSON symmetry and AccountInterface vs User

--- a/skills/waaseyaa/middleware-pipeline/SKILL.md
+++ b/skills/waaseyaa/middleware-pipeline/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: waaseyaa:middleware-pipeline
+description: Use when working with HTTP middleware, event middleware, job middleware, pipeline compilation, middleware discovery, or files in packages/foundation/src/Middleware/, packages/routing/, packages/user/src/Middleware/, packages/access/src/Middleware/, public/index.php
+---
+
+# Middleware Pipeline Specialist
+
+## Scope
+
+This skill covers:
+- The three typed middleware pipelines (HTTP, Event, Job) and their interface pairs
+- The onion execution pattern implemented by `HttpPipeline`, `EventPipeline`, `JobPipeline`
+- Middleware discovery via `#[AsMiddleware]` attribute and `PackageManifestCompiler`
+- The HTTP authorization chain (`SessionMiddleware` -> `AuthorizationMiddleware`)
+- Route-level access control via route options and `AccessChecker`
+- The front controller wiring in `public/index.php`
+
+## Key Interfaces
+
+All interfaces live in namespace `Waaseyaa\Foundation\Middleware` within `packages/foundation/src/Middleware/`.
+
+### HTTP pipeline
+
+```php
+// packages/foundation/src/Middleware/HttpMiddlewareInterface.php
+interface HttpMiddlewareInterface {
+    public function process(Request $request, HttpHandlerInterface $next): Response;
+}
+
+// packages/foundation/src/Middleware/HttpHandlerInterface.php
+interface HttpHandlerInterface {
+    public function handle(Request $request): Response;
+}
+```
+
+- `Request` = `Symfony\Component\HttpFoundation\Request`
+- `Response` = `Symfony\Component\HttpFoundation\Response`
+
+### Event pipeline
+
+```php
+// packages/foundation/src/Middleware/EventMiddlewareInterface.php
+interface EventMiddlewareInterface {
+    public function process(DomainEvent $event, EventHandlerInterface $next): void;
+}
+
+// packages/foundation/src/Middleware/EventHandlerInterface.php
+interface EventHandlerInterface {
+    public function handle(DomainEvent $event): void;
+}
+```
+
+- `DomainEvent` = `Waaseyaa\Foundation\Event\DomainEvent`
+
+### Job pipeline
+
+```php
+// packages/foundation/src/Middleware/JobMiddlewareInterface.php
+interface JobMiddlewareInterface {
+    public function process(Job $job, JobHandlerInterface $next): void;
+}
+
+// packages/foundation/src/Middleware/JobHandlerInterface.php
+interface JobHandlerInterface {
+    public function handle(Job $job): void;
+}
+```
+
+- `Job` = `Waaseyaa\Queue\Job`
+
+### Discovery attribute
+
+```php
+// packages/foundation/src/Attribute/AsMiddleware.php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMiddleware {
+    public function __construct(
+        public readonly string $pipeline,   // 'http', 'event', or 'job'
+        public readonly int $priority = 0,  // Higher = runs first (outermost)
+    ) {}
+}
+```
+
+### Access checking
+
+```php
+// packages/routing/src/AccessChecker.php
+final class AccessChecker {
+    public function __construct(private readonly ?GateInterface $gate = null) {}
+    public function check(Route $route, AccountInterface $account): AccessResult;
+}
+```
+
+Route options read by `AccessChecker`: `_public` (bool), `_permission` (string), `_role` (string), `_gate` (array).
+
+## Architecture
+
+### Pipeline construction pattern
+
+Pipelines are immutable. `withMiddleware()` returns a new instance:
+
+```php
+$pipeline = (new HttpPipeline())
+    ->withMiddleware(new SessionMiddleware($userStorage))
+    ->withMiddleware(new AuthorizationMiddleware($accessChecker));
+
+$response = $pipeline->handle($request, $finalHandler);
+```
+
+Middleware added first runs outermost (first in, first to execute). The `array_reverse()` inside the pipeline builds the onion from inside out.
+
+### Onion execution order
+
+Given `[A, B]`:
+```
+A::process() ->
+  B::process() ->
+    finalHandler::handle()
+  <- B returns
+<- A returns
+```
+
+A middleware can short-circuit by returning without calling `$next->handle()`.
+
+### HTTP authorization chain in public/index.php
+
+The front controller wires the pipeline in this order:
+
+1. **CORS handling** (pre-pipeline, bare headers)
+2. **Route matching** (pre-pipeline, sets `_route_object` on request)
+3. **HttpPipeline** with `SessionMiddleware` then `AuthorizationMiddleware`
+4. **Dispatch** to controllers (post-pipeline)
+
+SessionMiddleware always sets `_account` on the request. AuthorizationMiddleware reads both `_route_object` and `_account` to enforce access. If authorization fails, a 403 response is returned and dispatch never runs.
+
+### Access result semantics
+
+- Route with no access options: `AccessChecker` returns `AccessResult::neutral()` -> AuthorizationMiddleware passes through (open-by-default)
+- Route with `_public => true`: always allowed
+- Route with `_permission`: checks `$account->hasPermission()`
+- Route with `_role`: checks intersection of required roles and account roles
+- Route with `_gate`: delegates to `GateInterface::allows()`
+- Multiple options combine with AND logic
+
+### Middleware discovery flow
+
+1. `PackageManifestCompiler` scans Composer classmap for `Waaseyaa\\*` classes
+2. Classes with `#[AsMiddleware]` attribute are collected with their `pipeline` and `priority`
+3. Stacks are sorted by priority descending (`$b['priority'] <=> $a['priority']`)
+4. Compiled into `storage/framework/packages.php` (atomic write)
+5. `PackageManifest::$middleware` type: `array<string, list<array{class: string, priority: int}>>`
+
+## Common Mistakes
+
+### 1. Wrong handler interface name for jobs
+
+The design document references `JobNextHandlerInterface` but the actual implementation uses `JobHandlerInterface`. Always use the name from `packages/foundation/src/Middleware/JobHandlerInterface.php`.
+
+### 2. php://input double-read
+
+`HttpRequest::createFromGlobals()` consumes `php://input`. After that call, you must use `$httpRequest->getContent()` to read the body. Never call `file_get_contents('php://input')` after `createFromGlobals()`.
+
+```php
+// WRONG
+$httpRequest = HttpRequest::createFromGlobals();
+$raw = file_get_contents('php://input'); // empty string!
+
+// CORRECT
+$httpRequest = HttpRequest::createFromGlobals();
+$raw = $httpRequest->getContent();
+```
+
+### 3. Naming convention violations
+
+Handler interfaces must be `{Type}HandlerInterface`, middleware interfaces must be `{Type}MiddlewareInterface`. Do not use generic names like `MiddlewareInterface` or `HandlerInterface`.
+
+### 4. Circular dependency between access and user packages
+
+`AccountInterface` lives in the access package. `AnonymousUser` and `User` live in the user package. Access must not depend on user. Middleware that needs an account must type-hint `AccountInterface`, never `AnonymousUser` or `User` directly. `AuthorizationMiddleware` correctly depends on `AccountInterface` only.
+
+### 5. Final classes cannot be mocked
+
+All pipeline and middleware classes are `final class`. PHPUnit `createMock()` will fail on them. In tests, use real instances. For handlers, use anonymous classes implementing the interface:
+
+```php
+$next = new class implements HttpHandlerInterface {
+    public function handle(Request $request): Response {
+        return new Response('ok', 200);
+    }
+};
+```
+
+### 6. Missing _route_object on request
+
+`AuthorizationMiddleware` reads `$request->attributes->get('_route_object')`. If this is not set, it passes through without checking access. In tests, you must explicitly set it:
+
+```php
+$route = new Route('/api/node');
+$route->setOption('_permission', 'access content');
+$request->attributes->set('_route_object', $route);
+```
+
+### 7. Confusing entity-level and route-level access semantics
+
+Route-level: `AuthorizationMiddleware` uses `$result->isForbidden()` to decide. Neutral means pass through (open-by-default). This is different from entity-level access which uses `$result->isAllowed()` (deny-by-default).
+
+### 8. Middleware ordering matters
+
+SessionMiddleware must run before AuthorizationMiddleware because authorization reads `_account` which session sets. The pipeline preserves insertion order -- first `withMiddleware()` call is outermost.
+
+### 9. Using error_log not psr/log
+
+This project does not use `psr/log`. Both `SessionMiddleware` and `AuthorizationMiddleware` use `error_log()` for logging failures. Follow this pattern in new middleware.
+
+## Testing Patterns
+
+### Unit testing a middleware
+
+Create the middleware, a mock or real handler, and a Symfony `Request`. Capture state via anonymous handler classes:
+
+```php
+// From packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
+$capturedAccount = null;
+$next = new class($capturedAccount) implements HttpHandlerInterface {
+    public function __construct(private ?AccountInterface &$ref) {}
+    public function handle(Request $request): Response {
+        $this->ref = $request->attributes->get('_account');
+        return new Response('ok');
+    }
+};
+$middleware->process($request, $next);
+$this->assertInstanceOf(AnonymousUser::class, $capturedAccount);
+```
+
+### Integration testing the full pipeline
+
+Use `PdoDatabase::createSqlite()` for in-memory storage, real `User` entities, and the actual pipeline:
+
+```php
+// From tests/Integration/Phase11/AuthorizationPipelineTest.php
+$pipeline = (new HttpPipeline())
+    ->withMiddleware(new SessionMiddleware($userStorage))
+    ->withMiddleware(new AuthorizationMiddleware($accessChecker));
+
+$route = new Route('/api/node');
+$route->setOption('_permission', 'access content');
+$request = Request::create('/api/node');
+$request->attributes->set('_route_object', $route);
+
+$response = $pipeline->handle($request, $successHandler);
+$this->assertSame(403, $response->getStatusCode());
+```
+
+### Setting session data in tests
+
+Do not call `session_start()` in tests. Set session data via request attributes:
+
+```php
+$request->attributes->set('_session', ['waaseyaa_uid' => 42]);
+```
+
+`SessionMiddleware` reads `$request->attributes->get('_session')` first, falling back to `$_SESSION`.
+
+### Testing route access options
+
+Create a bare `Symfony\Component\Routing\Route` and set options directly:
+
+```php
+$route = new Route('/api/node');
+$route->setOption('_permission', 'access content');  // permission-protected
+$route->setOption('_public', true);                   // public route
+$route->setOption('_role', 'admin,editor');            // role-protected
+```
+
+### Test file locations
+
+| Test file | Covers |
+|-----------|--------|
+| `packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php` | `SessionMiddleware` |
+| `packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php` | `AuthorizationMiddleware` |
+| `tests/Integration/Phase11/AuthorizationPipelineTest.php` | Full Session + Auth pipeline |
+
+### PHPUnit attributes
+
+Unit tests use `#[CoversClass(TargetClass::class)]`. Integration tests use `#[CoversNothing]`. All test methods use `#[Test]` attribute.
+
+## Related Specs
+
+- `docs/specs/middleware-pipeline.md` -- full specification with interface signatures and file reference
+- `docs/plans/2026-03-01-laravel-integration-layer-design.md` -- original design document for middleware pipelines
+- `docs/plans/2026-03-01-authorization-wiring-design.md` -- design for Session + Authorization middleware wiring

--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# drift-detector.sh — Map recent git changes to subsystem specs that may need review.
+#
+# Usage: tools/drift-detector.sh [N]
+#   N = number of recent commits to check (default: 5)
+
+set -euo pipefail
+
+N="${1:-5}"
+
+# Verify we're in a git repo.
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+
+# Collect changed files.
+changed_files=$(git diff --name-only "HEAD~${N}..HEAD" 2>/dev/null) || {
+  echo "Error: could not compute diff for last ${N} commits." >&2
+  exit 1
+}
+
+if [ -z "$changed_files" ]; then
+  echo "No files changed in last ${N} commits."
+  echo "All specs up to date."
+  exit 0
+fi
+
+echo "Checking files changed in last ${N} commits..."
+echo ""
+
+declare -A affected_specs
+
+map_file_to_specs() {
+  local file="$1"
+  local specs=""
+
+  # Entity system
+  case "$file" in
+    packages/entity/*|packages/entity-storage/*|packages/field/*|packages/config/*)
+      specs="$specs docs/specs/entity-system.md" ;;
+  esac
+
+  # Access control
+  case "$file" in
+    packages/access/*|packages/user/src/Middleware/*)
+      specs="$specs docs/specs/access-control.md" ;;
+  esac
+
+  # Field access (FieldAccess in access, Schema in api)
+  case "$file" in
+    packages/access/src/*FieldAccess*)
+      specs="$specs docs/specs/field-access.md" ;;
+  esac
+  case "$file" in
+    packages/api/src/*Schema*)
+      specs="$specs docs/specs/field-access.md" ;;
+  esac
+
+  # API layer
+  case "$file" in
+    packages/api/*|packages/routing/*)
+      specs="$specs docs/specs/api-layer.md" ;;
+  esac
+
+  # Infrastructure
+  case "$file" in
+    packages/foundation/*|packages/cache/*|packages/database-legacy/*)
+      specs="$specs docs/specs/infrastructure.md" ;;
+  esac
+
+  # Package discovery
+  case "$file" in
+    packages/foundation/src/*Provider*)
+      specs="$specs docs/specs/package-discovery.md" ;;
+  esac
+  case "$file" in
+    packages/plugin/*)
+      specs="$specs docs/specs/package-discovery.md" ;;
+  esac
+
+  # Middleware pipeline
+  case "$file" in
+    public/index.php)
+      specs="$specs docs/specs/middleware-pipeline.md" ;;
+  esac
+  case "$file" in
+    packages/*/src/Middleware/*)
+      specs="$specs docs/specs/middleware-pipeline.md" ;;
+  esac
+
+  # Admin SPA
+  case "$file" in
+    packages/admin/*)
+      specs="$specs docs/specs/admin-spa.md" ;;
+  esac
+
+  # AI integration
+  case "$file" in
+    packages/ai-*/*)
+      specs="$specs docs/specs/ai-integration.md" ;;
+  esac
+
+  # MCP endpoint
+  case "$file" in
+    packages/mcp/*)
+      specs="$specs docs/specs/mcp-endpoint.md" ;;
+  esac
+
+  echo "$specs"
+}
+
+echo "Files changed -> Affected specs:"
+
+while IFS= read -r file; do
+  raw_specs=$(map_file_to_specs "$file")
+  if [ -z "$raw_specs" ]; then
+    continue
+  fi
+
+  # Deduplicate specs for this file.
+  declare -A seen_for_file
+  display_specs=""
+  for spec in $raw_specs; do
+    if [ -z "${seen_for_file[$spec]+x}" ]; then
+      seen_for_file[$spec]=1
+      affected_specs[$spec]=1
+      if [ -n "$display_specs" ]; then
+        display_specs="$display_specs, $spec"
+      else
+        display_specs="$spec"
+      fi
+    fi
+  done
+  unset seen_for_file
+
+  echo "  $file -> $display_specs"
+done <<< "$changed_files"
+
+echo ""
+
+count=${#affected_specs[@]}
+if [ "$count" -eq 0 ]; then
+  echo "All specs up to date."
+else
+  echo "$count spec(s) may need review:"
+  for spec in $(printf '%s\n' "${!affected_specs[@]}" | sort); do
+    echo "  - $spec"
+  done
+fi

--- a/tools/spec-retrieval/.gitignore
+++ b/tools/spec-retrieval/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/spec-retrieval/package-lock.json
+++ b/tools/spec-retrieval/package-lock.json
@@ -1,0 +1,1138 @@
+{
+  "name": "waaseyaa-spec-retrieval",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "waaseyaa-spec-retrieval",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/tools/spec-retrieval/package.json
+++ b/tools/spec-retrieval/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "waaseyaa-spec-retrieval",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "MCP server for retrieving Waaseyaa subsystem specs",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test test.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  }
+}

--- a/tools/spec-retrieval/server.js
+++ b/tools/spec-retrieval/server.js
@@ -1,0 +1,311 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_SPECS_DIR = path.resolve(__dirname, '../../docs/specs');
+
+// ---------------------------------------------------------------------------
+// Core functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a markdown spec file into {name, description, file}.
+ * Name comes from the first `# Title` line.
+ * Description comes from the first paragraph under `## Overview`, or the
+ * first non-heading paragraph if there is no Overview section.
+ */
+function parseSpec(content, filename) {
+  const lines = content.split('\n');
+
+  // Extract name from first H1.
+  let name = filename.replace(/\.md$/, '');
+  for (const line of lines) {
+    if (line.startsWith('# ')) {
+      name = line.slice(2).trim();
+      break;
+    }
+  }
+
+  // Extract description: prefer ## Overview section, else first paragraph.
+  let description = '';
+  let inOverview = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (/^## Overview/i.test(line)) {
+      inOverview = true;
+      continue;
+    }
+
+    if (inOverview) {
+      if (line.startsWith('## ')) {
+        // Left the Overview section.
+        break;
+      }
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        description = trimmed;
+        break;
+      }
+      continue;
+    }
+  }
+
+  // Fallback: first non-empty, non-heading line after the title.
+  if (!description) {
+    let pastTitle = false;
+    for (const line of lines) {
+      if (line.startsWith('# ')) {
+        pastTitle = true;
+        continue;
+      }
+      if (pastTitle) {
+        const trimmed = line.trim();
+        if (trimmed && !trimmed.startsWith('#')) {
+          description = trimmed;
+          break;
+        }
+      }
+    }
+  }
+
+  return { name, description, file: filename };
+}
+
+/**
+ * List all specs in the given directory.
+ */
+export async function listSpecs(specsDir = DEFAULT_SPECS_DIR) {
+  let entries;
+  try {
+    entries = await fs.readdir(specsDir);
+  } catch {
+    return [];
+  }
+
+  const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
+  const results = [];
+
+  for (const file of mdFiles) {
+    const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
+    results.push(parseSpec(content, file));
+  }
+
+  return results;
+}
+
+/**
+ * Get the full markdown content of a spec by name (filename without extension).
+ */
+export async function getSpec(name, specsDir = DEFAULT_SPECS_DIR) {
+  const filename = name.endsWith('.md') ? name : `${name}.md`;
+  const filePath = path.join(specsDir, filename);
+
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch {
+    throw new Error(`Spec not found: ${name}`);
+  }
+}
+
+/**
+ * Search across all specs for sections matching a query (case-insensitive
+ * substring). Returns an array of {file, section, content} objects.
+ */
+export async function searchSpecs(query, specsDir = DEFAULT_SPECS_DIR) {
+  let entries;
+  try {
+    entries = await fs.readdir(specsDir);
+  } catch {
+    return [];
+  }
+
+  const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
+  const lowerQuery = query.toLowerCase();
+  const results = [];
+
+  for (const file of mdFiles) {
+    const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
+    const sections = splitIntoSections(content);
+
+    for (const section of sections) {
+      if (section.content.toLowerCase().includes(lowerQuery)) {
+        results.push({
+          file,
+          section: section.heading,
+          content: section.content,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Split markdown content into sections by headings.
+ * Each section includes its heading and all content until the next heading
+ * of equal or higher level.
+ */
+function splitIntoSections(content) {
+  const lines = content.split('\n');
+  const sections = [];
+  let currentHeading = '(top)';
+  let currentLines = [];
+
+  for (const line of lines) {
+    if (/^#{1,6}\s/.test(line)) {
+      // Save previous section if it has content.
+      if (currentLines.length > 0) {
+        sections.push({
+          heading: currentHeading,
+          content: currentLines.join('\n').trim(),
+        });
+      }
+      currentHeading = line.replace(/^#+\s*/, '').trim();
+      currentLines = [line];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  // Save last section.
+  if (currentLines.length > 0) {
+    sections.push({
+      heading: currentHeading,
+      content: currentLines.join('\n').trim(),
+    });
+  }
+
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server (only starts when run directly, not when imported for tests)
+// ---------------------------------------------------------------------------
+
+const isMainModule =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) ===
+    path.resolve(fileURLToPath(import.meta.url));
+
+if (isMainModule) {
+  const server = new Server(
+    { name: 'waaseyaa-specs', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'waaseyaa_list_specs',
+        description:
+          'List all Waaseyaa subsystem specs. Returns an array of {name, description, file} objects.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+      {
+        name: 'waaseyaa_get_spec',
+        description:
+          'Get the full markdown content of a named Waaseyaa subsystem spec.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description:
+                'Spec name (filename without .md extension, e.g. "mcp-endpoint")',
+            },
+          },
+          required: ['name'],
+        },
+      },
+      {
+        name: 'waaseyaa_search_specs',
+        description:
+          'Search across all Waaseyaa specs for sections matching a keyword. Returns matching sections with headings and content.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Search query (case-insensitive substring match)',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    switch (name) {
+      case 'waaseyaa_list_specs': {
+        const specs = await listSpecs();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(specs, null, 2) }],
+        };
+      }
+
+      case 'waaseyaa_get_spec': {
+        if (!args?.name) {
+          return {
+            content: [
+              { type: 'text', text: 'Error: missing required parameter "name"' },
+            ],
+            isError: true,
+          };
+        }
+        try {
+          const content = await getSpec(args.name);
+          return { content: [{ type: 'text', text: content }] };
+        } catch (err) {
+          return {
+            content: [{ type: 'text', text: `Error: ${err.message}` }],
+            isError: true,
+          };
+        }
+      }
+
+      case 'waaseyaa_search_specs': {
+        if (!args?.query) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: missing required parameter "query"',
+              },
+            ],
+            isError: true,
+          };
+        }
+        const results = await searchSpecs(args.query);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      default:
+        return {
+          content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/tools/spec-retrieval/server.js
+++ b/tools/spec-retrieval/server.js
@@ -87,16 +87,23 @@ export async function listSpecs(specsDir = DEFAULT_SPECS_DIR) {
   let entries;
   try {
     entries = await fs.readdir(specsDir);
-  } catch {
-    return [];
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw new Error(`Failed to read specs directory "${specsDir}": ${err.message}`);
   }
 
   const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
   const results = [];
 
   for (const file of mdFiles) {
-    const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
-    results.push(parseSpec(content, file));
+    try {
+      const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
+      results.push(parseSpec(content, file));
+    } catch (err) {
+      console.error(`[waaseyaa-specs] Skipping unreadable spec "${file}": ${err.message}`);
+    }
   }
 
   return results;
@@ -106,13 +113,22 @@ export async function listSpecs(specsDir = DEFAULT_SPECS_DIR) {
  * Get the full markdown content of a spec by name (filename without extension).
  */
 export async function getSpec(name, specsDir = DEFAULT_SPECS_DIR) {
-  const filename = name.endsWith('.md') ? name : `${name}.md`;
-  const filePath = path.join(specsDir, filename);
+  const safeName = path.basename(name);
+  const filename = safeName.endsWith('.md') ? safeName : `${safeName}.md`;
+  const filePath = path.resolve(specsDir, filename);
+  const resolvedDir = path.resolve(specsDir);
+
+  if (!filePath.startsWith(resolvedDir + path.sep) && filePath !== resolvedDir) {
+    throw new Error(`Spec not found: ${name}`);
+  }
 
   try {
     return await fs.readFile(filePath, 'utf-8');
-  } catch {
-    throw new Error(`Spec not found: ${name}`);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error(`Spec not found: ${name}`);
+    }
+    throw new Error(`Failed to read spec "${name}": ${err.message}`);
   }
 }
 
@@ -124,8 +140,11 @@ export async function searchSpecs(query, specsDir = DEFAULT_SPECS_DIR) {
   let entries;
   try {
     entries = await fs.readdir(specsDir);
-  } catch {
-    return [];
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw new Error(`Failed to read specs directory "${specsDir}": ${err.message}`);
   }
 
   const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
@@ -133,17 +152,21 @@ export async function searchSpecs(query, specsDir = DEFAULT_SPECS_DIR) {
   const results = [];
 
   for (const file of mdFiles) {
-    const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
-    const sections = splitIntoSections(content);
+    try {
+      const content = await fs.readFile(path.join(specsDir, file), 'utf-8');
+      const sections = splitIntoSections(content);
 
-    for (const section of sections) {
-      if (section.content.toLowerCase().includes(lowerQuery)) {
-        results.push({
-          file,
-          section: section.heading,
-          content: section.content,
-        });
+      for (const section of sections) {
+        if (section.content.toLowerCase().includes(lowerQuery)) {
+          results.push({
+            file,
+            section: section.heading,
+            content: section.content,
+          });
+        }
       }
+    } catch (err) {
+      console.error(`[waaseyaa-specs] Skipping unreadable spec "${file}": ${err.message}`);
     }
   }
 
@@ -254,10 +277,17 @@ if (isMainModule) {
 
     switch (name) {
       case 'waaseyaa_list_specs': {
-        const specs = await listSpecs();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(specs, null, 2) }],
-        };
+        try {
+          const specs = await listSpecs();
+          return {
+            content: [{ type: 'text', text: JSON.stringify(specs, null, 2) }],
+          };
+        } catch (err) {
+          return {
+            content: [{ type: 'text', text: `Error: ${err.message}` }],
+            isError: true,
+          };
+        }
       }
 
       case 'waaseyaa_get_spec': {
@@ -292,10 +322,17 @@ if (isMainModule) {
             isError: true,
           };
         }
-        const results = await searchSpecs(args.query);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
-        };
+        try {
+          const results = await searchSpecs(args.query);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
+          };
+        } catch (err) {
+          return {
+            content: [{ type: 'text', text: `Error: ${err.message}` }],
+            isError: true,
+          };
+        }
       }
 
       default:

--- a/tools/spec-retrieval/test-fixtures/alpha-feature.md
+++ b/tools/spec-retrieval/test-fixtures/alpha-feature.md
@@ -1,0 +1,27 @@
+# Alpha Feature
+
+## Overview
+
+Alpha Feature provides caching and validation for the system.
+
+## Architecture
+
+The architecture uses a layered approach with three tiers:
+- Presentation layer
+- Business logic layer
+- Data access layer
+
+## Configuration
+
+Configure Alpha via environment variables:
+- `ALPHA_CACHE_TTL` -- cache time-to-live in seconds.
+- `ALPHA_STRICT_MODE` -- enable strict validation.
+
+## File Reference
+
+```
+packages/alpha/
+  src/
+    AlphaCache.php
+    AlphaValidator.php
+```

--- a/tools/spec-retrieval/test-fixtures/beta-service.md
+++ b/tools/spec-retrieval/test-fixtures/beta-service.md
@@ -1,0 +1,26 @@
+# Beta Service
+
+## Overview
+
+Beta Service handles message queuing and background job processing.
+
+## Queue System
+
+Messages are placed into named queues. Workers consume messages and execute the associated job handlers.
+
+### Queue Configuration
+
+Queues are defined in YAML configuration files with priority levels and retry policies.
+
+## Authentication
+
+Beta Service authenticates workers using API tokens validated against the central auth registry.
+
+## File Reference
+
+```
+packages/beta/
+  src/
+    BetaQueue.php
+    BetaWorker.php
+```

--- a/tools/spec-retrieval/test-fixtures/gamma-api.md
+++ b/tools/spec-retrieval/test-fixtures/gamma-api.md
@@ -1,0 +1,20 @@
+# Gamma API
+
+REST API gateway for external integrations.
+
+## Endpoints
+
+The API exposes CRUD operations for all registered entity types. Each entity type gets five endpoints automatically.
+
+## Rate Limiting
+
+Requests are throttled per API key. Default limit is 1000 requests per hour.
+
+## File Reference
+
+```
+packages/gamma/
+  src/
+    GammaRouter.php
+    GammaRateLimiter.php
+```

--- a/tools/spec-retrieval/test.js
+++ b/tools/spec-retrieval/test.js
@@ -1,0 +1,116 @@
+import { strict as assert } from 'node:assert';
+import { test, describe } from 'node:test';
+import { listSpecs, getSpec, searchSpecs } from './server.js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, 'test-fixtures');
+
+describe('waaseyaa_list_specs', () => {
+  test('returns all spec files from directory', async () => {
+    const result = await listSpecs(fixturesDir);
+    assert.ok(Array.isArray(result), 'Result should be an array');
+    assert.equal(result.length, 3, 'Should find 3 test fixtures');
+
+    const names = result.map((s) => s.name).sort();
+    assert.deepEqual(names, ['Alpha Feature', 'Beta Service', 'Gamma API']);
+  });
+
+  test('each spec has name, description, and file fields', async () => {
+    const result = await listSpecs(fixturesDir);
+    for (const spec of result) {
+      assert.ok(spec.name, `Spec should have a name: ${JSON.stringify(spec)}`);
+      assert.ok(spec.description, `Spec should have a description: ${JSON.stringify(spec)}`);
+      assert.ok(spec.file, `Spec should have a file: ${JSON.stringify(spec)}`);
+    }
+  });
+
+  test('description comes from Overview section or first paragraph', async () => {
+    const result = await listSpecs(fixturesDir);
+    const alpha = result.find((s) => s.name === 'Alpha Feature');
+    assert.ok(alpha);
+    assert.ok(
+      alpha.description.includes('caching and validation'),
+      'Alpha description should mention caching and validation'
+    );
+
+    const gamma = result.find((s) => s.name === 'Gamma API');
+    assert.ok(gamma);
+    assert.ok(
+      gamma.description.includes('REST API gateway'),
+      'Gamma description should come from first paragraph when no Overview section'
+    );
+  });
+
+  test('returns empty array for empty directory', async () => {
+    const emptyDir = path.join(__dirname, 'test-fixtures', 'nonexistent-subdir');
+    const result = await listSpecs(emptyDir);
+    assert.ok(Array.isArray(result));
+    assert.equal(result.length, 0);
+  });
+});
+
+describe('waaseyaa_get_spec', () => {
+  test('returns full content of a spec by name', async () => {
+    const content = await getSpec('alpha-feature', fixturesDir);
+    assert.ok(content.includes('# Alpha Feature'));
+    assert.ok(content.includes('## Architecture'));
+    assert.ok(content.includes('AlphaCache.php'));
+  });
+
+  test('returns full content of another spec', async () => {
+    const content = await getSpec('beta-service', fixturesDir);
+    assert.ok(content.includes('# Beta Service'));
+    assert.ok(content.includes('## Queue System'));
+  });
+
+  test('throws for nonexistent spec', async () => {
+    await assert.rejects(
+      () => getSpec('nonexistent-spec', fixturesDir),
+      { message: /not found/i }
+    );
+  });
+});
+
+describe('waaseyaa_search_specs', () => {
+  test('finds matching sections by keyword', async () => {
+    const results = await searchSpecs('authentication', fixturesDir);
+    assert.ok(Array.isArray(results), 'Results should be an array');
+    assert.ok(results.length > 0, 'Should find at least one match');
+
+    const files = results.map((r) => r.file);
+    assert.ok(
+      files.includes('beta-service.md'),
+      'Should find authentication in beta-service'
+    );
+  });
+
+  test('search is case-insensitive', async () => {
+    const upper = await searchSpecs('AUTHENTICATION', fixturesDir);
+    const lower = await searchSpecs('authentication', fixturesDir);
+    assert.equal(upper.length, lower.length, 'Case should not affect results');
+  });
+
+  test('returns matching section with heading', async () => {
+    const results = await searchSpecs('cache', fixturesDir);
+    const alphaMatch = results.find((r) => r.file === 'alpha-feature.md');
+    assert.ok(alphaMatch, 'Should find cache reference in alpha-feature');
+    assert.ok(alphaMatch.section, 'Match should include section heading');
+    assert.ok(alphaMatch.content, 'Match should include content');
+  });
+
+  test('returns empty array for no matches', async () => {
+    const results = await searchSpecs('zyxwvutsrqp_no_match', fixturesDir);
+    assert.ok(Array.isArray(results));
+    assert.equal(results.length, 0);
+  });
+
+  test('matches across multiple specs', async () => {
+    const results = await searchSpecs('entity', fixturesDir);
+    const files = [...new Set(results.map((r) => r.file))];
+    assert.ok(files.length >= 1, 'Should find entity references');
+  });
+});
+
+console.log('All tests defined. Running via node --test...');


### PR DESCRIPTION
## Summary
- Implements three-tier codified context architecture ([arxiv.org/abs/2602.20478](https://arxiv.org/abs/2602.20478)) for AI-assisted development
- **Tier 1 (Constitution):** Expanded CLAUDE.md with orchestration table, layer architecture, operation checklists, and codified context section
- **Tier 2 (Skills):** 7 domain specialist skills in `skills/waaseyaa/` + 1 meta-skill in `skills/codified-context/` for on-demand context loading
- **Tier 3 (Specs):** 10 subsystem specs in `docs/specs/` (entity-system, access-control, field-access, api-layer, middleware-pipeline, package-discovery, infrastructure, mcp-endpoint, admin-spa, ai-integration)
- **Tooling:** MCP spec retrieval server (`tools/spec-retrieval/`) with list/get/search operations; drift detector script (`tools/drift-detector.sh`)
- **MCP config:** `.mcp.json` registering the spec retrieval server for project-scoped tool access

## Test plan
- [ ] Verify `node tools/spec-retrieval/test.js` passes all 12 assertions
- [ ] Verify `tools/drift-detector.sh` runs and reports spec freshness
- [ ] Verify MCP tools (`waaseyaa_list_specs`, `waaseyaa_get_spec`, `waaseyaa_search_specs`) respond correctly in Claude Code
- [ ] Verify CLAUDE.md orchestration table triggers correct skill loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)