### PR TITLE
feat(#205): operator diagnostics — DiagnosticCode enum, DiagnosticEmitter, BootDiagnosticReport

### DIFF
--- a/packages/foundation/src/Diagnostic/BootDiagnosticReport.php
+++ b/packages/foundation/src/Diagnostic/BootDiagnosticReport.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Diagnostic;
+
+use Waaseyaa\Entity\EntityTypeInterface;
+
+/**
+ * A snapshot of the entity type registry status produced at boot time.
+ *
+ * Contains registered types, disabled type IDs, and per-type compatibility
+ * information derived from the type's manifest (when available).
+ */
+final class BootDiagnosticReport
+{
+    /**
+     * @param array<string, EntityTypeInterface> $registeredTypes
+     * @param string[]                           $disabledTypeIds
+     * @param array<string, mixed>               $schemaCompatibility  type_id → compatibility mode string
+     */
+    public function __construct(
+        public readonly array $registeredTypes,
+        public readonly array $disabledTypeIds,
+        public readonly array $schemaCompatibility,
+    ) {}
+
+    /** @return string[] */
+    public function enabledTypeIds(): array
+    {
+        return array_values(array_filter(
+            array_keys($this->registeredTypes),
+            fn(string $id): bool => !in_array($id, $this->disabledTypeIds, true),
+        ));
+    }
+
+    public function hasEnabledTypes(): bool
+    {
+        return $this->enabledTypeIds() !== [];
+    }
+
+    /**
+     * @return array{
+     *   registered: string[],
+     *   disabled: string[],
+     *   enabled: string[],
+     *   schema_compatibility: array<string, mixed>,
+     *   healthy: bool,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'registered'           => array_keys($this->registeredTypes),
+            'disabled'             => $this->disabledTypeIds,
+            'enabled'              => $this->enabledTypeIds(),
+            'schema_compatibility' => $this->schemaCompatibility,
+            'healthy'              => $this->hasEnabledTypes(),
+        ];
+    }
+}

--- a/packages/foundation/src/Diagnostic/DiagnosticCode.php
+++ b/packages/foundation/src/Diagnostic/DiagnosticCode.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Diagnostic;
+
+/**
+ * Canonical operator-facing diagnostic error codes.
+ *
+ * Each case documents the trigger condition, default human message, and
+ * remediation steps. When a code fires, DiagnosticEmitter logs a structured
+ * entry so operators can correlate errors across distributed systems.
+ */
+enum DiagnosticCode: string
+{
+    case DEFAULT_TYPE_MISSING        = 'DEFAULT_TYPE_MISSING';
+    case DEFAULT_TYPE_DISABLED       = 'DEFAULT_TYPE_DISABLED';
+    case UNAUTHORIZED_V1_TAG         = 'UNAUTHORIZED_V1_TAG';
+    case TAG_QUARANTINE_DETECTED     = 'TAG_QUARANTINE_DETECTED';
+    case MANIFEST_VERSIONING_MISSING = 'MANIFEST_VERSIONING_MISSING';
+    case NAMESPACE_RESERVED          = 'NAMESPACE_RESERVED';
+
+    public function defaultMessage(): string
+    {
+        return match ($this) {
+            self::DEFAULT_TYPE_MISSING =>
+                'No content types are registered. At least one must be available at boot.',
+            self::DEFAULT_TYPE_DISABLED =>
+                'All registered content types are disabled. At least one must remain enabled.',
+            self::UNAUTHORIZED_V1_TAG =>
+                'A v1.0 tag was created without the required owner approval sentinel file.',
+            self::TAG_QUARANTINE_DETECTED =>
+                'Existing unauthorized v1.0 tag(s) detected in the repository.',
+            self::MANIFEST_VERSIONING_MISSING =>
+                'A defaults manifest is missing the required project_versioning block.',
+            self::NAMESPACE_RESERVED =>
+                'The "core." namespace is reserved for built-in platform types and cannot be used by extensions or tenants.',
+        };
+    }
+
+    public function remediation(): string
+    {
+        return match ($this) {
+            self::DEFAULT_TYPE_MISSING =>
+                'Enable core.note (`waaseyaa type:enable note`) or register a custom content type via a service provider.',
+            self::DEFAULT_TYPE_DISABLED =>
+                'Run `waaseyaa type:enable note` to re-enable the default type, or enable any other registered type.',
+            self::UNAUTHORIZED_V1_TAG =>
+                'Open a release-quarantine issue and notify @jonesrussell. See VERSIONING.md §2 for the approval process.',
+            self::TAG_QUARANTINE_DETECTED =>
+                'Follow VERSIONING.md §2 to either approve the tag or delete it. Do not proceed with CI until resolved.',
+            self::MANIFEST_VERSIONING_MISSING =>
+                'Add a project_versioning block to the manifest per VERSIONING.md §3. Run `bin/check-milestones` to verify.',
+            self::NAMESPACE_RESERVED =>
+                'Use a custom namespace prefix (e.g., myorg.article). The "core." prefix is reserved for platform built-ins.',
+        };
+    }
+}

--- a/packages/foundation/src/Diagnostic/DiagnosticEmitter.php
+++ b/packages/foundation/src/Diagnostic/DiagnosticEmitter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Diagnostic;
+
+/**
+ * Emits structured diagnostic log entries for operator-facing error codes.
+ *
+ * Each call to emit() writes a single-line JSON object to error_log()
+ * (following the project's no-psr/log convention) and returns the entry
+ * for callers that need to inspect or re-throw it.
+ */
+final class DiagnosticEmitter
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function emit(DiagnosticCode $code, string $message, array $context = []): DiagnosticEntry
+    {
+        $entry = new DiagnosticEntry($code, $message, $context);
+
+        error_log(json_encode($entry->toArray(), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+        return $entry;
+    }
+}

--- a/packages/foundation/src/Diagnostic/DiagnosticEntry.php
+++ b/packages/foundation/src/Diagnostic/DiagnosticEntry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Diagnostic;
+
+/**
+ * Structured diagnostic log entry produced by DiagnosticEmitter.
+ */
+final class DiagnosticEntry
+{
+    public readonly string $remediation;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        public readonly DiagnosticCode $code,
+        public readonly string $message,
+        public readonly array $context,
+    ) {
+        $this->remediation = $code->remediation();
+    }
+
+    /**
+     * @return array{code: string, message: string, context: array<string, mixed>, remediation: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'code'        => $this->code->value,
+            'message'     => $this->message,
+            'context'     => $this->context,
+            'remediation' => $this->remediation,
+        ];
+    }
+}

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -13,6 +13,8 @@ use Waaseyaa\Entity\EntityTypeLifecycleManager;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticCode;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticEmitter;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -188,28 +190,31 @@ abstract class AbstractKernel
      */
     protected function validateContentTypes(): void
     {
+        $emitter     = new DiagnosticEmitter();
         $definitions = $this->entityTypeManager->getDefinitions();
 
         if ($definitions === []) {
-            throw new \RuntimeException(
-                '[CRITICAL] DEFAULT_TYPE_MISSING: No content types registered. '
-                . 'Remediation: Ensure core.note is not disabled, or register a custom type. '
-                . 'See defaults/core.note.yaml and defaults/README.md.',
+            $entry = $emitter->emit(
+                DiagnosticCode::DEFAULT_TYPE_MISSING,
+                DiagnosticCode::DEFAULT_TYPE_MISSING->defaultMessage(),
+                ['registered_type_count' => 0],
             );
+            throw new \RuntimeException('[CRITICAL] ' . $entry->code->value . ': ' . $entry->message);
         }
 
-        $disabledIds = $this->lifecycleManager->getDisabledTypeIds();
+        $disabledIds  = $this->lifecycleManager->getDisabledTypeIds();
         $enabledTypes = array_filter(
             $definitions,
             static fn(\Waaseyaa\Entity\EntityTypeInterface $def): bool => !in_array($def->id(), $disabledIds, true),
         );
 
         if ($enabledTypes === []) {
-            throw new \RuntimeException(
-                '[CRITICAL] DEFAULT_TYPE_DISABLED: All registered content types are disabled. '
-                . 'Remediation: Run `waaseyaa type:enable core.note` or enable at least one content type. '
-                . 'See defaults/core.note.yaml and defaults/README.md.',
+            $entry = $emitter->emit(
+                DiagnosticCode::DEFAULT_TYPE_DISABLED,
+                DiagnosticCode::DEFAULT_TYPE_DISABLED->defaultMessage(),
+                ['disabled_ids' => $disabledIds, 'registered_type_count' => count($definitions)],
             );
+            throw new \RuntimeException('[CRITICAL] ' . $entry->code->value . ': ' . $entry->message);
         }
     }
 
@@ -368,5 +373,29 @@ abstract class AbstractKernel
     public function getEventDispatcher(): EventDispatcherInterface
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Return a snapshot of entity type registry status for operator diagnostics.
+     *
+     * Schema compatibility is derived from each type's field definitions when a
+     * 'compatibility' key is present; otherwise defaults to 'liberal' (pre-v1 policy).
+     */
+    public function getBootReport(): \Waaseyaa\Foundation\Diagnostic\BootDiagnosticReport
+    {
+        $definitions      = $this->entityTypeManager->getDefinitions();
+        $disabledIds      = $this->lifecycleManager->getDisabledTypeIds();
+        $schemaCompat     = [];
+
+        foreach ($definitions as $id => $type) {
+            $fieldDefs = $type->getFieldDefinitions();
+            $schemaCompat[$id] = $fieldDefs['compatibility'] ?? 'liberal';
+        }
+
+        return new \Waaseyaa\Foundation\Diagnostic\BootDiagnosticReport(
+            registeredTypes:     $definitions,
+            disabledTypeIds:     $disabledIds,
+            schemaCompatibility: $schemaCompat,
+        );
     }
 }

--- a/packages/foundation/tests/Unit/Diagnostic/BootDiagnosticReportTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/BootDiagnosticReportTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Diagnostic;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Foundation\Diagnostic\BootDiagnosticReport;
+
+#[CoversClass(BootDiagnosticReport::class)]
+final class BootDiagnosticReportTest extends TestCase
+{
+    private function makeType(string $id): EntityType
+    {
+        return new EntityType(id: $id, label: ucfirst($id), class: \stdClass::class);
+    }
+
+    #[Test]
+    public function enabledTypeIdsExcludesDisabled(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: [
+                'note'    => $this->makeType('note'),
+                'article' => $this->makeType('article'),
+            ],
+            disabledTypeIds: ['article'],
+            schemaCompatibility: [],
+        );
+
+        $this->assertSame(['note'], $report->enabledTypeIds());
+    }
+
+    #[Test]
+    public function hasEnabledTypesReturnsTrueWhenAtLeastOneEnabled(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: [],
+            schemaCompatibility: [],
+        );
+
+        $this->assertTrue($report->hasEnabledTypes());
+    }
+
+    #[Test]
+    public function hasEnabledTypesReturnsFalseWhenAllDisabled(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: ['note'],
+            schemaCompatibility: [],
+        );
+
+        $this->assertFalse($report->hasEnabledTypes());
+    }
+
+    #[Test]
+    public function toArrayContainsAllExpectedKeys(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: [],
+            schemaCompatibility: ['note' => 'liberal'],
+        );
+
+        $arr = $report->toArray();
+
+        $this->assertArrayHasKey('registered', $arr);
+        $this->assertArrayHasKey('disabled', $arr);
+        $this->assertArrayHasKey('enabled', $arr);
+        $this->assertArrayHasKey('schema_compatibility', $arr);
+        $this->assertArrayHasKey('healthy', $arr);
+    }
+
+    #[Test]
+    public function toArrayHealthyIsTrueWhenEnabledTypesExist(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: [],
+            schemaCompatibility: [],
+        );
+
+        $this->assertTrue($report->toArray()['healthy']);
+    }
+
+    #[Test]
+    public function toArrayHealthyIsFalseWhenNoEnabledTypes(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: ['note'],
+            schemaCompatibility: [],
+        );
+
+        $this->assertFalse($report->toArray()['healthy']);
+    }
+
+    #[Test]
+    public function schemaCompatibilityIsIncludedInReport(): void
+    {
+        $report = new BootDiagnosticReport(
+            registeredTypes: ['note' => $this->makeType('note')],
+            disabledTypeIds: [],
+            schemaCompatibility: ['note' => 'liberal'],
+        );
+
+        $this->assertSame(['note' => 'liberal'], $report->toArray()['schema_compatibility']);
+    }
+}

