### PR TITLE
feat(packagist): POC artifacts — playbook, scripts, CI workflow, consumer example

### DIFF
--- a/ci/packagist/validate-composer.yml
+++ b/ci/packagist/validate-composer.yml
@@ -1,0 +1,165 @@
+name: Validate subpackage composer.json files
+
+# Runs on every PR and push to develop/v* branches.
+# Validates all 40 subpackage composer.json files and produces a JSON report.
+# This is a GATE that must pass before the split-and-publish workflow can run.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**/composer.json'
+      - 'ci/packagist/**'
+  push:
+    branches:
+      - 'develop/**'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  validate-subpackages:
+    name: Validate composer.json (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - access
+          - ai-agent
+          - ai-pipeline
+          - ai-schema
+          - ai-vector
+          - api
+          - cache
+          - cli
+          - cms
+          - config
+          - core
+          - database-legacy
+          - entity
+          - entity-storage
+          - field
+          - foundation
+          - full
+          - graphql
+          - i18n
+          - mail
+          - media
+          - menu
+          - mcp
+          - node
+          - note
+          - path
+          - plugin
+          - queue
+          - relationship
+          - routing
+          - search
+          - ssr
+          - state
+          - taxonomy
+          - telescope
+          - testing
+          - typed-data
+          - user
+          - validation
+          - workflows
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
+      - name: Validate composer.json (strict)
+        id: validate
+        run: |
+          composer validate packages/${{ matrix.package }}/composer.json --strict
+          echo "status=pass" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Check required Packagist fields
+        run: |
+          FILE="packages/${{ matrix.package }}/composer.json"
+          MISSING=""
+          jq -e '.name' "$FILE" > /dev/null || MISSING="${MISSING}name,"
+          jq -e '.description' "$FILE" > /dev/null || MISSING="${MISSING}description,"
+          jq -e '.license' "$FILE" > /dev/null || MISSING="${MISSING}license,"
+          TYPE=$(jq -r '.type // "library"' "$FILE")
+          if [ "$TYPE" != "metapackage" ]; then
+            jq -e '.autoload' "$FILE" > /dev/null || MISSING="${MISSING}autoload,"
+          fi
+          if [ -n "$MISSING" ]; then
+            echo "MISSING required fields: ${MISSING%,}"
+            exit 1
+          fi
+          echo "All required fields present for ${{ matrix.package }}"
+
+      - name: Write result to JSON
+        run: |
+          mkdir -p /tmp/validation-results
+          STATUS="${{ steps.validate.outputs.status }}"
+          STATUS="${STATUS:-fail}"
+          jq -n \
+            --arg pkg "${{ matrix.package }}" \
+            --arg status "$STATUS" \
+            --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{package: $pkg, status: $status, validated_at: $time}' \
+            > /tmp/validation-results/${{ matrix.package }}.json
+
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-${{ matrix.package }}
+          path: /tmp/validation-results/${{ matrix.package }}.json
+
+  aggregate-results:
+    name: Aggregate validation report
+    runs-on: ubuntu-latest
+    needs: validate-subpackages
+    if: always()
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: validation-*
+          path: /tmp/validation-results
+          merge-multiple: true
+
+      - name: Generate summary report
+        run: |
+          echo "# Composer Validation Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Package | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
+          PASS=0
+          FAIL=0
+          for f in /tmp/validation-results/*.json; do
+            PKG=$(jq -r '.package' "$f")
+            STATUS=$(jq -r '.status' "$f")
+            if [ "$STATUS" = "pass" ]; then
+              echo "| $PKG | ✅ pass |" >> $GITHUB_STEP_SUMMARY
+              PASS=$((PASS+1))
+            else
+              echo "| $PKG | ❌ fail |" >> $GITHUB_STEP_SUMMARY
+              FAIL=$((FAIL+1))
+            fi
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total:** ${PASS} pass, ${FAIL} fail" >> $GITHUB_STEP_SUMMARY
+          if [ "$FAIL" -gt 0 ]; then
+            echo "VALIDATION_FAILED: ${FAIL} packages did not pass"
+            exit 1
+          fi
+
+      - name: Upload consolidated report
+        uses: actions/upload-artifact@v4
+        with:
+          name: composer-validation-report
+          path: /tmp/validation-results/

--- a/docs/packagist/poc-playbook.md
+++ b/docs/packagist/poc-playbook.md
@@ -1,0 +1,180 @@
+# Packagist POC Playbook
+
+> **Authorization level:** Decision Point #1 approved. Decision Point #2 REQUIRED before
+> executing any step that creates mirror repos or touches Packagist.
+>
+> **Scope:** 3 packages — `waaseyaa/foundation`, `waaseyaa/entity`, `waaseyaa/api`
+
+---
+
+## Prerequisites
+
+Before beginning the POC sprint, confirm:
+
+- [ ] Russell has approved Decision Point #2 (mirror repo creation)
+- [ ] GitHub org `waaseyaa` has permission to create new repositories
+- [ ] `SPLIT_GITHUB_TOKEN` secret created in `waaseyaa/framework` repository settings
+  - Token needs: `repo` scope for the `waaseyaa` org (to push to mirror repos)
+  - Settings → Secrets and variables → Actions → New repository secret
+
+---
+
+## Phase 1: Install splitsh-lite (local)
+
+```bash
+# Download splitsh-lite binary
+curl -sL https://github.com/splitsh/lite/releases/latest/download/lite_linux_amd64.tar.gz \
+  | tar xz -C /usr/local/bin/
+chmod +x /usr/local/bin/splitsh-lite
+splitsh-lite --version
+```
+
+**Dry-run first (safe — no external effects):**
+```bash
+bash scripts/splitsh-lite-simulate.sh packages/foundation foundation
+bash scripts/splitsh-lite-simulate.sh packages/entity entity
+bash scripts/splitsh-lite-simulate.sh packages/api api
+```
+Expected: commit lists printed, no changes made.
+
+---
+
+## Phase 2: Normalize @dev constraints for POC packages
+
+⚠️ Do NOT commit these changes to `main` or `develop/v1.1`. Use a temporary branch.
+
+```bash
+git checkout -b poc/packagist-normalize develop/v1.1
+
+RELEASE="1.1"
+for pkg in foundation entity api; do
+  # Replace @dev with ^1.1 for waaseyaa/* dependencies only
+  sed -i "s/\"waaseyaa\/\([^\"]*\)\": \"@dev\"/\"waaseyaa\/\1\": \"^${RELEASE}\"/g" \
+    packages/$pkg/composer.json
+done
+
+# Verify no @dev constraints remain in the 3 POC packages
+grep '"@dev"' packages/foundation/composer.json packages/entity/composer.json packages/api/composer.json
+# Expected: no output (grep exits 1 = no matches = good)
+
+# Validate all three
+composer validate packages/foundation/composer.json --strict
+composer validate packages/entity/composer.json --strict
+composer validate packages/api/composer.json --strict
+```
+
+---
+
+## Phase 3: Create mirror repos (requires Decision Point #2 approval)
+
+```bash
+# Only run after Russell approves Decision Point #2
+
+gh repo create waaseyaa/foundation --public \
+  --description "Waaseyaa framework: foundation package (Layer 0)"
+gh repo create waaseyaa/entity --public \
+  --description "Waaseyaa framework: entity type system (Layer 1)"
+gh repo create waaseyaa/api --public \
+  --description "Waaseyaa framework: JSON:API controller and routing (Layer 4)"
+```
+
+---
+
+## Phase 4: Run the split
+
+```bash
+# Must be on a tagged commit
+git tag v1.1.0-poc  # POC test tag — do NOT use for production
+
+for pkg in foundation entity api; do
+  SHA=$(splitsh-lite --prefix=packages/$pkg)
+  echo "Split SHA for $pkg: $SHA"
+  # Push to mirror (requires SPLIT_GITHUB_TOKEN in env)
+  GITHUB_TOKEN=$SPLIT_GITHUB_TOKEN \
+    git push https://github.com/waaseyaa/$pkg.git "$SHA:refs/heads/main"
+  git push https://github.com/waaseyaa/$pkg.git v1.1.0-poc
+done
+```
+
+---
+
+## Phase 5: Register on Packagist
+
+1. Log in to https://packagist.org with the `waaseyaa` account
+2. Go to https://packagist.org/packages/submit
+3. Submit each mirror URL:
+   - `https://github.com/waaseyaa/foundation`
+   - `https://github.com/waaseyaa/entity`
+   - `https://github.com/waaseyaa/api`
+4. Enable GitHub webhook on each mirror repo (Packagist provides the URL)
+
+---
+
+## Phase 6: Consumer verification (Decision Point #3)
+
+```bash
+# Create fresh test project
+mkdir /tmp/waaseyaa-consumer-poc && cd /tmp/waaseyaa-consumer-poc
+composer init --no-interaction --name="test/waaseyaa-poc" --stability=stable
+
+# Install from Packagist
+composer require waaseyaa/api:^1.1
+
+# Smoke test autoloader
+php -r "
+  require 'vendor/autoload.php';
+  \$classes = [
+    'Waaseyaa\\\\Api\\\\JsonApiController',
+    'Waaseyaa\\\\Entity\\\\EntityType',
+    'Waaseyaa\\\\Foundation\\\\Kernel\\\\AbstractKernel',
+  ];
+  foreach (\$classes as \$c) {
+    echo class_exists(\$c) ? \"PASS: \$c\\n\" : \"FAIL: \$c\\n\";
+  }
+"
+# Expected: PASS for all three
+```
+
+---
+
+## Acceptance Criteria
+
+| Check | Command | Expected |
+|---|---|---|
+| Packagist lists foundation | `curl -s https://packagist.org/packages/waaseyaa/foundation.json \| jq '.package.name'` | `"waaseyaa/foundation"` |
+| Latest version indexed | `curl -s https://packagist.org/packages/waaseyaa/api.json \| jq '.package.versions \| keys \| .[0]'` | `"v1.1.0-poc"` |
+| Consumer install exit 0 | `composer require waaseyaa/api:^1.1; echo $?` | `0` |
+| Autoloader smoke test | see Phase 6 | `PASS` × 3 |
+| No @dev in published package | `curl https://raw.githubusercontent.com/waaseyaa/entity/main/composer.json \| jq '.require'` | no `@dev` values |
+
+---
+
+## Secrets Required
+
+| Secret name | Scope | Where to set |
+|---|---|---|
+| `SPLIT_GITHUB_TOKEN` | `repo` on `waaseyaa` org | `waaseyaa/framework` → Settings → Secrets |
+| Packagist API token | Packagist account | Local env only (for yank/update commands) |
+
+---
+
+## Rollback (if POC fails)
+
+```bash
+# Delete the POC tag (it was created only for POC, not a production tag)
+git push origin :refs/tags/v1.1.0-poc
+git tag -d v1.1.0-poc
+
+# Remove POC mirror repos if needed
+gh repo delete waaseyaa/foundation --yes
+gh repo delete waaseyaa/entity --yes
+gh repo delete waaseyaa/api --yes
+
+# Restore @dev constraints in the 3 packages
+git checkout develop/v1.1 -- packages/foundation/composer.json
+git checkout develop/v1.1 -- packages/entity/composer.json
+git checkout develop/v1.1 -- packages/api/composer.json
+```
+
+> The POC tag `v1.1.0-poc` is exclusively for the proof of concept.
+> Production tags (`v1.0.0-final`, `v1.1.0`) are not touched.

--- a/examples/consumer-test/composer.json
+++ b/examples/consumer-test/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "test/waaseyaa-consumer-poc",
+    "description": "Minimal consumer project for Waaseyaa Packagist POC verification",
+    "type": "project",
+    "license": "proprietary",
+    "require": {
+        "php": ">=8.3",
+        "waaseyaa/api": "@dev",
+        "waaseyaa/entity": "@dev",
+        "waaseyaa/foundation": "@dev"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/api",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "path",
+            "url": "../../packages/entity",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "path",
+            "url": "../../packages/foundation",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "_comment": "POC ONLY — path repos simulate what Packagist will serve after monorepo split. Replace path repos with packagist.org entries once packages are registered."
+}

--- a/scripts/splitsh-lite-simulate.sh
+++ b/scripts/splitsh-lite-simulate.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# splitsh-lite-simulate.sh — Dry-run simulation of the monorepo split.
+#
+# USAGE:
+#   bash scripts/splitsh-lite-simulate.sh <package-path> <target-repo-name>
+#
+# EXAMPLE:
+#   bash scripts/splitsh-lite-simulate.sh packages/foundation waaseyaa-foundation
+#
+# This script does NOT push, does NOT modify history, does NOT require splitsh-lite
+# to be installed. It prints what would happen if the real split ran.
+
+set -euo pipefail
+
+PACKAGE_PATH="${1:?Usage: $0 <package-path> <target-repo-name>}"
+TARGET_REPO="${2:?Usage: $0 <package-path> <target-repo-name>}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "====================================================="
+echo " splitsh-lite DRY RUN SIMULATION"
+echo "====================================================="
+echo " Package path : ${PACKAGE_PATH}"
+echo " Target repo  : github.com/waaseyaa/${TARGET_REPO}"
+echo " Repo root    : ${REPO_ROOT}"
+echo "====================================================="
+echo ""
+
+# Verify the package path exists and has a composer.json
+if [[ ! -f "${REPO_ROOT}/${PACKAGE_PATH}/composer.json" ]]; then
+  echo "ERROR: ${PACKAGE_PATH}/composer.json not found. Aborting."
+  exit 1
+fi
+
+PACKAGE_NAME=$(jq -r '.name' "${REPO_ROOT}/${PACKAGE_PATH}/composer.json")
+echo "Package name  : ${PACKAGE_NAME}"
+echo ""
+
+# Show commits that touch this path
+echo "--- Commits that would be included in the split ---"
+git -C "${REPO_ROOT}" log --pretty=format:"%h %ad %s" --date=short -- "${PACKAGE_PATH}" | head -20
+echo ""
+echo "  (showing last 20; run without | head to see all)"
+echo ""
+
+# Count total commits
+TOTAL=$(git -C "${REPO_ROOT}" rev-list HEAD -- "${PACKAGE_PATH}" | wc -l | tr -d ' ')
+echo "Total commits touching ${PACKAGE_PATH}: ${TOTAL}"
+echo ""
+
+# Show current tag
+LATEST_TAG=$(git -C "${REPO_ROOT}" describe --tags --abbrev=0 2>/dev/null || echo "no tags")
+echo "Latest monorepo tag: ${LATEST_TAG}"
+echo ""
+
+# Print the actual splitsh-lite command that would run
+echo "--- Command that WOULD be executed (commented out for safety) ---"
+echo ""
+echo "# Install splitsh-lite:"
+echo "# curl -sL https://github.com/splitsh/lite/releases/latest/download/lite_linux_amd64.tar.gz | tar xz"
+echo ""
+echo "# Run split (outputs the SHA of the new root commit):"
+echo "# SHA=\$(./splitsh-lite --prefix=${PACKAGE_PATH})"
+echo "# echo \"Split SHA: \$SHA\""
+echo ""
+echo "# Push to mirror repo (tag only — no history modification to monorepo):"
+echo "# git push https://github.com/waaseyaa/${TARGET_REPO}.git \"\$SHA:refs/heads/main\" --force-with-lease"
+echo "# git push https://github.com/waaseyaa/${TARGET_REPO}.git ${LATEST_TAG}"
+echo ""
+echo "--- GitHub Actions equivalent ---"
+echo ""
+echo "  uses: symplify/monorepo-split-github-action@v2"
+echo "  with:"
+echo "    package-directory: ${PACKAGE_PATH}"
+echo "    split-repository-organization: waaseyaa"
+echo "    split-repository-name: ${TARGET_REPO}"
+echo "    tag: \${{ github.ref_name }}"
+echo ""
+echo "====================================================="
+echo " DRY RUN COMPLETE — no changes made"
+echo "====================================================="


### PR DESCRIPTION
## Summary

- Adds `docs/packagist/poc-playbook.md` — step-by-step 6-phase POC execution guide with acceptance criteria and rollback procedure
- Adds `scripts/splitsh-lite-simulate.sh` — safe dry-run simulation of monorepo split (no push, no external effects)
- Adds `ci/packagist/validate-composer.yml` — GitHub Actions matrix workflow validating all 40 subpackage `composer.json` files
- Adds `examples/consumer-test/composer.json` — minimal consumer project template using path repos (simulates post-Packagist install)

## Authorization

Decision Point #1 (strategy approval) was approved by Russell on 2026-03-14. See `chore/packagist-approval` (PR #393) for the recorded approval.

**Decision Point #2 (mirror repo creation) is NOT yet approved.** None of these artifacts touch Packagist, push to mirror repos, or create tags. All changes are local/CI-only and fully reversible.

## Validation Results

All three POC packages (`foundation`, `entity`, `api`) and the consumer example pass `composer validate --no-check-lock`. Only expected `@dev` constraint warnings are present — these are normalized to `^1.1` in Phase 2 of the playbook.

## POC ZIP

A local ZIP of all artifacts is at `/tmp/waaseyaa-packagist-poc.zip` for Russell's inspection.

## Test plan

- [ ] Review `docs/packagist/poc-playbook.md` — phases, acceptance criteria, rollback steps
- [ ] Run `bash scripts/splitsh-lite-simulate.sh packages/foundation foundation` — confirms dry-run output, no changes
- [ ] Review `ci/packagist/validate-composer.yml` — matrix covers all 40 packages
- [ ] Review `examples/consumer-test/composer.json` — confirms path repo wiring for the 3 POC packages
- [ ] Await Decision Point #2 approval before executing Phase 3 (mirror repo creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)