### PR TITLE
fix(#330): add admin auth login UI and backend auth endpoints

### DIFF
--- a/packages/admin/app/composables/useAuth.ts
+++ b/packages/admin/app/composables/useAuth.ts
@@ -1,0 +1,38 @@
+export interface AuthUser {
+  id: number
+  name: string
+  email: string
+  roles: string[]
+}
+
+const STATE_KEY = 'waaseyaa.auth.user'
+
+export function useAuth() {
+  const currentUser = useState<AuthUser | null>(STATE_KEY, () => null)
+  const isAuthenticated = computed(() => currentUser.value !== null)
+
+  async function fetchMe(): Promise<void> {
+    try {
+      const response = await $fetch<{ data: AuthUser }>('/api/user/me')
+      currentUser.value = response.data ?? null
+    }
+    catch {
+      currentUser.value = null
+    }
+  }
+
+  async function login(username: string, password: string): Promise<void> {
+    const response = await $fetch<{ data: AuthUser }>('/api/auth/login', {
+      method: 'POST',
+      body: { username, password },
+    })
+    currentUser.value = response.data ?? null
+  }
+
+  async function logout(): Promise<void> {
+    await $fetch('/api/auth/logout', { method: 'POST' })
+    currentUser.value = null
+  }
+
+  return { currentUser, isAuthenticated, fetchMe, login, logout }
+}

--- a/packages/admin/app/middleware/auth.global.ts
+++ b/packages/admin/app/middleware/auth.global.ts
@@ -1,0 +1,15 @@
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (to.path === '/login') {
+    return
+  }
+
+  const { isAuthenticated, fetchMe } = useAuth()
+
+  if (!isAuthenticated.value) {
+    await fetchMe()
+  }
+
+  if (!isAuthenticated.value) {
+    return navigateTo('/login')
+  }
+})

--- a/packages/admin/app/pages/login.vue
+++ b/packages/admin/app/pages/login.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+definePageMeta({ layout: false })
+
+const { login, isAuthenticated } = useAuth()
+const router = useRouter()
+
+const username = ref('')
+const password = ref('')
+const error = ref('')
+const loading = ref(false)
+
+if (isAuthenticated.value) {
+  await navigateTo('/')
+}
+
+async function handleSubmit() {
+  error.value = ''
+  loading.value = true
+  try {
+    await login(username.value, password.value)
+    await router.push('/')
+  }
+  catch {
+    error.value = 'Invalid username or password.'
+  }
+  finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="login-page">
+    <form class="login-form" @submit.prevent="handleSubmit">
+      <h1>Sign in</h1>
+
+      <div v-if="error" class="login-error" role="alert">
+        {{ error }}
+      </div>
+
+      <label for="username">Username</label>
+      <input
+        id="username"
+        v-model="username"
+        type="text"
+        name="username"
+        autocomplete="username"
+        required
+        :disabled="loading"
+      >
+
+      <label for="password">Password</label>
+      <input
+        id="password"
+        v-model="password"
+        type="password"
+        name="password"
+        autocomplete="current-password"
+        required
+        :disabled="loading"
+      >
+
+      <button type="submit" :disabled="loading">
+        {{ loading ? 'Signing in…' : 'Sign in' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 360px;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.login-form h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.login-error {
+  padding: 0.5rem 0.75rem;
+  background: #fde8e8;
+  border: 1px solid #f5a0a0;
+  border-radius: 4px;
+  color: #c00;
+  font-size: 0.9rem;
+}
+
+.login-form label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.login-form input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.login-form input:focus {
+  outline: 2px solid #4f46e5;
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.login-form button {
+  margin-top: 0.5rem;
+  padding: 0.6rem;
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.login-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/packages/admin/tests/unit/composables/useAuth.test.ts
+++ b/packages/admin/tests/unit/composables/useAuth.test.ts
@@ -1,0 +1,74 @@
+// packages/admin/tests/unit/composables/useAuth.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { useAuth } from '~/composables/useAuth'
+
+describe('useAuth', () => {
+  it('isAuthenticated is false when no user is loaded', () => {
+    const { isAuthenticated } = useAuth()
+    expect(isAuthenticated.value).toBe(false)
+  })
+
+  it('fetchMe sets currentUser and isAuthenticated on success', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      data: { id: 1, name: 'alice', email: 'alice@example.com', roles: ['admin'] },
+    })
+    vi.stubGlobal('$fetch', mockFetch)
+
+    const { fetchMe, isAuthenticated, currentUser } = useAuth()
+    await fetchMe()
+
+    expect(isAuthenticated.value).toBe(true)
+    expect(currentUser.value?.name).toBe('alice')
+    expect(mockFetch).toHaveBeenCalledWith('/api/user/me')
+  })
+
+  it('fetchMe leaves isAuthenticated false on 401', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(Object.assign(new Error('Unauthorized'), { status: 401 }))
+    vi.stubGlobal('$fetch', mockFetch)
+
+    const { fetchMe, isAuthenticated } = useAuth()
+    await fetchMe()
+
+    expect(isAuthenticated.value).toBe(false)
+  })
+
+  it('login calls POST /api/auth/login with credentials', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      data: { id: 2, name: 'bob', email: 'bob@example.com', roles: [] },
+    })
+    vi.stubGlobal('$fetch', mockFetch)
+
+    const { login, isAuthenticated, currentUser } = useAuth()
+    await login('bob', 'secret')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/login', {
+      method: 'POST',
+      body: { username: 'bob', password: 'secret' },
+    })
+    expect(isAuthenticated.value).toBe(true)
+    expect(currentUser.value?.name).toBe('bob')
+  })
+
+  it('login throws on failed credentials', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(Object.assign(new Error('Unauthorized'), { status: 401 }))
+    vi.stubGlobal('$fetch', mockFetch)
+
+    const { login } = useAuth()
+    await expect(login('bad', 'creds')).rejects.toThrow()
+  })
+
+  it('logout calls POST /api/auth/logout and clears user', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ data: { id: 1, name: 'alice', email: '', roles: [] } })
+      .mockResolvedValueOnce({ meta: { message: 'Logged out.' } })
+    vi.stubGlobal('$fetch', mockFetch)
+
+    const { fetchMe, logout, isAuthenticated } = useAuth()
+    await fetchMe()
+    expect(isAuthenticated.value).toBe(true)
+
+    await logout()
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/auth/logout', { method: 'POST' })
+    expect(isAuthenticated.value).toBe(false)
+  })
+})

