### PR TITLE
feat(#218): add EnvLoader to AbstractKernel bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Waaseyaa — environment variables
+#
+# Copy to .env and fill in values.
+# Do NOT commit .env — it is gitignored.
+#
+# Precedence: process env (PHP-FPM pool, shell export) > .env file.
+# Existing process env vars are never overwritten by this file.
+
+# ── Database ─────────────────────────────────────────────────────────────────
+# Path to the SQLite database file.
+# Default: {project_root}/waaseyaa.sqlite
+#
+# WAASEYAA_DB=./waaseyaa.sqlite
+
+# ── Environment ──────────────────────────────────────────────────────────────
+# Controls debug mode, error display, and dev-only helpers.
+# Values: local | staging | production
+# Default: production
+#
+APP_ENV=local
+
+# ── Config ───────────────────────────────────────────────────────────────────
+# Path to the config sync directory (YAML entity configs).
+# Default: {project_root}/config/sync
+#
+# WAASEYAA_CONFIG_DIR=./config/sync
+
+# ── CORS ─────────────────────────────────────────────────────────────────────
+# Allowed origin for the admin SPA. Overrides cors_origins in config/waaseyaa.php.
+# Default: http://localhost:3000
+#
+# WAASEYAA_CORS_ORIGIN=http://localhost:3000
+
+# ── AI (optional) ────────────────────────────────────────────────────────────
+# Required only when using the ai-vector package (OpenAI embeddings).
+#
+# OPENAI_API_KEY=sk-...

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -53,6 +53,8 @@ abstract class AbstractKernel
             return;
         }
 
+        EnvLoader::load($this->projectRoot . '/.env');
+
         $this->config = ConfigLoader::load($this->projectRoot . '/config/waaseyaa.php');
 
         $this->dispatcher = new EventDispatcher();

