### PR TITLE
feat(#206): reserve core. namespace in entity type registration

### DIFF
--- a/defaults/README.md
+++ b/defaults/README.md
@@ -22,6 +22,26 @@ schemas, and configuration.
 Built-in types use the `core.` namespace prefix. Custom types must use a different namespace.
 The `core.` namespace is reserved and cannot be claimed by extensions or tenants.
 
+### Enforcement
+
+The `core.` namespace is enforced at registration time in `EntityTypeManager`:
+
+- `registerEntityType()` — throws `[NAMESPACE_RESERVED]` `\DomainException` if the type ID starts with `core.`
+- `registerCoreEntityType()` — bypasses the guard; for kernel boot and core service providers only
+
+**Extension and tenant code must use `registerEntityType()` and choose a non-`core.` namespace.**
+Attempting to register `core.*` types from extension service providers will fail at boot.
+
+### Choosing a namespace
+
+Use a short, globally-unique prefix for your organisation or extension:
+
+```
+myorg.article      ✓  custom type in myorg namespace
+acme.product       ✓  tenant-scoped type
+core.article       ✗  reserved — DomainException thrown
+```
+
 ## Adding a New Default
 
 1. Create `<namespace>.<type>.yaml` with `project_versioning` block.

--- a/packages/entity/src/EntityTypeManager.php
+++ b/packages/entity/src/EntityTypeManager.php
@@ -42,9 +42,40 @@ class EntityTypeManager implements EntityTypeManagerInterface
     /**
      * Register an entity type definition.
      *
+     * The `core.` namespace is reserved for built-in platform types. Attempting
+     * to register a type with a `core.*` ID via this method throws NAMESPACE_RESERVED.
+     * Use registerCoreEntityType() for platform-level registrations.
+     *
+     * @throws \DomainException        If the entity type ID uses the reserved `core.` namespace.
      * @throws \InvalidArgumentException If an entity type with the same ID is already registered.
      */
     public function registerEntityType(EntityTypeInterface $type): void
+    {
+        if (str_starts_with($type->id(), 'core.')) {
+            throw new \DomainException(\sprintf(
+                '[NAMESPACE_RESERVED] The "core." namespace is reserved for built-in platform types. '
+                . 'Entity type "%s" cannot be registered by extensions or tenants. '
+                . 'Use a custom namespace prefix instead.',
+                $type->id(),
+            ));
+        }
+
+        $this->persistDefinition($type);
+    }
+
+    /**
+     * Register a built-in platform entity type, bypassing the `core.` namespace guard.
+     *
+     * Only kernel boot code and core service providers should call this method.
+     *
+     * @throws \InvalidArgumentException If an entity type with the same ID is already registered.
+     */
+    public function registerCoreEntityType(EntityTypeInterface $type): void
+    {
+        $this->persistDefinition($type);
+    }
+
+    private function persistDefinition(EntityTypeInterface $type): void
     {
         if (isset($this->definitions[$type->id()])) {
             throw new \InvalidArgumentException(\sprintf(

--- a/packages/entity/src/EntityTypeManagerInterface.php
+++ b/packages/entity/src/EntityTypeManagerInterface.php
@@ -8,6 +8,11 @@ interface EntityTypeManagerInterface
 {
     public function getDefinition(string $entityTypeId): EntityTypeInterface;
 
+    /** @throws \DomainException If the entity type ID uses the reserved `core.` namespace. */
+    public function registerEntityType(EntityTypeInterface $type): void;
+
+    public function registerCoreEntityType(EntityTypeInterface $type): void;
+
     /** @return array<string, EntityTypeInterface> */
     public function getDefinitions(): array;
 

--- a/packages/entity/tests/Unit/EntityTypeManagerTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerTest.php
@@ -178,4 +178,65 @@ class EntityTypeManagerTest extends TestCase
     {
         $this->assertSame([], $this->manager->getDefinitions());
     }
+
+    // -----------------------------------------------------------------------
+    // Namespace reservation (#206)
+    // -----------------------------------------------------------------------
+
+    public function testRegisterEntityTypeWithCoreNamespaceThrows(): void
+    {
+        $type = new EntityType(id: 'core.custom', label: 'Custom', class: TestEntity::class);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('[NAMESPACE_RESERVED]');
+
+        $this->manager->registerEntityType($type);
+    }
+
+    public function testRegisterEntityTypeWithCoreNamespaceErrorIncludesTypeId(): void
+    {
+        $type = new EntityType(id: 'core.custom', label: 'Custom', class: TestEntity::class);
+
+        try {
+            $this->manager->registerEntityType($type);
+            $this->fail('Expected DomainException');
+        } catch (\DomainException $e) {
+            $this->assertStringContainsString('core.custom', $e->getMessage());
+        }
+    }
+
+    public function testRegisterEntityTypeWithoutCoreNamespaceSucceeds(): void
+    {
+        $type = new EntityType(id: 'note', label: 'Note', class: TestEntity::class);
+        $this->manager->registerEntityType($type);
+
+        $this->assertTrue($this->manager->hasDefinition('note'));
+    }
+
+    public function testRegisterCoreEntityTypeWithCoreNamespaceSucceeds(): void
+    {
+        $type = new EntityType(id: 'core.note', label: 'Note', class: TestEntity::class);
+        $this->manager->registerCoreEntityType($type);
+
+        $this->assertTrue($this->manager->hasDefinition('core.note'));
+    }
+
+    public function testRegisterCoreEntityTypeWithoutCoreNamespaceAlsoSucceeds(): void
+    {
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $this->manager->registerCoreEntityType($type);
+
+        $this->assertTrue($this->manager->hasDefinition('node'));
+    }
+
+    public function testRegisterCoreEntityTypeRejectsDuplicates(): void
+    {
+        $type = new EntityType(id: 'core.note', label: 'Note', class: TestEntity::class);
+        $this->manager->registerCoreEntityType($type);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $duplicate = new EntityType(id: 'core.note', label: 'Note v2', class: TestEntity::class);
+        $this->manager->registerCoreEntityType($duplicate);
+    }
 }

--- a/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
@@ -483,6 +483,16 @@ final class DiscoveryEntityTypeManager implements EntityTypeManagerInterface
 
         return $this->storages[$entityTypeId];
     }
+
+    public function registerEntityType(EntityTypeInterface $type): void
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
+
+    public function registerCoreEntityType(EntityTypeInterface $type): void
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
 }
 
 final class DiscoveryRelationshipStorage implements EntityStorageInterface

--- a/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
@@ -264,6 +264,16 @@ final class TraversalEntityTypeManager implements EntityTypeManagerInterface
 
         return $this->storages[$entityTypeId];
     }
+
+    public function registerEntityType(EntityTypeInterface $type): void
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
+
+    public function registerCoreEntityType(EntityTypeInterface $type): void
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
 }
 
 final class TraversalRelationshipStorage implements EntityStorageInterface


### PR DESCRIPTION
## Summary

- `EntityTypeManager::registerEntityType()` throws `[NAMESPACE_RESERVED]` `\DomainException` when type ID starts with `core.` — blocks extensions and tenants from claiming the built-in namespace
- New `registerCoreEntityType()` bypasses the guard for kernel boot / core service providers
- Both methods added to `EntityTypeManagerInterface`
- `defaults/README.md` updated with namespace rules, enforcement mechanism, and namespace selection guidance

Closes #206

## Test plan

- [ ] 6 new tests in `EntityTypeManagerTest`: extension/tenant attempts rejected, `registerCoreEntityType` succeeds for `core.*`, non-`core.*` still works, duplicate guard applies to both methods
- [ ] Two test-double implementations in `packages/relationship` updated for interface conformance
- [ ] Full 3651-test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)