### PR TITLE
fix: skip JSON body parsing for app controller POST routes

### DIFF
--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -462,7 +462,7 @@ final class HttpKernel extends AbstractKernel
         $schemaPresenter = new SchemaPresenter();
 
         $body = null;
-        if (in_array($method, ['POST', 'PATCH'], true)) {
+        if (in_array($method, ['POST', 'PATCH'], true) && !str_contains($controller, '::')) {
             $raw = $httpRequest->getContent();
             if ($raw !== '') {
                 try {


### PR DESCRIPTION
## Problem

`dispatch()` unconditionally attempted to JSON-decode the raw POST body before routing, causing all form submissions (Content-Type: `application/x-www-form-urlencoded`) to return:

```json
{"errors": [{"status": "400", "title": "Bad Request", "detail": "Invalid JSON in request body."}]}
```

App controllers registered as `Class::method` access form data via `HttpRequest::request->get()` — Symfony handles the decoding automatically. The JSON:API body parser was the wrong layer entirely.

## Fix

One character change — skip JSON body parsing when the controller is an app controller:

```php
// before
if (in_array($method, ['POST', 'PATCH'], true)) {

// after
if (in_array($method, ['POST', 'PATCH'], true) && !str_contains($controller, '::')) {
```

## Verified

- Elder support request form → submits → redirects to confirmation ✅
- Volunteer signup form → submits → redirects to confirmation ✅
- Server-side validation fires on empty submission ✅
- JSON:API POST routes unaffected (controller does not contain `::`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)