### PR TITLE
feat(#280,#281,#282,#283): SSR error pages, CSRF middleware, welcome hints

### DIFF
--- a/packages/access/src/Middleware/AuthorizationMiddleware.php
+++ b/packages/access/src/Middleware/AuthorizationMiddleware.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Waaseyaa\Access\Middleware;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
@@ -27,9 +29,15 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
         }
 
         $account = $request->attributes->get('_account');
+        $isRenderRoute = $this->isRenderRoute($route);
 
         if (!$account instanceof AccountInterface) {
             error_log('[Waaseyaa] AuthorizationMiddleware: _account not set or invalid; denying access.');
+
+            if ($isRenderRoute) {
+                return $this->renderHtmlError(403, 'Forbidden', 'No authenticated account available.', $request);
+            }
+
             return new JsonResponse([
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[
@@ -43,6 +51,11 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
         $result = $this->accessChecker->check($route, $account);
 
         if ($result->isUnauthenticated()) {
+            if ($isRenderRoute) {
+                $loginUrl = '/login?redirect=' . urlencode($request->getPathInfo());
+                return new RedirectResponse($loginUrl, 302);
+            }
+
             return new JsonResponse([
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[
@@ -57,6 +70,10 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
         }
 
         if ($result->isForbidden()) {
+            if ($isRenderRoute) {
+                return $this->renderHtmlError(403, 'Forbidden', $result->reason ?? 'You do not have permission to access this page.', $request);
+            }
+
             return new JsonResponse([
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[
@@ -68,5 +85,30 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
         }
 
         return $next->handle($request);
+    }
+
+    private function isRenderRoute(Route $route): bool
+    {
+        return $route->getOption('_render') === true;
+    }
+
+    private function renderHtmlError(int $statusCode, string $title, string $detail, Request $request): Response
+    {
+        $loginLink = $statusCode === 403
+            ? sprintf('<p><a href="/login?redirect=%s">Sign in</a> with a different account.</p>', urlencode($request->getPathInfo()))
+            : '';
+
+        $html = <<<HTML
+        <!DOCTYPE html>
+        <html lang="en">
+        <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{$statusCode} {$title}</title>
+        <style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#111827;color:#F3F4F6}
+        .box{text-align:center;max-width:420px;padding:2rem}.code{font-size:4rem;font-weight:700;color:#F59E0B;margin:0}.msg{color:#9CA3AF;margin:1rem 0;line-height:1.6}
+        a{color:#F59E0B;text-decoration:none}a:hover{text-decoration:underline}</style></head>
+        <body><div class="box"><p class="code">{$statusCode}</p><h1>{$title}</h1><p class="msg">{$detail}</p>{$loginLink}</div></body></html>
+        HTML;
+
+        return new Response($html, $statusCode, ['Content-Type' => 'text/html; charset=UTF-8']);
     }
 }

--- a/packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php
+++ b/packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php
@@ -174,4 +174,89 @@ final class AuthorizationMiddlewareTest extends TestCase
         $this->assertSame(403, $response->getStatusCode());
         $this->assertStringContainsString('No authenticated account', $response->getContent());
     }
+
+    #[Test]
+    public function render_route_401_redirects_to_login(): void
+    {
+        $route = new Route('/dashboard');
+        $route->setOption('_authenticated', true);
+        $route->setOption('_render', true);
+
+        $account = new AnonymousUser();
+        $accessChecker = new AccessChecker();
+        $middleware = new AuthorizationMiddleware($accessChecker);
+
+        $request = Request::create('/dashboard');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_route_object', $route);
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('should not reach here');
+            }
+        };
+
+        $response = $middleware->process($request, $next);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login?redirect=%2Fdashboard', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function render_route_403_returns_html_error_page(): void
+    {
+        $route = new Route('/admin/settings');
+        $route->setOption('_permission', 'administer site');
+        $route->setOption('_render', true);
+
+        $account = new AnonymousUser();
+        $accessChecker = new AccessChecker();
+        $middleware = new AuthorizationMiddleware($accessChecker);
+
+        $request = Request::create('/admin/settings');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_route_object', $route);
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('should not reach here');
+            }
+        };
+
+        $response = $middleware->process($request, $next);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('text/html', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('Forbidden', $response->getContent());
+        $this->assertStringContainsString('Sign in', $response->getContent());
+    }
+
+    #[Test]
+    public function api_route_403_still_returns_json(): void
+    {
+        $route = new Route('/api/admin');
+        $route->setOption('_permission', 'administer site');
+
+        $account = new AnonymousUser();
+        $accessChecker = new AccessChecker();
+        $middleware = new AuthorizationMiddleware($accessChecker);
+
+        $request = Request::create('/api/admin');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_route_object', $route);
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('should not reach here');
+            }
+        };
+
+        $response = $middleware->process($request, $next);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('application/vnd.api+json', $response->headers->get('Content-Type'));
+    }
 }

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -58,6 +58,7 @@ use Waaseyaa\Mcp\McpController;
 use Waaseyaa\Relationship\RelationshipDiscoveryService;
 use Waaseyaa\Relationship\RelationshipTraversalService;
 use Waaseyaa\User\Middleware\BearerAuthMiddleware;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
 use Waaseyaa\User\DevAdminAccount;
 use Waaseyaa\User\Middleware\SessionMiddleware;
 use Waaseyaa\Workflows\EditorialVisibilityResolver;
@@ -155,6 +156,7 @@ final class HttpKernel extends AbstractKernel
                 $userStorage,
                 $this->shouldUseDevFallbackAccount() ? new DevAdminAccount() : null,
             ))
+            ->withMiddleware(new CsrfMiddleware())
             ->withMiddleware(new AuthorizationMiddleware($accessChecker));
 
         try {
@@ -1260,6 +1262,20 @@ final class HttpKernel extends AbstractKernel
 
         $instance = $this->resolveControllerInstance($class, $twig, $account, $httpRequest);
         $response = $instance->{$method}($params, $query, $account, $httpRequest);
+
+        if (!$response instanceof HttpResponse) {
+            $route = $httpRequest->attributes->get('_route_object');
+            $isRenderRoute = $route instanceof \Symfony\Component\Routing\Route
+                && $route->getOption('_render') === true;
+            if (!$isRenderRoute) {
+                error_log(sprintf(
+                    '[Waaseyaa] Controller %s::%s returned SsrResponse on a non-render route. '
+                    . 'Add ->render() to the RouteBuilder chain to fix SSR dispatch.',
+                    $class,
+                    $method,
+                ));
+            }
+        }
 
         if ($response instanceof HttpResponse) {
             $cacheMaxAge = $this->resolveRenderCacheMaxAge();

--- a/packages/ssr/src/ThemeServiceProvider.php
+++ b/packages/ssr/src/ThemeServiceProvider.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\SSR;
 use Twig\Environment;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
 final class ThemeServiceProvider extends ServiceProvider
@@ -44,11 +45,21 @@ final class ThemeServiceProvider extends ServiceProvider
 
         $loader = self::createTemplateChainLoader($projectRoot, $activeTheme);
 
-        return new Environment($loader, [
+        $env = new Environment($loader, [
             'cache' => false,
             'auto_reload' => true,
             'strict_variables' => false,
         ]);
+
+        if (class_exists(\Waaseyaa\User\Middleware\CsrfMiddleware::class)) {
+            $env->addFunction(new TwigFunction(
+                'csrf_token',
+                [\Waaseyaa\User\Middleware\CsrfMiddleware::class, 'token'],
+                ['is_safe' => ['html']],
+            ));
+        }
+
+        return $env;
     }
 
     public static function createTemplateChainLoader(string $projectRoot, string $activeTheme = ''): ChainLoader

--- a/packages/ssr/templates/home.html.twig
+++ b/packages/ssr/templates/home.html.twig
@@ -147,6 +147,21 @@
       line-height: 1.5;
     }
 
+    .card-hint {
+      font-size: 0.75rem;
+      color: #6B7280;
+      margin-top: 8px;
+      line-height: 1.4;
+    }
+
+    .card-hint code {
+      background: rgba(245, 158, 11, 0.1);
+      color: #F59E0B;
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 0.7rem;
+    }
+
     .card-arrow {
       display: inline-block;
       margin-top: 16px;
@@ -355,12 +370,14 @@
           <div class="card-label">Interface</div>
           <h3 class="card-title">Admin SPA</h3>
           <div class="card-desc">Manage content, entities, and configuration through the admin dashboard.</div>
+          <div class="card-hint">Requires <code>npm run dev</code> in <code>packages/admin</code></div>
           <span class="card-arrow">/admin &rarr;</span>
         </a>
         <a href="/api" class="card">
           <div class="card-label">Endpoint</div>
           <h3 class="card-title">API</h3>
           <div class="card-desc">Explore the JSON:API endpoints for your entity types and resources.</div>
+          <div class="card-hint">Try <code>/api/{type}</code> — e.g. <code>/api/node</code>, <code>/api/user</code></div>
           <span class="card-arrow">/api &rarr;</span>
         </a>
         <a href="https://github.com/waaseyaa/framework" target="_blank" rel="noopener noreferrer" class="card">

--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Middleware;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+
+final class CsrfMiddleware implements HttpMiddlewareInterface
+{
+    private const TOKEN_SESSION_KEY = '_csrf_token';
+    private const TOKEN_FIELD_NAME = '_csrf_token';
+    private const TOKEN_HEADER_NAME = 'X-CSRF-Token';
+    private const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+    {
+        $this->ensureToken();
+
+        if (!$this->requiresValidation($request)) {
+            return $next->handle($request);
+        }
+
+        $submittedToken = $request->request->get(self::TOKEN_FIELD_NAME)
+            ?? $request->headers->get(self::TOKEN_HEADER_NAME);
+
+        if (!is_string($submittedToken) || !hash_equals($this->getToken(), $submittedToken)) {
+            $route = $request->attributes->get('_route_object');
+            $isRenderRoute = $route instanceof Route && $route->getOption('_render') === true;
+
+            if ($isRenderRoute) {
+                return new Response(
+                    $this->renderHtmlError(),
+                    403,
+                    ['Content-Type' => 'text/html; charset=UTF-8'],
+                );
+            }
+
+            return new JsonResponse([
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [[
+                    'status' => '403',
+                    'title' => 'Forbidden',
+                    'detail' => 'CSRF token validation failed.',
+                ]],
+            ], 403, ['Content-Type' => 'application/vnd.api+json']);
+        }
+
+        return $next->handle($request);
+    }
+
+    /**
+     * Get the current CSRF token for use in templates.
+     */
+    public static function token(): string
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION[self::TOKEN_SESSION_KEY])) {
+            $_SESSION[self::TOKEN_SESSION_KEY] = bin2hex(random_bytes(32));
+        }
+
+        return $_SESSION[self::TOKEN_SESSION_KEY];
+    }
+
+    /**
+     * Regenerate the CSRF token (call on login/logout).
+     */
+    public static function regenerate(): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            return;
+        }
+
+        $_SESSION[self::TOKEN_SESSION_KEY] = bin2hex(random_bytes(32));
+    }
+
+    private function ensureToken(): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            return;
+        }
+
+        if (!isset($_SESSION[self::TOKEN_SESSION_KEY])) {
+            $_SESSION[self::TOKEN_SESSION_KEY] = bin2hex(random_bytes(32));
+        }
+    }
+
+    private function getToken(): string
+    {
+        return $_SESSION[self::TOKEN_SESSION_KEY] ?? '';
+    }
+
+    private function requiresValidation(Request $request): bool
+    {
+        if (!in_array($request->getMethod(), self::STATE_CHANGING_METHODS, true)) {
+            return false;
+        }
+
+        $route = $request->attributes->get('_route_object');
+        if ($route instanceof Route && $route->getOption('_csrf') === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function renderHtmlError(): string
+    {
+        return <<<'HTML'
+        <!DOCTYPE html>
+        <html lang="en">
+        <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>403 Forbidden</title>
+        <style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#111827;color:#F3F4F6}
+        .box{text-align:center;max-width:420px;padding:2rem}.code{font-size:4rem;font-weight:700;color:#F59E0B;margin:0}.msg{color:#9CA3AF;margin:1rem 0;line-height:1.6}
+        a{color:#F59E0B;text-decoration:none}a:hover{text-decoration:underline}</style></head>
+        <body><div class="box"><p class="code">403</p><h1>Invalid Security Token</h1>
+        <p class="msg">Your form submission could not be verified. Please go back and try again.</p>
+        <p><a href="javascript:history.back()">Go back</a></p></div></body></html>
+        HTML;
+    }
+}

--- a/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+
+#[CoversClass(CsrfMiddleware::class)]
+final class CsrfMiddlewareTest extends TestCase
+{
+    private CsrfMiddleware $middleware;
+    private HttpHandlerInterface $passthrough;
+
+    protected function setUp(): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            // Use a mock session for tests.
+            $_SESSION = [];
+        }
+
+        $this->middleware = new CsrfMiddleware();
+
+        $this->passthrough = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('OK', 200);
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    #[Test]
+    public function getRequestsPassThrough(): void
+    {
+        $request = Request::create('/page', 'GET');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithoutTokenReturns403(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/submit', 'POST');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithValidTokenPassesThrough(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['_csrf_token'] = $token;
+
+        $request = Request::create('/submit', 'POST', ['_csrf_token' => $token]);
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithValidHeaderTokenPassesThrough(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['_csrf_token'] = $token;
+
+        $request = Request::create('/submit', 'POST');
+        $request->headers->set('X-CSRF-Token', $token);
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithInvalidTokenReturns403(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/submit', 'POST', ['_csrf_token' => 'wrong-token']);
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function csrfDisabledRouteSkipsValidation(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $route = new Route('/api/endpoint');
+        $route->setOption('_csrf', false);
+
+        $request = Request::create('/api/endpoint', 'POST');
+        $request->attributes->set('_route_object', $route);
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function putAndDeleteRequireToken(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $putRequest = Request::create('/resource/1', 'PUT');
+        $this->assertSame(403, $this->middleware->process($putRequest, $this->passthrough)->getStatusCode());
+
+        $deleteRequest = Request::create('/resource/1', 'DELETE');
+        $this->assertSame(403, $this->middleware->process($deleteRequest, $this->passthrough)->getStatusCode());
+    }
+
+    #[Test]
+    public function renderRouteReturnsHtmlError(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $route = new Route('/form');
+        $route->setOption('_render', true);
+
+        $request = Request::create('/form', 'POST');
+        $request->attributes->set('_route_object', $route);
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('text/html', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('Invalid Security Token', $response->getContent());
+    }
+
+    #[Test]
+    public function apiRouteReturnsJsonError(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/api/submit', 'POST');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('application/vnd.api+json', $response->headers->get('Content-Type'));
+    }
+
+    #[Test]
+    public function tokenStaticMethodReturnsConsistentToken(): void
+    {
+        $_SESSION = [];
+        $token1 = CsrfMiddleware::token();
+        $token2 = CsrfMiddleware::token();
+
+        $this->assertSame($token1, $token2);
+        $this->assertSame(64, strlen($token1)); // 32 bytes = 64 hex chars
+    }
+
+    #[Test]
+    public function regenerateChangesToken(): void
+    {
+        $_SESSION = [];
+        $original = CsrfMiddleware::token();
+        CsrfMiddleware::regenerate();
+        $regenerated = CsrfMiddleware::token();
+
+        $this->assertNotSame($original, $regenerated);
+    }
+}


### PR DESCRIPTION
## Summary
- **#280**: Add contextual hints to welcome page cards — Admin SPA needs `npm run dev`, API needs `/api/{type}` path
- **#281**: Log warning when `SsrResponse` is returned from a route without `.render()` — helps diagnose misrouted SSR controllers
- **#282**: Add `CsrfMiddleware` with per-session tokens, `X-CSRF-Token` header support, route opt-out via `_csrf: false`, and `csrf_token()` Twig function
- **#283**: Make `AuthorizationMiddleware` route-aware — SSR routes get styled HTML error pages and 401→login redirect, API routes keep JSON responses

## Test plan
- [x] 11 new CSRF tests: GET passthrough, POST validation, header token, invalid token, opt-out, render/API error formats, token lifecycle
- [x] 3 new AuthorizationMiddleware tests: SSR 401 redirect, SSR 403 HTML, API 403 JSON
- [x] Full unit suite passes (3435 tests, 7532 assertions)
- [ ] Manual: POST form without `_csrf_token` returns 403
- [ ] Manual: SSR route with wrong role shows styled 403 page
- [ ] Manual: Unauthenticated SSR route redirects to `/login?redirect=`

## Files changed
- `packages/user/src/Middleware/CsrfMiddleware.php` — new
- `packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php` — new
- `packages/access/src/Middleware/AuthorizationMiddleware.php` — SSR-aware error responses
- `packages/access/tests/Unit/Middleware/AuthorizationMiddlewareTest.php` — SSR error tests
- `packages/foundation/src/Kernel/HttpKernel.php` — CSRF pipeline wiring + SsrResponse warning
- `packages/ssr/src/ThemeServiceProvider.php` — `csrf_token()` Twig function
- `packages/ssr/templates/home.html.twig` — contextual hint text + CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)