### PR TITLE
fix(#345): add Firefox to Playwright E2E matrix and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           cache-dependency-path: packages/admin/package-lock.json
 
       - name: Install dependencies and Playwright
-        run: cd packages/admin && npm install --no-audit --no-fund && npx playwright install --with-deps chromium
+        run: cd packages/admin && npm install --no-audit --no-fund && npx playwright install --with-deps chromium firefox
 
       - name: Start PHP backend
         run: |
@@ -104,7 +104,7 @@ jobs:
           done
 
       - name: Run Playwright smoke tests
-        run: cd packages/admin && npx playwright test --project=chromium
+        run: cd packages/admin && npx playwright test --project=chromium --project=firefox
 
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4

--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
   ],
   webServer: {
     command: 'npm run dev',


### PR DESCRIPTION
## Summary
- Adds firefox project to packages/admin/playwright.config.ts
- Updates ci-playwright-smoke job to install and run Firefox alongside Chromium
- No new test files — existing specs run against both browsers

## Test plan
- [ ] CI Playwright job installs and runs chromium + firefox
- [ ] playwright.config.ts parses without errors

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)