### PR TITLE
fix(#329): add top-level exception handler for boot failures in HttpKernel

### DIFF
--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -51,7 +51,15 @@ final class HttpKernel extends AbstractKernel
 
     public function handle(): never
     {
-        $this->boot();
+        try {
+            $this->boot();
+        } catch (\Throwable $e) {
+            error_log(sprintf('[Waaseyaa] Boot failed: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+            ResponseSender::json(500, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Application failed to boot.']],
+            ]);
+        }
         $this->cacheConfigResolver = new CacheConfigResolver($this->config);
 
         $this->handleCors();

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+/**
+ * Verifies that HttpKernel handles boot() failures gracefully.
+ *
+ * The handle() method returns `never` (exits) so it cannot be called directly
+ * in unit tests. These tests verify the precondition (boot can throw) and the
+ * structural guards added to handle().
+ */
+#[CoversClass(HttpKernel::class)]
+final class HttpKernelBootFailureTest extends TestCase
+{
+    #[Test]
+    public function boot_throws_when_database_path_is_inaccessible(): void
+    {
+        $root = sys_get_temp_dir() . '/waaseyaa_boot_fail_' . uniqid();
+        mkdir($root . '/config', 0755, true);
+        // Point to a non-existent directory so PDO cannot create the file.
+        file_put_contents(
+            $root . '/config/waaseyaa.php',
+            "<?php return ['database' => '/nonexistent/deep/path/db.sqlite'];",
+        );
+
+        $kernel = new HttpKernel($root);
+        $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
+        $boot->setAccessible(true);
+
+        try {
+            $this->expectException(\Throwable::class);
+            $boot->invoke($kernel);
+        } finally {
+            @unlink($root . '/config/waaseyaa.php');
+            @rmdir($root . '/config');
+            @rmdir($root);
+        }
+    }
+
+    #[Test]
+    public function handle_method_wraps_boot_in_try_catch(): void
+    {
+        // Structural guard: verify the handle() method body contains a try-catch
+        // around the boot() call, so boot failures cannot propagate as uncaught exceptions.
+        $method = new \ReflectionMethod(HttpKernel::class, 'handle');
+        $file = (string) $method->getFileName();
+        $start = (int) $method->getStartLine();
+        $end = (int) $method->getEndLine();
+
+        $lines = file($file) ?: [];
+        $body = implode('', array_slice($lines, $start - 1, $end - $start + 1));
+
+        // The boot() call must be inside a try block.
+        $this->assertMatchesRegularExpression(
+            '/try\s*\{[^}]*\$this->boot\(\)/s',
+            $body,
+            'HttpKernel::handle() must wrap $this->boot() in a try-catch to handle boot failures gracefully.',
+        );
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -25,4 +25,15 @@ if (!$autoloaded) {
 }
 
 $kernel = new Waaseyaa\Foundation\Kernel\HttpKernel(dirname(__DIR__));
-$kernel->handle();
+try {
+    $kernel->handle();
+} catch (\Throwable $e) {
+    error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'jsonapi' => ['version' => '1.1'],
+        'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An unexpected error occurred.']],
+    ], JSON_THROW_ON_ERROR);
+    exit(1);
+}


### PR DESCRIPTION
Closes #329
Closes #340

## Summary

- Wrap `$this->boot()` in `HttpKernel::handle()` with `try-catch (\Throwable)` — boot failures now return a generic 500 JSON:API response instead of a PHP stack trace
- Add top-level `try-catch` in `public/index.php` as a last-resort safety net for any `\Throwable` that escapes the kernel
- Add `HttpKernelBootFailureTest` verifying the try-catch is present (structural test) and that `boot()` throws when the database path is inaccessible (precondition test)

The 10 pre-existing `HtmlFormatterTest` errors (`symfony/html-sanitizer` missing, tracked in #318) are not caused by this PR.

## Checklist

- [x] `Closes #329` above references the issue this PR resolves
- [x] The issue is assigned to a milestone
- [x] PR title includes the issue number