### PR TITLE
feat: add optional group property to EntityType for sidebar navigation

### DIFF
--- a/packages/admin/app/composables/useNavGroups.ts
+++ b/packages/admin/app/composables/useNavGroups.ts
@@ -2,15 +2,10 @@ export interface EntityTypeInfo {
   id: string
   label: string
   keys: Record<string, string>
+  group?: string | null
 }
 
 type NonEmptyArray<T> = [T, ...T[]]
-
-interface NavGroupDefinition {
-  key: string
-  labelKey: string
-  entityTypeIds: string[]
-}
 
 export interface ResolvedNavGroup {
   key: string
@@ -18,43 +13,56 @@ export interface ResolvedNavGroup {
   entityTypes: NonEmptyArray<EntityTypeInfo>
 }
 
-const navGroupDefinitions: NavGroupDefinition[] = [
-  { key: 'people', labelKey: 'nav_group_people', entityTypeIds: ['user'] },
-  { key: 'content', labelKey: 'nav_group_content', entityTypeIds: ['node', 'node_type'] },
-  { key: 'taxonomy', labelKey: 'nav_group_taxonomy', entityTypeIds: ['taxonomy_term', 'taxonomy_vocabulary'] },
-  { key: 'media', labelKey: 'nav_group_media', entityTypeIds: ['media', 'media_type'] },
-  { key: 'structure', labelKey: 'nav_group_structure', entityTypeIds: ['path_alias', 'menu', 'menu_link'] },
-  { key: 'workflows', labelKey: 'nav_group_workflows', entityTypeIds: ['workflow'] },
-  { key: 'ai', labelKey: 'nav_group_ai', entityTypeIds: ['pipeline'] },
+const groupOrder: string[] = [
+  'people',
+  'content',
+  'taxonomy',
+  'media',
+  'structure',
+  'workflows',
+  'ai',
 ]
 
 export function groupEntityTypes(entityTypes: EntityTypeInfo[]): ResolvedNavGroup[] {
-  const claimed = new Set<string>()
-  const groups: ResolvedNavGroup[] = []
+  const grouped = new Map<string, EntityTypeInfo[]>()
+  const ungrouped: EntityTypeInfo[] = []
 
-  for (const def of navGroupDefinitions) {
-    const matched = def.entityTypeIds
-      .map((id) => entityTypes.find((et) => et.id === id))
-      .filter((et): et is EntityTypeInfo => et !== undefined)
-
-    if (matched.length > 0) {
-      groups.push({
-        key: def.key,
-        labelKey: def.labelKey,
-        entityTypes: matched as NonEmptyArray<EntityTypeInfo>,
-      })
-      for (const et of matched) {
-        claimed.add(et.id)
-      }
+  for (const et of entityTypes) {
+    if (et.group) {
+      const list = grouped.get(et.group) ?? []
+      list.push(et)
+      grouped.set(et.group, list)
+    } else {
+      ungrouped.push(et)
     }
   }
 
-  const unclaimed = entityTypes.filter((et) => !claimed.has(et.id))
-  if (unclaimed.length > 0) {
+  // Sort groups: known order first, then unknown groups alphabetically
+  const sortedKeys = [...grouped.keys()].sort((a, b) => {
+    const ai = groupOrder.indexOf(a)
+    const bi = groupOrder.indexOf(b)
+    if (ai !== -1 && bi !== -1) return ai - bi
+    if (ai !== -1) return -1
+    if (bi !== -1) return 1
+    return a.localeCompare(b)
+  })
+
+  const groups: ResolvedNavGroup[] = []
+
+  for (const key of sortedKeys) {
+    const types = grouped.get(key)!
+    groups.push({
+      key,
+      labelKey: `nav_group_${key}`,
+      entityTypes: types as NonEmptyArray<EntityTypeInfo>,
+    })
+  }
+
+  if (ungrouped.length > 0) {
     groups.push({
       key: 'other',
       labelKey: 'nav_group_other',
-      entityTypes: unclaimed as NonEmptyArray<EntityTypeInfo>,
+      entityTypes: ungrouped as NonEmptyArray<EntityTypeInfo>,
     })
   }
 

--- a/packages/admin/app/i18n/en.json
+++ b/packages/admin/app/i18n/en.json
@@ -40,5 +40,9 @@
   "nav_group_structure": "Structure",
   "nav_group_workflows": "Workflows",
   "nav_group_ai": "AI",
+  "nav_group_events": "Events",
+  "nav_group_community": "Community",
+  "nav_group_knowledge": "Cultural Knowledge",
+  "nav_group_language": "Language",
   "nav_group_other": "Other"
 }

--- a/packages/admin/app/i18n/fr.json
+++ b/packages/admin/app/i18n/fr.json
@@ -40,5 +40,9 @@
   "nav_group_structure": "Structure",
   "nav_group_workflows": "Flux de travail",
   "nav_group_ai": "IA",
+  "nav_group_events": "Événements",
+  "nav_group_community": "Communauté",
+  "nav_group_knowledge": "Savoirs culturels",
+  "nav_group_language": "Langue",
   "nav_group_other": "Autre"
 }

--- a/packages/ai-pipeline/src/AIPipelineServiceProvider.php
+++ b/packages/ai-pipeline/src/AIPipelineServiceProvider.php
@@ -16,6 +16,7 @@ final class AIPipelineServiceProvider extends ServiceProvider
             label: 'Pipeline',
             class: Pipeline::class,
             keys: ['id' => 'id', 'label' => 'label'],
+            group: 'ai',
         ));
     }
 }

