### PR TITLE
fix(#328): fix SSR homepage admin link pointing to /admin (returns 404)

### DIFF
--- a/packages/ssr/templates/home.html.twig
+++ b/packages/ssr/templates/home.html.twig
@@ -366,12 +366,12 @@
   <section class="links">
     <div class="container">
       <div class="cards">
-        <a href="/admin" class="card">
+        <a href="http://localhost:3000" class="card" target="_blank" rel="noopener noreferrer">
           <div class="card-label">Interface</div>
           <h3 class="card-title">Admin SPA</h3>
           <div class="card-desc">Manage content, entities, and configuration through the admin dashboard.</div>
-          <div class="card-hint">Requires <code>npm run dev</code> in <code>packages/admin</code></div>
-          <span class="card-arrow">/admin &rarr;</span>
+          <div class="card-hint">Runs on a separate dev server — <code>npm run dev</code> in <code>packages/admin</code></div>
+          <span class="card-arrow">localhost:3000 &rarr;</span>
         </a>
         <a href="/api" class="card">
           <div class="card-label">Endpoint</div>

--- a/packages/ssr/tests/Unit/HomepageTemplateTest.php
+++ b/packages/ssr/tests/Unit/HomepageTemplateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Waaseyaa\SSR\Twig\WaaseyaaExtension;
+
+#[CoversNothing]
+final class HomepageTemplateTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $templateDir = dirname(__DIR__, 2) . '/templates';
+        if (!is_dir($templateDir)) {
+            $this->markTestSkipped('SSR templates directory not found');
+        }
+
+        $this->twig = new Environment(new FilesystemLoader($templateDir));
+        $this->twig->addExtension(new WaaseyaaExtension(assetBasePath: '/build'));
+    }
+
+    #[Test]
+    public function homepage_admin_link_does_not_point_to_backend_admin_route(): void
+    {
+        $html = $this->twig->render('home.html.twig');
+
+        $this->assertStringNotContainsString(
+            'href="/admin"',
+            $html,
+            'The /admin route does not exist on the PHP backend. The admin SPA runs on a separate Nuxt dev server.',
+        );
+    }
+
+    #[Test]
+    public function homepage_admin_link_points_to_nuxt_dev_server(): void
+    {
+        $html = $this->twig->render('home.html.twig');
+
+        $this->assertStringContainsString(
+            'localhost:3000',
+            $html,
+            'The admin SPA runs on the Nuxt dev server at localhost:3000.',
+        );
+    }
+}


### PR DESCRIPTION
Closes #328

## Summary

- Update `home.html.twig` admin card link from `/admin` to `http://localhost:3000`
- Add `target="_blank"` and update hint text to clarify the admin SPA runs on a separate dev server
- Add `HomepageTemplateTest` with two assertions guarding against regression

## Checklist

- [x] `Closes #328` above references the issue this PR resolves
- [x] The issue is assigned to a milestone
- [x] PR title includes the issue number