### PR TITLE
chore(#297,#298): PHP 8.4 bump, CS-Fixer, PHPStan, and coverage CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,70 @@ jobs:
       - name: Validate ingestion schema metadata and compatibility rules
         run: bash bin/check-ingestion-defaults
 
+  style:
+    name: Code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: php-cs-fixer
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: PHP-CS-Fixer (dry-run)
+        run: vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff
+
+  phpstan:
+    name: PHPStan (reporting)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=2G --error-format=table
+
+  coverage:
+    name: Code coverage (reporting)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_sqlite, sqlite3, mbstring, xml
+          coverage: xdebug
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests with coverage
+        run: ./vendor/bin/phpunit --testsuite Unit --coverage-text --coverage-clover=coverage.xml
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
   security-defaults:
     name: Security defaults
     runs-on: ubuntu-latest

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
+    ->in([
+        __DIR__ . '/packages/*/src',
+        __DIR__ . '/packages/*/tests',
+        __DIR__ . '/tests',
+    ])
+    ->exclude('vendor')
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        '@PHP84Migration' => true,
+        'strict_param' => true,
+        'declare_strict_types' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'single_quote' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
+        'no_whitespace_in_blank_line' => true,
+        'blank_line_before_statement' => ['statements' => ['return', 'throw', 'try']],
+        'cast_spaces' => ['space' => 'single'],
+        'concat_space' => ['spacing' => 'one'],
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'single_line_empty_body' => true,
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         { "type": "path", "url": "packages/full" }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/access": "@dev",
         "waaseyaa/ai-agent": "@dev",
         "waaseyaa/ai-pipeline": "@dev",

--- a/packages/access/composer.json
+++ b/packages/access/composer.json
@@ -13,7 +13,7 @@
         {"type": "path", "url": "../routing"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/plugin": "@dev",
         "waaseyaa/foundation": "@dev",

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -12,7 +12,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/ai-schema": "@dev",
         "waaseyaa/access": "@dev"
     },

--- a/packages/ai-pipeline/composer.json
+++ b/packages/ai-pipeline/composer.json
@@ -13,7 +13,7 @@
         {"type": "path", "url": "../ai-vector"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/queue": "@dev",
         "waaseyaa/ai-vector": "@dev"

--- a/packages/ai-schema/composer.json
+++ b/packages/ai-schema/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev"
     },
     "require-dev": {

--- a/packages/ai-vector/composer.json
+++ b/packages/ai-vector/composer.json
@@ -15,7 +15,7 @@
         {"type": "path", "url": "../workflows"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/queue": "@dev",
         "waaseyaa/api": "@dev",

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -14,7 +14,7 @@
         {"type": "path", "url": "../foundation"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/foundation": "@dev",
         "waaseyaa/routing": "@dev",

--- a/packages/cache/composer.json
+++ b/packages/cache/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "psr/cache": "^3.0",
         "psr/simple-cache": "^3.0"
     },

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -14,7 +14,7 @@
         {"type": "path", "url": "../routing"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/config": "@dev",
         "waaseyaa/cache": "@dev",

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "symfony/event-dispatcher": "^7.0",
         "symfony/yaml": "^7.0"
     },

--- a/packages/database-legacy/composer.json
+++ b/packages/database-legacy/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/entity-storage/composer.json
+++ b/packages/entity-storage/composer.json
@@ -13,7 +13,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/field": "@dev",
         "waaseyaa/cache": "@dev",

--- a/packages/entity/composer.json
+++ b/packages/entity/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../foundation"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/typed-data": "@dev",
         "waaseyaa/plugin": "@dev",
         "waaseyaa/cache": "@dev",

--- a/packages/field/composer.json
+++ b/packages/field/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/plugin": "@dev",
         "waaseyaa/typed-data": "@dev"

--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "doctrine/dbal": "^4.0",
         "symfony/dependency-injection": "^7.0",
         "symfony/event-dispatcher": "^7.0",

--- a/packages/graphql/composer.json
+++ b/packages/graphql/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "^0.1",
         "waaseyaa/field": "^0.1",
         "waaseyaa/access": "^0.1"

--- a/packages/i18n/composer.json
+++ b/packages/i18n/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -21,7 +21,7 @@
         {"type": "path", "url": "../workflows"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/ai-schema": "@dev",
         "waaseyaa/ai-agent": "@dev",
         "waaseyaa/routing": "@dev",

--- a/packages/media/composer.json
+++ b/packages/media/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev"
     },
     "require-dev": {

--- a/packages/menu/composer.json
+++ b/packages/menu/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev"
     },
     "require-dev": {

--- a/packages/node/composer.json
+++ b/packages/node/composer.json
@@ -14,7 +14,7 @@
         {"type": "path", "url": "../field"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/access": "@dev"
     },

--- a/packages/note/composer.json
+++ b/packages/note/composer.json
@@ -8,7 +8,7 @@
         {"type": "path", "url": "../access"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/access": "@dev"
     },

--- a/packages/path/composer.json
+++ b/packages/path/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev"
     },
     "require-dev": {

--- a/packages/plugin/composer.json
+++ b/packages/plugin/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/cache": "*"
     },
     "require-dev": {

--- a/packages/queue/composer.json
+++ b/packages/queue/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "symfony/messenger": "^7.3"
     },
     "require-dev": {

--- a/packages/relationship/composer.json
+++ b/packages/relationship/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/access": "@dev",
         "waaseyaa/database-legacy": "@dev",
         "waaseyaa/entity": "@dev",

--- a/packages/routing/composer.json
+++ b/packages/routing/composer.json
@@ -13,7 +13,7 @@
         {"type": "path", "url": "../i18n"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/access": "@dev",
         "waaseyaa/i18n": "@dev",

--- a/packages/search/composer.json
+++ b/packages/search/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/packages/ssr/composer.json
+++ b/packages/ssr/composer.json
@@ -14,7 +14,7 @@
         {"type": "path", "url": "../access"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/cache": "@dev",
         "waaseyaa/entity": "@dev",
         "waaseyaa/field": "@dev",

--- a/packages/state/composer.json
+++ b/packages/state/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/database-legacy": "@dev"
     },
     "require-dev": {

--- a/packages/taxonomy/composer.json
+++ b/packages/taxonomy/composer.json
@@ -12,7 +12,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/access": "@dev"
     },

--- a/packages/telescope/composer.json
+++ b/packages/telescope/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/testing/composer.json
+++ b/packages/testing/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {

--- a/packages/typed-data/composer.json
+++ b/packages/typed-data/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "symfony/validator": "^7.3"
     },
     "require-dev": {

--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -15,7 +15,7 @@
         {"type": "path", "url": "../queue"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/entity": "@dev",
         "waaseyaa/access": "@dev",
         "waaseyaa/foundation": "@dev",

--- a/packages/validation/composer.json
+++ b/packages/validation/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/typed-data": "@dev",
         "waaseyaa/entity": "@dev",
         "symfony/validator": "^7.3"

--- a/packages/workflows/composer.json
+++ b/packages/workflows/composer.json
@@ -11,7 +11,7 @@
         {"type": "path", "url": "../config"}
     ],
     "require": {
-        "php": ">=8.3",
+        "php": "^8.4",
         "waaseyaa/access": "@dev",
         "waaseyaa/entity": "@dev"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,41 @@
+parameters:
+    level: 5
+    paths:
+        - packages/foundation/src
+        - packages/cache/src
+        - packages/plugin/src
+        - packages/typed-data/src
+        - packages/database-legacy/src
+        - packages/testing/src
+        - packages/i18n/src
+        - packages/queue/src
+        - packages/state/src
+        - packages/validation/src
+        - packages/entity/src
+        - packages/entity-storage/src
+        - packages/field/src
+        - packages/config/src
+        - packages/access/src
+        - packages/user/src
+        - packages/node/src
+        - packages/taxonomy/src
+        - packages/media/src
+        - packages/menu/src
+        - packages/path/src
+        - packages/note/src
+        - packages/relationship/src
+        - packages/workflows/src
+        - packages/search/src
+        - packages/api/src
+        - packages/routing/src
+        - packages/ai-schema/src
+        - packages/ai-agent/src
+        - packages/ai-pipeline/src
+        - packages/ai-vector/src
+        - packages/cli/src
+        - packages/mcp/src
+        - packages/ssr/src
+        - packages/telescope/src
+    excludePaths:
+        - packages/*/vendor/*
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
## Summary

- Bump PHP version constraint from `>=8.3` to `^8.4` across root and all 36 package `composer.json` files
- Add `.php-cs-fixer.dist.php` with PSR-12 base + PHP 8.4 migration rules
- Add `phpstan.neon` at level 5 covering all 35 package `src/` directories
- Add three new CI jobs: **style** (CS-Fixer dry-run), **phpstan** (reporting mode), **coverage** (unit tests with xdebug + artifact upload)
- PHPStan and coverage jobs use `continue-on-error: true` to avoid blocking the pipeline until refactors land

## Commits

1. `chore(infra): require php ^8.4 in all composer.json files` — 37 files changed
2. `style: add PHP-CS-Fixer config with PSR-12 and PHP 8.4 rules` — config only
3. `ci: add PHPStan config, code coverage, and style jobs` — phpstan.neon + ci.yml

## Test plan

- [ ] CI lint job passes on PHP 8.4 (already using 8.4 images)
- [ ] PHPUnit unit + integration tests pass with `^8.4` constraint
- [ ] PHP-CS-Fixer dry-run reports violations (expected — formatting PR follows)
- [ ] PHPStan runs and reports errors without failing pipeline
- [ ] Coverage job produces `coverage.xml` artifact

## References

- #297 — HttpKernel decomposition (P0)
- #298 — McpController decomposition (P0)
- `docs/plans/v2-package-map.md` §5 (P2-29, P2-30, P2-31, P3-32)
- `docs/plans/v2-repo-audit-report.md` §7

🤖 Generated with [Claude Code](https://claude.com/claude-code)