### PR TITLE
feat(#309): add base SSR layout template

### DIFF
--- a/packages/ssr/templates/404.html.twig
+++ b/packages/ssr/templates/404.html.twig
@@ -1,13 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>404 Not Found</title>
-</head>
-<body>
-  <main>
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}404 Not Found{% endblock %}
+
+{% block body %}
     <h1>Not Found</h1>
     <p>{{ path }}</p>
-  </main>
-</body>
-</html>
+{% endblock %}

--- a/packages/ssr/templates/layouts/base.html.twig
+++ b/packages/ssr/templates/layouts/base.html.twig
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="{{ lang|default('en') }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{% endblock %}</title>
+  {% block meta %}{% endblock %}
+  {% block styles %}{% endblock %}
+</head>
+<body>
+  <header>
+    {% block header %}{% endblock %}
+  </header>
+
+  <main>
+    {% block body %}{% endblock %}
+  </main>
+
+  <footer>
+    {% block footer %}{% endblock %}
+  </footer>
+
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/packages/ssr/templates/page.html.twig
+++ b/packages/ssr/templates/page.html.twig
@@ -1,14 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ title }}</title>
-</head>
-<body>
-  <main>
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block body %}
     <h1>{{ title }}</h1>
     <p>{{ path }}</p>
-  </main>
-</body>
-</html>
+{% endblock %}

--- a/packages/ssr/tests/Unit/Layout/BaseLayoutTest.php
+++ b/packages/ssr/tests/Unit/Layout/BaseLayoutTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit\Layout;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Waaseyaa\SSR\Twig\WaaseyaaExtension;
+
+#[CoversNothing]
+final class BaseLayoutTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $templateDir = dirname(__DIR__, 3) . '/templates';
+        if (!is_dir($templateDir)) {
+            $this->markTestSkipped('SSR templates directory not found');
+        }
+
+        $this->twig = new Environment(new FilesystemLoader($templateDir));
+        $this->twig->addExtension(new WaaseyaaExtension(assetBasePath: '/build'));
+    }
+
+    // ---------------------------------------------------------------
+    // Base layout structure
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function base_layout_renders_valid_html_document(): void
+    {
+        $html = $this->twig->render('layouts/base.html.twig');
+
+        $this->assertStringContainsString('<!doctype html>', $html);
+        $this->assertStringContainsString('<html', $html);
+        $this->assertStringContainsString('</html>', $html);
+        $this->assertStringContainsString('<head>', $html);
+        $this->assertStringContainsString('</head>', $html);
+        $this->assertStringContainsString('<body>', $html);
+        $this->assertStringContainsString('</body>', $html);
+    }
+
+    #[Test]
+    public function base_layout_contains_header_and_footer_placeholders(): void
+    {
+        $html = $this->twig->render('layouts/base.html.twig');
+
+        $this->assertStringContainsString('<header>', $html);
+        $this->assertStringContainsString('</header>', $html);
+        $this->assertStringContainsString('<footer>', $html);
+        $this->assertStringContainsString('</footer>', $html);
+    }
+
+    #[Test]
+    public function base_layout_includes_viewport_meta(): void
+    {
+        $html = $this->twig->render('layouts/base.html.twig');
+
+        $this->assertStringContainsString('name="viewport"', $html);
+        $this->assertStringContainsString('charset="utf-8"', $html);
+    }
+
+    #[Test]
+    public function base_layout_accepts_lang_attribute(): void
+    {
+        $html = $this->twig->render('layouts/base.html.twig', ['lang' => 'fr']);
+
+        $this->assertStringContainsString('lang="fr"', $html);
+    }
+
+    #[Test]
+    public function base_layout_defaults_to_english(): void
+    {
+        $html = $this->twig->render('layouts/base.html.twig');
+
+        $this->assertStringContainsString('lang="en"', $html);
+    }
+
+    // ---------------------------------------------------------------
+    // Block overrides
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function child_template_can_override_title_block(): void
+    {
+        $this->twig->getLoader()->addPath($this->fixtureDir());
+        $html = $this->twig->render('child_title.html.twig');
+
+        $this->assertStringContainsString('<title>Custom Title</title>', $html);
+    }
+
+    #[Test]
+    public function child_template_can_override_body_block(): void
+    {
+        $this->twig->getLoader()->addPath($this->fixtureDir());
+        $html = $this->twig->render('child_body.html.twig');
+
+        $this->assertStringContainsString('<h1>Hello World</h1>', $html);
+        $this->assertStringContainsString('<main>', $html);
+    }
+
+    #[Test]
+    public function child_template_can_add_styles_block(): void
+    {
+        $this->twig->getLoader()->addPath($this->fixtureDir());
+        $html = $this->twig->render('child_styles.html.twig');
+
+        $this->assertStringContainsString('<link rel="stylesheet" href="/build/css/custom.css">', $html);
+    }
+
+    #[Test]
+    public function child_template_can_add_scripts_block(): void
+    {
+        $this->twig->getLoader()->addPath($this->fixtureDir());
+        $html = $this->twig->render('child_scripts.html.twig');
+
+        $this->assertStringContainsString('<script src="/build/js/app.js"></script>', $html);
+    }
+
+    #[Test]
+    public function child_template_can_add_meta_block(): void
+    {
+        $this->twig->getLoader()->addPath($this->fixtureDir());
+        $html = $this->twig->render('child_meta.html.twig');
+
+        $this->assertStringContainsString('<meta name="description" content="A test page">', $html);
+    }
+
+    // ---------------------------------------------------------------
+    // Existing templates extend base
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function page_template_extends_base_layout(): void
+    {
+        $html = $this->twig->render('page.html.twig', [
+            'title' => 'Test Page',
+            'path' => '/test',
+        ]);
+
+        $this->assertStringContainsString('<!doctype html>', $html);
+        $this->assertStringContainsString('<title>Test Page</title>', $html);
+        $this->assertStringContainsString('<h1>Test Page</h1>', $html);
+        $this->assertStringContainsString('<header>', $html);
+        $this->assertStringContainsString('<footer>', $html);
+    }
+
+    #[Test]
+    public function error_404_template_extends_base_layout(): void
+    {
+        $html = $this->twig->render('404.html.twig', ['path' => '/missing']);
+
+        $this->assertStringContainsString('<!doctype html>', $html);
+        $this->assertStringContainsString('<title>404 Not Found</title>', $html);
+        $this->assertStringContainsString('Not Found', $html);
+        $this->assertStringContainsString('<header>', $html);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private function fixtureDir(): string
+    {
+        $dir = dirname(__DIR__, 3) . '/tests/fixtures/layouts';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        return $dir;
+    }
+}

