### PR TITLE
feat(#204): ingestion pipeline defaults — envelope format and strict validation

### DIFF
--- a/packages/note/src/Ingestion/IngestionEnvelope.php
+++ b/packages/note/src/Ingestion/IngestionEnvelope.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Ingestion;
+
+/**
+ * A validated ingestion envelope for core.note.
+ *
+ * Construct only via IngestionEnvelope::fromValidated() after running
+ * IngestionEnvelopeValidator — the validator guarantees all fields are present
+ * and non-empty before this object is created.
+ */
+final class IngestionEnvelope
+{
+    private function __construct(
+        public readonly string $envelopeVersion,
+        public readonly string $source,
+        public readonly string $ingestedAt,
+        public readonly string $title,
+        public readonly string $tenantId,
+        public readonly string $body,
+    ) {}
+
+    /** @param array<string, mixed> $raw A raw array that has already passed IngestionEnvelopeValidator. */
+    public static function fromValidated(array $raw): self
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $raw['payload'];
+
+        return new self(
+            envelopeVersion: (string) $raw['envelope_version'],
+            source:          trim((string) $raw['source']),
+            ingestedAt:      trim((string) $raw['ingested_at']),
+            title:           trim((string) $payload['title']),
+            tenantId:        trim((string) $payload['tenant_id']),
+            body:            isset($payload['body']) ? trim((string) $payload['body']) : '',
+        );
+    }
+}

--- a/packages/note/src/Ingestion/IngestionEnvelopeValidator.php
+++ b/packages/note/src/Ingestion/IngestionEnvelopeValidator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Ingestion;
+
+/**
+ * Validates a raw ingestion envelope array against the core.note envelope spec v1.
+ *
+ * Returns a list of ValidationError — an empty list means the envelope is valid.
+ *
+ * Error codes:
+ *   INVALID_ENVELOPE   — structural problems (missing/unsupported version, missing payload)
+ *   MISSING_PROVENANCE — source or ingested_at absent or blank
+ *   SCHEMA_VIOLATION   — payload fields violate core.note schema constraints
+ */
+final class IngestionEnvelopeValidator
+{
+    private const SUPPORTED_VERSIONS = ['1'];
+
+    /**
+     * @param array<string, mixed> $raw
+     * @return ValidationError[]
+     */
+    public function validate(array $raw): array
+    {
+        $errors = [];
+
+        $this->validateEnvelopeVersion($raw, $errors);
+        $this->validateProvenance($raw, $errors);
+        $this->validatePayload($raw, $errors);
+
+        return $errors;
+    }
+
+    /** @param ValidationError[] $errors */
+    private function validateEnvelopeVersion(array $raw, array &$errors): void
+    {
+        $version = $raw['envelope_version'] ?? null;
+
+        if (!is_string($version) || !in_array($version, self::SUPPORTED_VERSIONS, true)) {
+            $errors[] = new ValidationError(
+                '/envelope_version',
+                'INVALID_ENVELOPE',
+                sprintf(
+                    'envelope_version must be one of [%s]; got %s.',
+                    implode(', ', self::SUPPORTED_VERSIONS),
+                    json_encode($version),
+                ),
+            );
+        }
+    }
+
+    /** @param ValidationError[] $errors */
+    private function validateProvenance(array $raw, array &$errors): void
+    {
+        $source = $raw['source'] ?? null;
+        if (!is_string($source) || trim($source) === '') {
+            $errors[] = new ValidationError(
+                '/source',
+                'MISSING_PROVENANCE',
+                'source is required and must be a non-empty string.',
+            );
+        }
+
+        $ingestedAt = $raw['ingested_at'] ?? null;
+        if (!is_string($ingestedAt) || trim($ingestedAt) === '') {
+            $errors[] = new ValidationError(
+                '/ingested_at',
+                'MISSING_PROVENANCE',
+                'ingested_at is required and must be a non-empty ISO 8601 timestamp string.',
+            );
+        }
+    }
+
+    /** @param ValidationError[] $errors */
+    private function validatePayload(array $raw, array &$errors): void
+    {
+        $payload = $raw['payload'] ?? null;
+
+        if (!is_array($payload)) {
+            $errors[] = new ValidationError(
+                '/payload',
+                'INVALID_ENVELOPE',
+                'payload is required and must be an object.',
+            );
+            return;
+        }
+
+        $title = $payload['title'] ?? null;
+        if (!is_string($title) || trim($title) === '') {
+            $errors[] = new ValidationError(
+                '/payload/title',
+                'SCHEMA_VIOLATION',
+                'payload.title is required and must be a non-empty string.',
+            );
+        }
+
+        $tenantId = $payload['tenant_id'] ?? null;
+        if (!is_string($tenantId) || trim($tenantId) === '') {
+            $errors[] = new ValidationError(
+                '/payload/tenant_id',
+                'SCHEMA_VIOLATION',
+                'payload.tenant_id is required and must be a non-empty string.',
+            );
+        }
+    }
+}

