### PR TITLE
fix(#286): replace $isAppController heuristic with _json_api route option

### DIFF
--- a/packages/api/src/JsonApiRouteProvider.php
+++ b/packages/api/src/JsonApiRouteProvider.php
@@ -72,6 +72,7 @@ final class JsonApiRouteProvider
                 ->controller("Waaseyaa\\Api\\JsonApiController::store")
                 ->methods('POST')
                 ->requireAuthentication()
+                ->jsonApi()
                 ->default('_entity_type', $entityTypeId)
                 ->build(),
         );
@@ -83,6 +84,7 @@ final class JsonApiRouteProvider
                 ->controller("Waaseyaa\\Api\\JsonApiController::update")
                 ->methods('PATCH')
                 ->requireAuthentication()
+                ->jsonApi()
                 ->default('_entity_type', $entityTypeId)
                 ->build(),
         );

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -390,6 +390,7 @@ final class HttpKernel extends AbstractKernel
             RouteBuilder::create('/mcp')
                 ->controller('mcp.endpoint')
                 ->allowAll()
+                ->jsonApi()
                 ->methods('GET', 'POST')
                 ->build(),
         );
@@ -463,13 +464,13 @@ final class HttpKernel extends AbstractKernel
         $serializer = new ResourceSerializer($this->entityTypeManager);
         $schemaPresenter = new SchemaPresenter();
 
-        // JSON body parsing only applies to JSON API controllers.
-        // SSR app controllers (identified by '::' in the controller name) receive
-        // form-encoded POST data via $httpRequest->request and must not be subjected
-        // to JSON parsing, which would reject application/x-www-form-urlencoded bodies.
+        // JSON body parsing only applies to routes explicitly marked as JSON:API
+        // via the _json_api route option. SSR and form-based routes receive
+        // form-encoded POST data and must not be subjected to JSON parsing.
         $body = null;
-        $isAppController = str_contains($controller, '::') || $controller === 'render.page';
-        if (!$isAppController && in_array($method, ['POST', 'PATCH'], true)) {
+        $matchedRoute = $httpRequest->attributes->get('_route_object');
+        $isJsonApi = $matchedRoute !== null && $matchedRoute->getOption('_json_api') === true;
+        if ($isJsonApi && in_array($method, ['POST', 'PATCH'], true)) {
             $raw = $httpRequest->getContent();
             if ($raw !== '') {
                 try {

--- a/packages/routing/src/RouteBuilder.php
+++ b/packages/routing/src/RouteBuilder.php
@@ -127,6 +127,15 @@ final class RouteBuilder
     }
 
     /**
+     * Mark route as a JSON:API route (enables JSON body parsing on POST/PATCH).
+     */
+    public function jsonApi(): self
+    {
+        $this->options['_json_api'] = true;
+        return $this;
+    }
+
+    /**
      * Add a regex requirement for a route parameter.
      */
     public function requirement(string $key, string $regex): self


### PR DESCRIPTION
## Summary
- Adds `RouteBuilder::jsonApi()` method to explicitly tag routes that accept JSON:API request bodies
- Tags POST/PATCH routes in `JsonApiRouteProvider` and the `mcp.endpoint` route with `->jsonApi()`
- Replaces the brittle `$isAppController` heuristic in `HttpKernel::dispatch()` with a check for the `_json_api` route option

Closes #286

## Test plan
- [x] All 3910 tests pass
- [x] JSON body parsing only triggers on routes with `_json_api: true`
- [x] SSR/form routes unaffected (no `_json_api` option = no JSON parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)