### PR TITLE
fix: explicit PDO type binding and skip JSON parsing for app controllers

### DIFF
--- a/packages/database-legacy/src/Query/PdoSelect.php
+++ b/packages/database-legacy/src/Query/PdoSelect.php
@@ -158,7 +158,16 @@ final class PdoSelect implements SelectInterface
         $sql = $this->buildSql();
 
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($this->params);
+        foreach ($this->params as $i => $value) {
+            $type = match (true) {
+                is_int($value)  => \PDO::PARAM_INT,
+                is_bool($value) => \PDO::PARAM_BOOL,
+                is_null($value) => \PDO::PARAM_NULL,
+                default         => \PDO::PARAM_STR,
+            };
+            $stmt->bindValue($i + 1, $value, $type);
+        }
+        $stmt->execute();
 
         return $stmt;
     }

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -461,8 +461,13 @@ final class HttpKernel extends AbstractKernel
         $serializer = new ResourceSerializer($this->entityTypeManager);
         $schemaPresenter = new SchemaPresenter();
 
+        // JSON body parsing only applies to JSON API controllers.
+        // SSR app controllers (identified by '::' in the controller name) receive
+        // form-encoded POST data via $httpRequest->request and must not be subjected
+        // to JSON parsing, which would reject application/x-www-form-urlencoded bodies.
         $body = null;
-        if (in_array($method, ['POST', 'PATCH'], true)) {
+        $isAppController = str_contains($controller, '::') || $controller === 'render.page';
+        if (!$isAppController && in_array($method, ['POST', 'PATCH'], true)) {
             $raw = $httpRequest->getContent();
             if ($raw !== '') {
                 try {


### PR DESCRIPTION
## Summary

- **PdoSelect**: Bind query parameters with explicit `PDO::PARAM_INT/BOOL/NULL/STR` types instead of relying on PDO's implicit string coercion. Fixes queries that filter on integer or boolean columns.
- **HttpKernel**: Skip JSON body parsing for SSR app controllers (identified by `::` in the controller name) and `render.page` routes. These controllers consume form-encoded POST data via `$httpRequest->request` and must not be subjected to JSON parsing, which would reject `application/x-www-form-urlencoded` bodies.

## Test plan

- [ ] Verify integer/boolean column queries return correct results (no implicit string coercion)
- [ ] Verify form POST to an SSR route is not rejected with a JSON parse error
- [ ] Verify JSON API POST/PATCH routes still parse JSON bodies as before
- [ ] Run full test suite: `./vendor/bin/phpunit --configuration phpunit.xml.dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)