--- a/packages/note/src/Ingestion/NoteIngester.php
+++ b/packages/note/src/Ingestion/NoteIngester.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Ingestion;
+
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Note\Note;
+
+/**
+ * Creates and persists a core.note entity from a validated ingestion envelope.
+ */
+final class NoteIngester
+{
+    public function __construct(private readonly EntityStorageInterface $storage) {}
+
+    public function ingest(IngestionEnvelope $envelope): Note
+    {
+        /** @var Note $note */
+        $note = $this->storage->create([
+            'title'            => $envelope->title,
+            'tenant_id'        => $envelope->tenantId,
+            'body'             => $envelope->body,
+            'ingestion_source' => $envelope->source,
+            'ingested_at'      => $envelope->ingestedAt,
+        ]);
+
+        $this->storage->save($note);
+
+        return $note;
+    }
+}

--- a/packages/note/src/Ingestion/ValidationError.php
+++ b/packages/note/src/Ingestion/ValidationError.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Ingestion;
+
+final class ValidationError
+{
+    public function __construct(
+        public readonly string $path,
+        public readonly string $code,
+        public readonly string $message,
+    ) {}
+
+    /** @return array{path: string, code: string, message: string} */
+    public function toArray(): array
+    {
+        return [
+            'path'    => $this->path,
+            'code'    => $this->code,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/packages/note/tests/Unit/Ingestion/IngestionEnvelopeValidatorTest.php
+++ b/packages/note/tests/Unit/Ingestion/IngestionEnvelopeValidatorTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Tests\Unit\Ingestion;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Note\Ingestion\IngestionEnvelopeValidator;
+use Waaseyaa\Note\Ingestion\ValidationError;
+
+#[CoversClass(IngestionEnvelopeValidator::class)]
+#[CoversClass(ValidationError::class)]
+final class IngestionEnvelopeValidatorTest extends TestCase
+{
+    private IngestionEnvelopeValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new IngestionEnvelopeValidator();
+    }
+
+    // -----------------------------------------------------------------------
+    // Valid envelopes
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function validEnvelopeProducesNoErrors(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:import-script',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => [
+                'tenant_id' => 'acme',
+                'title'     => 'Imported Note',
+                'body'      => 'Content here.',
+            ],
+        ]);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validEnvelopeWithoutBodyIsAccepted(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => [
+                'tenant_id' => 'acme',
+                'title'     => 'A Title',
+            ],
+        ]);
+
+        $this->assertSame([], $errors);
+    }
+
+    // -----------------------------------------------------------------------
+    // INVALID_ENVELOPE — structural problems
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function missingEnvelopeVersionProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'source'      => 'api:test',
+            'ingested_at' => '2026-03-07T12:00:00Z',
+            'payload'     => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'INVALID_ENVELOPE', '/envelope_version');
+    }
+
+    #[Test]
+    public function unsupportedEnvelopeVersionProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '99',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'INVALID_ENVELOPE', '/envelope_version');
+    }
+
+    #[Test]
+    public function missingPayloadProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+        ]);
+
+        $this->assertErrorWithCode($errors, 'INVALID_ENVELOPE', '/payload');
+    }
+
+    #[Test]
+    public function payloadNotArrayProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => 'not-an-array',
+        ]);
+
+        $this->assertErrorWithCode($errors, 'INVALID_ENVELOPE', '/payload');
+    }
+
+    // -----------------------------------------------------------------------
+    // MISSING_PROVENANCE — source / ingested_at
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function missingSourceProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'MISSING_PROVENANCE', '/source');
+    }
+
+    #[Test]
+    public function emptySourceProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => '   ',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'MISSING_PROVENANCE', '/source');
+    }
+
+    #[Test]
+    public function missingIngestedAtProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'MISSING_PROVENANCE', '/ingested_at');
+    }
+
+    #[Test]
+    public function emptyIngestedAtProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'MISSING_PROVENANCE', '/ingested_at');
+    }
+
+    // -----------------------------------------------------------------------
+    // SCHEMA_VIOLATION — payload field constraints
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function missingTitleInPayloadProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'SCHEMA_VIOLATION', '/payload/title');
+    }
+
+    #[Test]
+    public function emptyTitleInPayloadProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => '  '],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'SCHEMA_VIOLATION', '/payload/title');
+    }
+
+    #[Test]
+    public function missingTenantIdInPayloadProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['title' => 'A Title'],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'SCHEMA_VIOLATION', '/payload/tenant_id');
+    }
+
+    #[Test]
+    public function emptyTenantIdInPayloadProducesError(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['title' => 'A Title', 'tenant_id' => ''],
+        ]);
+
+        $this->assertErrorWithCode($errors, 'SCHEMA_VIOLATION', '/payload/tenant_id');
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidationError value object
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function validationErrorExposesPathCodeAndMessage(): void
+    {
+        $error = new ValidationError('/source', 'MISSING_PROVENANCE', 'source is required');
+
+        $this->assertSame('/source', $error->path);
+        $this->assertSame('MISSING_PROVENANCE', $error->code);
+        $this->assertSame('source is required', $error->message);
+    }
+
+    #[Test]
+    public function validationErrorSerializesToArray(): void
+    {
+        $error = new ValidationError('/payload/title', 'SCHEMA_VIOLATION', 'title is required');
+
+        $this->assertSame([
+            'path'    => '/payload/title',
+            'code'    => 'SCHEMA_VIOLATION',
+            'message' => 'title is required',
+        ], $error->toArray());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple errors accumulate
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function multipleViolationsAreAllReported(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'ingested_at'      => '',
+            'payload'          => ['title' => ''],
+        ]);
+
+        $codes = array_map(static fn(ValidationError $e): string => $e->code, $errors);
+        $this->assertContains('MISSING_PROVENANCE', $codes);
+        $this->assertContains('SCHEMA_VIOLATION', $codes);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * @param ValidationError[] $errors
+     */
+    private function assertErrorWithCode(array $errors, string $code, string $path): void
+    {
+        foreach ($errors as $error) {
+            if ($error->code === $code && $error->path === $path) {
+                $this->addToAssertionCount(1);
+                return;
+            }
+        }
+
+        $this->fail(sprintf(
+            'Expected error with code "%s" at path "%s", got: %s',
+            $code,
+            $path,
+            json_encode(array_map(static fn(ValidationError $e): array => $e->toArray(), $errors)),
+        ));
+    }
+}