--- a/packages/foundation/tests/Unit/Diagnostic/DiagnosticEmitterTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/DiagnosticEmitterTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Diagnostic;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticCode;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticEmitter;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticEntry;
+
+#[CoversClass(DiagnosticCode::class)]
+#[CoversClass(DiagnosticEmitter::class)]
+#[CoversClass(DiagnosticEntry::class)]
+final class DiagnosticEmitterTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // DiagnosticCode enum
+    // -----------------------------------------------------------------------
+
+    /** @return array<string, array{string}> */
+    public static function allCodeNames(): array
+    {
+        return [
+            'DEFAULT_TYPE_MISSING'        => ['DEFAULT_TYPE_MISSING'],
+            'DEFAULT_TYPE_DISABLED'       => ['DEFAULT_TYPE_DISABLED'],
+            'UNAUTHORIZED_V1_TAG'         => ['UNAUTHORIZED_V1_TAG'],
+            'TAG_QUARANTINE_DETECTED'     => ['TAG_QUARANTINE_DETECTED'],
+            'MANIFEST_VERSIONING_MISSING' => ['MANIFEST_VERSIONING_MISSING'],
+            'NAMESPACE_RESERVED'          => ['NAMESPACE_RESERVED'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('allCodeNames')]
+    public function allCodesExist(string $name): void
+    {
+        $code = DiagnosticCode::from($name);
+        $this->assertSame($name, $code->value);
+    }
+
+    #[Test]
+    #[DataProvider('allCodeNames')]
+    public function allCodesHaveRemediationSteps(string $name): void
+    {
+        $code = DiagnosticCode::from($name);
+        $this->assertNotEmpty($code->remediation());
+    }
+
+    #[Test]
+    #[DataProvider('allCodeNames')]
+    public function allCodesHaveDefaultMessage(string $name): void
+    {
+        $code = DiagnosticCode::from($name);
+        $this->assertNotEmpty($code->defaultMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // DiagnosticEntry value object
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function entryExposesAllFields(): void
+    {
+        $entry = new DiagnosticEntry(
+            code: DiagnosticCode::DEFAULT_TYPE_MISSING,
+            message: 'No types at boot.',
+            context: ['registered' => 0],
+        );
+
+        $this->assertSame(DiagnosticCode::DEFAULT_TYPE_MISSING, $entry->code);
+        $this->assertSame('No types at boot.', $entry->message);
+        $this->assertSame(['registered' => 0], $entry->context);
+        $this->assertSame(DiagnosticCode::DEFAULT_TYPE_MISSING->remediation(), $entry->remediation);
+    }
+
+    #[Test]
+    public function entrySerializesToArray(): void
+    {
+        $entry = new DiagnosticEntry(
+            code: DiagnosticCode::DEFAULT_TYPE_DISABLED,
+            message: 'All types disabled.',
+            context: ['disabled' => ['note']],
+        );
+
+        $arr = $entry->toArray();
+
+        $this->assertSame('DEFAULT_TYPE_DISABLED', $arr['code']);
+        $this->assertSame('All types disabled.', $arr['message']);
+        $this->assertSame(['disabled' => ['note']], $arr['context']);
+        $this->assertArrayHasKey('remediation', $arr);
+        $this->assertNotEmpty($arr['remediation']);
+    }
+
+    // -----------------------------------------------------------------------
+    // DiagnosticEmitter
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function emitReturnsCorrectEntry(): void
+    {
+        $emitter = new DiagnosticEmitter();
+
+        $entry = $emitter->emit(
+            DiagnosticCode::DEFAULT_TYPE_MISSING,
+            'Zero types registered at boot.',
+            ['entity_type_count' => 0],
+        );
+
+        $this->assertSame(DiagnosticCode::DEFAULT_TYPE_MISSING, $entry->code);
+        $this->assertSame('Zero types registered at boot.', $entry->message);
+        $this->assertSame(['entity_type_count' => 0], $entry->context);
+    }
+
+    #[Test]
+    public function emitWritesToErrorLog(): void
+    {
+        $emitter = new DiagnosticEmitter();
+
+        // Capture error_log output by redirecting to a temp file.
+        $logFile = sys_get_temp_dir() . '/waaseyaa_diag_test_' . uniqid() . '.log';
+        ini_set('error_log', $logFile);
+
+        $emitter->emit(DiagnosticCode::NAMESPACE_RESERVED, 'core.foo blocked.', []);
+
+        ini_restore('error_log');
+
+        $contents = file_get_contents($logFile) ?: '';
+        @unlink($logFile);
+
+        $this->assertStringContainsString('NAMESPACE_RESERVED', $contents);
+    }
+
+    #[Test]
+    public function emitLogLineIsValidJson(): void
+    {
+        $emitter = new DiagnosticEmitter();
+
+        $logFile = sys_get_temp_dir() . '/waaseyaa_diag_test_' . uniqid() . '.log';
+        ini_set('error_log', $logFile);
+
+        $emitter->emit(DiagnosticCode::DEFAULT_TYPE_DISABLED, 'All disabled.', ['count' => 2]);
+
+        ini_restore('error_log');
+
+        $raw = file_get_contents($logFile) ?: '';
+        @unlink($logFile);
+
+        // error_log prepends a timestamp like "[DD-Mon-YYYY HH:MM:SS UTC] ".
+        // Extract the JSON part after the first ']'.
+        $jsonStart = strpos($raw, '{');
+        $this->assertNotFalse($jsonStart, 'Log line should contain a JSON object');
+
+        $json = substr($raw, $jsonStart);
+        $decoded = json_decode(trim($json), true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('code', $decoded);
+        $this->assertArrayHasKey('message', $decoded);
+        $this->assertArrayHasKey('remediation', $decoded);
+    }
+}

--- a/tests/Integration/Phase17/KernelBootValidationTest.php
+++ b/tests/Integration/Phase17/KernelBootValidationTest.php
@@ -38,7 +38,7 @@ final class KernelBootValidationTest extends TestCase
             $this->fail('Expected RuntimeException was not thrown.');
         } catch (\RuntimeException $e) {
             $this->assertStringContainsString('DEFAULT_TYPE_MISSING', $e->getMessage());
-            $this->assertStringContainsString('core.note', $e->getMessage());
+            $this->assertStringContainsString('content type', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

- `DiagnosticCode` enum with 6 canonical codes, each exposing `defaultMessage()` and `remediation()` steps
- `DiagnosticEntry` typed value object — code, message, context, remediation — with `toArray()` serialization
- `DiagnosticEmitter` — writes structured JSON to `error_log()` (project convention: no psr/log), returns entry
- `BootDiagnosticReport` — boot-time snapshot: registered/disabled/enabled types, schema compatibility, `healthy` flag
- `AbstractKernel::validateContentTypes()` refactored to emit structured diagnostics before throwing
- `AbstractKernel::getBootReport()` added for operator diagnostics access

**Codes covered:**
| Code | Trigger |
|---|---|
| `DEFAULT_TYPE_MISSING` | Zero types at boot |
| `DEFAULT_TYPE_DISABLED` | All types disabled |
| `UNAUTHORIZED_V1_TAG` | v1.0 tag without approval |
| `TAG_QUARANTINE_DETECTED` | Existing v1.0 tags found |
| `MANIFEST_VERSIONING_MISSING` | Manifest lacks `project_versioning` |
| `NAMESPACE_RESERVED` | Extension attempts `core.*` registration |

Closes #205

## Test plan

- [ ] 23 unit tests in `DiagnosticEmitterTest` — all codes exist, have remediation + message; entry serialization; log output is valid JSON
- [ ] 7 unit tests in `BootDiagnosticReportTest` — enabled filtering, healthy flag, toArray shape
- [ ] Full 3681-test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)