### PR TITLE
feat(#209): security defaults — RBAC enforcement, secrets handling, encryption policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,32 +6,71 @@
 # Precedence: process env (PHP-FPM pool, shell export) > .env file.
 # Existing process env vars are never overwritten by this file.
 
-# ── Database ─────────────────────────────────────────────────────────────────
-# Path to the SQLite database file.
-# Default: {project_root}/waaseyaa.sqlite
-#
-# WAASEYAA_DB=./waaseyaa.sqlite
-
-# ── Environment ──────────────────────────────────────────────────────────────
+# ── Application ────────────────────────────────────────────────────────────────
 # Controls debug mode, error display, and dev-only helpers.
 # Values: local | staging | production
 # Default: production
 #
 APP_ENV=local
 
-# ── Config ───────────────────────────────────────────────────────────────────
+# ── Database ───────────────────────────────────────────────────────────────────
+# Path to the SQLite database file.
+# Default: {project_root}/waaseyaa.sqlite
+#
+# WAASEYAA_DB=./waaseyaa.sqlite
+
+# ── Config ─────────────────────────────────────────────────────────────────────
 # Path to the config sync directory (YAML entity configs).
 # Default: {project_root}/config/sync
 #
 # WAASEYAA_CONFIG_DIR=./config/sync
 
-# ── CORS ─────────────────────────────────────────────────────────────────────
+# ── File Storage ───────────────────────────────────────────────────────────────
+# Root directory for LocalFileRepository (media uploads).
+# Default: {project_root}/files
+#
+# WAASEYAA_FILES_DIR=./files
+
+# ── Authentication ─────────────────────────────────────────────────────────────
+# Shared secret for HS256 JWT tokens issued to machine clients.
+# Required if bearer auth is used. Must be a cryptographically random string.
+# Minimum recommended length: 32 characters.
+#
+# WAASEYAA_JWT_SECRET=
+
+# Dev-only fallback: automatically authenticates every request as a platform admin.
+# MUST remain false (or unset) in staging and production.
+# Default: false
+#
+# WAASEYAA_DEV_FALLBACK_ACCOUNT=false
+
+# ── CORS ───────────────────────────────────────────────────────────────────────
 # Allowed origin for the admin SPA. Overrides cors_origins in config/waaseyaa.php.
 # Default: http://localhost:3000
 #
 # WAASEYAA_CORS_ORIGIN=http://localhost:3000
 
-# ── AI (optional) ────────────────────────────────────────────────────────────
-# Required only when using the ai-vector package (OpenAI embeddings).
+# ── SSR ────────────────────────────────────────────────────────────────────────
+# Theme ID discovered from the active Composer theme package.
+# Corresponds to extra.waaseyaa.theme in the theme package's composer.json.
 #
+# WAASEYAA_SSR_THEME=
+
+# Cache max-age for SSR responses (seconds).
+# Default: 300
+#
+# WAASEYAA_SSR_CACHE_MAX_AGE=300
+
+# ── AI / Embeddings (optional) ─────────────────────────────────────────────────
+# Required only when using the ai-vector package.
+#
+# Embedding provider: 'ollama' (local) or 'openai'. Empty string disables embeddings.
+# WAASEYAA_EMBEDDING_PROVIDER=
+
+# Ollama (local embedding server)
+# WAASEYAA_OLLAMA_ENDPOINT=http://127.0.0.1:11434/api/embeddings
+# WAASEYAA_OLLAMA_MODEL=nomic-embed-text
+
+# OpenAI
 # OPENAI_API_KEY=sk-...
+# WAASEYAA_OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,25 @@ jobs:
             fi
           done
           exit $fail
+
+  security-defaults:
+    name: Security defaults
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check no secrets in defaults/
+        run: bash bin/check-no-secrets
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run structural secrets scan
+        run: ./vendor/bin/phpunit --filter Phase22

--- a/bin/check-no-secrets
+++ b/bin/check-no-secrets
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/defaults"
+FAIL=0
+
+check_pattern() {
+  local label="$1"
+  local pattern="$2"
+  local results
+  results=$(grep -rEn "$pattern" "$DEFAULTS_DIR" 2>/dev/null || true)
+  if [[ -n "$results" ]]; then
+    echo "FAIL [$label]: secret-like content found:"
+    echo "$results"
+    FAIL=1
+  fi
+}
+
+echo "=== Secrets check: $DEFAULTS_DIR ==="
+
+check_pattern "API key (sk-)"         'sk-[A-Za-z0-9]{20,}'
+check_pattern "GitHub token (ghp_)"   'ghp_[A-Za-z0-9]{20,}'
+check_pattern "Slack token"           'xox[bp]-[A-Za-z0-9\-]+'
+check_pattern "Google OAuth token"    'ya29\.[A-Za-z0-9\-_]+'
+check_pattern "Google API key (AIza)" 'AIza[A-Za-z0-9\-_]{35}'
+check_pattern "PEM private key"       '\-\-\-\-\-BEGIN [A-Z ]*PRIVATE KEY\-\-\-\-\-'
+check_pattern "DSN with credentials"  '(mysql|postgres|postgresql|mongodb|redis)://[^@[:space:]]+:[^@[:space:]]+@'
+
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "OK: No secrets found in defaults/"
+fi
+
+exit "$FAIL"

--- a/defaults/core.note.yaml
+++ b/defaults/core.note.yaml
@@ -17,6 +17,7 @@ schema:
   ref: core.note.schema.json
   version: "0.1.0"
   compatibility: liberal  # pre-v1: breaking changes allowed with migration task
+  encryption_policy: none  # body stored plaintext; opt-in field encryption not yet implemented
 
 entity_keys:
   id: id

--- a/docs/specs/security-defaults.md
+++ b/docs/specs/security-defaults.md
@@ -1,0 +1,118 @@
+# Security Defaults
+
+## Purpose
+
+Defines the security model for Waaseyaa's default content types, API access, and configuration handling. Ensures secrets never leak into version-controlled manifests and that RBAC is enforced at the API layer before entity-level access checks fire.
+
+## Threat Model
+
+The `defaults/` directory contains declarative manifests (YAML) and JSON Schema files. These files are:
+
+- **Version-controlled** — committed to the repository
+- **Non-executable** — never `require`d or `eval`d at runtime
+- **Read by `DefaultsSchemaRegistry`** — only `*.schema.json` files, only `x-waaseyaa` metadata
+
+Attack surfaces:
+
+| Threat | Mitigation |
+|--------|-----------|
+| Secret committed to `defaults/` | `bin/check-no-secrets` (CI gate) + `DefaultsSecretsIntegrationTest` (structural) |
+| Manifest referencing external endpoint | YAML manifests are governance docs, not runtime config |
+| Anonymous write to entity API | Route-level `_authenticated` option on POST/PATCH/DELETE |
+
+## RBAC Enforcement at the API Layer
+
+Access control is enforced in three layers, evaluated in sequence:
+
+| Layer | Mechanism | Failure code |
+|-------|-----------|-------------|
+| **Route-level authentication** | `_authenticated` route option → `AccessChecker` → `AuthorizationMiddleware` | 401 Unauthorized |
+| **Route-level authorization** | `_permission` / `_role` / `_gate` route options → `AccessChecker` | 403 Forbidden |
+| **Entity-level access** | `EntityAccessHandler` → `AccessPolicyInterface` implementations | 403 Forbidden |
+| **Field-level access** | `EntityAccessHandler::checkFieldAccess()` → `FieldAccessPolicyInterface` | Field omitted from response |
+
+### Route-level authentication
+
+All entity CRUD write routes (POST, PATCH, DELETE) require authentication via the `_authenticated` route option. Anonymous requests receive HTTP 401 with a `WWW-Authenticate: Bearer` header.
+
+Read routes (GET index, GET show) do **not** require authentication at the route level. Entity access policies control read authorization — this preserves the ability for entity types to serve public content.
+
+### Entity-level access for core.note
+
+The `NoteAccessPolicy` enforces:
+
+| Operation | tenant.member | tenant.admin | platform.admin | anonymous |
+|-----------|--------------|-------------|---------------|-----------|
+| view | Allowed | Allowed | Allowed | Neutral (denied) |
+| create | — | Allowed | Allowed | Neutral (denied) |
+| update | — | Allowed | Allowed | Neutral (denied) |
+| delete | Forbidden | Forbidden | Forbidden | Forbidden |
+
+### Field-level access for core.note
+
+System fields (`id`, `uuid`, `created_at`, `updated_at`) are read-only for all roles except `platform.admin`. `tenant_id` is settable on creation but immutable on update.
+
+See also: `docs/specs/access-control.md`, `docs/specs/field-access.md`.
+
+## Encryption Policy
+
+### Current (pre-v1)
+
+- `body` field is stored as plaintext in the `_data` JSON blob column
+- No at-rest encryption is applied by `SqlEntityStorage`
+- Transport-layer encryption (TLS) is the operator's responsibility
+- The `core.note.yaml` manifest declares `encryption_policy: none`
+
+### Future opt-in path
+
+When field-level encryption is implemented:
+
+- The manifest value will become the algorithm name (e.g., `aes-256-gcm`)
+- Key management will be the operator's responsibility via a `WAASEYAA_ENCRYPTION_KEY` env var
+- Existing plaintext data will require a migration command
+
+## Secrets Handling
+
+### Invariant: no secrets in manifests
+
+`defaults/*.yaml` and `defaults/*.schema.json` are version-controlled and must **never** contain credentials, tokens, or connection strings. All secrets enter the application exclusively via environment variables.
+
+### Environment variable contract
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `WAASEYAA_JWT_SECRET` | HS256 shared secret for bearer auth | Only if bearer auth is used |
+| `OPENAI_API_KEY` | OpenAI API key for embeddings | Only if `embedding_provider=openai` |
+| `WAASEYAA_DEV_FALLBACK_ACCOUNT` | Dev-only auto-auth as platform admin | **Must be false in production** |
+
+Full listing: `.env.example`.
+
+### Configuration secrets
+
+`api_keys` in `config/waaseyaa.php` maps raw API keys to UIDs. This file is **not** version-controlled in deployments (only `skeleton/config/waaseyaa.php` is committed as a template). Deployments must override it via environment-specific config.
+
+### Enforcement
+
+| Check | Type | Location |
+|-------|------|----------|
+| `bin/check-no-secrets` | Shell grep for token patterns | CI: `security-defaults` job |
+| `DefaultsSecretsIntegrationTest` | Structural YAML/JSON value scanning | CI: PHPUnit `--filter Phase22` |
+
+Patterns checked: `sk-*` (OpenAI), `ghp_*` (GitHub), `xox[bp]-*` (Slack), `ya29.*` (Google OAuth), `AIza*` (Google API), PEM private keys, DSN with embedded credentials.
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `packages/access/src/AccessStatus.php` | `UNAUTHENTICATED` enum case |
+| `packages/access/src/AccessResult.php` | `unauthenticated()` factory, `isUnauthenticated()` predicate |
+| `packages/access/src/Middleware/AuthorizationMiddleware.php` | 401 response branch |
+| `packages/routing/src/AccessChecker.php` | `_authenticated` route option evaluation |
+| `packages/routing/src/RouteBuilder.php` | `requireAuthentication()` fluent method |
+| `packages/api/src/JsonApiRouteProvider.php` | Authentication on write routes |
+| `packages/note/src/NoteAccessPolicy.php` | Entity + field access for core.note |
+| `defaults/core.note.yaml` | Governance manifest with encryption_policy |
+| `bin/check-no-secrets` | CI shell gate for secret patterns |
+| `tests/Integration/Phase22/DefaultsSecretsIntegrationTest.php` | Structural secrets scan |
+| `.env.example` | Canonical env var reference |
+| `.github/workflows/ci.yml` | `security-defaults` CI job |

--- a/packages/access/src/AccessResult.php
+++ b/packages/access/src/AccessResult.php
@@ -7,11 +7,11 @@ namespace Waaseyaa\Access;
 /**
  * Value object representing an access check result.
  *
- * An AccessResult is one of three states: Allowed, Neutral, or Forbidden.
+ * An AccessResult is one of four states: Allowed, Neutral, Forbidden, or Unauthenticated.
  * Results can be combined with AND (andIf) and OR (orIf) logic:
  *
- * - andIf: Forbidden wins over all; both must be Allowed for Allowed.
- * - orIf:  Forbidden wins over all; either Allowed yields Allowed.
+ * - andIf: Forbidden/Unauthenticated wins over all; both must be Allowed for Allowed.
+ * - orIf:  Forbidden/Unauthenticated wins over all; either Allowed yields Allowed.
  */
 final readonly class AccessResult
 {
@@ -44,6 +44,16 @@ final readonly class AccessResult
         return new self(AccessStatus::FORBIDDEN, $reason);
     }
 
+    /**
+     * Create an Unauthenticated result (no valid identity).
+     *
+     * Semantically distinct from Forbidden: 401 vs 403.
+     */
+    public static function unauthenticated(string $reason = ''): self
+    {
+        return new self(AccessStatus::UNAUTHENTICATED, $reason);
+    }
+
     public function isAllowed(): bool
     {
         return $this->status === AccessStatus::ALLOWED;
@@ -59,16 +69,29 @@ final readonly class AccessResult
         return $this->status === AccessStatus::NEUTRAL;
     }
 
+    public function isUnauthenticated(): bool
+    {
+        return $this->status === AccessStatus::UNAUTHENTICATED;
+    }
+
     /**
      * Combine with AND logic.
      *
-     * - If either is Forbidden, the result is Forbidden.
+     * - If either is Forbidden or Unauthenticated, that result wins.
      * - If both are Allowed, the result is Allowed.
      * - Otherwise, the result is Neutral.
      */
     public function andIf(self $other): self
     {
-        // Forbidden wins over everything.
+        // Unauthenticated wins over all (401 before 403).
+        if ($this->isUnauthenticated()) {
+            return $this;
+        }
+        if ($other->isUnauthenticated()) {
+            return $other;
+        }
+
+        // Forbidden wins over allowed/neutral.
         if ($this->isForbidden()) {
             return $this;
         }
@@ -92,13 +115,21 @@ final readonly class AccessResult
     /**
      * Combine with OR logic.
      *
-     * - If either is Forbidden, the result is Forbidden.
+     * - If either is Forbidden or Unauthenticated, that result wins.
      * - If either is Allowed, the result is Allowed.
      * - Otherwise, the result is Neutral.
      */
     public function orIf(self $other): self
     {
-        // Forbidden wins over everything.
+        // Unauthenticated wins over all (401 before 403).
+        if ($this->isUnauthenticated()) {
+            return $this;
+        }
+        if ($other->isUnauthenticated()) {
+            return $other;
+        }
+
+        // Forbidden wins over allowed/neutral.
         if ($this->isForbidden()) {
             return $this;
         }

--- a/packages/access/src/AccessStatus.php
+++ b/packages/access/src/AccessStatus.php
@@ -9,4 +9,5 @@ enum AccessStatus: string
     case ALLOWED = 'allowed';
     case NEUTRAL = 'neutral';
     case FORBIDDEN = 'forbidden';
+    case UNAUTHENTICATED = 'unauthenticated';
 }

--- a/packages/access/src/Middleware/AuthorizationMiddleware.php
+++ b/packages/access/src/Middleware/AuthorizationMiddleware.php
@@ -42,6 +42,20 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
 
         $result = $this->accessChecker->check($route, $account);
 
+        if ($result->isUnauthenticated()) {
+            return new JsonResponse([
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [[
+                    'status' => '401',
+                    'title' => 'Unauthorized',
+                    'detail' => $result->reason,
+                ]],
+            ], 401, [
+                'Content-Type' => 'application/vnd.api+json',
+                'WWW-Authenticate' => 'Bearer realm="Waaseyaa API"',
+            ]);
+        }
+
         if ($result->isForbidden()) {
             return new JsonResponse([
                 'jsonapi' => ['version' => '1.1'],

--- a/packages/access/tests/Unit/AccessResultTest.php
+++ b/packages/access/tests/Unit/AccessResultTest.php
@@ -51,11 +51,24 @@ class AccessResultTest extends TestCase
         $this->assertSame('denied', $result->reason);
     }
 
+    public function testUnauthenticatedFactory(): void
+    {
+        $result = AccessResult::unauthenticated('no identity');
+
+        $this->assertTrue($result->isUnauthenticated());
+        $this->assertFalse($result->isAllowed());
+        $this->assertFalse($result->isForbidden());
+        $this->assertFalse($result->isNeutral());
+        $this->assertSame(AccessStatus::UNAUTHENTICATED, $result->status);
+        $this->assertSame('no identity', $result->reason);
+    }
+
     public function testDefaultReasonIsEmpty(): void
     {
         $this->assertSame('', AccessResult::allowed()->reason);
         $this->assertSame('', AccessResult::neutral()->reason);
         $this->assertSame('', AccessResult::forbidden()->reason);
+        $this->assertSame('', AccessResult::unauthenticated()->reason);
     }
 
     // ---------------------------------------------------------------
@@ -129,6 +142,36 @@ class AccessResultTest extends TestCase
             AccessResult::forbidden(),
             AccessStatus::FORBIDDEN,
         ];
+
+        yield 'unauthenticated AND allowed = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::allowed(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'allowed AND unauthenticated = unauthenticated' => [
+            AccessResult::allowed(),
+            AccessResult::unauthenticated(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'unauthenticated AND neutral = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::neutral(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'unauthenticated AND forbidden = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::forbidden(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'forbidden AND unauthenticated = unauthenticated' => [
+            AccessResult::forbidden(),
+            AccessResult::unauthenticated(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
     }
 
     // ---------------------------------------------------------------
@@ -201,6 +244,36 @@ class AccessResultTest extends TestCase
             AccessResult::forbidden(),
             AccessResult::forbidden(),
             AccessStatus::FORBIDDEN,
+        ];
+
+        yield 'unauthenticated OR allowed = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::allowed(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'allowed OR unauthenticated = unauthenticated' => [
+            AccessResult::allowed(),
+            AccessResult::unauthenticated(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'unauthenticated OR neutral = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::neutral(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'unauthenticated OR forbidden = unauthenticated' => [
+            AccessResult::unauthenticated(),
+            AccessResult::forbidden(),
+            AccessStatus::UNAUTHENTICATED,
+        ];
+
+        yield 'forbidden OR unauthenticated = unauthenticated' => [
+            AccessResult::forbidden(),
+            AccessResult::unauthenticated(),
+            AccessStatus::UNAUTHENTICATED,
         ];
     }
 
@@ -293,6 +366,7 @@ class AccessResultTest extends TestCase
         $this->assertSame('allowed', AccessStatus::ALLOWED->value);
         $this->assertSame('neutral', AccessStatus::NEUTRAL->value);
         $this->assertSame('forbidden', AccessStatus::FORBIDDEN->value);
+        $this->assertSame('unauthenticated', AccessStatus::UNAUTHENTICATED->value);
     }
 
     public function testAccessStatusFromString(): void
@@ -300,5 +374,6 @@ class AccessResultTest extends TestCase
         $this->assertSame(AccessStatus::ALLOWED, AccessStatus::from('allowed'));
         $this->assertSame(AccessStatus::NEUTRAL, AccessStatus::from('neutral'));
         $this->assertSame(AccessStatus::FORBIDDEN, AccessStatus::from('forbidden'));
+        $this->assertSame(AccessStatus::UNAUTHENTICATED, AccessStatus::from('unauthenticated'));
     }
 }

--- a/packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php
+++ b/packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php
@@ -120,6 +120,37 @@ final class AuthorizationMiddlewareTest extends TestCase
     }
 
     #[Test]