--- a/packages/note/tests/Unit/Ingestion/NoteIngesterTest.php
+++ b/packages/note/tests/Unit/Ingestion/NoteIngesterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Note\Tests\Unit\Ingestion;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Note\Ingestion\IngestionEnvelope;
+use Waaseyaa\Note\Ingestion\NoteIngester;
+use Waaseyaa\Note\Note;
+
+#[CoversClass(NoteIngester::class)]
+#[CoversClass(IngestionEnvelope::class)]
+final class NoteIngesterTest extends TestCase
+{
+    private CapturingStorage $storage;
+    private NoteIngester $ingester;
+
+    protected function setUp(): void
+    {
+        $this->storage = new CapturingStorage();
+        $this->ingester = new NoteIngester($this->storage);
+    }
+
+    #[Test]
+    public function ingestCreatesNoteWithPayloadValues(): void
+    {
+        $envelope = IngestionEnvelope::fromValidated([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => [
+                'tenant_id' => 'acme',
+                'title'     => 'Test Note',
+                'body'      => 'Hello world.',
+            ],
+        ]);
+
+        $note = $this->ingester->ingest($envelope);
+
+        $this->assertInstanceOf(Note::class, $note);
+        $this->assertSame('Test Note', $note->getTitle());
+        $this->assertSame('acme', $note->getTenantId());
+        $this->assertSame('Hello world.', $note->getBody());
+    }
+
+    #[Test]
+    public function ingestPersistsNoteViaStorage(): void
+    {
+        $envelope = IngestionEnvelope::fromValidated([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'Saved Note'],
+        ]);
+
+        $this->ingester->ingest($envelope);
+
+        $this->assertTrue($this->storage->saveCalled);
+    }
+
+    #[Test]
+    public function ingestStoresProvenanceOnNote(): void
+    {
+        $envelope = IngestionEnvelope::fromValidated([
+            'envelope_version' => '1',
+            'source'           => 'api:import-script',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'Provenance Note'],
+        ]);
+
+        $note = $this->ingester->ingest($envelope);
+
+        $this->assertSame('api:import-script', $note->get('ingestion_source'));
+        $this->assertSame('2026-03-07T12:00:00Z', $note->get('ingested_at'));
+    }
+
+    #[Test]
+    public function ingestWithoutBodyDefaultsToEmptyString(): void
+    {
+        $envelope = IngestionEnvelope::fromValidated([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'No Body Note'],
+        ]);
+
+        $note = $this->ingester->ingest($envelope);
+
+        $this->assertSame('', $note->getBody());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test double
+// ---------------------------------------------------------------------------
+
+final class CapturingStorage implements EntityStorageInterface
+{
+    public bool $saveCalled = false;
+
+    public function create(array $values = []): EntityInterface
+    {
+        $note = new Note($values);
+        $note->enforceIsNew();
+        return $note;
+    }
+
+    public function save(EntityInterface $entity): int
+    {
+        $this->saveCalled = true;
+        return 1;
+    }
+
+    public function load(int|string $id): ?EntityInterface { return null; }
+
+    public function loadMultiple(array $ids = []): array { return []; }
+
+    public function delete(array $entities): void {}
+
+    public function getQuery(): EntityQueryInterface
+    {
+        throw new \LogicException('Not implemented in test double.');
+    }
+
+    public function getEntityTypeId(): string { return 'note'; }
+}

