### PR TITLE
feat(#199): full RBAC + field-level ACL for core.note

### DIFF
--- a/packages/note/src/NoteAccessPolicy.php
+++ b/packages/note/src/NoteAccessPolicy.php
@@ -7,19 +7,38 @@ namespace Waaseyaa\Note;
 use Waaseyaa\Access\AccessPolicyInterface;
 use Waaseyaa\Access\AccessResult;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
 use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 
 /**
  * Access policy for the built-in Note content type.
  *
- * core.note is non-deletable via API — this policy enforces that
- * unconditionally, regardless of account role or permissions.
- * Disable/lifecycle management is handled via #198.
+ * Entity-level (deny-by-default):
+ *   - tenant.member  : view only
+ *   - tenant.admin   : view + create + update
+ *   - platform.admin : view + create + update (all fields including system)
+ *   - anonymous      : neutral (denied by EntityAccessHandler's isAllowed() check)
+ *   - DELETE          : unconditionally forbidden — core.note is non-deletable via API
+ *
+ * Field-level (open-by-default, Forbidden restricts):
+ *   - System fields (id, uuid, tenant_id, created_at, updated_at):
+ *     edit forbidden for everyone except platform.admin.
+ *   - User fields (title, body): neutral for all — no restriction.
  */
 #[PolicyAttribute(entityType: 'note')]
-final class NoteAccessPolicy implements AccessPolicyInterface
+final class NoteAccessPolicy implements AccessPolicyInterface, FieldAccessPolicyInterface
 {
+    /**
+     * Fields that are always read-only after creation for non-platform.admin roles.
+     * 'tenant_id' is settable on creation (identifying the owning tenant) but
+     * immutable on update — enforced via the isNew() check in fieldAccess().
+     */
+    private const ALWAYS_READONLY_FIELDS = ['id', 'uuid', 'created_at', 'updated_at'];
+
+    /** Settable on creation, immutable on update for non-platform.admin roles. */
+    private const CREATE_ONLY_FIELDS = ['tenant_id'];
+
     public function appliesTo(string $entityTypeId): bool
     {
         return $entityTypeId === 'note';
@@ -28,14 +47,28 @@ final class NoteAccessPolicy implements AccessPolicyInterface
     public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
     {
         if ($operation === 'delete') {
-            return AccessResult::forbidden('core.note is a built-in type and cannot be deleted. See #198 for lifecycle management.');
+            return AccessResult::forbidden(
+                'core.note is a built-in type and cannot be deleted. See #198 for lifecycle management.',
+            );
         }
 
-        return AccessResult::neutral("No opinion on '$operation' operation.");
+        return match ($operation) {
+            'view'   => $this->viewAccess($account),
+            'update' => $this->updateAccess($account),
+            default  => AccessResult::neutral("No opinion on '$operation' operation."),
+        };
     }
 
     public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
     {
+        if ($this->hasRole('platform.admin', $account)) {
+            return AccessResult::allowed('platform.admin can create notes.');
+        }
+
+        if ($this->hasRole('tenant.admin', $account)) {
+            return AccessResult::allowed('tenant.admin can create notes.');
+        }
+
         if ($account->hasPermission('administer notes')) {
             return AccessResult::allowed('User has administer notes permission.');
         }
@@ -45,5 +78,53 @@ final class NoteAccessPolicy implements AccessPolicyInterface
         }
 
         return AccessResult::neutral('User lacks note creation permission.');
+    }
+
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation,
+        AccountInterface $account,
+    ): AccessResult {
+        if ($operation === 'edit') {
+            $isSystemField = in_array($fieldName, self::ALWAYS_READONLY_FIELDS, true)
+                || (!$entity->isNew() && in_array($fieldName, self::CREATE_ONLY_FIELDS, true));
+
+            if ($isSystemField) {
+                if ($this->hasRole('platform.admin', $account)) {
+                    return AccessResult::neutral('platform.admin may edit system fields.');
+                }
+
+                return AccessResult::forbidden("System field '$fieldName' is read-only.");
+            }
+        }
+
+        return AccessResult::neutral();
+    }
+
+    private function viewAccess(AccountInterface $account): AccessResult
+    {
+        if ($this->hasRole('platform.admin', $account)
+            || $this->hasRole('tenant.admin', $account)
+            || $this->hasRole('tenant.member', $account)
+        ) {
+            return AccessResult::allowed('Authenticated tenant member can view notes.');
+        }
+
+        return AccessResult::neutral('Account has no tenant role; view not granted.');
+    }
+
+    private function updateAccess(AccountInterface $account): AccessResult
+    {
+        if ($this->hasRole('platform.admin', $account) || $this->hasRole('tenant.admin', $account)) {
+            return AccessResult::allowed('Account can update notes.');
+        }
+
+        return AccessResult::neutral('tenant.member cannot update notes.');
+    }
+
+    private function hasRole(string $role, AccountInterface $account): bool
+    {
+        return in_array($role, $account->getRoles(), true);
     }
 }