--- a/packages/entity/src/EntityType.php
+++ b/packages/entity/src/EntityType.php
@@ -35,6 +35,7 @@ final readonly class EntityType implements EntityTypeInterface
         private ?string $bundleEntityType = null,
         private array $constraints = [],
         private array $fieldDefinitions = [],
+        private ?string $group = null,
     ) {}
 
     public function id(): string
@@ -89,5 +90,10 @@ final readonly class EntityType implements EntityTypeInterface
     public function getFieldDefinitions(): array
     {
         return $this->fieldDefinitions;
+    }
+
+    public function getGroup(): ?string
+    {
+        return $this->group;
     }
 }

--- a/packages/entity/src/EntityTypeInterface.php
+++ b/packages/entity/src/EntityTypeInterface.php
@@ -29,4 +29,7 @@ interface EntityTypeInterface
 
     /** @return array<string, array<string, mixed>> Field definitions keyed by field name. */
     public function getFieldDefinitions(): array;
+
+    /** @return string|null Admin sidebar group key (e.g. 'content', 'taxonomy'). */
+    public function getGroup(): ?string;
 }

--- a/packages/entity/tests/Unit/EntityTypeTest.php
+++ b/packages/entity/tests/Unit/EntityTypeTest.php
@@ -51,6 +51,7 @@ class EntityTypeTest extends TestCase
         $this->assertFalse($type->isTranslatable());
         $this->assertNull($type->getBundleEntityType());
         $this->assertSame([], $type->getConstraints());
+        $this->assertNull($type->getGroup());
     }
 
     public function testAllProperties(): void
@@ -79,6 +80,19 @@ class EntityTypeTest extends TestCase
         $this->assertTrue($type->isTranslatable());
         $this->assertSame('node_type', $type->getBundleEntityType());
         $this->assertSame($constraints, $type->getConstraints());
+        $this->assertNull($type->getGroup());
+    }
+
+    public function testGroupProperty(): void
+    {
+        $type = new EntityType(
+            id: 'event',
+            label: 'Event',
+            class: 'Waaseyaa\\Entity\\Tests\\Unit\\TestEntity',
+            group: 'events',
+        );
+
+        $this->assertSame('events', $type->getGroup());
     }
 
     public function testFieldDefinitionsDefaultsToEmptyArray(): void

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -488,6 +488,7 @@ final class HttpKernel extends AbstractKernel
                             'keys' => $def->getKeys(),
                             'translatable' => $def->isTranslatable(),
                             'revisionable' => $def->isRevisionable(),
+                            'group' => $def->getGroup(),
                         ];
                     }
                     $this->sendJson(200, ['data' => $types]);

--- a/packages/media/src/MediaServiceProvider.php
+++ b/packages/media/src/MediaServiceProvider.php
@@ -16,6 +16,7 @@ final class MediaServiceProvider extends ServiceProvider
             label: 'Media',
             class: Media::class,
             keys: ['id' => 'mid', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'bundle'],