--- a/tests/Integration/Phase19/NoteIngestionIntegrationTest.php
+++ b/tests/Integration/Phase19/NoteIngestionIntegrationTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase19;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Note\Ingestion\IngestionEnvelope;
+use Waaseyaa\Note\Ingestion\IngestionEnvelopeValidator;
+use Waaseyaa\Note\Ingestion\NoteIngester;
+use Waaseyaa\Note\Ingestion\ValidationError;
+use Waaseyaa\Note\Note;
+
+/**
+ * End-to-end ingestion pipeline for core.note (#204).
+ *
+ * Validates that the validator + ingester compose correctly:
+ * - Valid envelopes produce a persisted Note with correct field values.
+ * - Invalid envelopes are rejected with structured errors before any write occurs.
+ */
+#[CoversNothing]
+final class NoteIngestionIntegrationTest extends TestCase
+{
+    private InMemoryNoteStorage $storage;
+    private IngestionEnvelopeValidator $validator;
+    private NoteIngester $ingester;
+
+    protected function setUp(): void
+    {
+        $this->storage   = new InMemoryNoteStorage();
+        $this->validator = new IngestionEnvelopeValidator();
+        $this->ingester  = new NoteIngester($this->storage);
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy paths
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function validEnvelopeIngestsNoteWithCorrectFields(): void
+    {
+        $raw = [
+            'envelope_version' => '1',
+            'source'           => 'api:import-script',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => [
+                'tenant_id' => 'acme',
+                'title'     => 'Imported Note',
+                'body'      => 'Content here.',
+            ],
+        ];
+
+        $errors = $this->validator->validate($raw);
+        $this->assertSame([], $errors, 'Valid envelope must produce no errors.');
+
+        $envelope = IngestionEnvelope::fromValidated($raw);
+        $note     = $this->ingester->ingest($envelope);
+
+        $this->assertInstanceOf(Note::class, $note);
+        $this->assertSame('Imported Note', $note->getTitle());
+        $this->assertSame('acme', $note->getTenantId());
+        $this->assertSame('Content here.', $note->getBody());
+        $this->assertCount(1, $this->storage->saved);
+    }
+
+    #[Test]
+    public function provenanceFieldsAreStoredOnNote(): void
+    {
+        $raw = [
+            'envelope_version' => '1',
+            'source'           => 'cli:batch-import',
+            'ingested_at'      => '2026-03-07T09:30:00Z',
+            'payload'          => ['tenant_id' => 'beta', 'title' => 'CLI Import'],
+        ];
+
+        $note = $this->ingester->ingest(IngestionEnvelope::fromValidated($raw));
+
+        $this->assertSame('cli:batch-import', $note->get('ingestion_source'));
+        $this->assertSame('2026-03-07T09:30:00Z', $note->get('ingested_at'));
+    }
+
+    #[Test]
+    public function missingBodyDefaultsToEmptyString(): void
+    {
+        $raw = [
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'No Body'],
+        ];
+
+        $note = $this->ingester->ingest(IngestionEnvelope::fromValidated($raw));
+
+        $this->assertSame('', $note->getBody());
+    }
+
+    #[Test]
+    public function multipleEnvelopesAreEachPersisted(): void
+    {
+        $base = [
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+        ];
+
+        $this->ingester->ingest(IngestionEnvelope::fromValidated(
+            $base + ['payload' => ['tenant_id' => 'acme', 'title' => 'Note One']],
+        ));
+        $this->ingester->ingest(IngestionEnvelope::fromValidated(
+            $base + ['payload' => ['tenant_id' => 'acme', 'title' => 'Note Two']],
+        ));
+
+        $this->assertCount(2, $this->storage->saved);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rejection paths — no storage writes occur
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function invalidEnvelopeIsRejectedWithInvalidEnvelopeCode(): void
+    {
+        $errors = $this->validator->validate([
+            'source'      => 'api:test',
+            'ingested_at' => '2026-03-07T12:00:00Z',
+            'payload'     => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertNotEmpty($errors);
+        $this->assertContainsOnlyInstancesOf(ValidationError::class, $errors);
+        $this->assertSame('INVALID_ENVELOPE', $errors[0]->code);
+        $this->assertCount(0, $this->storage->saved);
+    }
+
+    #[Test]
+    public function missingProvenanceIsRejectedWithMissingProvenanceCode(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $codes = array_map(static fn(ValidationError $e): string => $e->code, $errors);
+        $this->assertContains('MISSING_PROVENANCE', $codes);
+        $this->assertCount(0, $this->storage->saved);
+    }
+
+    #[Test]
+    public function schemaViolationIsRejectedWithSchemaViolationCode(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => 'api:test',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme'],
+        ]);
+
+        $codes = array_map(static fn(ValidationError $e): string => $e->code, $errors);
+        $this->assertContains('SCHEMA_VIOLATION', $codes);
+        $this->assertCount(0, $this->storage->saved);
+    }
+
+    #[Test]
+    public function errorResponseIncludesPathCodeAndMessage(): void
+    {
+        $errors = $this->validator->validate([
+            'envelope_version' => '1',
+            'source'           => '',
+            'ingested_at'      => '2026-03-07T12:00:00Z',
+            'payload'          => ['tenant_id' => 'acme', 'title' => 'T'],
+        ]);
+
+        $this->assertNotEmpty($errors);
+        $serialized = $errors[0]->toArray();
+        $this->assertArrayHasKey('path', $serialized);
+        $this->assertArrayHasKey('code', $serialized);
+        $this->assertArrayHasKey('message', $serialized);
+        $this->assertNotEmpty($serialized['path']);
+        $this->assertNotEmpty($serialized['message']);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory storage double for integration tests
+// ---------------------------------------------------------------------------
+
+final class InMemoryNoteStorage implements EntityStorageInterface
+{
+    /** @var Note[] */
+    public array $saved = [];
+
+    private int $nextId = 1;
+
+    public function create(array $values = []): EntityInterface
+    {
+        $note = new Note($values);
+        $note->enforceIsNew();
+        return $note;
+    }
+
+    public function save(EntityInterface $entity): int
+    {
+        $id = $this->nextId++;
+        $entity->set('id', $id);
+        $this->saved[] = $entity;
+        return $id;
+    }
+
+    public function load(int|string $id): ?EntityInterface { return null; }
+
+    public function loadMultiple(array $ids = []): array { return []; }
+
+    public function delete(array $entities): void {}
+
+    public function getQuery(): EntityQueryInterface
+    {
+        throw new \LogicException('Not implemented in test double.');
+    }
+
+    public function getEntityTypeId(): string { return 'note'; }
+}


### PR DESCRIPTION
## Summary

- `IngestionEnvelopeValidator` — validates raw `array<string, mixed>` against envelope v1 spec; returns list of `ValidationError` (empty = valid)
- `IngestionEnvelope` — typed value object constructed only from validated data via `fromValidated()`
- `NoteIngester` — creates and persists a `Note` from a valid envelope, stamping `ingestion_source` + `ingested_at` as provenance metadata
- `ValidationError` — readonly value object with `path` (JSON pointer), `code`, `message` and `toArray()` serialization

**Error codes:**
| Code | When |
|---|---|
| `INVALID_ENVELOPE` | missing/unsupported `envelope_version`, missing/non-array `payload` |
| `MISSING_PROVENANCE` | `source` or `ingested_at` absent or blank |
| `SCHEMA_VIOLATION` | `payload.title` or `payload.tenant_id` missing/blank |

Closes #204

## Test plan

- [ ] 17 unit tests — `IngestionEnvelopeValidatorTest` (all error codes + valid paths)
- [ ] 4 unit tests — `NoteIngesterTest` (field mapping, provenance, save called)
- [ ] 8 integration tests — `NoteIngestionIntegrationTest` (happy path + all rejection codes end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)