### PR TITLE
feat(#208): entity write audit trail — EntityAuditLogger, listener, CLI

### DIFF
--- a/packages/cli/src/Command/AuditLogCommand.php
+++ b/packages/cli/src/Command/AuditLogCommand.php
@@ -10,30 +10,45 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
 
 #[AsCommand(
     name: 'audit:log',
-    description: 'Display the entity type lifecycle audit log',
+    description: 'Display the entity type lifecycle audit log, or entity-write audit log with --entity-type',
 )]
 final class AuditLogCommand extends Command
 {
     public function __construct(
         private readonly EntityTypeLifecycleManager $lifecycleManager,
+        private readonly ?EntityAuditLogger $entityAuditLogger = null,
     ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by entity type ID (e.g. note)', '');
+        $this
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter lifecycle log by entity type ID (e.g. note)', '')
+            ->addOption('entity-type', null, InputOption::VALUE_REQUIRED, 'Show entity-write audit log, optionally filtered by type (e.g. note)', null);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $entityTypeFilter = $input->getOption('entity-type');
+
+        if ($entityTypeFilter !== null) {
+            return $this->showEntityWriteLog((string) $entityTypeFilter, $output);
+        }
+
         /** @var string $typeFilter */
         $typeFilter = $input->getOption('type') ?? '';
 
+        return $this->showLifecycleLog($typeFilter, $output);
+    }
+
+    private function showLifecycleLog(string $typeFilter, OutputInterface $output): int
+    {
         $entries = $this->lifecycleManager->readAuditLog($typeFilter);
 
         if ($entries === []) {
@@ -54,6 +69,44 @@ final class AuditLogCommand extends Command
                 $entry['action']         ?? '',
                 $entry['actor_id']       ?? '',
                 $entry['timestamp']      ?? '',
+            ]);
+        }
+
+        $table->render();
+
+        return self::SUCCESS;
+    }
+
+    private function showEntityWriteLog(string $entityTypeFilter, OutputInterface $output): int
+    {
+        if ($this->entityAuditLogger === null) {
+            $output->writeln('<error>Entity audit logger is not configured.</error>');
+
+            return self::FAILURE;
+        }
+
+        $entries = $this->entityAuditLogger->read($entityTypeFilter);
+
+        if ($entries === []) {
+            $output->writeln($entityTypeFilter !== ''
+                ? sprintf('No entity audit entries found for type "%s".', $entityTypeFilter)
+                : 'No entity audit entries found.',
+            );
+
+            return self::SUCCESS;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Entity Type', 'Action', 'Entity ID', 'Tenant', 'Actor', 'Timestamp']);
+
+        foreach ($entries as $entry) {
+            $table->addRow([
+                $entry['entity_type'] ?? '',
+                $entry['action']      ?? '',
+                $entry['entity_id']   ?? '',
+                $entry['tenant_id']   ?? '',
+                $entry['actor']       ?? '',
+                $entry['timestamp']   ?? '',
             ]);
         }
 

--- a/packages/entity/src/Audit/EntityAuditEntry.php
+++ b/packages/entity/src/Audit/EntityAuditEntry.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Audit;
+
+/**
+ * A single entity-write audit record.
+ *
+ * Required fields capture who did what to which entity and when.
+ * Optional replay metadata links entries back to their ingestion envelope.
+ */
+final class EntityAuditEntry
+{
+    public readonly string $timestamp;
+
+    public function __construct(
+        public readonly string $actor,
+        public readonly string $action,
+        public readonly string $entityId,
+        public readonly string $entityType,
+        public readonly string $tenantId,
+        public readonly ?string $envelopeVersion = null,
+        public readonly ?string $ingestSource    = null,
+        public readonly ?string $ingestedAt      = null,
+        string $timestamp = '',
+    ) {
+        $this->timestamp = $timestamp !== ''
+            ? $timestamp
+            : (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        $entry = [
+            'actor'       => $this->actor,
+            'action'      => $this->action,
+            'entity_id'   => $this->entityId,
+            'entity_type' => $this->entityType,
+            'tenant_id'   => $this->tenantId,
+            'timestamp'   => $this->timestamp,
+        ];
+
+        if ($this->envelopeVersion !== null) {
+            $entry['envelope_version'] = $this->envelopeVersion;
+        }
+
+        if ($this->ingestSource !== null) {
+            $entry['ingest_source'] = $this->ingestSource;
+        }
+
+        if ($this->ingestedAt !== null) {
+            $entry['ingested_at'] = $this->ingestedAt;
+        }
+
+        return $entry;
+    }
+}

--- a/packages/entity/src/Audit/EntityAuditLogger.php
+++ b/packages/entity/src/Audit/EntityAuditLogger.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Audit;
+
+/**
+ * Appends and reads entity-write audit entries from a JSONL file.
+ *
+ * Entries are stored at storage/framework/entity-audit.jsonl.
+ * Atomic append via FILE_APPEND | LOCK_EX prevents interleaving.
+ * Default retention is 90 days — call prune() periodically to enforce it.
+ */
+final class EntityAuditLogger
+{
+    public const int DEFAULT_RETENTION_DAYS = 90;
+
+    private const AUDIT_FILE = '/storage/framework/entity-audit.jsonl';
+
+    public function __construct(private readonly string $projectRoot) {}
+
+    public function append(EntityAuditEntry $entry): void
+    {
+        $file = $this->auditFile();
+        $this->ensureDirectory(dirname($file));
+
+        file_put_contents(
+            $file,
+            json_encode($entry->toArray(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES) . "\n",
+            FILE_APPEND | LOCK_EX,
+        );
+    }
+
+    /**
+     * Read audit entries, optionally filtered by entity type.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function read(string $entityTypeFilter = ''): array
+    {
+        $file = $this->auditFile();
+
+        if (!file_exists($file)) {
+            return [];
+        }
+
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if ($lines === false) {
+            return [];
+        }
+
+        $entries = [];
+
+        foreach ($lines as $line) {
+            try {
+                /** @var array<string, mixed> $entry */
+                $entry = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+
+                if ($entityTypeFilter === '' || $entry['entity_type'] === $entityTypeFilter) {
+                    $entries[] = $entry;
+                }
+            } catch (\JsonException) {
+                // Skip malformed lines without crashing.
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Remove entries older than $retentionDays. Rewrites the log atomically.
+     */
+    public function prune(int $retentionDays = self::DEFAULT_RETENTION_DAYS): void
+    {
+        $file = $this->auditFile();
+
+        if (!file_exists($file)) {
+            return;
+        }
+
+        $cutoff  = new \DateTimeImmutable("-{$retentionDays} days");
+        $entries = $this->read();
+        $kept    = [];
+
+        foreach ($entries as $entry) {
+            try {
+                $ts = new \DateTimeImmutable((string) ($entry['timestamp'] ?? ''));
+
+                if ($ts >= $cutoff) {
+                    $kept[] = $entry;
+                }
+            } catch (\Throwable) {
+                $kept[] = $entry; // Keep unparseable entries rather than silently drop.
+            }
+        }
+
+        $tmp = $file . '.tmp.' . getmypid();
+        file_put_contents(
+            $tmp,
+            implode("\n", array_map(
+                static fn(array $e): string => json_encode($e, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                $kept,
+            )) . ($kept !== [] ? "\n" : ''),
+        );
+        rename($tmp, $file);
+    }
+
+    private function auditFile(): string
+    {
+        return $this->projectRoot . self::AUDIT_FILE;
+    }
+
+    private function ensureDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+    }
+}

--- a/packages/entity/src/Audit/EntityWriteAuditListener.php
+++ b/packages/entity/src/Audit/EntityWriteAuditListener.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Audit;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+
+/**
+ * Subscribes to entity lifecycle events and appends audit entries.
+ *
+ * PRE_SAVE captures whether the entity is new (before storage mutates state).
+ * POST_SAVE uses the captured flag to log 'create' or 'update'.
+ * POST_DELETE logs 'delete'.
+ */
+final class EntityWriteAuditListener implements EventSubscriberInterface
+{
+    private bool $pendingIsNew = false;
+
+    public function __construct(private readonly EntityAuditLogger $logger) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EntityEvents::PRE_SAVE->value    => 'onPreSave',
+            EntityEvents::POST_SAVE->value   => 'onPostSave',
+            EntityEvents::POST_DELETE->value => 'onPostDelete',
+        ];
+    }
+
+    public function onPreSave(EntityEvent $event): void
+    {
+        $this->pendingIsNew = $event->entity->isNew();
+    }
+
+    public function onPostSave(EntityEvent $event): void
+    {
+        $entity   = $event->entity;
+        $action   = $this->pendingIsNew ? 'create' : 'update';
+        $tenantId = $entity instanceof \Waaseyaa\Entity\FieldableInterface
+            ? (string) ($entity->get('tenant_id') ?? '')
+            : '';
+
+        $this->logger->append(new EntityAuditEntry(
+            actor:      $this->resolveActor($entity),
+            action:     $action,
+            entityId:   (string) ($entity->id() ?? ''),
+            entityType: $entity->getEntityTypeId(),
+            tenantId:   $tenantId,
+        ));
+    }
+
+    public function onPostDelete(EntityEvent $event): void
+    {
+        $entity   = $event->entity;
+        $tenantId = $entity instanceof \Waaseyaa\Entity\FieldableInterface
+            ? (string) ($entity->get('tenant_id') ?? '')
+            : '';
+
+        $this->logger->append(new EntityAuditEntry(
+            actor:      $this->resolveActor($entity),
+            action:     'delete',
+            entityId:   (string) ($entity->id() ?? ''),
+            entityType: $entity->getEntityTypeId(),
+            tenantId:   $tenantId,
+        ));
+    }
+
+    private function resolveActor(\Waaseyaa\Entity\EntityInterface $entity): string
+    {
+        if ($entity instanceof \Waaseyaa\Entity\FieldableInterface) {
+            $uid = $entity->get('uid');
+
+            if ($uid !== null && $uid !== '') {
+                return 'uid:' . $uid;
+            }
+        }
+
+        return 'system';
+    }
+}

--- a/packages/entity/tests/Unit/Audit/EntityAuditLoggerTest.php
+++ b/packages/entity/tests/Unit/Audit/EntityAuditLoggerTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Audit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\Audit\EntityAuditEntry;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+
+#[CoversClass(EntityAuditLogger::class)]
+#[CoversClass(EntityAuditEntry::class)]
+final class EntityAuditLoggerTest extends TestCase
+{
+    private string $projectRoot;
+    private EntityAuditLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_entity_audit_test_' . uniqid();
+        mkdir($this->projectRoot . '/storage/framework', 0755, true);
+        $this->logger = new EntityAuditLogger($this->projectRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    // -----------------------------------------------------------------------
+    // EntityAuditEntry value object
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function entryExposesRequiredFields(): void
+    {
+        $entry = new EntityAuditEntry(
+            actor:      'uid:42',
+            action:     'create',
+            entityId:   '1',
+            entityType: 'note',
+            tenantId:   'acme',
+        );
+
+        $this->assertSame('uid:42', $entry->actor);
+        $this->assertSame('create', $entry->action);
+        $this->assertSame('1', $entry->entityId);
+        $this->assertSame('note', $entry->entityType);
+        $this->assertSame('acme', $entry->tenantId);
+        $this->assertNotEmpty($entry->timestamp);
+    }
+
+    #[Test]
+    public function entryTimestampIsIso8601(): void
+    {
+        $entry = new EntityAuditEntry(
+            actor: 'system', action: 'write', entityId: '1', entityType: 'note', tenantId: 'acme',
+        );
+
+        $parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $entry->timestamp);
+        $this->assertNotFalse($parsed, 'timestamp must be ISO 8601 / ATOM format');
+    }
+
+    #[Test]
+    public function entryAcceptsOptionalReplayMetadata(): void
+    {
+        $entry = new EntityAuditEntry(
+            actor:           'system',
+            action:          'create',
+            entityId:        '5',
+            entityType:      'note',
+            tenantId:        'acme',
+            envelopeVersion: '1',
+            ingestSource:    'api:import-script',
+            ingestedAt:      '2026-03-07T12:00:00Z',
+        );
+
+        $this->assertSame('1', $entry->envelopeVersion);
+        $this->assertSame('api:import-script', $entry->ingestSource);
+        $this->assertSame('2026-03-07T12:00:00Z', $entry->ingestedAt);
+    }
+
+    #[Test]
+    public function entrySerializesToArray(): void
+    {
+        $entry = new EntityAuditEntry(
+            actor: 'uid:1', action: 'delete', entityId: '7', entityType: 'note', tenantId: 'beta',
+        );
+
+        $arr = $entry->toArray();
+
+        $this->assertArrayHasKey('actor', $arr);
+        $this->assertArrayHasKey('action', $arr);
+        $this->assertArrayHasKey('entity_id', $arr);
+        $this->assertArrayHasKey('entity_type', $arr);
+        $this->assertArrayHasKey('tenant_id', $arr);
+        $this->assertArrayHasKey('timestamp', $arr);
+    }
+
+    // -----------------------------------------------------------------------
+    // EntityAuditLogger — append
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function appendWritesEntryToJSONL(): void
+    {
+        $entry = new EntityAuditEntry(
+            actor: 'uid:1', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        );
+
+        $this->logger->append($entry);
+
+        $entries = $this->logger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('create', $entries[0]['action']);
+        $this->assertSame('note', $entries[0]['entity_type']);
+    }
+
+    #[Test]
+    public function appendAccumulatesMultipleEntries(): void
+    {
+        $this->logger->append(new EntityAuditEntry(
+            actor: 'uid:1', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+        $this->logger->append(new EntityAuditEntry(
+            actor: 'uid:2', action: 'update', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+
+        $this->assertCount(2, $this->logger->read());
+    }
+
+    #[Test]
+    public function readReturnsEmptyWhenNoLogExists(): void
+    {
+        $this->assertSame([], $this->logger->read());
+    }
+
+    #[Test]
+    public function readFiltersbyEntityType(): void
+    {
+        $this->logger->append(new EntityAuditEntry(
+            actor: 'system', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+        $this->logger->append(new EntityAuditEntry(
+            actor: 'system', action: 'create', entityId: '2', entityType: 'article', tenantId: 'acme',
+        ));
+
+        $noteEntries = $this->logger->read('note');
+        $this->assertCount(1, $noteEntries);
+        $this->assertSame('note', $noteEntries[0]['entity_type']);
+    }
+
+    #[Test]
+    public function logPersistsAcrossInstances(): void
+    {
+        $this->logger->append(new EntityAuditEntry(
+            actor: 'uid:1', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+
+        $another = new EntityAuditLogger($this->projectRoot);
+        $this->assertCount(1, $another->read());
+    }
+
+    #[Test]
+    public function replayMetadataIsStoredAndRetrieved(): void
+    {
+        $this->logger->append(new EntityAuditEntry(
+            actor:           'system',
+            action:          'create',
+            entityId:        '3',
+            entityType:      'note',
+            tenantId:        'acme',
+            envelopeVersion: '1',
+            ingestSource:    'api:test',
+            ingestedAt:      '2026-03-07T12:00:00Z',
+        ));
+
+        $entries = $this->logger->read();
+        $this->assertSame('1', $entries[0]['envelope_version']);
+        $this->assertSame('api:test', $entries[0]['ingest_source']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Retention
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function pruneRemovesEntriesOlderThanRetentionDays(): void
+    {
+        $old = new EntityAuditEntry(
+            actor: 'system', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+            timestamp: (new \DateTimeImmutable('-100 days'))->format(\DateTimeInterface::ATOM),
+        );
+        $recent = new EntityAuditEntry(
+            actor: 'system', action: 'update', entityId: '1', entityType: 'note', tenantId: 'acme',
+        );
+
+        $this->logger->append($old);
+        $this->logger->append($recent);
+        $this->logger->prune(retentionDays: 90);
+
+        $entries = $this->logger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('update', $entries[0]['action']);
+    }
+
+    #[Test]
+    public function defaultRetentionIs90Days(): void
+    {
+        $this->assertSame(90, EntityAuditLogger::DEFAULT_RETENTION_DAYS);
+    }
+}

--- a/packages/entity/tests/Unit/Audit/EntityWriteAuditListenerTest.php
+++ b/packages/entity/tests/Unit/Audit/EntityWriteAuditListenerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Audit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+use Waaseyaa\Entity\Audit\EntityWriteAuditListener;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+
+#[CoversClass(EntityWriteAuditListener::class)]
+final class EntityWriteAuditListenerTest extends TestCase
+{
+    private string $projectRoot;
+    private EntityAuditLogger $logger;
+    private EntityWriteAuditListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_entity_audit_listener_test_' . uniqid();
+        mkdir($this->projectRoot . '/storage/framework', 0755, true);
+        $this->logger   = new EntityAuditLogger($this->projectRoot);
+        $this->listener = new EntityWriteAuditListener($this->logger);
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    #[Test]
+    public function onPreSaveRecordsIsNewState(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme'], isNew: true);
+
+        $this->listener->onPreSave(new EntityEvent($entity));
+        $this->listener->onPostSave(new EntityEvent($entity));
+
+        $entries = $this->logger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('create', $entries[0]['action']);
+    }
+
+    #[Test]
+    public function onPostSaveLogsUpdateWhenEntityWasNotNew(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme'], isNew: false);
+
+        $this->listener->onPreSave(new EntityEvent($entity));
+        $this->listener->onPostSave(new EntityEvent($entity));
+
+        $entries = $this->logger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('update', $entries[0]['action']);
+    }
+
+    #[Test]
+    public function onPostSaveIncludesRequiredAuditFields(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme'], isNew: true);
+        $entity->set('id', 42);
+
+        $this->listener->onPreSave(new EntityEvent($entity));
+        $this->listener->onPostSave(new EntityEvent($entity));
+
+        $entry = $this->logger->read()[0];
+        $this->assertArrayHasKey('actor', $entry);
+        $this->assertArrayHasKey('action', $entry);
+        $this->assertArrayHasKey('entity_id', $entry);
+        $this->assertArrayHasKey('entity_type', $entry);
+        $this->assertArrayHasKey('tenant_id', $entry);
+        $this->assertArrayHasKey('timestamp', $entry);
+        $this->assertSame('note', $entry['entity_type']);
+        $this->assertSame('acme', $entry['tenant_id']);
+    }
+
+    #[Test]
+    public function onPostDeleteLogsDeleteAction(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme'], isNew: false);
+        $entity->set('id', 7);
+
+        $this->listener->onPostDelete(new EntityEvent($entity));
+
+        $entries = $this->logger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('delete', $entries[0]['action']);
+    }
+
+    #[Test]
+    public function actorDefaultsToSystemWhenNoUidOnEntity(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme'], isNew: true);
+
+        $this->listener->onPreSave(new EntityEvent($entity));
+        $this->listener->onPostSave(new EntityEvent($entity));
+
+        $this->assertSame('system', $this->logger->read()[0]['actor']);
+    }
+
+    #[Test]
+    public function actorIsUidPrefixedWhenEntityHasUid(): void
+    {
+        $entity = $this->makeEntity('note', ['tenant_id' => 'acme', 'uid' => 99], isNew: true);
+
+        $this->listener->onPreSave(new EntityEvent($entity));
+        $this->listener->onPostSave(new EntityEvent($entity));
+
+        $this->assertSame('uid:99', $this->logger->read()[0]['actor']);
+    }
+
+    #[Test]
+    public function getSubscribedEventsCoversPreSavePostSaveAndPostDelete(): void
+    {
+        $events = EntityWriteAuditListener::getSubscribedEvents();
+
+        $this->assertArrayHasKey(EntityEvents::PRE_SAVE->value, $events);
+        $this->assertArrayHasKey(EntityEvents::POST_SAVE->value, $events);
+        $this->assertArrayHasKey(EntityEvents::POST_DELETE->value, $events);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** @param array<string, mixed> $values */
+    private function makeEntity(string $typeId, array $values, bool $isNew): EntityInterface
+    {
+        return new class($typeId, $values, $isNew) extends ContentEntityBase {
+            private bool $new;
+
+            public function __construct(string $typeId, array $values, bool $isNew)
+            {
+                parent::__construct($values, $typeId, ['id' => 'id']);
+                $this->new = $isNew;
+            }
+
+            public function isNew(): bool { return $this->new; }
+        };
+    }
+}

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -9,6 +9,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Waaseyaa\Access\EntityAccessHandler;
 use Waaseyaa\Database\PdoDatabase;
 use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+use Waaseyaa\Entity\Audit\EntityWriteAuditListener;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
@@ -31,6 +33,7 @@ abstract class AbstractKernel
     protected PackageManifest $manifest;
     protected EntityAccessHandler $accessHandler;
     protected EntityTypeLifecycleManager $lifecycleManager;
+    protected EntityAuditLogger $entityAuditLogger;
 
     /** @var array<string, mixed> */
     protected array $config = [];
@@ -61,8 +64,14 @@ abstract class AbstractKernel
 
         $this->config = ConfigLoader::load($this->projectRoot . '/config/waaseyaa.php');
 
-        $this->dispatcher = new EventDispatcher();
-        $this->lifecycleManager = new EntityTypeLifecycleManager($this->projectRoot);
+        $this->dispatcher         = new EventDispatcher();
+        $this->lifecycleManager   = new EntityTypeLifecycleManager($this->projectRoot);
+        $this->entityAuditLogger  = new EntityAuditLogger($this->projectRoot);
+
+        $auditListener = new EntityWriteAuditListener($this->entityAuditLogger);
+        $this->dispatcher->addListener(\Waaseyaa\Entity\Event\EntityEvents::PRE_SAVE->value,    [$auditListener, 'onPreSave']);
+        $this->dispatcher->addListener(\Waaseyaa\Entity\Event\EntityEvents::POST_SAVE->value,   [$auditListener, 'onPostSave']);
+        $this->dispatcher->addListener(\Waaseyaa\Entity\Event\EntityEvents::POST_DELETE->value, [$auditListener, 'onPostDelete']);
         $this->bootDatabase();
         $this->bootEntityTypeManager();
         $this->compileManifest();
@@ -353,6 +362,11 @@ abstract class AbstractKernel
     public function getLifecycleManager(): EntityTypeLifecycleManager
     {
         return $this->lifecycleManager;
+    }
+
+    public function getEntityAuditLogger(): EntityAuditLogger
+    {
+        return $this->entityAuditLogger;
     }
 
     public function getProjectRoot(): string

--- a/packages/foundation/src/Kernel/ConsoleKernel.php
+++ b/packages/foundation/src/Kernel/ConsoleKernel.php
@@ -156,7 +156,7 @@ final class ConsoleKernel extends AbstractKernel
             new EntityTypeListCommand($this->entityTypeManager),
             new TypeDisableCommand($this->entityTypeManager, $this->lifecycleManager),
             new TypeEnableCommand($this->entityTypeManager, $this->lifecycleManager),
-            new AuditLogCommand($this->lifecycleManager),
+            new AuditLogCommand($this->lifecycleManager, $this->entityAuditLogger),
             new EventListCommand($this->dispatcher),
             new RouteListCommand($router),
             new PermissionListCommand($permissionHandler),

--- a/tests/Integration/Phase20/EntityAuditIntegrationTest.php
+++ b/tests/Integration/Phase20/EntityAuditIntegrationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase20;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\CLI\Command\AuditLogCommand;
+use Waaseyaa\Entity\Audit\EntityAuditEntry;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+use Waaseyaa\Entity\Audit\EntityWriteAuditListener;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeLifecycleManager;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+
+/**
+ * End-to-end audit trail (#208): entity write → logger → CLI display.
+ */
+#[CoversNothing]
+final class EntityAuditIntegrationTest extends TestCase
+{
+    private string $tempDir;
+    private EntityAuditLogger $auditLogger;
+    private EventDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->tempDir     = sys_get_temp_dir() . '/waaseyaa_audit_integration_' . uniqid();
+        mkdir($this->tempDir . '/storage/framework', 0755, true);
+
+        $this->auditLogger = new EntityAuditLogger($this->tempDir);
+        $this->dispatcher  = new EventDispatcher();
+
+        $listener = new EntityWriteAuditListener($this->auditLogger);
+        $this->dispatcher->addSubscriber($listener);
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->tempDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->tempDir);
+    }
+
+    #[Test]
+    public function entitySaveDispatchesAuditEntry(): void
+    {
+        $entity = $this->makeNote(['tenant_id' => 'acme'], isNew: true);
+
+        $this->dispatcher->dispatch(new EntityEvent($entity), EntityEvents::PRE_SAVE->value);
+        $entity->set('id', 1);
+        $this->dispatcher->dispatch(new EntityEvent($entity), EntityEvents::POST_SAVE->value);
+
+        $entries = $this->auditLogger->read();
+        $this->assertCount(1, $entries);
+        $this->assertSame('create', $entries[0]['action']);
+        $this->assertSame('note', $entries[0]['entity_type']);
+        $this->assertSame('acme', $entries[0]['tenant_id']);
+    }
+
+    #[Test]
+    public function entityUpdateDispatchesUpdateAuditEntry(): void
+    {
+        $entity = $this->makeNote(['tenant_id' => 'acme', 'id' => 5], isNew: false);
+
+        $this->dispatcher->dispatch(new EntityEvent($entity), EntityEvents::PRE_SAVE->value);
+        $this->dispatcher->dispatch(new EntityEvent($entity), EntityEvents::POST_SAVE->value);
+
+        $this->assertSame('update', $this->auditLogger->read()[0]['action']);
+    }
+
+    #[Test]
+    public function entityDeleteDispatchesDeleteAuditEntry(): void
+    {
+        $entity = $this->makeNote(['tenant_id' => 'acme', 'id' => 3], isNew: false);
+
+        $this->dispatcher->dispatch(new EntityEvent($entity), EntityEvents::POST_DELETE->value);
+
+        $this->assertSame('delete', $this->auditLogger->read()[0]['action']);
+    }
+
+    #[Test]
+    public function cliAuditLogEntityTypeShowsEntries(): void
+    {
+        $this->auditLogger->append(new EntityAuditEntry(
+            actor: 'uid:1', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+        $this->auditLogger->append(new EntityAuditEntry(
+            actor: 'uid:2', action: 'update', entityId: '2', entityType: 'article', tenantId: 'acme',
+        ));
+
+        $tester = $this->runAuditCommand(['--entity-type' => 'note']);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('note', $output);
+        $this->assertStringContainsString('create', $output);
+        $this->assertStringNotContainsString('article', $output);
+    }
+
+    #[Test]
+    public function cliAuditLogEntityTypeShowsAllWhenNoFilter(): void
+    {
+        $this->auditLogger->append(new EntityAuditEntry(
+            actor: 'uid:1', action: 'create', entityId: '1', entityType: 'note', tenantId: 'acme',
+        ));
+        $this->auditLogger->append(new EntityAuditEntry(
+            actor: 'uid:2', action: 'delete', entityId: '2', entityType: 'article', tenantId: 'acme',
+        ));
+
+        $tester = $this->runAuditCommand(['--entity-type' => '']);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('note', $output);
+        $this->assertStringContainsString('article', $output);
+    }
+
+    #[Test]
+    public function defaultRetentionIsNinetyDays(): void
+    {
+        $this->assertSame(90, EntityAuditLogger::DEFAULT_RETENTION_DAYS);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** @param array<string, mixed> $values */
+    private function makeNote(array $values, bool $isNew): EntityInterface
+    {
+        return new class($values, $isNew) extends ContentEntityBase {
+            private bool $new;
+
+            public function __construct(array $values, bool $isNew)
+            {
+                parent::__construct($values, 'note', ['id' => 'id']);
+                $this->new = $isNew;
+            }
+
+            public function isNew(): bool { return $this->new; }
+        };
+    }
+
+    private function runAuditCommand(array $input): CommandTester
+    {
+        $lifecycleManager = new EntityTypeLifecycleManager($this->tempDir);
+
+        $app = new Application();
+        $app->add(new AuditLogCommand($lifecycleManager, $this->auditLogger));
+
+        $command = $app->find('audit:log');
+        $tester  = new CommandTester($command);
+        $tester->execute($input);
+
+        return $tester;
+    }
+}


### PR DESCRIPTION
## Summary

- `EntityAuditEntry` — value object with required fields (actor, action, entity_id, entity_type, tenant_id, timestamp) + optional ingestion replay metadata
- `EntityAuditLogger` — JSONL append/read/prune to `storage/framework/entity-audit.jsonl`; atomic prune; `DEFAULT_RETENTION_DAYS = 90`
- `EntityWriteAuditListener` — subscribes to `PRE_SAVE` / `POST_SAVE` / `POST_DELETE`; captures `isNew()` at `PRE_SAVE` to distinguish `create` vs `update`; resolves actor from `uid` field or `'system'`
- `AbstractKernel` — wires listener at boot; exposes `getEntityAuditLogger()`
- `AuditLogCommand` — new `--entity-type` option shows entity-write log; existing `--type` unchanged (lifecycle log)
- `ConsoleKernel` — passes `EntityAuditLogger` to `AuditLogCommand`

**CLI usage:**
```bash
waaseyaa audit:log --entity-type=note    # entity writes for core.note
waaseyaa audit:log --entity-type=        # all entity writes
waaseyaa audit:log --type=note           # type lifecycle (existing)
```

Closes #208

## Test plan

- [ ] 12 unit tests — `EntityAuditLoggerTest`: append, read, filter, persistence, replay metadata, prune, retention constant
- [ ] 7 unit tests — `EntityWriteAuditListenerTest`: create/update detection, required fields, delete, actor resolution, subscribed events
- [ ] 6 integration tests — `EntityAuditIntegrationTest`: dispatcher→logger→CLI end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)