### PR TITLE
fix(#333): add README.md to all 40 packages

### DIFF
--- a/packages/access/README.md
+++ b/packages/access/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/access
+
+**Layer 1 — Core Data**
+
+Access control primitives for Waaseyaa applications.
+
+Provides `AccessPolicyInterface`, `AccessResult` (allowed / neutral / forbidden), `AccountInterface`, and the `#[PolicyAttribute]` attribute used for auto-discovery of entity-level and field-level access policies. The `AccessGate` evaluates registered policies and the `AccessChecker` enforces route-level constraints (`_public`, `_permission`, `_role`, `_gate`).
+
+Key classes: `AccessPolicyInterface`, `FieldAccessPolicyInterface`, `AccessResult`, `AccountInterface`, `AccessGate`, `AccessChecker`.

--- a/packages/ai-agent/README.md
+++ b/packages/ai-agent/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/ai-agent
+
+**Layer 5 — AI**
+
+AI agent orchestration for Waaseyaa applications.
+
+Provides the agent runner that chains tool calls, manages conversation context, and integrates with the AI pipeline. Depends on `waaseyaa/ai-schema` for structured input/output schemas.
+
+Key classes: `AgentRunner`, `AgentContext`, `ToolRegistry`.

--- a/packages/ai-pipeline/README.md
+++ b/packages/ai-pipeline/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/ai-pipeline
+
+**Layer 5 — AI**
+
+AI inference pipeline for Waaseyaa applications.
+
+Orchestrates model invocation, prompt assembly, response parsing, and retry logic. Acts as the execution layer between agent logic and LLM providers.
+
+Key classes: `Pipeline`, `PipelineStage`, `InferenceClient`.

--- a/packages/ai-schema/README.md
+++ b/packages/ai-schema/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/ai-schema
+
+**Layer 5 — AI**
+
+JSON Schema generation and validation for AI integrations.
+
+Derives structured schemas from Waaseyaa entity type definitions and field definitions. Used by the AI agent and pipeline layers to enforce typed input/output contracts with language models.
+
+Key classes: `SchemaGenerator`, `SchemaValidator`.

--- a/packages/ai-vector/README.md
+++ b/packages/ai-vector/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/ai-vector
+
+**Layer 5 — AI**
+
+Vector embedding storage and similarity search for Waaseyaa applications.
+
+Provides an abstraction over vector databases for storing entity embeddings and performing semantic search queries. Integrates with the AI pipeline for retrieval-augmented generation (RAG) workflows.
+
+Key classes: `VectorStore`, `EmbeddingProvider`, `SimilarityQuery`.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/api
+
+**Layer 4 — API**
+
+JSON:API endpoint layer for Waaseyaa applications.
+
+Provides `JsonApiController` with CRUD patterns, `ResourceSerializer` for entity-to-JSON:API serialization (with optional field-level access filtering), `SchemaPresenter` for JSON Schema output, and `DiscoveryApiHandler` for resource discovery. Access is enforced via route options processed by `AccessChecker`.
+
+Key classes: `JsonApiController`, `ResourceSerializer`, `SchemaPresenter`, `DiscoveryApiHandler`.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/cache
+
+**Layer 0 — Foundation**
+
+Cache abstraction for Waaseyaa applications.
+
+Provides a backend-agnostic `CacheInterface` with a `MemoryBackend` for tests and a filesystem backend for production. Supports atomic file writes (write-to-temp-then-rename) to prevent partial reads. Also includes `CacheConfigResolver` for cache-control header computation.
+
+Key classes: `CacheInterface`, `MemoryBackend`, `FilesystemBackend`, `CacheConfigResolver`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/cli
+
+**Layer 6 — Interfaces**
+
+Command-line interface for Waaseyaa applications.
+
+Provides Symfony Console commands for entity management (`entity:create`), configuration export/import (`config:export`, `config:import`), schema checking, health diagnostics, and the `optimize:manifest` command that runs `PackageManifestCompiler`. Entry point: `bin/waaseyaa`.
+
+Key classes: `ConsoleKernel`, health and schema check commands.

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -1,0 +1,7 @@
+# waaseyaa/cms
+
+**Meta-package**
+
+CMS feature bundle for Waaseyaa.
+
+A meta-package that pulls in the standard CMS content type packages: `node`, `taxonomy`, `media`, `path`, `menu`, `relationship`, and `workflows`. Install this to get a full content management feature set without having to require each package individually.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/config
+
+**Layer 1 — Core Data**
+
+Configuration management for Waaseyaa applications.
+
+Provides `ConfigFactoryInterface`, `ConfigInterface`, and a file-backed `ConfigFactory` that reads YAML/PHP config files from a sync directory. `MemoryStorage` is available for tests. Config keys follow a `config_name.key.path` dot-notation convention.
+
+Key classes: `ConfigFactoryInterface`, `ConfigFactory`, `MemoryStorage`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,7 @@
+# waaseyaa/core
+
+**Meta-package**
+
+Core infrastructure bundle for Waaseyaa.
+
+A meta-package that requires all Layer 0 (Foundation) and Layer 1 (Core Data) packages: `foundation`, `cache`, `plugin`, `entity`, `entity-storage`, `access`, `user`, `config`, `field`, `database-legacy`, `typed-data`, `validation`, and related infrastructure. Install this as a starting point for custom applications that don't need the full CMS feature set.

--- a/packages/database-legacy/README.md
+++ b/packages/database-legacy/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/database-legacy
+
+**Layer 0 — Foundation**
+
+PDO-based database abstraction for Waaseyaa applications.
+
+Provides `PdoDatabase` with a fluent query builder (`select()`, `insert()`, `update()`, `delete()`), LIKE-safe escaping, and `FETCH_ASSOC` mode to avoid duplicate numeric-indexed columns. `PdoDatabase::createSqlite()` creates an in-memory SQLite instance for tests. `DatabaseInterface` intentionally omits `getPdo()`; use `PdoDatabase` directly when raw PDO access is needed.
+
+Key classes: `PdoDatabase`, `DatabaseInterface`, `PdoSelect`.

--- a/packages/entity-storage/README.md
+++ b/packages/entity-storage/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/entity-storage
+
+**Layer 1 — Core Data**
+
+SQL and in-memory entity storage for Waaseyaa applications.
+
+`SqlEntityStorage` persists entities to a relational database using a `_data` JSON blob for non-schema columns. `SqlSchemaHandler` generates and synchronizes column definitions. `InMemoryEntityStorage` (in `waaseyaa/api/tests/Fixtures/`) provides a fast in-memory store for unit tests. Entity values are split on write and merged on read via `splitForStorage()` / `mapRowToEntity()`.
+
+Key classes: `SqlEntityStorage`, `SqlSchemaHandler`, `EntityStorageInterface`.

--- a/packages/entity/README.md
+++ b/packages/entity/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/entity
+
+**Layer 1 — Core Data**
+
+Entity type system for Waaseyaa applications.
+
+Defines `EntityInterface`, `EntityBase`, `EntityType` (with id, label, class, keys, and field definitions), and `EntityTypeManager`. Entity subclasses accept `(array $values)` and hardcode their `entityTypeId` and `entityKeys`. Use `$entity->enforceIsNew()` before saving pre-keyed entities to force `INSERT` over `UPDATE`.
+
+Key classes: `EntityInterface`, `EntityBase`, `EntityType`, `EntityTypeManager`, `EntityTypeManagerInterface`.

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/field
+
+**Layer 1 — Core Data**
+
+Field definition and typed-data integration for Waaseyaa entities.
+
+Defines field types, field definitions attached to `EntityType`, and the bridge between entity values and the `typed-data` validation layer. Field definitions drive JSON Schema generation in `SchemaPresenter` and formatter selection in SSR rendering.
+
+Key classes: `FieldDefinitionInterface`, `FieldTypeRegistry`.

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/foundation
+
+**Layer 0 — Foundation**
+
+Application bootstrapping and kernel infrastructure for Waaseyaa.
+
+Provides `AbstractKernel` (base for `HttpKernel` and `ConsoleKernel`), `ServiceProvider` base class, `PackageManifestCompiler` (discovers access policies, middleware, and providers via attribute scanning), and `DomainEvent` primitives. Kernels intentionally import from all layers as entry-point orchestrators. Run `waaseyaa optimize:manifest` after adding new providers or policies.
+
+Key classes: `AbstractKernel`, `HttpKernel`, `ConsoleKernel`, `ServiceProvider`, `PackageManifestCompiler`.

--- a/packages/full/README.md
+++ b/packages/full/README.md
@@ -1,0 +1,7 @@
+# waaseyaa/full
+
+**Meta-package**
+
+Full Waaseyaa stack bundle.
+
+A meta-package that requires all layers: `waaseyaa/core` (infrastructure), `waaseyaa/cms` (content types), `waaseyaa/api`, `waaseyaa/routing`, `waaseyaa/cli`, `waaseyaa/admin`, `waaseyaa/ssr`, and the AI layer packages. Install this for a batteries-included deployment.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,0 +1,7 @@
+# waaseyaa/graphql
+
+**Layer 6 — Interfaces** *(stub)*
+
+GraphQL endpoint for Waaseyaa applications.
+
+Planned GraphQL API layer. Currently a stub — not yet implemented. Tracked for a future milestone. Use `waaseyaa/api` for the stable JSON:API layer.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/i18n
+
+**Layer 0 — Foundation**
+
+Internationalisation and language negotiation for Waaseyaa applications.
+
+Provides `Language`, `LanguageManager`, and negotiators (`AcceptHeaderNegotiator`, `UrlPrefixNegotiator`) used by the SSR page handler to resolve the active language from HTTP requests. Designed for multi-lingual content delivery.
+
+Key classes: `Language`, `LanguageManager`, `LanguageNegotiatorInterface`.

--- a/packages/mail/README.md
+++ b/packages/mail/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/mail
+
+**Layer 0 — Foundation**
+
+Email delivery abstraction for Waaseyaa applications.
+
+Provides a `MailerInterface` and Twig-powered `TwigMailRenderer` for template-based emails. Best-effort side effects (e.g. notification listeners) should wrap mailer calls in try-catch and use `error_log()` on failure to avoid crashing the primary request.
+
+Key classes: `MailerInterface`, `TwigMailRenderer`, `MailMessage`.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/mcp
+
+**Layer 6 — Interfaces**
+
+Model Context Protocol (MCP) endpoint for Waaseyaa applications.
+
+Exposes Waaseyaa entity types and content operations via the MCP specification, enabling AI agents and IDE tools (e.g. Claude Code) to read and write application data. Depends on the API and entity layers.
+
+Key classes: `McpServer`, `McpToolHandler`.

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/media
+
+**Layer 2 — Content Types**
+
+Media entity type for Waaseyaa applications.
+
+Defines the `media` entity type for images, documents, and other binary assets. Includes upload handling, file metadata storage, and access policy integration. Managed via the admin SPA and JSON:API endpoint.
+
+Key classes: `Media`, `MediaAccessPolicy`, `MediaServiceProvider`.

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/menu
+
+**Layer 2 — Content Types**
+
+Menu and menu link entity types for Waaseyaa applications.
+
+Defines the `menu` and `menu_link` entity types for site navigation. `MenuAccessPolicy` (auto-discovered via `#[PolicyAttribute]`) allows authenticated users to view menus and requires `administer menu` permission for create/edit operations.
+
+Key classes: `Menu`, `MenuLink`, `MenuAccessPolicy`, `MenuServiceProvider`.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/node
+
+**Layer 2 — Content Types**
+
+Node (content) entity type for Waaseyaa applications.
+
+Defines the `node` entity type — the primary content entity. Supports arbitrary bundles (content types), editorial workflow states (published/unpublished), and field-based rendering via the SSR layer. Access control follows the standard pattern: `administer nodes` for admin, `access content` for viewing published nodes.
+
+Key classes: `Node`, `NodeAccessPolicy`, `NodeServiceProvider`.

--- a/packages/note/README.md
+++ b/packages/note/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/note
+
+**Layer 2 — Content Types**
+
+Note entity type for Waaseyaa applications.
+
+Defines the `note` entity type for lightweight, unstructured content entries (e.g. editorial annotations, internal notes). Simpler than `node` — no bundles, no editorial workflow. See `docs/specs/ingestion-defaults.md` for ingestion context.
+
+Key classes: `Note`, `NoteAccessPolicy`, `NoteServiceProvider`.

--- a/packages/path/README.md
+++ b/packages/path/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/path
+
+**Layer 2 — Content Types**
+
+Path alias management for Waaseyaa applications.
+
+Defines the `path_alias` entity type mapping human-readable URLs to internal entity identifiers. `PathAliasResolver` is used by the SSR page handler to look up entities from request paths. `PathAliasAccessPolicy` (auto-discovered via `#[PolicyAttribute]`) makes aliases publicly viewable; create/edit/delete requires `administer url aliases`.
+
+Key classes: `PathAlias`, `PathAliasResolver`, `PathAliasAccessPolicy`, `PathServiceProvider`.

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/plugin
+
+**Layer 0 — Foundation**
+
+Plugin and extension discovery for Waaseyaa applications.
+
+Provides the base infrastructure for third-party extension packages including the extension point registry, compatibility checking, and the `PackageManifest` format consumed by `PackageManifestCompiler`. See `docs/specs/plugin-extension-points.md` for the extension SDK.
+
+Key classes: `PluginManagerInterface`, `PackageManifest`.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/queue
+
+**Layer 0 — Foundation**
+
+Async job queue for Waaseyaa applications.
+
+Provides a `JobInterface`, `JobMiddlewareInterface`, and queue backend abstraction for dispatching and processing background jobs. Uses Symfony Messenger conventions. Workers consume jobs outside the HTTP request lifecycle.
+
+Key classes: `JobInterface`, `JobMiddlewareInterface`, `QueueInterface`.

--- a/packages/relationship/README.md
+++ b/packages/relationship/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/relationship
+
+**Layer 2 — Content Types**
+
+Entity relationship modeling for Waaseyaa applications.
+
+Defines the `relationship` entity type for typed connections between entities (e.g. author→article, tag→post). `RelationshipDiscoveryService` and `RelationshipTraversalService` power relationship-aware rendering in the SSR layer. `RelationshipAccessPolicy` is auto-discovered via `#[PolicyAttribute]`. See `docs/specs/relationship-modeling.md`.
+
+Key classes: `Relationship`, `RelationshipDiscoveryService`, `RelationshipTraversalService`, `RelationshipAccessPolicy`, `RelationshipServiceProvider`.

--- a/packages/routing/README.md
+++ b/packages/routing/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/routing
+
+**Layer 4 — API**
+
+HTTP routing for Waaseyaa applications.
+
+Wraps Symfony Routing with a `RouteBuilder` fluent API and adds route-level access options (`_public`, `_permission`, `_role`, `_gate`) evaluated by `AccessChecker`. Includes language negotiation middleware (`UrlPrefixNegotiator`, `AcceptHeaderNegotiator`).
+
+Key classes: `RouteBuilder`, `Router`, `AccessChecker`.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/search
+
+**Layer 3 — Services**
+
+Full-text and structured search for Waaseyaa applications.
+
+Provides a search index abstraction and query builder for finding entities across types. Supports indexed field selection, faceting, and relevance ranking. Integrates with the API layer for search endpoints.
+
+Key classes: `SearchIndex`, `SearchQuery`, `SearchResult`.

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -1,0 +1,11 @@
+# waaseyaa/ssr
+
+**Layer 6 — Interfaces**
+
+Server-side rendering layer for Waaseyaa applications.
+
+Renders entity and page content as HTML using Twig templates. `SsrPageHandler` handles path alias resolution, editorial visibility checks, language negotiation, and cache headers. `RenderController` resolves template candidates (entity-specific, path-based, or fallback). `ThemeServiceProvider` manages the Twig environment with a theme chain loader. `EntityRenderer` produces field bags consumed by entity templates.
+
+Twig functions: `asset()`, `env()`, `config()` (when wired), `csrf_token()` (when User middleware present).
+
+Key classes: `SsrPageHandler`, `RenderController`, `ThemeServiceProvider`, `EntityRenderer`, `WaaseyaaExtension`.

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/state
+
+**Layer 0 — Foundation**
+
+Application state management for Waaseyaa.
+
+Provides a key-value state store for cross-request application state that doesn't belong in the config system (e.g. runtime flags, feature toggles, install status). Backed by the database or a simple file store.
+
+Key classes: `StateInterface`, `StateFactory`.

--- a/packages/taxonomy/README.md
+++ b/packages/taxonomy/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/taxonomy
+
+**Layer 2 — Content Types**
+
+Taxonomy (vocabulary and term) entity types for Waaseyaa applications.
+
+Defines `vocabulary` and `taxonomy_term` entity types for hierarchical classification of content. Terms can be nested (parent/child), ordered by weight, and referenced by other entity types via relationship fields.
+
+Key classes: `Vocabulary`, `TaxonomyTerm`, `TaxonomyAccessPolicy`, `TaxonomyServiceProvider`.

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/telescope
+
+**Layer 6 — Interfaces**
+
+Request inspection and observability dashboard for Waaseyaa applications.
+
+Telescope captures HTTP requests, responses, database queries, cache operations, and queue jobs for local development debugging. Rendered as an SSR Twig page at `/_telescope`. See `docs/specs/` for the context observability integration spec.
+
+Key classes: `TelescopeRecorder`, `TelescopeServiceProvider`.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/testing
+
+**Layer 0 — Foundation**
+
+Test utilities and fixtures for Waaseyaa packages.
+
+Provides shared test helpers, in-memory storage stubs, and fixture factories used across the monorepo test suite. Includes `InMemoryEntityStorage`, mock account helpers, and integration test bootstrap utilities. PHPUnit 10.5+ with `#[Test]`, `#[CoversClass]`, `#[CoversNothing]` attributes.
+
+Key classes: `InMemoryEntityStorage`, test fixture helpers.

--- a/packages/typed-data/README.md
+++ b/packages/typed-data/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/typed-data
+
+**Layer 0 — Foundation**
+
+Typed data validation and coercion for Waaseyaa applications.
+
+Provides a type system for entity field values with runtime coercion (string→int, null→default, etc.) and validation constraints. Integrates with Symfony Validator for constraint-based validation. Used by the field system to validate entity values before persistence.
+
+Key classes: `TypedDataInterface`, `DataDefinition`, `TypedDataManager`.

--- a/packages/user/README.md
+++ b/packages/user/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/user
+
+**Layer 1 — Core Data**
+
+User entity type and authentication middleware for Waaseyaa applications.
+
+Defines the `user` entity type. `SessionMiddleware` reads `$_SESSION['waaseyaa_uid']` and sets `_account` on the request (anonymous via `AnonymousUser` with `id: 0` when no session). Includes `CsrfMiddleware` for form protection. `AnonymousUser` and `DevAdminAccount` (id: `PHP_INT_MAX`, gated to `cli-server` SAPI) are the system sentinel accounts.
+
+Key classes: `User`, `AnonymousUser`, `SessionMiddleware`, `CsrfMiddleware`, `UserServiceProvider`.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/validation
+
+**Layer 0 — Foundation**
+
+Input validation for Waaseyaa applications.
+
+Wraps Symfony Validator with Waaseyaa conventions for validating request data, entity field values, and configuration inputs. Provides a `ValidatorInterface` and constraint set aligned with the typed-data layer.
+
+Key classes: `ValidatorInterface`, `ValidationResult`, `ValidationViolation`.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -1,0 +1,9 @@
+# waaseyaa/workflows
+
+**Layer 3 — Services**
+
+Editorial workflow and content visibility for Waaseyaa applications.
+
+`EditorialVisibilityResolver` determines whether an entity can be rendered based on its publish status, the requesting account's permissions, and preview mode. Returns `allowed`, `neutral`, or `forbidden` results consumed by `SsrPageHandler`. Also provides workflow state transition primitives for moderation queues.
+
+Key classes: `EditorialVisibilityResolver`, `WorkflowState`, `WorkflowTransition`.


### PR DESCRIPTION
## Summary

- Add `README.md` to all 40 packages that lacked documentation (only `packages/admin` had one)
- Each README describes: layer position, purpose, key classes, and notable architectural notes
- Content derived from `CLAUDE.md` layer architecture table and package source code

Closes #333

## Test plan

- [x] All 40 packages now have a README.md
- [ ] Verify content accuracy for unfamiliar packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)