--- a/packages/note/tests/Unit/NoteAccessPolicyTest.php
+++ b/packages/note/tests/Unit/NoteAccessPolicyTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Waaseyaa\Note\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
 use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Note\NoteAccessPolicy;
@@ -129,5 +131,182 @@ final class NoteAccessPolicyTest extends TestCase
         $this->assertCount(1, $attributes);
         $instance = $attributes[0]->newInstance();
         $this->assertContains('note', $instance->entityTypes);
+    }
+
+    #[Test]
+    public function implementsFieldAccessPolicyInterface(): void
+    {
+        $this->assertInstanceOf(FieldAccessPolicyInterface::class, $this->policy);
+    }
+
+    // -----------------------------------------------------------------------
+    // Role-based entity access
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantMemberCanViewNote(): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->access($this->entity, 'view', $member);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function tenantAdminCanViewNote(): void
+    {
+        $admin = $this->accountWithRoles(['tenant.admin']);
+        $result = $this->policy->access($this->entity, 'view', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function platformAdminCanViewNote(): void
+    {
+        $admin = $this->accountWithRoles(['platform.admin']);
+        $result = $this->policy->access($this->entity, 'view', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function tenantMemberCannotUpdateNote(): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->access($this->entity, 'update', $member);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function tenantAdminCanUpdateNote(): void
+    {
+        $admin = $this->accountWithRoles(['tenant.admin']);
+        $result = $this->policy->access($this->entity, 'update', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function platformAdminCanUpdateNote(): void
+    {
+        $admin = $this->accountWithRoles(['platform.admin']);
+        $result = $this->policy->access($this->entity, 'update', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function deleteIsForbiddenForPlatformAdmin(): void
+    {
+        $admin = $this->accountWithRoles(['platform.admin']);
+        $result = $this->policy->access($this->entity, 'delete', $admin);
+        $this->assertTrue($result->isForbidden());
+    }
+
+    // -----------------------------------------------------------------------
+    // Role-based create access
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantMemberCannotCreate(): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->createAccess('note', '', $member);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function tenantAdminCanCreate(): void
+    {
+        $admin = $this->accountWithRoles(['tenant.admin']);
+        $result = $this->policy->createAccess('note', '', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function platformAdminCanCreate(): void
+    {
+        $admin = $this->accountWithRoles(['platform.admin']);
+        $result = $this->policy->createAccess('note', '', $admin);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // -----------------------------------------------------------------------
+    // Field-level access: system fields
+    // -----------------------------------------------------------------------
+
+    /** @return array<string, array{string}> */
+    public static function systemFieldProvider(): array
+    {
+        return [
+            'id'         => ['id'],
+            'uuid'       => ['uuid'],
+            'tenant_id'  => ['tenant_id'],
+            'created_at' => ['created_at'],
+            'updated_at' => ['updated_at'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('systemFieldProvider')]
+    public function systemFieldEditIsForbiddenForTenantMember(string $field): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->fieldAccess($this->entity, $field, 'edit', $member);
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    #[DataProvider('systemFieldProvider')]
+    public function systemFieldEditIsForbiddenForTenantAdmin(string $field): void
+    {
+        $admin = $this->accountWithRoles(['tenant.admin']);
+        $result = $this->policy->fieldAccess($this->entity, $field, 'edit', $admin);
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    #[DataProvider('systemFieldProvider')]
+    public function systemFieldEditIsNeutralForPlatformAdmin(string $field): void
+    {
+        $admin = $this->accountWithRoles(['platform.admin']);
+        $result = $this->policy->fieldAccess($this->entity, $field, 'edit', $admin);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    #[DataProvider('systemFieldProvider')]
+    public function systemFieldViewIsNeutralForAll(string $field): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->fieldAccess($this->entity, $field, 'view', $member);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function userFieldEditIsNeutralForTenantAdmin(): void
+    {
+        $admin = $this->accountWithRoles(['tenant.admin']);
+        $result = $this->policy->fieldAccess($this->entity, 'title', 'edit', $admin);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function userFieldEditIsNeutralForTenantMember(): void
+    {
+        $member = $this->accountWithRoles(['tenant.member']);
+        $result = $this->policy->fieldAccess($this->entity, 'body', 'edit', $member);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function accountWithRoles(array $roles): AccountInterface
+    {
+        return new class($roles) implements AccountInterface {
+            public function __construct(private readonly array $roles) {}
+            public function id(): int { return 42; }
+            public function isAuthenticated(): bool { return true; }
+            public function hasPermission(string $permission): bool { return false; }
+            public function getRoles(): array { return $this->roles; }
+        };
     }
 }

--- a/tests/Integration/Phase18/NoteRbacIntegrationTest.php
+++ b/tests/Integration/Phase18/NoteRbacIntegrationTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase18;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Api\JsonApiController;
+use Waaseyaa\Api\ResourceSerializer;
+use Waaseyaa\Api\Tests\Fixtures\InMemoryEntityStorage;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Note\Note;
+use Waaseyaa\Note\NoteAccessPolicy;
+use Waaseyaa\User\AnonymousUser;
+use Waaseyaa\User\User;
+
+/**
+ * Integration tests for #199 — baseline RBAC on core.note.
+ *
+ * Covers:
+ * - tenant.member  : view → 200, create → 403, update → 403
+ * - tenant.admin   : view → 200, create → 201, update → 200
+ * - platform.admin : view → 200, create → 201, update → 200
+ * - anonymous      : view → 403, create → 403
+ * - System field edit guard: forbidden for tenant.admin, allowed for platform.admin
+ */
+#[CoversNothing]
+final class NoteRbacIntegrationTest extends TestCase
+{
+    private NoteRbacStorage $storage;
+    private EntityTypeManager $entityTypeManager;
+    private EntityAccessHandler $accessHandler;
+
+    protected function setUp(): void
+    {
+        $this->storage = new NoteRbacStorage('note');
+
+        $this->entityTypeManager = new EntityTypeManager(
+            new EventDispatcher(),
+            fn() => $this->storage,
+        );
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'note',
+            label: 'Note',
+            class: Note::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+            fieldDefinitions: [
+                'id'         => ['type' => 'integer', 'label' => 'ID'],
+                'uuid'       => ['type' => 'string',  'label' => 'UUID'],
+                'tenant_id'  => ['type' => 'string',  'label' => 'Tenant ID'],
+                'title'      => ['type' => 'string',  'label' => 'Title'],
+                'body'       => ['type' => 'string',  'label' => 'Body'],
+                'created_at' => ['type' => 'string',  'label' => 'Created At'],
+                'updated_at' => ['type' => 'string',  'label' => 'Updated At'],
+            ],
+        ));
+
+        $this->accessHandler = new EntityAccessHandler([new NoteAccessPolicy()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // tenant.member
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantMemberCanViewNote(): void
+    {
+        $note = $this->seedNote('Member View Test');
+        $user = $this->makeUser(roles: ['tenant.member']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->show('note', $note->id());
+
+        $this->assertSame(200, $doc->statusCode);
+    }
+
+    #[Test]
+    public function tenantMemberCannotCreateNote(): void
+    {
+        $user = $this->makeUser(roles: ['tenant.member']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->store('note', [
+            'data' => ['type' => 'note', 'attributes' => ['title' => 'Nope', 'tenant_id' => 'acme']],
+        ]);
+
+        $this->assertSame(403, $doc->statusCode);
+    }
+
+    #[Test]
+    public function tenantMemberCannotUpdateNote(): void
+    {
+        $note = $this->seedNote('Member Update Test');
+        $user = $this->makeUser(roles: ['tenant.member']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->update('note', $note->id(), [
+            'data' => ['type' => 'note', 'id' => $note->uuid(), 'attributes' => ['title' => 'Updated']],
+        ]);
+
+        $this->assertSame(403, $doc->statusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // tenant.admin
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantAdminCanViewNote(): void
+    {
+        $note = $this->seedNote('Admin View Test');
+        $user = $this->makeUser(roles: ['tenant.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->show('note', $note->id());
+
+        $this->assertSame(200, $doc->statusCode);
+    }
+
+    #[Test]
+    public function tenantAdminCanCreateNote(): void
+    {
+        $user = $this->makeUser(roles: ['tenant.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->store('note', [
+            'data' => ['type' => 'note', 'attributes' => ['title' => 'New Note', 'tenant_id' => 'acme']],
+        ]);
+
+        $this->assertSame(201, $doc->statusCode);
+    }
+
+    #[Test]
+    public function tenantAdminCanUpdateNote(): void
+    {
+        $note = $this->seedNote('Admin Update Test');
+        $user = $this->makeUser(roles: ['tenant.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->update('note', $note->id(), [
+            'data' => ['type' => 'note', 'id' => $note->uuid(), 'attributes' => ['title' => 'Updated']],
+        ]);
+
+        $this->assertSame(200, $doc->statusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // platform.admin
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function platformAdminCanViewNote(): void
+    {
+        $note = $this->seedNote('Platform View Test');
+        $user = $this->makeUser(id: PHP_INT_MAX, roles: ['platform.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->show('note', $note->id());
+
+        $this->assertSame(200, $doc->statusCode);
+    }
+
+    #[Test]
+    public function platformAdminCanCreateNote(): void
+    {
+        $user = $this->makeUser(id: PHP_INT_MAX, roles: ['platform.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->store('note', [
+            'data' => ['type' => 'note', 'attributes' => ['title' => 'Platform Note', 'tenant_id' => 'sys']],
+        ]);
+
+        $this->assertSame(201, $doc->statusCode);
+    }
+
+    #[Test]
+    public function platformAdminCanUpdateNote(): void
+    {
+        $note = $this->seedNote('Platform Update Test');
+        $user = $this->makeUser(id: PHP_INT_MAX, roles: ['platform.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->update('note', $note->id(), [
+            'data' => ['type' => 'note', 'id' => $note->uuid(), 'attributes' => ['title' => 'Updated']],
+        ]);
+
+        $this->assertSame(200, $doc->statusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // anonymous
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function anonymousCannotViewNote(): void
+    {
+        $note = $this->seedNote('Anon View Test');
+        $controller = $this->buildController(new AnonymousUser());
+
+        $doc = $controller->show('note', $note->id());
+
+        $this->assertSame(403, $doc->statusCode);
+    }
+
+    #[Test]
+    public function anonymousCannotCreateNote(): void
+    {
+        $controller = $this->buildController(new AnonymousUser());
+
+        $doc = $controller->store('note', [
+            'data' => ['type' => 'note', 'attributes' => ['title' => 'Anon', 'tenant_id' => 'acme']],
+        ]);
+
+        $this->assertSame(403, $doc->statusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // DELETE — always forbidden (verified in Phase16; one regression guard here)
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantAdminCannotDeleteNote(): void
+    {
+        $note = $this->seedNote('Delete Guard Test');
+        $user = $this->makeUser(roles: ['tenant.admin']);
+        $controller = $this->buildController($user);
+
+        $doc = $controller->destroy('note', $note->id());
+
+        $this->assertSame(403, $doc->statusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // Field-level access via EntityAccessHandler
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function tenantAdminCannotEditSystemFields(): void
+    {
+        $note = $this->seedNote('Field Test');
+        $user = $this->makeUser(roles: ['tenant.admin']);
+
+        foreach (['id', 'uuid', 'tenant_id', 'created_at', 'updated_at'] as $field) {
+            $result = $this->accessHandler->checkFieldAccess($note, $field, 'edit', $user);
+            $this->assertTrue($result->isForbidden(), "Expected '$field' edit to be forbidden for tenant.admin");
+        }
+    }
+
+    #[Test]
+    public function platformAdminCanEditSystemFields(): void
+    {
+        $note = $this->seedNote('Platform Field Test');
+        $user = $this->makeUser(id: PHP_INT_MAX, roles: ['platform.admin']);
+
+        foreach (['id', 'uuid', 'tenant_id', 'created_at', 'updated_at'] as $field) {
+            $result = $this->accessHandler->checkFieldAccess($note, $field, 'edit', $user);
+            $this->assertFalse($result->isForbidden(), "Expected '$field' edit to be allowed for platform.admin");
+        }
+    }
+
+    #[Test]
+    public function tenantAdminCanEditUserFields(): void
+    {
+        $note = $this->seedNote('User Field Test');
+        $user = $this->makeUser(roles: ['tenant.admin']);
+
+        foreach (['title', 'body'] as $field) {
+            $result = $this->accessHandler->checkFieldAccess($note, $field, 'edit', $user);
+            $this->assertFalse($result->isForbidden(), "Expected '$field' edit to be allowed for tenant.admin");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function buildController(User|AnonymousUser $account): JsonApiController
+    {
+        return new JsonApiController(
+            $this->entityTypeManager,
+            new ResourceSerializer($this->entityTypeManager),
+            $this->accessHandler,
+            $account,
+        );
+    }
+
+    private function makeUser(int $id = 10, array $roles = [], array $permissions = []): User
+    {
+        return new User([
+            'uid'         => $id,
+            'name'        => 'test_user',
+            'permissions' => $permissions,
+            'roles'       => $roles,
+        ]);
+    }
+
+    private function seedNote(string $title, string $tenantId = 'acme'): Note
+    {
+        $note = new Note(['title' => $title, 'tenant_id' => $tenantId]);
+        $this->storage->save($note);
+
+        return $note;
+    }
+}
+
+/**
+ * In-memory storage that creates Note entities.
+ */
+class NoteRbacStorage extends InMemoryEntityStorage
+{
+    /** @var array<int|string, Note> */
+    private array $notes = [];
+    private int $nextId = 1;
+
+    public function create(array $values = []): Note
+    {
+        return new Note($values);
+    }
+
+    public function load(int|string $id): ?Note
+    {
+        return $this->notes[$id] ?? null;
+    }
+
+    public function loadMultiple(array $ids = []): array
+    {
+        if ($ids === []) {
+            return $this->notes;
+        }
+
+        $result = [];
+        foreach ($ids as $id) {
+            if (isset($this->notes[$id])) {
+                $result[$id] = $this->notes[$id];
+            }
+        }
+
+        return $result;
+    }
+
+    public function save(EntityInterface $entity): int
+    {
+        $isNew = $entity->isNew();
+
+        if ($isNew) {
+            $id = $this->nextId++;
+            $entity->set('id', $id);
+            $entity->enforceIsNew(false);
+        }
+
+        $this->notes[$entity->id()] = $entity;
+
+        return $isNew ? 1 : 2;
+    }
+
+    public function delete(array $entities): void
+    {
+        foreach ($entities as $entity) {
+            unset($this->notes[$entity->id()]);
+        }
+    }
+
+    public function getQuery(): \Waaseyaa\Entity\Storage\EntityQueryInterface
+    {
+        return new \Waaseyaa\Api\Tests\Fixtures\InMemoryEntityQuery(
+            array_keys($this->notes),
+            $this->notes,
+        );
+    }
+
+    public function getEntityTypeId(): string
+    {
+        return 'note';
+    }
+}


### PR DESCRIPTION
## Summary

- Expands `NoteAccessPolicy` from a minimal DELETE-guard to full RBAC with field-level access control
- Implements `FieldAccessPolicyInterface` on the same class (intersection type pattern)
- Role matrix: `tenant.member` view-only · `tenant.admin` view+create+update · `platform.admin` all operations · anonymous denied
- System field protection: `id`, `uuid`, `created_at`, `updated_at` forbidden on edit for non-platform.admin; `tenant_id` settable on create, immutable after (via `isNew()` check)
- Adds 33 new unit tests (42 total in `NoteAccessPolicyTest`) and 15 Phase18 integration tests

## Test plan

- [x] All 42 unit tests pass (role × operation matrix + field-level guards + DataProvider coverage)
- [x] All 15 Phase18 integration tests pass (tenant.member/admin/platform.admin/anonymous × view/create/update/delete + field guards)
- [x] Phase16 integration tests unaffected (update-without-role still 403 ✓)
- [x] Full suite green: 3587 tests, 8887 assertions

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)