### PR TITLE
feat(#207): schema registry defaults — storage, versioning, and compatibility rules

### DIFF
--- a/defaults/core.note.schema.json
+++ b/defaults/core.note.schema.json
@@ -51,6 +51,7 @@
     "entity_type": "core.note",
     "namespace": "core",
     "version": "0.1.0",
+    "compatibility": "liberal",
     "project_versioning": {
       "release_stage": "pre-v1",
       "owner": "jonesrussell",

--- a/packages/cli/src/Command/SchemaListCommand.php
+++ b/packages/cli/src/Command/SchemaListCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Foundation\Schema\SchemaRegistryInterface;
+
+#[AsCommand(
+    name: 'schema:list',
+    description: 'List registered schemas with versions and compatibility policy',
+)]
+final class SchemaListCommand extends Command
+{
+    public function __construct(
+        private readonly SchemaRegistryInterface $registry,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $entries = $this->registry->list();
+
+        if ($entries === []) {
+            $output->writeln('No schemas found.');
+
+            return self::SUCCESS;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Entity Type', 'Version', 'Compatibility', 'Schema Path']);
+
+        foreach ($entries as $entry) {
+            $table->addRow([
+                $entry->id,
+                $entry->version,
+                $entry->compatibility,
+                $entry->schemaPath,
+            ]);
+        }
+
+        $table->render();
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/cli/tests/Unit/Command/SchemaListCommandTest.php
+++ b/packages/cli/tests/Unit/Command/SchemaListCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\SchemaListCommand;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+
+#[CoversClass(SchemaListCommand::class)]
+final class SchemaListCommandTest extends TestCase
+{
+    private string $defaultsDir;
+
+    protected function setUp(): void
+    {
+        $this->defaultsDir = sys_get_temp_dir() . '/waaseyaa_schema_list_cmd_test_' . uniqid();
+        mkdir($this->defaultsDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->defaultsDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->defaultsDir);
+    }
+
+    #[Test]
+    public function outputsNoSchemasFoundWhenRegistryIsEmpty(): void
+    {
+        $tester = $this->execute();
+
+        $this->assertStringContainsString('No schemas found', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    #[Test]
+    public function outputsTableWithSchemaDetails(): void
+    {
+        $this->writeSchema('core.note', 'core.note', '0.1.0', 'liberal');
+
+        $output = $this->execute()->getDisplay();
+
+        $this->assertStringContainsString('core.note', $output);
+        $this->assertStringContainsString('0.1.0', $output);
+        $this->assertStringContainsString('liberal', $output);
+    }
+
+    #[Test]
+    public function outputsMultipleSchemasInTable(): void
+    {
+        $this->writeSchema('core.note', 'core.note', '0.1.0', 'liberal');
+        $this->writeSchema('core.article', 'core.article', '0.2.0', 'strict');
+
+        $output = $this->execute()->getDisplay();
+
+        $this->assertStringContainsString('core.note', $output);
+        $this->assertStringContainsString('core.article', $output);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function execute(): CommandTester
+    {
+        $registry = new DefaultsSchemaRegistry($this->defaultsDir);
+
+        $app = new Application();
+        $app->add(new SchemaListCommand($registry));
+
+        $command = $app->find('schema:list');
+        $tester  = new CommandTester($command);
+        $tester->execute([]);
+
+        return $tester;
+    }
+
+    private function writeSchema(string $filename, string $entityType, string $version, string $compatibility): void
+    {
+        file_put_contents(
+            $this->defaultsDir . '/' . $filename . '.schema.json',
+            json_encode([
+                '$schema'    => 'http://json-schema.org/draft-07/schema#',
+                'title'      => $entityType,
+                'x-waaseyaa' => [
+                    'entity_type'   => $entityType,
+                    'version'       => $version,
+                    'compatibility' => $compatibility,
+                ],
+            ], JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/packages/foundation/src/Kernel/ConsoleKernel.php
+++ b/packages/foundation/src/Kernel/ConsoleKernel.php
@@ -47,6 +47,7 @@ use Waaseyaa\CLI\Command\Perf\PerformanceCompareCommand;
 use Waaseyaa\CLI\Command\PermissionListCommand;
 use Waaseyaa\CLI\Command\RelationshipTypeScaffoldCommand;
 use Waaseyaa\CLI\Command\RouteListCommand;
+use Waaseyaa\CLI\Command\SchemaListCommand;
 use Waaseyaa\CLI\Command\SemanticRefreshCommand;
 use Waaseyaa\CLI\Command\SemanticWarmCommand;
 use Waaseyaa\CLI\Command\Telescope\TelescopeClearCommand;
@@ -62,6 +63,7 @@ use Waaseyaa\Config\Cache\ConfigCacheCompiler;
 use Waaseyaa\Config\ConfigManager;
 use Waaseyaa\Config\Storage\FileStorage;
 use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class ConsoleKernel extends AbstractKernel
@@ -124,6 +126,7 @@ final class ConsoleKernel extends AbstractKernel
             embeddingStorage: $embeddingStorage,
             embeddingProvider: $embeddingProvider,
         );
+        $schemaRegistry = new DefaultsSchemaRegistry($this->projectRoot . '/defaults');
 
         $app = new WaaseyaaApplication();
         $app->setAutoExit(false);
@@ -159,6 +162,7 @@ final class ConsoleKernel extends AbstractKernel
             new AuditLogCommand($this->lifecycleManager, $this->entityAuditLogger),
             new EventListCommand($this->dispatcher),
             new RouteListCommand($router),
+            new SchemaListCommand($schemaRegistry),
             new PermissionListCommand($permissionHandler),
             new SemanticWarmCommand($semanticWarmer),
             new SemanticRefreshCommand($semanticWarmer),

--- a/packages/foundation/src/Schema/DefaultsSchemaRegistry.php
+++ b/packages/foundation/src/Schema/DefaultsSchemaRegistry.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Schema;
+
+/**
+ * Loads schema entries from *.schema.json files in a defaults directory.
+ *
+ * Each schema file must contain an `x-waaseyaa` extension object with:
+ *   - `entity_type` (string) — the schema's canonical ID
+ *   - `version`     (string) — semver string
+ *   - `compatibility` (string) — 'liberal' (pre-v1) or 'strict' (post-v1)
+ */
+final class DefaultsSchemaRegistry implements SchemaRegistryInterface
+{
+    /** @var list<SchemaEntry>|null */
+    private ?array $entries = null;
+
+    public function __construct(
+        private readonly string $defaultsDir,
+    ) {}
+
+    public function list(): array
+    {
+        return $this->entries ??= $this->load();
+    }
+
+    public function get(string $id): ?SchemaEntry
+    {
+        foreach ($this->list() as $entry) {
+            if ($entry->id === $id) {
+                return $entry;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<SchemaEntry> */
+    private function load(): array
+    {
+        if (!is_dir($this->defaultsDir)) {
+            return [];
+        }
+
+        $pattern = $this->defaultsDir . '/*.schema.json';
+        $files   = glob($pattern);
+        if ($files === false || $files === []) {
+            return [];
+        }
+
+        sort($files);
+
+        $entries = [];
+        foreach ($files as $file) {
+            $entry = $this->parseFile($file);
+            if ($entry !== null) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+
+    private function parseFile(string $file): ?SchemaEntry
+    {
+        $raw = @file_get_contents($file);
+        if ($raw === false) {
+            return null;
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        $ext = $data['x-waaseyaa'] ?? null;
+        if (!is_array($ext)) {
+            return null;
+        }
+
+        $id            = (string) ($ext['entity_type'] ?? '');
+        $version       = (string) ($ext['version'] ?? '');
+        $compatibility = (string) ($ext['compatibility'] ?? '');
+
+        if ($id === '' || $version === '' || $compatibility === '') {
+            return null;
+        }
+
+        return new SchemaEntry(
+            id:            $id,
+            version:       $version,
+            compatibility: $compatibility,
+            schemaPath:    $file,
+        );
+    }
+}

--- a/packages/foundation/src/Schema/SchemaEntry.php
+++ b/packages/foundation/src/Schema/SchemaEntry.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Schema;
+
+final readonly class SchemaEntry
+{
+    public function __construct(
+        public string $id,
+        public string $version,
+        public string $compatibility,
+        public string $schemaPath,
+    ) {}
+}

--- a/packages/foundation/src/Schema/SchemaRegistryInterface.php
+++ b/packages/foundation/src/Schema/SchemaRegistryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Schema;
+
+interface SchemaRegistryInterface
+{
+    /** @return list<SchemaEntry> Schemas sorted by entity type ID */
+    public function list(): array;
+
+    public function get(string $id): ?SchemaEntry;
+}

--- a/packages/foundation/tests/Unit/Schema/DefaultsSchemaRegistryTest.php
+++ b/packages/foundation/tests/Unit/Schema/DefaultsSchemaRegistryTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+use Waaseyaa\Foundation\Schema\SchemaEntry;
+
+#[CoversClass(DefaultsSchemaRegistry::class)]
+#[CoversClass(SchemaEntry::class)]
+final class DefaultsSchemaRegistryTest extends TestCase
+{
+    private string $defaultsDir;
+
+    protected function setUp(): void
+    {
+        $this->defaultsDir = sys_get_temp_dir() . '/waaseyaa_schema_registry_test_' . uniqid();
+        mkdir($this->defaultsDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->defaultsDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->defaultsDir);
+    }
+
+    #[Test]
+    public function listReturnsEmptyArrayWhenNoSchemasExist(): void
+    {
+        $registry = new DefaultsSchemaRegistry($this->defaultsDir);
+
+        $this->assertSame([], $registry->list());
+    }
+
+    #[Test]
+    public function listReturnsSchemaEntryForEachSchemaFile(): void
+    {
+        $this->writeSchema('core.note', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.note',
+            'x-waaseyaa' => [
+                'entity_type'   => 'core.note',
+                'version'       => '0.1.0',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $registry = new DefaultsSchemaRegistry($this->defaultsDir);
+        $entries  = $registry->list();
+
+        $this->assertCount(1, $entries);
+        $this->assertInstanceOf(SchemaEntry::class, $entries[0]);
+    }
+
+    #[Test]
+    public function listPopulatesEntryFieldsFromSchemaFile(): void
+    {
+        $this->writeSchema('core.note', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.note',
+            'x-waaseyaa' => [
+                'entity_type'   => 'core.note',
+                'version'       => '0.1.0',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $entry = (new DefaultsSchemaRegistry($this->defaultsDir))->list()[0];
+
+        $this->assertSame('core.note', $entry->id);
+        $this->assertSame('0.1.0', $entry->version);
+        $this->assertSame('liberal', $entry->compatibility);
+        $this->assertStringEndsWith('core.note.schema.json', $entry->schemaPath);
+    }
+
+    #[Test]
+    public function getReturnsNullWhenIdNotFound(): void
+    {
+        $registry = new DefaultsSchemaRegistry($this->defaultsDir);
+
+        $this->assertNull($registry->get('nonexistent'));
+    }
+
+    #[Test]
+    public function getReturnsEntryByEntityTypeId(): void
+    {
+        $this->writeSchema('core.note', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.note',
+            'x-waaseyaa' => [
+                'entity_type'   => 'core.note',
+                'version'       => '0.1.0',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $entry = (new DefaultsSchemaRegistry($this->defaultsDir))->get('core.note');
+
+        $this->assertNotNull($entry);
+        $this->assertSame('core.note', $entry->id);
+    }
+
+    #[Test]
+    public function listIgnoresNonSchemaJsonFiles(): void
+    {
+        file_put_contents($this->defaultsDir . '/README.md', '# readme');
+        file_put_contents($this->defaultsDir . '/core.note.yaml', 'id: core.note');
+        $this->writeSchema('core.note', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.note',
+            'x-waaseyaa' => [
+                'entity_type'   => 'core.note',
+                'version'       => '0.1.0',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertCount(1, $entries);
+    }
+
+    #[Test]
+    public function listIgnoresMalformedJsonFiles(): void
+    {
+        file_put_contents($this->defaultsDir . '/broken.schema.json', '{not-valid-json');
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertSame([], $entries);
+    }
+
+    #[Test]
+    public function listIgnoresSchemasWithMissingXWaaseyaaExtension(): void
+    {
+        file_put_contents(
+            $this->defaultsDir . '/noext.schema.json',
+            json_encode(['$schema' => 'http://json-schema.org/draft-07/schema#', 'title' => 'noext']),
+        );
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertSame([], $entries);
+    }
+
+    #[Test]
+    public function listMultipleSchemasInAlphabeticalOrder(): void
+    {
+        $this->writeSchema('core.article', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.article',
+            'x-waaseyaa' => ['entity_type' => 'core.article', 'version' => '0.2.0', 'compatibility' => 'strict'],
+        ]);
+        $this->writeSchema('core.note', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title'   => 'core.note',
+            'x-waaseyaa' => ['entity_type' => 'core.note', 'version' => '0.1.0', 'compatibility' => 'liberal'],
+        ]);
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertCount(2, $entries);
+        $this->assertSame('core.article', $entries[0]->id);
+        $this->assertSame('core.note', $entries[1]->id);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** @param array<string, mixed> $data */
+    private function writeSchema(string $name, array $data): void
+    {
+        file_put_contents(
+            $this->defaultsDir . '/' . $name . '.schema.json',
+            json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/tests/Integration/Phase21/SchemaRegistryIntegrationTest.php
+++ b/tests/Integration/Phase21/SchemaRegistryIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase21;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\SchemaListCommand;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+
+/**
+ * End-to-end schema registry (#207): defaults/ → registry → CLI schema:list.
+ */
+#[CoversNothing]
+final class SchemaRegistryIntegrationTest extends TestCase
+{
+    private DefaultsSchemaRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $defaultsDir    = dirname(__DIR__, 3) . '/defaults';
+        $this->registry = new DefaultsSchemaRegistry($defaultsDir);
+    }
+
+    #[Test]
+    public function registryLoadsCoreNoteSchema(): void
+    {
+        $entry = $this->registry->get('core.note');
+
+        $this->assertNotNull($entry);
+        $this->assertSame('core.note', $entry->id);
+        $this->assertNotEmpty($entry->version);
+        $this->assertSame('liberal', $entry->compatibility);
+        $this->assertFileExists($entry->schemaPath);
+    }
+
+    #[Test]
+    public function registryListContainsCoreNote(): void
+    {
+        $entries = $this->registry->list();
+
+        $ids = array_map(static fn($e) => $e->id, $entries);
+        $this->assertContains('core.note', $ids);
+    }
+
+    #[Test]
+    public function registryListIsSortedAlphabetically(): void
+    {
+        $entries = $this->registry->list();
+        $ids     = array_map(static fn($e) => $e->id, $entries);
+        $sorted  = $ids;
+        sort($sorted);
+
+        $this->assertSame($sorted, $ids);
+    }
+
+    #[Test]
+    public function cliSchemaListOutputsCoreNote(): void
+    {
+        $app = new Application();
+        $app->add(new SchemaListCommand($this->registry));
+
+        $command = $app->find('schema:list');
+        $tester  = new CommandTester($command);
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('core.note', $output);
+        $this->assertStringContainsString('liberal', $output);
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DefaultsSchemaRegistry` that loads `*.schema.json` files from `defaults/`, extracting entity type ID, version, and compatibility policy from the `x-waaseyaa` extension block
- Adds `schema:list` CLI command that renders a table of registered schemas with versions and compatibility (liberal/strict)
- Adds `compatibility: liberal` to `defaults/core.note.schema.json` so the registry can surface it
- Wires `SchemaListCommand` into `ConsoleKernel` backed by a `DefaultsSchemaRegistry` pointed at `<projectRoot>/defaults`

Closes #207

## Test plan

- [x] `DefaultsSchemaRegistryTest` (9 tests) — empty dir, single schema, multi-schema sort, malformed JSON, missing x-waaseyaa extension, non-schema files ignored
- [x] `SchemaListCommandTest` (3 tests) — empty registry output, table with version/compatibility, multiple schemas
- [x] `SchemaRegistryIntegrationTest` (Phase21, 4 tests) — real `defaults/` dir: loads `core.note`, list contains it, alphabetical order, CLI output
- [x] Full suite: 3722 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)