### PR TITLE
fix(#326): middleware ordering via #[AsMiddleware] attribute priority

### DIFF
--- a/packages/access/src/Middleware/AuthorizationMiddleware.php
+++ b/packages/access/src/Middleware/AuthorizationMiddleware.php
@@ -11,10 +11,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Route;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\ErrorPageRendererInterface;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\Routing\AccessChecker;
 
+#[AsMiddleware(pipeline: 'http', priority: 10)]
 final class AuthorizationMiddleware implements HttpMiddlewareInterface
 {
     public function __construct(

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -16,6 +16,7 @@ use Waaseyaa\Cache\CacheBackendInterface;
 use Waaseyaa\Cache\CacheConfigResolver;
 use Waaseyaa\Cache\CacheFactory;
 use Waaseyaa\Cache\CacheConfiguration;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Http\CorsHandler;
 use Waaseyaa\Foundation\Http\ResponseSender;
 use Waaseyaa\Api\Http\DiscoveryApiHandler;
@@ -140,18 +141,26 @@ final class HttpKernel extends AbstractKernel
         $twigEnv = SsrServiceProvider::getTwigEnvironment();
         $errorPageRenderer = $twigEnv !== null ? new TwigErrorPageRenderer($twigEnv) : null;
 
-        $pipeline = (new HttpPipeline())
-            ->withMiddleware(new BearerAuthMiddleware(
+        $middlewares = [
+            new BearerAuthMiddleware(
                 $userStorage,
                 (string) ($this->config['jwt_secret'] ?? ''),
                 is_array($this->config['api_keys'] ?? null) ? $this->config['api_keys'] : [],
-            ))
-            ->withMiddleware(new SessionMiddleware(
+            ),
+            new SessionMiddleware(
                 $userStorage,
                 $this->shouldUseDevFallbackAccount() ? new DevAdminAccount() : null,
-            ))
-            ->withMiddleware(new CsrfMiddleware())
-            ->withMiddleware(new AuthorizationMiddleware($accessChecker, $errorPageRenderer));
+            ),
+            new CsrfMiddleware(),
+            new AuthorizationMiddleware($accessChecker, $errorPageRenderer),
+        ];
+
+        usort($middlewares, fn (object $a, object $b) => $this->getMiddlewarePriority($b) <=> $this->getMiddlewarePriority($a));
+
+        $pipeline = new HttpPipeline();
+        foreach ($middlewares as $middleware) {
+            $pipeline = $pipeline->withMiddleware($middleware);
+        }
 
         try {
             $authResponse = $pipeline->handle(
@@ -192,6 +201,16 @@ final class HttpKernel extends AbstractKernel
             config: $this->config,
         );
         $controllerDispatcher->dispatch($method, $params, $httpRequest, $queryString, $broadcastStorage, $account);
+    }
+
+    private function getMiddlewarePriority(object $middleware): int
+    {
+        $reflection = new \ReflectionClass($middleware);
+        $attributes = $reflection->getAttributes(AsMiddleware::class);
+        if (empty($attributes)) {
+            return 0;
+        }
+        return $attributes[0]->newInstance()->priority;
     }
 
     private function handleCors(): void

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -210,7 +210,11 @@ final class HttpKernel extends AbstractKernel
         if (empty($attributes)) {
             return 0;
         }
-        return $attributes[0]->newInstance()->priority;
+        $instance = $attributes[0]->newInstance();
+        if ($instance->pipeline !== 'http') {
+            return 0;
+        }
+        return $instance->priority;
     }
 
     private function handleCors(): void

--- a/packages/foundation/tests/Unit/Middleware/MiddlewareOrderingTest.php
+++ b/packages/foundation/tests/Unit/Middleware/MiddlewareOrderingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\Middleware\AuthorizationMiddleware;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\User\Middleware\BearerAuthMiddleware;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+use Waaseyaa\User\Middleware\SessionMiddleware;
+
+#[CoversClass(AsMiddleware::class)]
+final class MiddlewareOrderingTest extends TestCase
+{
+    #[Test]
+    public function middleware_have_correct_priority_attributes(): void
+    {
+        $this->assertMiddlewarePriority(BearerAuthMiddleware::class, 40);
+        $this->assertMiddlewarePriority(SessionMiddleware::class, 30);
+        $this->assertMiddlewarePriority(CsrfMiddleware::class, 20);
+        $this->assertMiddlewarePriority(AuthorizationMiddleware::class, 10);
+    }
+
+    #[Test]
+    public function sort_order_is_determined_by_priority_not_registration_order(): void
+    {
+        // Provide class names in REVERSE priority order to prove registration order is irrelevant.
+        $classes = [
+            AuthorizationMiddleware::class, // priority 10
+            CsrfMiddleware::class,          // priority 20
+            SessionMiddleware::class,       // priority 30
+            BearerAuthMiddleware::class,    // priority 40
+        ];
+
+        usort(
+            $classes,
+            fn (string $a, string $b) => $this->readPriority($b) <=> $this->readPriority($a),
+        );
+
+        $this->assertSame(
+            [
+                BearerAuthMiddleware::class,
+                SessionMiddleware::class,
+                CsrfMiddleware::class,
+                AuthorizationMiddleware::class,
+            ],
+            $classes,
+        );
+    }
+
+    private function assertMiddlewarePriority(string $class, int $expected): void
+    {
+        $reflection = new \ReflectionClass($class);
+        $attributes = $reflection->getAttributes(AsMiddleware::class);
+        $this->assertNotEmpty($attributes, "No AsMiddleware attribute on {$class}");
+        $this->assertSame($expected, $attributes[0]->newInstance()->priority);
+    }
+
+    private function readPriority(string $class): int
+    {
+        $reflection = new \ReflectionClass($class);
+        $attributes = $reflection->getAttributes(AsMiddleware::class);
+        if (empty($attributes)) {
+            return 0;
+        }
+        return $attributes[0]->newInstance()->priority;
+    }
+}

--- a/packages/foundation/tests/Unit/Middleware/MiddlewareOrderingTest.php
+++ b/packages/foundation/tests/Unit/Middleware/MiddlewareOrderingTest.php
@@ -7,11 +7,48 @@ namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Waaseyaa\Access\Middleware\AuthorizationMiddleware;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
-use Waaseyaa\User\Middleware\BearerAuthMiddleware;
-use Waaseyaa\User\Middleware\CsrfMiddleware;
-use Waaseyaa\User\Middleware\SessionMiddleware;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+
+// Local stubs — no cross-layer imports needed.
+#[AsMiddleware(pipeline: 'http', priority: 40)]
+final class StubPriority40Middleware implements HttpMiddlewareInterface
+{
+    public function process(HttpRequest $request, HttpHandlerInterface $next): HttpResponse
+    {
+        return $next->handle($request);
+    }
+}
+
+#[AsMiddleware(pipeline: 'http', priority: 30)]
+final class StubPriority30Middleware implements HttpMiddlewareInterface
+{
+    public function process(HttpRequest $request, HttpHandlerInterface $next): HttpResponse
+    {
+        return $next->handle($request);
+    }
+}
+
+#[AsMiddleware(pipeline: 'http', priority: 20)]
+final class StubPriority20Middleware implements HttpMiddlewareInterface
+{
+    public function process(HttpRequest $request, HttpHandlerInterface $next): HttpResponse
+    {
+        return $next->handle($request);
+    }
+}
+
+#[AsMiddleware(pipeline: 'http', priority: 10)]
+final class StubPriority10Middleware implements HttpMiddlewareInterface
+{
+    public function process(HttpRequest $request, HttpHandlerInterface $next): HttpResponse
+    {
+        return $next->handle($request);
+    }
+}
 
 #[CoversClass(AsMiddleware::class)]
 final class MiddlewareOrderingTest extends TestCase
@@ -19,10 +56,10 @@ final class MiddlewareOrderingTest extends TestCase
     #[Test]
     public function middleware_have_correct_priority_attributes(): void
     {
-        $this->assertMiddlewarePriority(BearerAuthMiddleware::class, 40);
-        $this->assertMiddlewarePriority(SessionMiddleware::class, 30);
-        $this->assertMiddlewarePriority(CsrfMiddleware::class, 20);
-        $this->assertMiddlewarePriority(AuthorizationMiddleware::class, 10);
+        $this->assertMiddlewarePriority(StubPriority40Middleware::class, 40);
+        $this->assertMiddlewarePriority(StubPriority30Middleware::class, 30);
+        $this->assertMiddlewarePriority(StubPriority20Middleware::class, 20);
+        $this->assertMiddlewarePriority(StubPriority10Middleware::class, 10);
     }
 
     #[Test]
@@ -30,10 +67,10 @@ final class MiddlewareOrderingTest extends TestCase
     {
         // Provide class names in REVERSE priority order to prove registration order is irrelevant.
         $classes = [
-            AuthorizationMiddleware::class, // priority 10
-            CsrfMiddleware::class,          // priority 20
-            SessionMiddleware::class,       // priority 30
-            BearerAuthMiddleware::class,    // priority 40
+            StubPriority10Middleware::class, // priority 10
+            StubPriority20Middleware::class, // priority 20
+            StubPriority30Middleware::class, // priority 30
+            StubPriority40Middleware::class, // priority 40
         ];
 
         usort(
@@ -43,10 +80,10 @@ final class MiddlewareOrderingTest extends TestCase
 
         $this->assertSame(
             [
-                BearerAuthMiddleware::class,
-                SessionMiddleware::class,
-                CsrfMiddleware::class,
-                AuthorizationMiddleware::class,
+                StubPriority40Middleware::class,
+                StubPriority30Middleware::class,
+                StubPriority20Middleware::class,
+                StubPriority10Middleware::class,
             ],
             $classes,
         );

--- a/packages/user/src/Middleware/BearerAuthMiddleware.php
+++ b/packages/user/src/Middleware/BearerAuthMiddleware.php
@@ -8,10 +8,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\User\AnonymousUser;
 
+#[AsMiddleware(pipeline: 'http', priority: 40)]
 final class BearerAuthMiddleware implements HttpMiddlewareInterface
 {
     /**

--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -8,9 +8,11 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Route;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 
+#[AsMiddleware(pipeline: 'http', priority: 20)]
 final class CsrfMiddleware implements HttpMiddlewareInterface
 {
     private const TOKEN_SESSION_KEY = '_csrf_token';

--- a/packages/user/src/Middleware/SessionMiddleware.php
+++ b/packages/user/src/Middleware/SessionMiddleware.php
@@ -8,10 +8,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\User\AnonymousUser;
 
+#[AsMiddleware(pipeline: 'http', priority: 30)]
 final class SessionMiddleware implements HttpMiddlewareInterface
 {
     /**


### PR DESCRIPTION
## Summary
- Adds #[AsMiddleware(priority: N)] to BearerAuth (40), Session (30), Csrf (20), Authorization (10)
- Updates HttpKernel to sort middleware by attribute priority instead of hard-coded order
- Adds MiddlewareOrderingTest verifying registration order doesn't affect pipeline order

## Test plan
- [ ] ./vendor/bin/phpunit --testsuite Unit passes with no regressions
- [ ] Full test suite passes
- [ ] Middleware pipeline order matches priority (40→30→20→10) regardless of registration order

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)