### PR TITLE
fix(#271): change default uploaded file storage path to storage/files

### DIFF
--- a/config/waaseyaa.php
+++ b/config/waaseyaa.php
@@ -12,7 +12,7 @@ return [
     'config_dir' => getenv('WAASEYAA_CONFIG_DIR') ?: __DIR__ . '/sync',
 
     // File storage root for LocalFileRepository (media package).
-    'files_dir' => getenv('WAASEYAA_FILES_DIR') ?: __DIR__ . '/../files',
+    'files_dir' => getenv('WAASEYAA_FILES_DIR') ?: __DIR__ . '/../storage/files',
 
     // Bearer auth settings for machine clients.
     // JWT uses HS256 with this shared secret.

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -1948,7 +1948,7 @@ final class HttpKernel extends AbstractKernel
             return $configured;
         }
 
-        return $this->projectRoot . '/files';
+        return $this->projectRoot . '/storage/files';
     }
 
     private function resolveUploadMaxBytes(): int

--- a/skeleton/config/waaseyaa.php
+++ b/skeleton/config/waaseyaa.php
@@ -12,7 +12,7 @@ return [
     'config_dir' => getenv('WAASEYAA_CONFIG_DIR') ?: __DIR__ . '/sync',
 
     // File storage root for LocalFileRepository (media package).
-    'files_dir' => getenv('WAASEYAA_FILES_DIR') ?: __DIR__ . '/../files',
+    'files_dir' => getenv('WAASEYAA_FILES_DIR') ?: __DIR__ . '/../storage/files',
 
     // Bearer auth settings for machine clients.
     // JWT uses HS256 with this shared secret.


### PR DESCRIPTION
## Summary

- Changes the default upload directory from `{project_root}/files` to `{project_root}/storage/files`
- Updates `HttpKernel::resolveFilesRootDir()` fallback, `config/waaseyaa.php`, and `skeleton/config/waaseyaa.php`
- Existing installs with a custom `files_dir` config key are unaffected

## Test plan

- [ ] Verify fresh install stores uploads under `storage/files/`
- [ ] Verify existing install with explicit `files_dir` config still uses configured path
- [ ] Run integration tests: `./vendor/bin/phpunit --testsuite Unit`

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)