### PR TITLE
feat(#200): add ajv-cli draft-07 JSON Schema validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,22 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli
+
+      - name: Validate defaults JSON Schemas are valid draft-07
+        run: |
+          fail=0
+          for f in defaults/*.schema.json; do
+            if ! ajv compile --spec=draft7 -s "$f" > /dev/null 2>&1; then
+              echo "FAIL: $f is not a valid JSON Schema draft-07"
+              fail=1
+            fi
+          done
+          exit $fail


### PR DESCRIPTION
## Summary

- Adds `ajv compile --spec=draft7` step to `manifest-conformance` CI job, satisfying the strict JSON Schema draft-07 validation requirement from #200
- Keeps the existing `python3 json.load` well-formedness check as a fast pre-check
- The `ci.yml` already triggers on `pull_request` to `main`, covering the on-PR manifest conformance requirement from #202

Closes #200
Closes #202

## Test plan

- [ ] Verify `manifest-conformance` job passes on `defaults/core.note.schema.json` (valid draft-07)
- [ ] Confirm both jobs trigger on PR open/update

🤖 Generated with [Claude Code](https://claude.com/claude-code)