### PR TITLE
chore: record packagist strategy approval

### DIFF
--- a/docs/roadmap/packagist-approval.md
+++ b/docs/roadmap/packagist-approval.md
@@ -1,0 +1,41 @@
+# Packagist Strategy Approval
+
+**Approved by:** Russell Jones
+**Approval timestamp (UTC):** 2026-03-14T15:52:20Z
+**Recommended strategy:** `monorepo-splitsh-per-package-packagist`
+
+---
+
+## Decision Points
+
+| Decision Point | Description | State |
+|---|---|---|
+| **#1** | Confirm Strategy B (Monorepo + splitsh-lite + per-package Packagist) | ✅ **Approved** |
+| **#2** | Create 40 mirror repos under `waaseyaa` GitHub org and configure `SPLIT_GITHUB_TOKEN` | ⏳ Pending |
+| **#3** | Russell verifies POC consumer install and signs off before full rollout | ⏳ Pending |
+
+---
+
+## Scope Authorization
+
+**Authorized actions (POC only):**
+- Prepare local scripts and CI workflow artifacts
+- Run `composer validate` against POC packages locally
+- Create `examples/consumer-test` with path-repo configuration
+
+**Explicitly NOT authorized until Decision Point #2:**
+- Creating mirror GitHub repositories
+- Publishing any package to Packagist
+- Pushing the split workflow to production CI
+- Modifying or rewriting any existing public tags
+- Force pushes of any kind
+
+---
+
+## Safety Note
+
+> No destructive actions authorized. Proceed to POC preparation only.
+
+All work in the POC sprint must be local and reversible. The plan document is at
+`docs/roadmap/packagist-publishing-plan.md`. Full rollout requires explicit approval
+of Decision Points #2 and #3 by Russell before any external side effects occur.


### PR DESCRIPTION
## Summary

Records Russell's approval of the recommended Packagist publishing strategy.

**Strategy:** `monorepo-splitsh-per-package-packagist`
**Approved:** 2026-03-14T15:52:20Z

### Decision Points

| | Status |
|---|---|
| Decision Point #1 — Strategy approved | ✅ Approved |
| Decision Point #2 — Create mirror repos | ⏳ Pending |
| Decision Point #3 — POC sign-off | ⏳ Pending |

### What this PR does NOT authorize

- No mirror repos created
- No Packagist publishing
- No tag modifications or force pushes
- No external side effects of any kind

> Do NOT merge until POC artifacts are reviewed (STEP 2 of the preparation plan).

See `docs/roadmap/packagist-publishing-plan.md` for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)