--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -29,6 +29,8 @@ use Waaseyaa\AI\Vector\SearchController;
 use Waaseyaa\AI\Vector\SqliteEmbeddingStorage;
 use Waaseyaa\Mcp\McpController;
 use Waaseyaa\SSR\SsrPageHandler;
+use Waaseyaa\User\Http\AuthController;
+use Waaseyaa\User\User;
 
 /**
  * Routes a matched controller name to the appropriate handler.
@@ -566,6 +568,57 @@ final class ControllerDispatcher
                         ResponseSender::json($result['status'], $result['content'], $result['headers']);
                     }
                     ResponseSender::html($result['status'], $result['content'], $result['headers']);
+                })(),
+
+                $controller === 'user.me' => (function () use ($account): never {
+                    $authController = new AuthController();
+                    $result = $authController->me($account);
+                    ResponseSender::json($result['statusCode'], array_filter([
+                        'jsonapi' => ['version' => '1.1'],
+                        'data' => $result['data'] ?? null,
+                        'errors' => $result['errors'] ?? null,
+                    ]));
+                })(),
+
+                $controller === 'auth.login' => (function () use ($body): never {
+                    $username = is_string($body['username'] ?? null) ? trim((string) $body['username']) : '';
+                    $password = is_string($body['password'] ?? null) ? (string) $body['password'] : '';
+
+                    if ($username === '' || $password === '') {
+                        ResponseSender::json(400, [
+                            'jsonapi' => ['version' => '1.1'],
+                            'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'username and password are required.']],
+                        ]);
+                    }
+
+                    $userStorage = $this->entityTypeManager->getStorage('user');
+                    $authController = new AuthController();
+                    $user = $authController->findUserByName($userStorage, $username);
+
+                    if ($user === null || !$user->isActive() || !$user->checkPassword($password)) {
+                        ResponseSender::json(401, [
+                            'jsonapi' => ['version' => '1.1'],
+                            'errors' => [['status' => '401', 'title' => 'Unauthorized', 'detail' => 'Invalid credentials.']],
+                        ]);
+                    }
+
+                    $_SESSION['waaseyaa_uid'] = $user->id();
+                    ResponseSender::json(200, [
+                        'jsonapi' => ['version' => '1.1'],
+                        'data' => [
+                            'id' => $user->id(),
+                            'name' => $user->getName(),
+                            'email' => $user->getEmail(),
+                            'roles' => $user->getRoles(),
+                        ],
+                    ]);
+                })(),
+
+                $controller === 'auth.logout' => (function (): never {
+                    if (isset($_SESSION['waaseyaa_uid'])) {
+                        unset($_SESSION['waaseyaa_uid']);
+                    }
+                    ResponseSender::json(200, ['jsonapi' => ['version' => '1.1'], 'meta' => ['message' => 'Logged out.']]);
                 })(),
 
                 default => (function () use ($controller): never {

--- a/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
+++ b/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
@@ -145,6 +145,33 @@ final class BuiltinRouteRegistrar
                 ->build(),
         );
 
+        $router->addRoute(
+            'api.user.me',
+            RouteBuilder::create('/api/user/me')
+                ->controller('user.me')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.auth.login',
+            RouteBuilder::create('/api/auth/login')
+                ->controller('auth.login')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.auth.logout',
+            RouteBuilder::create('/api/auth/logout')
+                ->controller('auth.logout')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
         // App routes — registered before SSR catchall so they take priority.
         foreach ($this->providers as $provider) {
             $provider->routes($router);

--- a/packages/user/src/Http/AuthController.php
+++ b/packages/user/src/Http/AuthController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Http;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\User\User;
+
+/**
+ * Handles authentication API endpoints: me, login, logout.
+ */
+final class AuthController
+{
+    /**
+     * Returns the current user's data or a 401 payload for anonymous users.
+     *
+     * @return array{statusCode: int, data?: array<string, mixed>, errors?: list<array<string, string>>}
+     */
+    public function me(AccountInterface $account): array
+    {
+        if (!$account->isAuthenticated()) {
+            return [
+                'statusCode' => 401,
+                'errors' => [['status' => '401', 'title' => 'Unauthorized', 'detail' => 'Not authenticated.']],
+            ];
+        }
+
+        $data = [
+            'id' => $account->id(),
+            'name' => $account instanceof User ? $account->getName() : '',
+            'email' => $account instanceof User ? $account->getEmail() : '',
+            'roles' => $account instanceof User ? $account->getRoles() : $account->getRoles(),
+        ];
+
+        return ['statusCode' => 200, 'data' => $data];
+    }
+
+    /**
+     * Looks up a user by name in storage. Returns null if not found.
+     */
+    public function findUserByName(EntityStorageInterface $storage, string $name): ?User
+    {
+        $ids = $storage->getQuery()
+            ->condition('name', $name)
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $user = $storage->load(reset($ids));
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/packages/user/tests/Unit/Http/AuthControllerTest.php
+++ b/packages/user/tests/Unit/Http/AuthControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit\Http;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\User\AnonymousUser;
+use Waaseyaa\User\Http\AuthController;
+use Waaseyaa\User\User;
+
+#[CoversClass(AuthController::class)]
+final class AuthControllerTest extends TestCase
+{
+    #[Test]
+    public function meReturnsUserDataForAuthenticatedAccount(): void
+    {
+        $user = new User(['uid' => 5, 'name' => 'alice', 'mail' => 'alice@example.com', 'roles' => ['editor']]);
+        $controller = new AuthController();
+
+        $result = $controller->me($user);
+
+        $this->assertSame(200, $result['statusCode']);
+        $this->assertSame(5, $result['data']['id']);
+        $this->assertSame('alice', $result['data']['name']);
+        $this->assertSame('alice@example.com', $result['data']['email']);
+        $this->assertSame(['editor'], $result['data']['roles']);
+    }
+
+    #[Test]
+    public function meReturns401ForAnonymousAccount(): void
+    {
+        $controller = new AuthController();
+
+        $result = $controller->me(new AnonymousUser());
+
+        $this->assertSame(401, $result['statusCode']);
+    }
+
+    #[Test]
+    public function findUserByNameReturnsUserWhenFound(): void
+    {
+        $user = new User(['uid' => 3, 'name' => 'bob']);
+        $storage = $this->makeStorageThatReturnsIds([(string) $user->id()]);
+        $controller = new AuthController();
+
+        $found = $controller->findUserByName($storage, 'bob');
+
+        $this->assertInstanceOf(User::class, $found);
+        $this->assertSame(3, $found->id());
+    }
+
+    #[Test]
+    public function findUserByNameReturnsNullWhenNotFound(): void
+    {
+        $storage = $this->makeStorageThatReturnsIds([]);
+        $controller = new AuthController();
+
+        $found = $controller->findUserByName($storage, 'nobody');
+
+        $this->assertNull($found);
+    }
+
+    /**
+     * @param array<int|string> $ids
+     */
+    private function makeStorageThatReturnsIds(array $ids): EntityStorageInterface
+    {
+        $user = $ids !== [] ? new User(['uid' => (int) reset($ids), 'name' => 'bob']) : null;
+
+        $query = new class($ids) implements EntityQueryInterface {
+            public function __construct(private array $ids) {}
+            public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
+            public function exists(string $field): static { return $this; }
+            public function notExists(string $field): static { return $this; }
+            public function sort(string $field, string $direction = 'ASC'): static { return $this; }
+            public function range(int $offset, int $limit): static { return $this; }
+            public function count(): static { return $this; }
+            public function accessCheck(bool $check = true): static { return $this; }
+            public function execute(): array { return $this->ids; }
+        };
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        if ($user !== null) {
+            $storage->method('load')->with((int) reset($ids))->willReturn($user);
+        } else {
+            $storage->method('load')->willReturn(null);
+        }
+
+        return $storage;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/user/me`, `POST /api/auth/login`, `POST /api/auth/logout` endpoints via a new `AuthController` in `packages/user/src/Http/`
- Wire routes into `BuiltinRouteRegistrar` and dispatch cases into `ControllerDispatcher`
- Add `useAuth` composable (`login`, `logout`, `fetchMe`, `isAuthenticated`, `currentUser`)
- Add global Nuxt route middleware (`auth.global.ts`) that redirects unauthenticated users to `/login`
- Add `pages/login.vue` — unstyled login form with username/password, error display, and loading state

Closes #330

## Test plan

- [ ] PHP unit: `./vendor/bin/phpunit --filter AuthControllerTest` — 4 tests pass (me, findUserByName)
- [ ] Frontend unit: `npm test -- useAuth` (in `packages/admin`) — 6 tests pass (login, logout, fetchMe, isAuthenticated)
- [ ] Manual: visit `/admin` unauthenticated → redirected to `/login`; submit valid credentials → redirected to dashboard; logout → redirected to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)