### PR TITLE
fix(#342): add GET /api discovery endpoint

### DIFF
--- a/packages/api/src/ApiDiscoveryController.php
+++ b/packages/api/src/ApiDiscoveryController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api;
+
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+/**
+ * Handles GET /api — returns a JSON:API-style discovery document.
+ *
+ * Lists all registered entity types with their collection endpoint URLs.
+ */
+final class ApiDiscoveryController
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly string $basePath = '/api',
+    ) {}
+
+    /**
+     * Returns a discovery document describing all available entity type endpoints.
+     *
+     * @return array{meta: array<string, string>, links: array<string, mixed>}
+     */
+    public function discover(): array
+    {
+        $links = ['self' => $this->basePath];
+
+        foreach ($this->entityTypeManager->getDefinitions() as $id => $definition) {
+            $links[$id] = [
+                'href' => $this->basePath . '/' . $id,
+                'meta' => ['type' => $id],
+            ];
+        }
+
+        return [
+            'meta' => [
+                'api' => 'waaseyaa',
+                'version' => '1.0',
+            ],
+            'links' => $links,
+        ];
+    }
+}

--- a/packages/api/src/JsonApiRouteProvider.php
+++ b/packages/api/src/JsonApiRouteProvider.php
@@ -32,6 +32,16 @@ final class JsonApiRouteProvider
      */
     public function registerRoutes(WaaseyaaRouter $router): void
     {
+        // Discovery endpoint: GET /api
+        $router->addRoute(
+            'api.discovery',
+            RouteBuilder::create($this->basePath)
+                ->controller('Waaseyaa\\Api\\ApiDiscoveryController::discover')
+                ->methods('GET')
+                ->allowAll()
+                ->build(),
+        );
+
         foreach ($this->entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
             $this->registerEntityTypeRoutes($router, $entityTypeId);
         }

--- a/packages/api/tests/Unit/ApiDiscoveryControllerTest.php
+++ b/packages/api/tests/Unit/ApiDiscoveryControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Api\ApiDiscoveryController;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[CoversClass(ApiDiscoveryController::class)]
+final class ApiDiscoveryControllerTest extends TestCase
+{
+    #[Test]
+    public function discover_returns_links_for_all_entity_types(): void
+    {
+        $manager = new EntityTypeManager(new EventDispatcher());
+        $manager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: \stdClass::class,
+            keys: ['id' => 'id'],
+        ));
+        $manager->registerEntityType(new EntityType(
+            id: 'tag',
+            label: 'Tag',
+            class: \stdClass::class,
+            keys: ['id' => 'id'],
+        ));
+
+        $controller = new ApiDiscoveryController($manager, '/api');
+        $doc = $controller->discover();
+
+        $this->assertSame('waaseyaa', $doc['meta']['api']);
+        $this->assertArrayHasKey('article', $doc['links']);
+        $this->assertSame('/api/article', $doc['links']['article']['href']);
+        $this->assertArrayHasKey('tag', $doc['links']);
+        $this->assertSame('/api/tag', $doc['links']['tag']['href']);
+        $this->assertArrayHasKey('self', $doc['links']);
+    }
+
+    #[Test]
+    public function discover_returns_empty_links_when_no_entity_types(): void
+    {
+        $manager = new EntityTypeManager(new EventDispatcher());
+        $controller = new ApiDiscoveryController($manager);
+
+        $doc = $controller->discover();
+
+        $this->assertSame(['self' => '/api'], $doc['links']);
+    }
+}

--- a/packages/api/tests/Unit/JsonApiRouteProviderTest.php
+++ b/packages/api/tests/Unit/JsonApiRouteProviderTest.php
@@ -40,8 +40,8 @@ final class JsonApiRouteProviderTest extends TestCase
 
         $routes = $this->router->getRouteCollection();
 
-        // Five routes per entity type.
-        $this->assertCount(5, $routes);
+        // Five routes per entity type, plus the discovery route.
+        $this->assertCount(6, $routes);
         $this->assertNotNull($routes->get('api.article.index'));
         $this->assertNotNull($routes->get('api.article.show'));
         $this->assertNotNull($routes->get('api.article.store'));
@@ -196,8 +196,8 @@ final class JsonApiRouteProviderTest extends TestCase
 
         $routes = $this->router->getRouteCollection();
 
-        // 5 routes per entity type x 2 entity types = 10 routes.
-        $this->assertCount(10, $routes);
+        // 5 routes per entity type x 2 entity types + 1 discovery route = 11 routes.
+        $this->assertCount(11, $routes);
         $this->assertNotNull($routes->get('api.article.index'));
         $this->assertNotNull($routes->get('api.user.index'));
     }
@@ -227,7 +227,9 @@ final class JsonApiRouteProviderTest extends TestCase
 
         $routes = $this->router->getRouteCollection();
 
-        $this->assertCount(0, $routes);
+        // Discovery route always registered even with no entity types.
+        $this->assertCount(1, $routes);
+        $this->assertNotNull($routes->get('api.discovery'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Adds `ApiDiscoveryController` with `discover()` returning a JSON:API-style meta + links document
- Registers `GET /api` route in `JsonApiRouteProvider` (public, no auth required via `allowAll()`)
- Returns document listing all entity type collection endpoints with `href` and `meta.type` per entry

## Test plan
- [x] `ApiDiscoveryControllerTest` (2 tests): covers multi-entity and empty-registry cases
- [x] `JsonApiRouteProviderTest` updated: count assertions reflect new discovery route
- [x] Full PHP suite passes (4354 tests, 0 failures)

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)