### PR TITLE
fix(#322-#334): SSR/Twig rendering fixes (6 issues)

### DIFF
--- a/packages/ssr/src/RenderController.php
+++ b/packages/ssr/src/RenderController.php
@@ -165,4 +165,27 @@ final class RenderController
             statusCode: 404,
         );
     }
+
+    public function renderForbidden(string $path): SsrResponse
+    {
+        $context = ['path' => $path];
+        foreach (['403.html.twig', 'ssr/403.html.twig'] as $template) {
+            try {
+                return new SsrResponse(
+                    content: $this->twig->render($template, $context),
+                    statusCode: 403,
+                );
+            } catch (LoaderError) {
+                continue;
+            }
+        }
+
+        return new SsrResponse(
+            content: sprintf(
+                '<!doctype html><html><head><meta charset="utf-8"><title>403</title></head><body><main><h1>Forbidden</h1><p>%s</p></main></body></html>',
+                htmlspecialchars($path, ENT_QUOTES, 'UTF-8'),
+            ),
+            statusCode: 403,
+        );
+    }
 }

--- a/packages/ssr/src/SsrPageHandler.php
+++ b/packages/ssr/src/SsrPageHandler.php
@@ -137,7 +137,7 @@ final class SsrPageHandler
             $visibilityResolver = new EditorialVisibilityResolver();
             $visibility = $visibilityResolver->canRender($entity, $account, $previewRequested);
             if ($visibility->isForbidden()) {
-                $response = (new RenderController($twig))->renderNotFound($aliasLookupPath);
+                $response = (new RenderController($twig))->renderForbidden($aliasLookupPath);
                 $headers = $response->headers;
                 $headers['Cache-Control'] = $cacheControlHeader;
                 return $this->htmlResult($response->statusCode, $response->content, $headers);

--- a/packages/ssr/src/ThemeServiceProvider.php
+++ b/packages/ssr/src/ThemeServiceProvider.php
@@ -47,8 +47,16 @@ final class ThemeServiceProvider extends ServiceProvider
 
         $loader = self::createTemplateChainLoader($projectRoot, $activeTheme);
 
+        $cacheDir = false;
+        if (is_array($config['ssr'] ?? null) && is_string($config['ssr']['cache_dir'] ?? null)) {
+            $configured = trim((string) $config['ssr']['cache_dir']);
+            if ($configured !== '' && PHP_SAPI !== 'cli-server') {
+                $cacheDir = $configured;
+            }
+        }
+
         $env = new Environment($loader, [
-            'cache' => false,
+            'cache' => $cacheDir,
             'auto_reload' => true,
             'strict_variables' => false,
         ]);

--- a/packages/ssr/src/Twig/WaaseyaaExtension.php
+++ b/packages/ssr/src/Twig/WaaseyaaExtension.php
@@ -33,11 +33,16 @@ final class WaaseyaaExtension extends AbstractExtension
     /** @return TwigFunction[] */
     public function getFunctions(): array
     {
-        return [
+        $functions = [
             new TwigFunction('asset', $this->asset(...)),
-            new TwigFunction('config', $this->config(...)),
             new TwigFunction('env', $this->env(...)),
         ];
+
+        if ($this->configFactory !== null) {
+            $functions[] = new TwigFunction('config', $this->config(...));
+        }
+
+        return $functions;
     }
 
     /**

--- a/packages/ssr/templates/403.html.twig
+++ b/packages/ssr/templates/403.html.twig
@@ -1,0 +1,9 @@
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}403 Forbidden{% endblock %}
+
+{% block body %}
+    <h1>Access Denied</h1>
+    <p>You do not have permission to view this page.</p>
+    <p><a href="/">Return to home</a></p>
+{% endblock %}

--- a/packages/ssr/templates/404.html.twig
+++ b/packages/ssr/templates/404.html.twig
@@ -2,7 +2,14 @@
 
 {% block title %}404 Not Found{% endblock %}
 
+{% block header %}
+    <nav>
+        <a href="/">Waaseyaa</a>
+    </nav>
+{% endblock %}
+
 {% block body %}
-    <h1>Not Found</h1>
-    <p>{{ path }}</p>
+    <h1>Page Not Found</h1>
+    <p>The page <code>{{ path }}</code> could not be found.</p>
+    <p><a href="/">Return to home</a></p>
 {% endblock %}

--- a/packages/ssr/templates/500.html.twig
+++ b/packages/ssr/templates/500.html.twig
@@ -1,0 +1,9 @@
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}500 Server Error{% endblock %}
+
+{% block body %}
+    <h1>Server Error</h1>
+    <p>Something went wrong. Please try again later.</p>
+    <p><a href="/">Return to home</a></p>
+{% endblock %}

--- a/packages/ssr/templates/home.html.twig
+++ b/packages/ssr/templates/home.html.twig
@@ -1,12 +1,14 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Waaseyaa</title>
+{% extends "layouts/base.html.twig" %}
+
+{% block title %}Waaseyaa{% endblock %}
+
+{% block meta %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+{% endblock %}
+
+{% block styles %}
   <style>
     *, *::before, *::after {
       box-sizing: border-box;
@@ -347,10 +349,9 @@
       }
     }
   </style>
-</head>
-<body>
+{% endblock %}
 
-  <main>
+{% block body %}
   <section class="hero">
     <h1 class="wordmark">Waaseyaa</h1>
     <p class="tagline">A light for the modern web</p>
@@ -421,14 +422,13 @@
       </div>
     </div>
   </section>
-  </main>
+{% endblock %}
 
-  <footer class="footer">
+{% block footer %}
+  <div class="footer">
     <div class="container">
       <p>To replace this page, edit or delete <code>templates/home.html.twig</code></p>
       <p><a href="https://github.com/waaseyaa/framework" target="_blank" rel="noopener noreferrer">github.com/waaseyaa/framework</a></p>
     </div>
-  </footer>
-
-</body>
-</html>
+  </div>
+{% endblock %}

--- a/packages/ssr/tests/Unit/RenderControllerTest.php
+++ b/packages/ssr/tests/Unit/RenderControllerTest.php
@@ -253,6 +253,32 @@ final class RenderControllerTest extends TestCase
         $this->assertSame(404, $response->statusCode);
         $this->assertSame('<h1>Not Found /missing</h1>', $response->content);
     }
+
+    #[Test]
+    public function renderForbiddenReturns403WithTemplate(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            '403.html.twig' => '<h1>Forbidden {{ path }}</h1>',
+        ]));
+        $controller = new RenderController($twig);
+
+        $response = $controller->renderForbidden('/secret');
+
+        $this->assertSame(403, $response->statusCode);
+        $this->assertSame('<h1>Forbidden /secret</h1>', $response->content);
+    }
+
+    #[Test]
+    public function renderForbiddenFallsBackToInlineHtmlWhenNoTemplate(): void
+    {
+        $twig = new Environment(new ArrayLoader([]));
+        $controller = new RenderController($twig);
+
+        $response = $controller->renderForbidden('/secret');
+
+        $this->assertSame(403, $response->statusCode);
+        $this->assertStringContainsString('403', $response->content);
+    }
 }
 
 final readonly class RenderControllerEntity implements \Waaseyaa\Entity\EntityInterface

--- a/packages/ssr/tests/Unit/ThemeServiceProviderTest.php
+++ b/packages/ssr/tests/Unit/ThemeServiceProviderTest.php
@@ -106,6 +106,35 @@ final class ThemeServiceProviderTest extends TestCase
         $this->removeDirectory($projectRoot);
     }
 
+    #[Test]
+    public function twigCacheIsDisabledByDefault(): void
+    {
+        $projectRoot = sys_get_temp_dir() . '/waaseyaa_twig_cache_default_' . uniqid();
+        mkdir($projectRoot . '/packages/ssr/templates', 0755, true);
+
+        $twig = ThemeServiceProvider::createTwigEnvironment($projectRoot);
+
+        $this->assertFalse($twig->getCache(true), 'Cache must be false when no cache_dir is configured.');
+
+        $this->removeDirectory($projectRoot);
+    }
+
+    #[Test]
+    public function twigCacheUsesConfiguredCacheDir(): void
+    {
+        $projectRoot = sys_get_temp_dir() . '/waaseyaa_twig_cache_dir_' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/waaseyaa_twig_cache_' . uniqid();
+        mkdir($projectRoot . '/packages/ssr/templates', 0755, true);
+
+        $twig = ThemeServiceProvider::createTwigEnvironment($projectRoot, ['ssr' => ['cache_dir' => $cacheDir]]);
+        $cache = $twig->getCache(true);
+
+        $this->assertNotFalse($cache, 'Cache must be enabled when cache_dir is configured.');
+        $this->assertStringContainsString($cacheDir, (string) $cache);
+
+        $this->removeDirectory($projectRoot);
+    }
+
     private function removeDirectory(string $directory): void
     {
         if (!is_dir($directory)) {

--- a/packages/ssr/tests/Unit/Twig/WaaseyaaExtensionTest.php
+++ b/packages/ssr/tests/Unit/Twig/WaaseyaaExtensionTest.php
@@ -76,13 +76,6 @@ final class WaaseyaaExtensionTest extends TestCase
         $this->assertSame('localhost', $twig->render('test'));
     }
 
-    #[Test]
-    public function config_returns_empty_string_when_no_factory(): void
-    {
-        $twig = $this->createTwig('{{ config("site.name") }}', configFactory: null);
-
-        $this->assertSame('', $twig->render('test'));
-    }
 
     // ---------------------------------------------------------------
     // env()
@@ -141,16 +134,26 @@ final class WaaseyaaExtensionTest extends TestCase
     // ---------------------------------------------------------------
 
     #[Test]
-    public function extension_registers_three_functions(): void
+    public function extension_registers_only_asset_and_env_when_no_config_factory(): void
     {
         $extension = new WaaseyaaExtension();
-        $functions = $extension->getFunctions();
+        $names = array_map(fn($f) => $f->getName(), $extension->getFunctions());
 
-        $names = array_map(fn($f) => $f->getName(), $functions);
         $this->assertContains('asset', $names);
-        $this->assertContains('config', $names);
         $this->assertContains('env', $names);
-        $this->assertCount(3, $functions);
+        $this->assertNotContains('config', $names, 'config() must not be registered when no factory is wired — it always returned "" and was misleading dead code.');
+        $this->assertCount(2, $extension->getFunctions());
+    }
+
+    #[Test]
+    public function extension_registers_config_function_when_factory_is_provided(): void
+    {
+        $factory = $this->createMock(ConfigFactoryInterface::class);
+        $extension = new WaaseyaaExtension(configFactory: $factory);
+        $names = array_map(fn($f) => $f->getName(), $extension->getFunctions());
+
+        $this->assertContains('config', $names);
+        $this->assertCount(3, $extension->getFunctions());
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves 6 high-severity SSR/Twig issues in a single branch:

- **#322** — Return HTTP 403 (not 404) when editorial visibility forbids access; prevents status code information leak
- **#323** — Add `403.html.twig` and `500.html.twig` error templates extending `layouts/base.html.twig`
- **#324** — Style `404.html.twig` with site nav and home link
- **#331** — Refactor `home.html.twig` to extend `layouts/base.html.twig`; CSS moved into `{% block styles %}`
- **#332** — Remove dead `config()` Twig function when no `ConfigFactory` is wired (was silently returning `''`)
- **#334** — Enable Twig template caching via `config['ssr']['cache_dir']`; disabled automatically in `cli-server` dev mode

Closes #322
Closes #323
Closes #324
Closes #331
Closes #332
Closes #334

## Test plan

- [x] `./vendor/bin/phpunit --testsuite Unit --filter SSR` — 200/200 pass
- [x] `RenderControllerTest::renderForbiddenReturns403WithTemplate` — new test
- [x] `WaaseyaaExtensionTest::extension_registers_only_asset_and_env_when_no_config_factory` — updated
- [x] `ThemeServiceProviderTest::twigCacheUsesConfiguredCacheDir` — new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)