### PR TITLE
fix(#329): correct Content-Type header and add stack trace logging in exception handler

### DIFF
--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -51,7 +51,15 @@ final class HttpKernel extends AbstractKernel
 
     public function handle(): never
     {
-        $this->boot();
+        try {
+            $this->boot();
+        } catch (\Throwable $e) {
+            error_log(sprintf('[Waaseyaa] Boot failed: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+            ResponseSender::json(500, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Application failed to boot.']],
+            ]);
+        }
         $this->cacheConfigResolver = new CacheConfigResolver($this->config);
 
         $this->handleCors();

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+/**
+ * Verifies that HttpKernel handles boot() failures gracefully.
+ *
+ * The handle() method returns `never` (exits) so it cannot be called directly
+ * in unit tests. These tests verify the precondition (boot can throw) and the
+ * structural guards added to handle().
+ */
+#[CoversClass(HttpKernel::class)]
+final class HttpKernelBootFailureTest extends TestCase
+{
+    #[Test]
+    public function boot_throws_when_database_path_is_inaccessible(): void
+    {
+        $root = sys_get_temp_dir() . '/waaseyaa_boot_fail_' . uniqid();
+        mkdir($root . '/config', 0755, true);
+        // Point to a non-existent directory so PDO cannot create the file.
+        file_put_contents(
+            $root . '/config/waaseyaa.php',
+            "<?php return ['database' => '/nonexistent/deep/path/db.sqlite'];",
+        );
+
+        $kernel = new HttpKernel($root);
+        $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
+        $boot->setAccessible(true);
+
+        try {
+            $this->expectException(\Throwable::class);
+            $boot->invoke($kernel);
+        } finally {
+            @unlink($root . '/config/waaseyaa.php');
+            @rmdir($root . '/config');
+            @rmdir($root);
+        }
+    }
+
+    #[Test]
+    public function handle_method_wraps_boot_in_try_catch(): void
+    {
+        // Structural guard: verify the handle() method body contains a try-catch
+        // around the boot() call, so boot failures cannot propagate as uncaught exceptions.
+        $method = new \ReflectionMethod(HttpKernel::class, 'handle');
+        $file = (string) $method->getFileName();
+        $start = (int) $method->getStartLine();
+        $end = (int) $method->getEndLine();
+
+        $lines = file($file) ?: [];
+        $body = implode('', array_slice($lines, $start - 1, $end - $start + 1));
+
+        // The boot() call must be inside a try block.
+        $this->assertMatchesRegularExpression(
+            '/try\s*\{[^}]*\$this->boot\(\)/s',
+            $body,
+            'HttpKernel::handle() must wrap $this->boot() in a try-catch to handle boot failures gracefully.',
+        );
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -28,9 +28,9 @@ $kernel = new Waaseyaa\Foundation\Kernel\HttpKernel(dirname(__DIR__));
 try {
     $kernel->handle();
 } catch (\Throwable $e) {
-    error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+    error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d%s', $e->getMessage(), $e->getFile(), $e->getLine(), PHP_EOL . $e->getTraceAsString()));
     http_response_code(500);
-    header('Content-Type: application/json');
+    header('Content-Type: application/vnd.api+json');
     echo json_encode([
         'jsonapi' => ['version' => '1.1'],
         'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An unexpected error occurred.']],

--- a/public/index.php
+++ b/public/index.php
@@ -25,4 +25,15 @@ if (!$autoloaded) {
 }
 
 $kernel = new Waaseyaa\Foundation\Kernel\HttpKernel(dirname(__DIR__));
-$kernel->handle();
+try {
+    $kernel->handle();
+} catch (\Throwable $e) {
+    error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'jsonapi' => ['version' => '1.1'],
+        'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An unexpected error occurred.']],
+    ], JSON_THROW_ON_ERROR);
+    exit(1);
+}


### PR DESCRIPTION
## Summary

Review fixes for PR #368 (top-level exception handler for boot failures).

- **`public/index.php` — Content-Type fix (blocking):** The outer `catch (\Throwable)` block emitted `Content-Type: application/json`. JSON:API requires `application/vnd.api+json`. Fixed to match what `ResponseSender::json()` emits in the `HttpKernel` boot-failure catch block — both paths now use the same content type.

- **`public/index.php` — stack trace logging (should-fix):** Added `$e->getTraceAsString()` to the `error_log()` call. A single-line log with only message/file/line loses the call stack, making boot failures very hard to diagnose. Stack trace is server-side only — not included in the client response.

## Before / After

```php
// Before
header('Content-Type: application/json');
error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d', ...));

// After
header('Content-Type: application/vnd.api+json');
error_log(sprintf('[Waaseyaa] Unhandled top-level exception: %s in %s:%d%s', ..., PHP_EOL . $e->getTraceAsString()));
```

## Verification

- PHP suite: **4314 tests, 10485 assertions — all pass**
- `HttpKernelBootFailureTest`: 2/2 pass
- No TS or Playwright changes (no frontend behavior changed)

## Test plan

- [ ] `./vendor/bin/phpunit --filter HttpKernelBootFailure` — 2/2 pass
- [ ] `./vendor/bin/phpunit --configuration phpunit.xml.dist` — full suite green
- [ ] On boot failure, `error_log` output includes stack trace
- [ ] On boot failure, response has `Content-Type: application/vnd.api+json`

Closes review items for #329 (companion to PR #368)

🤖 Generated with [Claude Code](https://claude.com/claude-code)