+    public function returns_401_when_authentication_required_and_anonymous(): void
+    {
+        $route = new Route('/api/node');
+        $route->setOption('_authenticated', true);
+
+        $account = new AnonymousUser();
+        $accessChecker = new AccessChecker();
+        $middleware = new AuthorizationMiddleware($accessChecker);
+
+        $request = Request::create('/api/node', 'POST');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_route_object', $route);
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('should not reach here');
+            }
+        };
+
+        $response = $middleware->process($request, $next);
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertStringContainsString('401', $response->getContent());
+        $this->assertSame(
+            'Bearer realm="Waaseyaa API"',
+            $response->headers->get('WWW-Authenticate'),
+        );
+    }
+
+    #[Test]
     public function returns_403_when_no_account_set(): void
     {
         $route = new Route('/api/node');

--- a/packages/api/src/JsonApiRouteProvider.php
+++ b/packages/api/src/JsonApiRouteProvider.php
@@ -71,6 +71,7 @@ final class JsonApiRouteProvider
             RouteBuilder::create($collectionPath)
                 ->controller("Waaseyaa\\Api\\JsonApiController::store")
                 ->methods('POST')
+                ->requireAuthentication()
                 ->default('_entity_type', $entityTypeId)
                 ->build(),
         );
@@ -81,6 +82,7 @@ final class JsonApiRouteProvider
             RouteBuilder::create($resourcePath)
                 ->controller("Waaseyaa\\Api\\JsonApiController::update")
                 ->methods('PATCH')