--- a/packages/foundation/src/Kernel/EnvLoader.php
+++ b/packages/foundation/src/Kernel/EnvLoader.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Kernel;
+
+/**
+ * Loads a .env file into the process environment.
+ *
+ * Resolution rules:
+ * - Missing file is silently ignored — no error.
+ * - Lines starting with # and blank lines are skipped.
+ * - Only lines containing = are parsed.
+ * - Values wrapped in matching " or ' quotes have the quotes stripped.
+ * - Existing process env vars are never overwritten — PHP-FPM pool vars win.
+ */
+final class EnvLoader
+{
+    public static function load(string $path): void
+    {
+        if (!is_file($path)) {
+            return;
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return;
+        }
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $line, 2);
+            $key   = trim($key);
+            $value = trim($value);
+
+            if ($key === '') {
+                continue;
+            }
+
+            $value = self::stripQuotes($value);
+
+            // Never overwrite an already-set process env var.
+            if (getenv($key) === false) {
+                putenv("{$key}={$value}");
+            }
+        }
+    }
+
+    private static function stripQuotes(string $value): string
+    {
+        if (strlen($value) >= 2) {
+            $first = $value[0];
+            $last  = $value[strlen($value) - 1];
+
+            if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+                return substr($value, 1, -1);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/packages/foundation/tests/Unit/Kernel/EnvLoaderTest.php
+++ b/packages/foundation/tests/Unit/Kernel/EnvLoaderTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Kernel\EnvLoader;
+
+#[CoversClass(EnvLoader::class)]
+final class EnvLoaderTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_env_test_' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tempDir . '/{,.}*', GLOB_BRACE) ?: [] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        rmdir($this->tempDir);
+    }
+
+    #[Test]
+    public function missing_file_is_silently_ignored(): void
+    {
+        EnvLoader::load($this->tempDir . '/.env.nonexistent');
+
+        // No exception thrown — test passes by reaching this line.
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function empty_file_is_silently_ignored(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, '');
+
+        EnvLoader::load($path);
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function loads_simple_key_value_pair(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, 'WAASEYAA_TEST_SIMPLE=hello');
+
+        EnvLoader::load($path);
+
+        $this->assertSame('hello', getenv('WAASEYAA_TEST_SIMPLE'));
+
+        putenv('WAASEYAA_TEST_SIMPLE');
+    }
+
+    #[Test]
+    public function skips_comment_lines(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, "# This is a comment\nWAASEYAA_TEST_AFTER_COMMENT=value");
+
+        EnvLoader::load($path);
+
+        $this->assertSame('value', getenv('WAASEYAA_TEST_AFTER_COMMENT'));
+
+        putenv('WAASEYAA_TEST_AFTER_COMMENT');
+    }
+
+    #[Test]
+    public function skips_blank_lines(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, "\n\nWAASEYAA_TEST_AFTER_BLANK=set\n\n");
+
+        EnvLoader::load($path);
+
+        $this->assertSame('set', getenv('WAASEYAA_TEST_AFTER_BLANK'));
+
+        putenv('WAASEYAA_TEST_AFTER_BLANK');
+    }
+
+    #[Test]
+    public function skips_lines_without_equals_sign(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, "INVALID_LINE_NO_EQUALS\nWAASEYAA_TEST_VALID=ok");
+
+        EnvLoader::load($path);
+
+        $this->assertFalse(getenv('INVALID_LINE_NO_EQUALS'));
+        $this->assertSame('ok', getenv('WAASEYAA_TEST_VALID'));
+
+        putenv('WAASEYAA_TEST_VALID');
+    }
+
+    #[Test]
+    public function strips_double_quotes_from_value(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, 'WAASEYAA_TEST_DQUOTE="quoted value"');
+
+        EnvLoader::load($path);
+
+        $this->assertSame('quoted value', getenv('WAASEYAA_TEST_DQUOTE'));
+
+        putenv('WAASEYAA_TEST_DQUOTE');
+    }
+
+    #[Test]
+    public function strips_single_quotes_from_value(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, "WAASEYAA_TEST_SQUOTE='single quoted'");
+
+        EnvLoader::load($path);
+
+        $this->assertSame('single quoted', getenv('WAASEYAA_TEST_SQUOTE'));
+
+        putenv('WAASEYAA_TEST_SQUOTE');
+    }
+
+    #[Test]
+    public function does_not_strip_mismatched_quotes(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, "WAASEYAA_TEST_MISMATCH=\"mismatched'");
+
+        EnvLoader::load($path);
+
+        $this->assertSame("\"mismatched'", getenv('WAASEYAA_TEST_MISMATCH'));
+
+        putenv('WAASEYAA_TEST_MISMATCH');
+    }
+
+    #[Test]
+    public function existing_env_var_is_not_overwritten(): void
+    {
+        putenv('WAASEYAA_TEST_EXISTING=original');
+
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, 'WAASEYAA_TEST_EXISTING=overwritten');
+
+        EnvLoader::load($path);
+
+        $this->assertSame('original', getenv('WAASEYAA_TEST_EXISTING'));
+
+        putenv('WAASEYAA_TEST_EXISTING');
+    }
+
+    #[Test]
+    public function value_after_first_equals_is_preserved(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, 'WAASEYAA_TEST_URL=http://localhost:8080/path?a=1&b=2');
+
+        EnvLoader::load($path);
+
+        $this->assertSame('http://localhost:8080/path?a=1&b=2', getenv('WAASEYAA_TEST_URL'));
+
+        putenv('WAASEYAA_TEST_URL');
+    }
+
+    #[Test]
+    public function loads_multiple_vars_from_one_file(): void
+    {
+        $path = $this->tempDir . '/.env';
+        file_put_contents($path, implode("\n", [
+            '# Database',
+            'WAASEYAA_TEST_DB=/tmp/test.sqlite',
+            '',
+            '# Server',
+            'WAASEYAA_TEST_ENV=local',
+        ]));
+
+        EnvLoader::load($path);
+
+        $this->assertSame('/tmp/test.sqlite', getenv('WAASEYAA_TEST_DB'));
+        $this->assertSame('local', getenv('WAASEYAA_TEST_ENV'));
+
+        putenv('WAASEYAA_TEST_DB');
+        putenv('WAASEYAA_TEST_ENV');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `EnvLoader::load()` — pure stdlib `.env` parser, no new dependencies
- Calls it as the first step in `AbstractKernel::boot()`, before `ConfigLoader`
- Existing process env vars (PHP-FPM pool, shell) always take precedence
- Missing `.env` is silently ignored — zero BC impact on existing deployments
- Adds `.env.example` documenting all known `WAASEYAA_*` vars

## Test plan

- [ ] 12 unit tests pass: missing file, blank/comment lines, quote stripping (double + single), mismatched quotes, existing-env precedence, multi-var file, URL values with `=` in them
- [ ] Full suite (3505 tests) green — confirmed locally before push
- [ ] Minoo dev server works with only a `.env` file, no shell exports required

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)