+            group: 'media',
         ));
 
         $this->entityType(new EntityType(
@@ -23,6 +24,7 @@ final class MediaServiceProvider extends ServiceProvider
             label: 'Media Type',
             class: MediaType::class,
             keys: ['id' => 'id', 'label' => 'label'],
+            group: 'media',
         ));
     }
 }

--- a/packages/menu/src/MenuServiceProvider.php
+++ b/packages/menu/src/MenuServiceProvider.php
@@ -16,6 +16,7 @@ final class MenuServiceProvider extends ServiceProvider
             label: 'Menu',
             class: Menu::class,
             keys: ['id' => 'id', 'label' => 'label'],
+            group: 'structure',
         ));
 
         $this->entityType(new EntityType(
@@ -23,6 +24,7 @@ final class MenuServiceProvider extends ServiceProvider
             label: 'Menu Link',
             class: MenuLink::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'menu_name'],
+            group: 'structure',
         ));
     }
 }

--- a/packages/node/src/NodeServiceProvider.php
+++ b/packages/node/src/NodeServiceProvider.php
@@ -16,6 +16,7 @@ final class NodeServiceProvider extends ServiceProvider
             label: 'Content',
             class: Node::class,
             keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            group: 'content',
             fieldDefinitions: [
                 'status' => [
                     'type' => 'boolean',
@@ -65,6 +66,7 @@ final class NodeServiceProvider extends ServiceProvider
             label: 'Content Type',
             class: NodeType::class,
             keys: ['id' => 'type', 'label' => 'name'],
+            group: 'content',
         ));
     }
 }

--- a/packages/path/src/PathServiceProvider.php
+++ b/packages/path/src/PathServiceProvider.php
@@ -16,6 +16,7 @@ final class PathServiceProvider extends ServiceProvider
             label: 'Path Alias',
             class: PathAlias::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'alias', 'langcode' => 'langcode'],
+            group: 'structure',
             fieldDefinitions: [
                 'path' => [
                     'type' => 'string',

--- a/packages/taxonomy/src/TaxonomyServiceProvider.php
+++ b/packages/taxonomy/src/TaxonomyServiceProvider.php
@@ -16,6 +16,7 @@ final class TaxonomyServiceProvider extends ServiceProvider
             label: 'Taxonomy Term',
             class: Term::class,
             keys: ['id' => 'tid', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'vid'],
+            group: 'taxonomy',
             fieldDefinitions: [
                 'description' => [
                     'type' => 'text',
@@ -50,6 +51,7 @@ final class TaxonomyServiceProvider extends ServiceProvider
             label: 'Vocabulary',
             class: Vocabulary::class,
             keys: ['id' => 'vid', 'label' => 'name'],
+            group: 'taxonomy',
             fieldDefinitions: [
                 'description' => [
                     'type' => 'text',

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -16,6 +16,7 @@ final class UserServiceProvider extends ServiceProvider
             label: 'User',
             class: User::class,
             keys: ['id' => 'uid', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'people',
             fieldDefinitions: [
                 'mail' => [
                     'type' => 'email',

--- a/packages/workflows/src/WorkflowServiceProvider.php
+++ b/packages/workflows/src/WorkflowServiceProvider.php
@@ -16,6 +16,7 @@ final class WorkflowServiceProvider extends ServiceProvider
             label: 'Workflow',
             class: Workflow::class,
             keys: ['id' => 'id', 'label' => 'label'],
+            group: 'workflows',
         ));
     }
 }


### PR DESCRIPTION
## Summary
- Adds optional `group` property to `EntityType` and `EntityTypeInterface`
- Exposes `group` in `/api/entity-types` API response
- Refactors `useNavGroups.ts` to group by API-provided `group` field instead of hardcoded entity type ID lists
- All 8 built-in service providers now declare their group
- Translation keys added for en/fr (events, community, knowledge, language)

## Motivation
Apps defining custom entity types (like Minoo) had all their types fall into an "Other" sidebar group. This makes the grouping declarative and app-driven.

## Test plan
- [x] All 3471 framework tests pass
- [x] New test for `EntityType::getGroup()` (null default + explicit value)
- [x] Verified admin SPA sidebar renders grouped navigation correctly via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)