+                ->requireAuthentication()
                 ->default('_entity_type', $entityTypeId)
                 ->build(),
         );
@@ -91,6 +93,7 @@ final class JsonApiRouteProvider
             RouteBuilder::create($resourcePath)
                 ->controller("Waaseyaa\\Api\\JsonApiController::destroy")
                 ->methods('DELETE')
+                ->requireAuthentication()
                 ->default('_entity_type', $entityTypeId)
                 ->build(),
         );

--- a/packages/api/tests/Unit/JsonApiRouteProviderTest.php
+++ b/packages/api/tests/Unit/JsonApiRouteProviderTest.php
@@ -141,6 +141,43 @@ final class JsonApiRouteProviderTest extends TestCase
     }
 
     #[Test]
+    public function writeRoutesRequireAuthentication(): void
+    {
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: TestEntity::class,
+        ));
+
+        $provider = new JsonApiRouteProvider($this->entityTypeManager);
+        $provider->registerRoutes($this->router);
+
+        $routes = $this->router->getRouteCollection();
+
+        $this->assertTrue($routes->get('api.article.store')->getOption('_authenticated'));
+        $this->assertTrue($routes->get('api.article.update')->getOption('_authenticated'));
+        $this->assertTrue($routes->get('api.article.destroy')->getOption('_authenticated'));
+    }
+
+    #[Test]
+    public function readRoutesDoNotRequireAuthentication(): void
+    {
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: TestEntity::class,
+        ));
+
+        $provider = new JsonApiRouteProvider($this->entityTypeManager);
+        $provider->registerRoutes($this->router);
+
+        $routes = $this->router->getRouteCollection();
+
+        $this->assertNull($routes->get('api.article.index')->getOption('_authenticated'));
+        $this->assertNull($routes->get('api.article.show')->getOption('_authenticated'));
+    }
+
+    #[Test]
     public function registersRoutesForMultipleEntityTypes(): void
     {
         $this->entityTypeManager->registerEntityType(new EntityType(

--- a/packages/routing/src/AccessChecker.php
+++ b/packages/routing/src/AccessChecker.php
@@ -46,6 +46,16 @@ final class AccessChecker
             // Remains allowed — no change needed.
         }
 
+        // Check _authenticated option (requires a non-anonymous identity).
+        // Short-circuits: no point evaluating permissions for an anonymous user.
+        $authenticated = $route->getOption('_authenticated');
+        if ($authenticated === true) {
+            $hasRequirement = true;
+            if (!$account->isAuthenticated()) {
+                return AccessResult::unauthenticated('Authentication is required to access this resource.');
+            }
+        }
+
         // Check _permission option.
         $permission = $route->getOption('_permission');
         if ($permission !== null) {

--- a/packages/routing/src/RouteBuilder.php
+++ b/packages/routing/src/RouteBuilder.php
@@ -100,6 +100,15 @@ final class RouteBuilder
     }
 
     /**
+     * Require that the request is from an authenticated (non-anonymous) account.
+     */
+    public function requireAuthentication(): self
+    {
+        $this->options['_authenticated'] = true;
+        return $this;
+    }
+
+    /**
      * Allow all users (marks route as public).
      */
     public function allowAll(): self

--- a/packages/routing/tests/Unit/AccessCheckerTest.php
+++ b/packages/routing/tests/Unit/AccessCheckerTest.php
@@ -145,6 +145,70 @@ final class AccessCheckerTest extends TestCase
         $this->assertTrue($result->isForbidden());
     }
 
+    // --- _authenticated ---
+
+    #[Test]
+    public function authenticatedOptionWithAuthenticatedAccountReturnsAllowed(): void
+    {
+        $route = new Route('/api/node');
+        $route->setOption('_authenticated', true);
+
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(true);
+
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function authenticatedOptionWithAnonymousAccountReturnsUnauthenticated(): void
+    {
+        $route = new Route('/api/node');
+        $route->setOption('_authenticated', true);
+
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(false);
+
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isUnauthenticated());
+        $this->assertStringContainsString('Authentication is required', $result->reason);
+    }
+
+    #[Test]
+    public function authenticatedOptionShortCircuitsBeforePermissionCheck(): void
+    {
+        $route = new Route('/api/node');
+        $route->setOption('_authenticated', true);
+        $route->setOption('_permission', 'access content');
+
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(false);
+        // hasPermission should never be called — short-circuited.
+        $account->expects($this->never())->method('hasPermission');
+
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isUnauthenticated());
+    }
+
+    #[Test]
+    public function authenticatedWithPermissionBothCheckedWhenAuthenticated(): void
+    {
+        $route = new Route('/api/node');
+        $route->setOption('_authenticated', true);
+        $route->setOption('_permission', 'access content');
+
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('isAuthenticated')->willReturn(true);
+        $account->method('hasPermission')->with('access content')->willReturn(true);
+
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
     // --- Combined requirements (AND logic) ---
 
     #[Test]

--- a/packages/routing/tests/Unit/RouteBuilderTest.php
+++ b/packages/routing/tests/Unit/RouteBuilderTest.php
@@ -96,6 +96,16 @@ final class RouteBuilderTest extends TestCase
     }
 
     #[Test]
