### PR TITLE
fix(#341): remove redundant nitro.devProxy

### DIFF
--- a/packages/admin/nuxt.config.ts
+++ b/packages/admin/nuxt.config.ts
@@ -7,15 +7,6 @@ export default defineNuxtConfig({
   },
   srcDir: 'app/',
 
-  nitro: {
-    devProxy: {
-      '/api': {
-        target: 'http://localhost:8081/api',
-        changeOrigin: true,
-      },
-    },
-  },
-
   routeRules: {
     '/api/**': { proxy: 'http://localhost:8081/api/**' },
   },


### PR DESCRIPTION
## Summary
- Removes nitro.devProxy block from nuxt.config.ts
- routeRules already proxies /api/** to localhost:8081 in all environments
- Single proxy definition is less confusing and avoids potential routing conflicts

## Test plan
- [ ] npm test passes (78+ Vitest tests)
- [ ] API calls still route correctly in dev mode via routeRules

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)