### PR TITLE
fix(#336): add i18n labels for note and relationship entity types

### DIFF
--- a/packages/admin/app/i18n/en.json
+++ b/packages/admin/app/i18n/en.json
@@ -80,6 +80,8 @@
   "entity_type_path_alias": "Path Alias",
   "entity_type_workflow": "Workflow",
   "entity_type_pipeline": "Pipeline",
+  "entity_type_note": "Note",
+  "entity_type_relationship": "Relationship",
 
   "field_title": "Title",
   "field_machine_name": "Machine name",

--- a/packages/admin/tests/unit/i18n/entityTypeLabels.test.ts
+++ b/packages/admin/tests/unit/i18n/entityTypeLabels.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import en from '../../../app/i18n/en.json'
+
+describe('entity type i18n labels', () => {
+  it('has a label for the note entity type', () => {
+    expect((en as Record<string, string>)['entity_type_note']).toBeTruthy()
+  })
+
+  it('has a label for the relationship entity type', () => {
+    expect((en as Record<string, string>)['entity_type_relationship']).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds entity_type_note and entity_type_relationship keys to en.json
- Adds Vitest test verifying both keys are present
- Fixes admin nav showing raw machine names for these entity types

## Test plan
- [x] entityTypeLabels test passes
- [x] Full frontend suite passes (83 tests)

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)