+    public function requireAuthenticationSetsOption(): void
+    {
+        $route = RouteBuilder::create('/api/node')
+            ->requireAuthentication()
+            ->build();
+
+        $this->assertTrue($route->getOption('_authenticated'));
+    }
+
+    #[Test]
     public function allowAllSetsPublicOption(): void
     {
         $route = RouteBuilder::create('/public')

--- a/tests/Integration/Phase22/DefaultsSecretsIntegrationTest.php
+++ b/tests/Integration/Phase22/DefaultsSecretsIntegrationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase22;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+final class DefaultsSecretsIntegrationTest extends TestCase
+{
+    private string $defaultsDir;
+
+    /** @var list<string> */
+    private array $patterns = [
+        '/sk-[A-Za-z0-9]{20,}/',
+        '/ghp_[A-Za-z0-9]{20,}/',
+        '/xox[bp]-[A-Za-z0-9\-]+/',
+        '/ya29\.[A-Za-z0-9\-_]+/',
+        '/AIza[A-Za-z0-9\-_]{35}/',
+        '/-----BEGIN [A-Z ]*PRIVATE KEY-----/',
+        '%(mysql|postgres|postgresql|mongodb|redis)://[^@\s]+:[^@\s]+@%',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->defaultsDir = dirname(__DIR__, 3) . '/defaults';
+    }
+
+    #[Test]
+    public function yamlFilesContainNoSecrets(): void
+    {
+        $violations = [];
+
+        foreach ($this->findFiles('yaml') as $file) {
+            $data = Yaml::parseFile($file);
+
+            foreach ($this->walkValues($data) as $value) {
+                foreach ($this->patterns as $pattern) {
+                    if (preg_match($pattern, (string) $value)) {
+                        $violations[] = sprintf(
+                            '%s: value "%s" matched pattern %s',
+                            basename($file),
+                            substr((string) $value, 0, 60),
+                            $pattern,
+                        );
+                    }
+                }
+            }
+        }
+
+        $this->assertEmpty($violations, "Secret-like values found:\n" . implode("\n", $violations));
+    }
+
+    #[Test]
+    public function jsonFilesContainNoSecrets(): void
+    {
+        $violations = [];
+
+        foreach ($this->findFiles('json') as $file) {
+            $data = json_decode(
+                (string) file_get_contents($file),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            );
+
+            foreach ($this->walkValues($data) as $value) {
+                foreach ($this->patterns as $pattern) {
+                    if (preg_match($pattern, (string) $value)) {
+                        $violations[] = sprintf(
+                            '%s: value "%s" matched pattern %s',
+                            basename($file),
+                            substr((string) $value, 0, 60),
+                            $pattern,
+                        );
+                    }
+                }
+            }
+        }
+
+        $this->assertEmpty($violations, "Secret-like values found:\n" . implode("\n", $violations));
+    }
+
+    /** @return list<string> */
+    private function findFiles(string $extension): array
+    {
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->defaultsDir),
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === $extension) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        return $files;
+    }
+
+    /** @return iterable<int, scalar> */
+    private function walkValues(mixed $node): iterable
+    {
+        if (is_array($node)) {
+            foreach ($node as $child) {
+                yield from $this->walkValues($child);
+            }
+        } elseif (is_string($node) || is_int($node) || is_float($node)) {
+            yield $node;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Route-level authentication**: New `_authenticated` route option enforces authentication on entity CRUD write routes (POST/PATCH/DELETE). Anonymous requests get HTTP 401 with `WWW-Authenticate: Bearer` header. Read routes (GET) stay open for entity-policy gating.
- **UNAUTHENTICATED access status**: New terminal state in `AccessResult` — distinct from FORBIDDEN (401 vs 403). Takes priority over FORBIDDEN in `andIf`/`orIf` combination logic.
- **CI secrets scanning**: `bin/check-no-secrets` shell script + `DefaultsSecretsIntegrationTest` (Phase22) structurally scan `defaults/` for token patterns. New `security-defaults` CI job.
- **Documentation & config**: `docs/specs/security-defaults.md` spec, expanded `.env.example` with all supported env vars, `encryption_policy: none` placeholder in `core.note.yaml`.

Closes #209

## Test plan

- [x] 3280 unit tests pass (0 failures)
- [x] Phase22 integration tests pass (2 tests)
- [x] `bin/check-no-secrets` exits 0
- [ ] Verify 401 response for anonymous POST to entity endpoint
- [ ] Verify 200/entity-policy gating for anonymous GET
- [ ] Verify CI `security-defaults` job runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)