### PR TITLE
test(#271): add coverage for resolveFilesRootDir and clarify URL/path separation

### DIFF
--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -2023,6 +2023,13 @@ final class HttpKernel extends AbstractKernel
         return $clean;
     }
 
+    /**
+     * Maps a file URI to its public HTTP path (e.g. public://images/a.jpg → /files/images/a.jpg).
+     *
+     * Note: the /files/ URL prefix is intentionally independent of the filesystem storage root
+     * (resolveFilesRootDir()). The web server or front controller is responsible for mapping
+     * /files/* requests to the configured storage directory.
+     */
     private function buildPublicFileUrl(string $uri): string
     {
         $prefix = 'public://';

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
@@ -244,6 +244,30 @@ final class HttpKernelTest extends TestCase
     }
 
     #[Test]
+    public function resolves_files_root_dir_defaults_to_storage_files(): void
+    {
+        $kernel = new HttpKernel('/var/www/myapp');
+        $method = new \ReflectionMethod(HttpKernel::class, 'resolveFilesRootDir');
+        $method->setAccessible(true);
+
+        $this->assertSame('/var/www/myapp/storage/files', $method->invoke($kernel));
+    }
+
+    #[Test]
+    public function resolves_files_root_dir_uses_configured_path_when_set(): void
+    {
+        $kernel = new HttpKernel('/var/www/myapp');
+        $configProp = new \ReflectionProperty(\Waaseyaa\Foundation\Kernel\AbstractKernel::class, 'config');
+        $configProp->setAccessible(true);
+        $configProp->setValue($kernel, ['files_dir' => '/mnt/uploads']);
+
+        $method = new \ReflectionMethod(HttpKernel::class, 'resolveFilesRootDir');
+        $method->setAccessible(true);
+
+        $this->assertSame('/mnt/uploads', $method->invoke($kernel));
+    }
+
+    #[Test]
     public function builds_public_file_url_from_public_uri(): void
     {
         $kernel = new HttpKernel('/tmp/test-project');


### PR DESCRIPTION
## Summary

Follow-up to #272.

- Adds two unit tests for `resolveFilesRootDir()`: default path (`storage/files`) and explicit `files_dir` config override
- Adds a docblock on `buildPublicFileUrl()` clarifying that the `/files/` HTTP prefix is intentionally independent of the filesystem storage root

## Test plan

- [ ] `./vendor/bin/phpunit --filter resolves_files_root_dir` — 2 tests pass

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)