### PR TITLE
feat(#230,#231,#232): schema registry polish

### DIFF
--- a/packages/cli/tests/Unit/Command/SchemaListCommandTest.php
+++ b/packages/cli/tests/Unit/Command/SchemaListCommandTest.php
@@ -10,35 +10,16 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Waaseyaa\CLI\Command\SchemaListCommand;
-use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+use Waaseyaa\Foundation\Schema\SchemaEntry;
+use Waaseyaa\Foundation\Schema\SchemaRegistryInterface;
 
 #[CoversClass(SchemaListCommand::class)]
 final class SchemaListCommandTest extends TestCase
 {
-    private string $defaultsDir;
-
-    protected function setUp(): void
-    {
-        $this->defaultsDir = sys_get_temp_dir() . '/waaseyaa_schema_list_cmd_test_' . uniqid();
-        mkdir($this->defaultsDir, 0755, true);
-    }
-
-    protected function tearDown(): void
-    {
-        $items = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($this->defaultsDir, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST,
-        );
-        foreach ($items as $item) {
-            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
-        }
-        rmdir($this->defaultsDir);
-    }
-
     #[Test]
     public function outputsNoSchemasFoundWhenRegistryIsEmpty(): void
     {
-        $tester = $this->execute();
+        $tester = $this->execute([]);
 
         $this->assertStringContainsString('No schemas found', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
@@ -47,9 +28,9 @@ final class SchemaListCommandTest extends TestCase
     #[Test]
     public function outputsTableWithSchemaDetails(): void
     {
-        $this->writeSchema('core.note', 'core.note', '0.1.0', 'liberal');
-
-        $output = $this->execute()->getDisplay();
+        $output = $this->execute([
+            new SchemaEntry('core.note', '0.1.0', 'liberal', '/defaults/core.note.schema.json'),
+        ])->getDisplay();
 
         $this->assertStringContainsString('core.note', $output);
         $this->assertStringContainsString('0.1.0', $output);
@@ -59,10 +40,10 @@ final class SchemaListCommandTest extends TestCase
     #[Test]
     public function outputsMultipleSchemasInTable(): void
     {
-        $this->writeSchema('core.note', 'core.note', '0.1.0', 'liberal');
-        $this->writeSchema('core.article', 'core.article', '0.2.0', 'strict');
-
-        $output = $this->execute()->getDisplay();
+        $output = $this->execute([
+            new SchemaEntry('core.note', '0.1.0', 'liberal', '/defaults/core.note.schema.json'),
+            new SchemaEntry('core.article', '0.2.0', 'strict', '/defaults/core.article.schema.json'),
+        ])->getDisplay();
 
         $this->assertStringContainsString('core.note', $output);
         $this->assertStringContainsString('core.article', $output);
@@ -72,9 +53,29 @@ final class SchemaListCommandTest extends TestCase
     // Helpers
     // -----------------------------------------------------------------------
 
-    private function execute(): CommandTester
+    /** @param list<SchemaEntry> $entries */
+    private function execute(array $entries): CommandTester
     {
-        $registry = new DefaultsSchemaRegistry($this->defaultsDir);
+        $registry = new class ($entries) implements SchemaRegistryInterface {
+            /** @param list<SchemaEntry> $entries */
+            public function __construct(private readonly array $entries) {}
+
+            public function list(): array
+            {
+                return $this->entries;
+            }
+
+            public function get(string $id): ?SchemaEntry
+            {
+                foreach ($this->entries as $entry) {
+                    if ($entry->id === $id) {
+                        return $entry;
+                    }
+                }
+
+                return null;
+            }
+        };
 
         $app = new Application();
         $app->add(new SchemaListCommand($registry));
@@ -84,21 +85,5 @@ final class SchemaListCommandTest extends TestCase
         $tester->execute([]);
 
         return $tester;
-    }
-
-    private function writeSchema(string $filename, string $entityType, string $version, string $compatibility): void
-    {
-        file_put_contents(
-            $this->defaultsDir . '/' . $filename . '.schema.json',
-            json_encode([
-                '$schema'    => 'http://json-schema.org/draft-07/schema#',
-                'title'      => $entityType,
-                'x-waaseyaa' => [
-                    'entity_type'   => $entityType,
-                    'version'       => $version,
-                    'compatibility' => $compatibility,
-                ],
-            ], JSON_THROW_ON_ERROR),
-        );
     }
 }

--- a/packages/foundation/src/Schema/SchemaEntry.php
+++ b/packages/foundation/src/Schema/SchemaEntry.php
@@ -12,4 +12,15 @@ final readonly class SchemaEntry
         public string $compatibility,
         public string $schemaPath,
     ) {}
+
+    /** @return array{id: string, version: string, compatibility: string, schema_path: string} */
+    public function toArray(): array
+    {
+        return [
+            'id'            => $this->id,
+            'version'       => $this->version,
+            'compatibility' => $this->compatibility,
+            'schema_path'   => $this->schemaPath,
+        ];
+    }
 }

--- a/packages/foundation/tests/Unit/Schema/DefaultsSchemaRegistryTest.php
+++ b/packages/foundation/tests/Unit/Schema/DefaultsSchemaRegistryTest.php
@@ -154,6 +154,54 @@ final class DefaultsSchemaRegistryTest extends TestCase
     }
 
     #[Test]
+    public function listIgnoresSchemasWithMissingEntityType(): void
+    {
+        $this->writeSchema('no-type', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'x-waaseyaa' => [
+                'version'       => '0.1.0',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertSame([], $entries);
+    }
+
+    #[Test]
+    public function listIgnoresSchemasWithMissingVersion(): void
+    {
+        $this->writeSchema('no-version', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'x-waaseyaa' => [
+                'entity_type'   => 'core.note',
+                'compatibility' => 'liberal',
+            ],
+        ]);
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertSame([], $entries);
+    }
+
+    #[Test]
+    public function listIgnoresSchemasWithMissingCompatibility(): void
+    {
+        $this->writeSchema('no-compat', [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'x-waaseyaa' => [
+                'entity_type' => 'core.note',
+                'version'     => '0.1.0',
+            ],
+        ]);
+
+        $entries = (new DefaultsSchemaRegistry($this->defaultsDir))->list();
+
+        $this->assertSame([], $entries);
+    }
+
+    #[Test]
     public function listMultipleSchemasInAlphabeticalOrder(): void
     {
         $this->writeSchema('core.article', [

--- a/packages/foundation/tests/Unit/Schema/SchemaEntryTest.php
+++ b/packages/foundation/tests/Unit/Schema/SchemaEntryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Schema\SchemaEntry;
+
+#[CoversClass(SchemaEntry::class)]
+final class SchemaEntryTest extends TestCase
+{
+    #[Test]
+    public function toArrayReturnsExpectedShape(): void
+    {
+        $entry = new SchemaEntry(
+            id:            'core.note',
+            version:       '0.1.0',
+            compatibility: 'liberal',
+            schemaPath:    '/defaults/core.note.schema.json',
+        );
+
+        $this->assertSame([
+            'id'            => 'core.note',
+            'version'       => '0.1.0',
+            'compatibility' => 'liberal',
+            'schema_path'   => '/defaults/core.note.schema.json',
+        ], $entry->toArray());
+    }
+}


### PR DESCRIPTION
## Summary

- **#230** — Add `SchemaEntry::toArray()` returning `['id', 'version', 'compatibility', 'schema_path']` with unit test
- **#231** — Replace concrete `DefaultsSchemaRegistry` in `SchemaListCommandTest` with anonymous `SchemaRegistryInterface` stub; remove temp dir setup/teardown
- **#232** — Add 3 tests for partial empty `x-waaseyaa` fields (missing `entity_type`, `version`, `compatibility` individually)

All follow-ups from review of #229.

Closes #230, closes #231, closes #232.

## Test plan

- [x] 16 tests across `DefaultsSchemaRegistryTest`, `SchemaEntryTest`, `SchemaListCommandTest` — all pass
- [x] Full suite: 3726 tests, 9150 assertions — all pass
- [x] No production behavior changes (test isolation + serialization method only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)