--- a/packages/ssr/tests/fixtures/layouts/child_body.html.twig
+++ b/packages/ssr/tests/fixtures/layouts/child_body.html.twig
@@ -1,0 +1,2 @@
+{% extends "layouts/base.html.twig" %}
+{% block body %}<h1>Hello World</h1>{% endblock %}

--- a/packages/ssr/tests/fixtures/layouts/child_meta.html.twig
+++ b/packages/ssr/tests/fixtures/layouts/child_meta.html.twig
@@ -1,0 +1,2 @@
+{% extends "layouts/base.html.twig" %}
+{% block meta %}<meta name="description" content="A test page">{% endblock %}

--- a/packages/ssr/tests/fixtures/layouts/child_scripts.html.twig
+++ b/packages/ssr/tests/fixtures/layouts/child_scripts.html.twig
@@ -1,0 +1,2 @@
+{% extends "layouts/base.html.twig" %}
+{% block scripts %}<script src="{{ asset('js/app.js') }}"></script>{% endblock %}

--- a/packages/ssr/tests/fixtures/layouts/child_styles.html.twig
+++ b/packages/ssr/tests/fixtures/layouts/child_styles.html.twig
@@ -1,0 +1,2 @@
+{% extends "layouts/base.html.twig" %}
+{% block styles %}<link rel="stylesheet" href="{{ asset('css/custom.css') }}">{% endblock %}

--- a/packages/ssr/tests/fixtures/layouts/child_title.html.twig
+++ b/packages/ssr/tests/fixtures/layouts/child_title.html.twig
@@ -1,0 +1,2 @@
+{% extends "layouts/base.html.twig" %}
+{% block title %}Custom Title{% endblock %}


### PR DESCRIPTION
## Summary

- Add `layouts/base.html.twig` with named blocks: `title`, `meta`, `styles`, `header`, `body`, `footer`, `scripts`
- Update `page.html.twig` and `404.html.twig` to extend the base layout instead of duplicating HTML scaffolding
- All page-level templates now share consistent HTML structure (doctype, charset, viewport, header/footer)
- 5 test fixture templates verify each block can be independently overridden

## Test plan

- [ ] 12 unit tests covering layout structure, block overrides, and existing template migration pass
- [ ] Full test suite (4120 tests, 10,000 assertions) passes with no regressions
- [ ] PHPStan reports no errors
- [ ] Only SSR package files modified — no cross-package changes

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)