### PR TITLE
feat(search): add baseTopics to SearchTwigExtension

### DIFF
--- a/packages/search/src/Twig/SearchTwigExtension.php
+++ b/packages/search/src/Twig/SearchTwigExtension.php
@@ -13,8 +13,12 @@ use Waaseyaa\Search\SearchResult;
 
 final class SearchTwigExtension extends AbstractExtension
 {
+    /**
+     * @param string[] $baseTopics When set, overrides user topic selection (OR semantics make merging unsafe).
+     */
     public function __construct(
         private readonly SearchProviderInterface $provider,
+        private readonly array $baseTopics = [],
     ) {}
 
     /** @return TwigFunction[] */
@@ -36,9 +40,9 @@ final class SearchTwigExtension extends AbstractExtension
         }
 
         $searchFilters = new SearchFilters(
-            topics: isset($filters['topic']) && $filters['topic'] !== ''
-                ? [(string) $filters['topic']]
-                : [],
+            topics: $this->baseTopics !== []
+                ? $this->baseTopics
+                : (isset($filters['topic']) && $filters['topic'] !== '' ? [(string) $filters['topic']] : []),
             contentType: (string) ($filters['content_type'] ?? ''),
             sourceNames: isset($filters['source']) && $filters['source'] !== ''
                 ? [(string) $filters['source']]

--- a/packages/search/tests/Unit/Twig/SearchTwigExtensionTest.php
+++ b/packages/search/tests/Unit/Twig/SearchTwigExtensionTest.php
@@ -68,6 +68,51 @@ final class SearchTwigExtensionTest extends TestCase
     }
 
     #[Test]
+    public function it_uses_base_topics_ignoring_user_topic(): void
+    {
+        $provider = $this->createMock(SearchProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function (SearchRequest $req): bool {
+                return $req->filters->topics === ['indigenous'];
+            }))
+            ->willReturn(SearchResult::empty());
+
+        $ext = new SearchTwigExtension($provider, baseTopics: ['indigenous']);
+        $ext->search('test', ['topic' => 'education']);
+    }
+
+    #[Test]
+    public function it_sends_base_topics_when_no_user_topic(): void
+    {
+        $provider = $this->createMock(SearchProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function (SearchRequest $req): bool {
+                return $req->filters->topics === ['indigenous'];
+            }))
+            ->willReturn(SearchResult::empty());
+
+        $ext = new SearchTwigExtension($provider, baseTopics: ['indigenous']);
+        $ext->search('test');
+    }
+
+    #[Test]
+    public function it_uses_user_topic_when_no_base_topics(): void
+    {
+        $provider = $this->createMock(SearchProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function (SearchRequest $req): bool {
+                return $req->filters->topics === ['education'];
+            }))
+            ->willReturn(SearchResult::empty());
+
+        $ext = new SearchTwigExtension($provider);
+        $ext->search('test', ['topic' => 'education']);
+    }
+
+    #[Test]
     public function query_param_reads_from_get(): void
     {
         $_GET['q'] = 'test query';


### PR DESCRIPTION
## Summary
- Add constructor-injected `baseTopics` parameter to `SearchTwigExtension` that overrides user topic selection when set
- Enables site-wide content filtering (e.g. Minoo filtering to indigenous content only)
- OR semantics make merging base + user topics unsafe, so base topics fully replace user selection

## Test plan
- [x] Unit test: base topics override user-provided topic filter
- [x] Unit test: base topics sent when no user topic provided
- [x] Unit test: user topic used when no base topics configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)