### PR TITLE
feat(#310): add SSR InteractsWithRenderer test assertion trait

### DIFF
--- a/packages/ssr/tests/Support/InteractsWithRenderer.php
+++ b/packages/ssr/tests/Support/InteractsWithRenderer.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Support;
+
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\FilesystemLoader;
+
+trait InteractsWithRenderer
+{
+    /**
+     * Render a Twig template string with the given context.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function render(string $template, array $context = []): string
+    {
+        $twig = new Environment(new ArrayLoader(['__inline__' => $template]));
+
+        return $twig->render('__inline__', $context);
+    }
+
+    /**
+     * Render a Twig template file from a directory.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function renderFile(string $templateDir, string $templateName, array $context = []): string
+    {
+        $twig = new Environment(new FilesystemLoader($templateDir));
+
+        return $twig->render($templateName, $context);
+    }
+
+    /**
+     * Assert that rendered template output contains the given string.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function assertRenderContains(string $needle, string $template, array $context = []): void
+    {
+        $html = $this->render($template, $context);
+
+        $this->assertStringContainsString(
+            $needle,
+            $html,
+            "Expected rendered output to contain '{$needle}'.",
+        );
+    }
+
+    /**
+     * Assert that rendered template output matches the given regex pattern.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function assertRenderMatches(string $pattern, string $template, array $context = []): void
+    {
+        $html = $this->render($template, $context);
+
+        $this->assertMatchesRegularExpression(
+            $pattern,
+            $html,
+            "Expected rendered output to match pattern '{$pattern}'.",
+        );
+    }
+}

--- a/packages/ssr/tests/Unit/Support/InteractsWithRendererTest.php
+++ b/packages/ssr/tests/Unit/Support/InteractsWithRendererTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit\Support;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Twig\Error\LoaderError;
+use Waaseyaa\SSR\Tests\Support\InteractsWithRenderer;
+
+#[CoversClass(InteractsWithRenderer::class)]
+final class InteractsWithRendererTest extends TestCase
+{
+    use InteractsWithRenderer;
+
+    // ---------------------------------------------------------------
+    // render()
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function render_returns_rendered_html(): void
+    {
+        $html = $this->render('<p>{{ greeting }}</p>', ['greeting' => 'Hi']);
+
+        $this->assertSame('<p>Hi</p>', $html);
+    }
+
+    #[Test]
+    public function render_works_with_empty_context(): void
+    {
+        $html = $this->render('<p>Static</p>');
+
+        $this->assertSame('<p>Static</p>', $html);
+    }
+
+    #[Test]
+    public function render_supports_twig_filters_and_tags(): void
+    {
+        $html = $this->render('{% if show %}<em>{{ text|upper }}</em>{% endif %}', [
+            'show' => true,
+            'text' => 'hello',
+        ]);
+
+        $this->assertSame('<em>HELLO</em>', $html);
+    }
+
+    #[Test]
+    public function render_throws_on_syntax_error(): void
+    {
+        $this->expectException(\Twig\Error\SyntaxError::class);
+        $this->render('{% if %}broken{% endif %}');
+    }
+
+    // ---------------------------------------------------------------
+    // assertRenderContains()
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function assert_render_contains_passes_when_needle_found(): void
+    {
+        $this->assertRenderContains('Hello', '<p>Hello World</p>');
+    }
+
+    #[Test]
+    public function assert_render_contains_passes_with_context(): void
+    {
+        $this->assertRenderContains('Alice', '<p>{{ name }}</p>', ['name' => 'Alice']);
+    }
+
+    #[Test]
+    public function assert_render_contains_fails_when_needle_missing(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->assertRenderContains('Missing', '<p>Hello</p>');
+    }
+
+    // ---------------------------------------------------------------
+    // assertRenderMatches()
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function assert_render_matches_passes_on_pattern_match(): void
+    {
+        $this->assertRenderMatches('/<h1>.*<\/h1>/', '<h1>Title</h1>');
+    }
+
+    #[Test]
+    public function assert_render_matches_passes_with_context(): void
+    {
+        $this->assertRenderMatches('/Hello \w+/', '<p>Hello {{ name }}</p>', ['name' => 'Bob']);
+    }
+
+    #[Test]
+    public function assert_render_matches_fails_on_no_match(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->assertRenderMatches('/^<div>/', '<p>Not a div</p>');
+    }
+
+    // ---------------------------------------------------------------
+    // Filesystem template support
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function render_file_renders_fixture_template(): void
+    {
+        $fixtureDir = dirname(__DIR__, 2) . '/fixtures';
+        $html = $this->renderFile($fixtureDir, 'greeting.html.twig', ['name' => 'Twig']);
+
+        $this->assertStringContainsString('<h1>Hello Twig</h1>', $html);
+    }
+
+    #[Test]
+    public function render_file_throws_on_missing_template(): void
+    {
+        $this->expectException(LoaderError::class);
+        $this->renderFile(dirname(__DIR__, 2) . '/fixtures', 'nonexistent.html.twig');
+    }
+}

--- a/packages/ssr/tests/fixtures/greeting.html.twig
+++ b/packages/ssr/tests/fixtures/greeting.html.twig
@@ -1,0 +1,1 @@
+<h1>Hello {{ name|default('World') }}</h1>


### PR DESCRIPTION
## Summary

- Add `InteractsWithRenderer` trait to `packages/ssr/tests/Support/` with 4 helpers:
  - `render(template, context)` — render inline Twig template string
  - `renderFile(dir, name, context)` — render filesystem template
  - `assertRenderContains(needle, template, context)` — assert rendered output contains string
  - `assertRenderMatches(pattern, template, context)` — assert rendered output matches regex
- Include `greeting.html.twig` fixture for filesystem template tests
- Trait lives in SSR test namespace — no cross-package coupling

## Test plan

- [ ] 12 unit tests covering all 4 methods + error cases pass
- [ ] Full test suite (4132 tests, 10,014 assertions) passes with no regressions
- [ ] PHPStan reports no errors
- [ ] Only SSR test files modified — no production code changes

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)