### PR TITLE
fix(#262-#268): API validation guards and health diagnostic improvements

### DIFF
--- a/packages/api/src/JsonApiController.php
+++ b/packages/api/src/JsonApiController.php
@@ -189,19 +189,45 @@ final class JsonApiController
 
         $attributes = $data['data']['attributes'] ?? [];
 
-        // Auto-generate machine name for config entities if ID is empty.
+        // Validate required fields for content entities.
         $definition = $this->entityTypeManager->getDefinition($entityTypeId);
         $keys = $definition->getKeys();
+
+        // Bundle validation: if bundle key is explicitly provided but empty, reject it.
+        $bundleKey = $keys['bundle'] ?? null;
+        if ($bundleKey !== null && isset($keys['uuid'])
+            && array_key_exists($bundleKey, $attributes) && trim((string) $attributes[$bundleKey]) === '') {
+            return $this->errorDocument(
+                JsonApiError::unprocessable(
+                    "The '{$bundleKey}' attribute cannot be empty for {$entityTypeId} entities.",
+                ),
+            );
+        }
+
+        // Label validation: if entity type has a label key, require non-empty value.
+        $labelKey = $keys['label'] ?? null;
+        if ($labelKey !== null && array_key_exists($labelKey, $attributes)) {
+            $labelValue = trim((string) ($attributes[$labelKey] ?? ''));
+            if ($labelValue === '') {
+                return $this->errorDocument(
+                    JsonApiError::unprocessable(
+                        "The '{$labelKey}' field cannot be empty.",
+                    ),
+                );
+            }
+        }
+
+        // Auto-generate machine name for config entities if ID is empty.
         if (!isset($keys['uuid'])) {
             $idKey = $keys['id'] ?? 'id';
-            $labelKey = $keys['label'] ?? 'label';
+            $configLabelKey = $keys['label'] ?? 'label';
             if ((!isset($attributes[$idKey]) || $attributes[$idKey] === '')
-                && isset($attributes[$labelKey]) && $attributes[$labelKey] !== '') {
-                $machineName = self::toMachineName((string) $attributes[$labelKey]);
+                && isset($attributes[$configLabelKey]) && $attributes[$configLabelKey] !== '') {
+                $machineName = self::toMachineName((string) $attributes[$configLabelKey]);
                 if ($machineName === '') {
                     return $this->errorDocument(
                         JsonApiError::unprocessable(
-                            "Cannot generate a machine name from label '{$attributes[$labelKey]}'. "
+                            "Cannot generate a machine name from label '{$attributes[$configLabelKey]}'. "
                             . 'Provide an explicit ID or use a label with alphanumeric characters.',
                         ),
                     );
@@ -239,7 +265,21 @@ final class JsonApiController
             }
         }
 
-        $storage->save($entity);
+        try {
+            $storage->save($entity);
+        } catch (\PDOException $e) {
+            if (str_contains($e->getMessage(), 'UNIQUE constraint failed')
+                || str_starts_with($e->getCode(), '23')) {
+                return $this->errorDocument(
+                    new JsonApiError(
+                        '409',
+                        'Conflict',
+                        sprintf("An entity of type '%s' with this ID already exists.", $entityTypeId),
+                    ),
+                );
+            }
+            throw $e;
+        }
 
         $resource = $this->serializer->serialize($entity, $this->accessHandler, $this->account);
 

--- a/packages/api/tests/Unit/JsonApiControllerTest.php
+++ b/packages/api/tests/Unit/JsonApiControllerTest.php
@@ -201,6 +201,38 @@ final class JsonApiControllerTest extends TestCase
         $this->assertSame('404', $array['errors'][0]['status']);
     }
 
+    #[Test]
+    public function storeRejectsEmptyBundleType(): void
+    {
+        $doc = $this->controller->store('article', [
+            'data' => [
+                'type' => 'article',
+                'attributes' => ['title' => 'No Bundle', 'type' => ''],
+            ],
+        ]);
+
+        $array = $doc->toArray();
+        $this->assertArrayHasKey('errors', $array);
+        $this->assertSame('422', $array['errors'][0]['status']);
+        $this->assertStringContainsString('type', $array['errors'][0]['detail']);
+    }
+
+    #[Test]
+    public function storeRejectsEmptyLabel(): void
+    {
+        $doc = $this->controller->store('article', [
+            'data' => [
+                'type' => 'article',
+                'attributes' => ['title' => '', 'type' => 'blog_post'],
+            ],
+        ]);
+
+        $array = $doc->toArray();
+        $this->assertArrayHasKey('errors', $array);
+        $this->assertSame('422', $array['errors'][0]['status']);
+        $this->assertStringContainsString('title', $array['errors'][0]['detail']);
+    }
+
     // --- Update (PATCH) ---
 
     #[Test]

--- a/packages/cli/src/Command/HealthReportCommand.php
+++ b/packages/cli/src/Command/HealthReportCommand.php
@@ -40,6 +40,12 @@ final class HealthReportCommand extends Command
         $healthResults = $this->checker->runAll();
         $ingestionSummary = $this->gatherIngestionSummary();
 
+        $outputFile = $input->getOption('output');
+        if ($outputFile !== null && !$input->getOption('json')) {
+            $output->writeln('<error>The --output option requires --json. Use: health:report --json --output report.json</error>');
+            return self::FAILURE;
+        }
+
         if ($input->getOption('json')) {
             $report = [
                 'generated_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
@@ -53,7 +59,6 @@ final class HealthReportCommand extends Command
 
             $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
 
-            $outputFile = $input->getOption('output');
             if ($outputFile !== null) {
                 file_put_contents($outputFile, $json . "\n");
                 $output->writeln(sprintf('<info>Report written to %s</info>', $outputFile));
@@ -135,7 +140,13 @@ final class HealthReportCommand extends Command
     private function gatherIngestionSummary(): array
     {
         $logger = new IngestionLogger($this->projectRoot);
-        $entries = $logger->read();
+
+        try {
+            $entries = $logger->read();
+        } catch (\Throwable $e) {
+            error_log(sprintf('[Waaseyaa] Failed to read ingestion log: %s', $e->getMessage()));
+            return [];
+        }
 
         if ($entries === []) {
             return [];

--- a/packages/cli/tests/Unit/Command/HealthReportCommandTest.php
+++ b/packages/cli/tests/Unit/Command/HealthReportCommandTest.php
@@ -86,6 +86,24 @@ final class HealthReportCommandTest extends TestCase
         $this->assertArrayHasKey('system', $decoded);
     }
 
+    #[Test]
+    public function outputWithoutJsonReturnsFailure(): void
+    {
+        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker->method('runAll')->willReturn([
+            HealthCheckResult::pass('Database', 'OK'),
+        ]);
+
+        $outputFile = $this->projectRoot . '/report.json';
+
+        $tester = $this->createTester($checker);
+        $tester->execute(['--output' => $outputFile]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('--json', $tester->getDisplay());
+        $this->assertFileDoesNotExist($outputFile);
+    }
+
     private function createTester(HealthCheckerInterface $checker): CommandTester
     {
         $app = new Application();

--- a/packages/foundation/src/Diagnostic/HealthCheckResult.php
+++ b/packages/foundation/src/Diagnostic/HealthCheckResult.php
@@ -67,8 +67,9 @@ final class HealthCheckResult
             $result['remediation'] = $this->remediation;
         }
 
-        if ($this->context !== []) {
-            $result['context'] = $this->context;
+        $filteredContext = array_filter($this->context, static fn(mixed $v): bool => $v !== null);
+        if ($filteredContext !== []) {
+            $result['context'] = $filteredContext;
         }
 
         return $result;

--- a/packages/foundation/src/Diagnostic/HealthChecker.php
+++ b/packages/foundation/src/Diagnostic/HealthChecker.php
@@ -178,6 +178,7 @@ final class HealthChecker implements HealthCheckerInterface
 
             if (!$schema->tableExists($tableName)) {
                 // Table doesn't exist yet (lazy creation) — not drift, just uninitialized.
+                error_log(sprintf('[Waaseyaa] Schema drift: skipping %s — table %s does not exist (lazy creation)', $id, $tableName));
                 continue;
             }
 

--- a/packages/foundation/tests/Unit/Diagnostic/HealthCheckResultTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/HealthCheckResultTest.php
@@ -87,4 +87,35 @@ final class HealthCheckResultTest extends TestCase
         $this->assertArrayNotHasKey('remediation', $arr);
         $this->assertArrayNotHasKey('context', $arr);
     }
+
+    #[Test]
+    public function toArrayFiltersAllNullContextValues(): void
+    {
+        $result = HealthCheckResult::fail(
+            'Test',
+            DiagnosticCode::DATABASE_SCHEMA_DRIFT,
+            'Drift detected.',
+            ['table' => null, 'drift' => null],
+        );
+
+        $arr = $result->toArray();
+
+        $this->assertArrayNotHasKey('context', $arr);
+    }
+
+    #[Test]
+    public function toArrayKeepsNonNullContextValues(): void
+    {
+        $result = HealthCheckResult::fail(
+            'Test',
+            DiagnosticCode::DATABASE_SCHEMA_DRIFT,
+            'Drift detected.',
+            ['table' => 'node', 'drift' => null],
+        );
+
+        $arr = $result->toArray();
+
+        $this->assertArrayHasKey('context', $arr);
+        $this->assertSame(['table' => 'node'], $arr['context']);
+    }
 }


### PR DESCRIPTION
## Summary
- **#266**: Catch `PDOException` (SQLSTATE 23000) on duplicate config entity creation, return 409 Conflict instead of 500
- **#267**: Reject empty bundle type on content entities (uuid + bundle keys) with 422
- **#268**: Reject empty label values with 422 when label key is present in attributes
- **#262**: Log skipped tables during schema drift check (`error_log` when table doesn't exist)
- **#263**: Wrap `IngestionLogger::read()` in try-catch to guard against read failures
- **#264**: Filter null values from `HealthCheckResult::toArray()` context before emptiness check
- **#265**: `--output` without `--json` now returns FAILURE with clear error message

## Test plan
- [x] 2 new JsonApiController tests: empty bundle rejection, empty label rejection
- [x] 1 new HealthReportCommand test: `--output` without `--json` returns failure
- [x] 2 new HealthCheckResult tests: all-null context filtered, mixed context preserved
- [x] Full unit suite passes (3440 tests, 7544 assertions)
- [ ] Manual: POST duplicate config entity returns 409

## Design note
Bundle validation only applies to content entities (those with both `uuid` and `bundle` keys). Config entities and test fixtures without `uuid` are unaffected. The validation triggers only when the bundle key is *explicitly provided as empty string* — omitting it entirely is allowed (falls back to entity type ID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)