### PR TITLE
Fix #317 — Exempt JSON:API from CSRF validation

### DIFF
--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -17,6 +17,7 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
     private const TOKEN_FIELD_NAME = '_csrf_token';
     private const TOKEN_HEADER_NAME = 'X-CSRF-Token';
     private const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+    private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json'];
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
@@ -102,6 +103,15 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
     {
         if (!in_array($request->getMethod(), self::STATE_CHANGING_METHODS, true)) {
             return false;
+        }
+
+        // JSON:API requests are not vulnerable to CSRF (browsers cannot send
+        // application/vnd.api+json from HTML forms), so exempt them.
+        $contentType = $request->headers->get('Content-Type', '');
+        foreach (self::CSRF_EXEMPT_CONTENT_TYPES as $exemptType) {
+            if (str_starts_with($contentType, $exemptType)) {
+                return false;
+            }
         }
 
         $route = $request->attributes->get('_route_object');

--- a/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
@@ -174,4 +174,64 @@ final class CsrfMiddlewareTest extends TestCase
 
         $this->assertNotSame($original, $regenerated);
     }
+
+    #[Test]
+    public function postWithJsonApiContentTypeSkipsCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/api/nodes', 'POST', [], [], [], [], '{"data":{}}');
+        $request->headers->set('Content-Type', 'application/vnd.api+json');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function putWithJsonApiContentTypeSkipsCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/api/nodes/1', 'PUT', [], [], [], [], '{"data":{}}');
+        $request->headers->set('Content-Type', 'application/vnd.api+json');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function deleteWithJsonApiContentTypeSkipsCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/api/nodes/1', 'DELETE');
+        $request->headers->set('Content-Type', 'application/vnd.api+json');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithFormUrlencodedStillRequiresCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/submit', 'POST', ['field' => 'value']);
+        $request->headers->set('Content-Type', 'application/x-www-form-urlencoded');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postWithMultipartFormDataStillRequiresCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/upload', 'POST');
+        $request->headers->set('Content-Type', 'multipart/form-data; boundary=----WebKitFormBoundary');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
## Summary
- Exempted `application/vnd.api+json` requests from CSRF token validation
- JSON:API content type cannot be sent by HTML forms, so CSRF attacks via this content type are not possible
- Admin SPA (Nuxt) can now create, edit, and delete content via JSON:API

## Reproduction before
1. Start backend + admin SPA
2. Create/edit/delete any content → 403 "CSRF token validation failed"

## Behavior after
- JSON:API requests pass through without CSRF token
- Standard form POSTs still require CSRF token (security preserved)

## Test plan
- [x] New tests for JSON:API CSRF exemption (POST, PUT, DELETE)
- [x] Tests confirming form-urlencoded and multipart still require CSRF
- [x] Existing CSRF tests still pass
- [x] Full test suite passes (4137 tests, 10019 assertions)

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>