### PR TITLE
feat(packagist): normalize @dev constraints to ^1.1 for all packages

### DIFF
--- a/packages/access/composer.json
+++ b/packages/access/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/plugin": "@dev",
-        "waaseyaa/foundation": "@dev",
-        "waaseyaa/routing": "@dev",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/plugin": "^1.1",
+        "waaseyaa/foundation": "^1.1",
+        "waaseyaa/routing": "^1.1",
         "symfony/http-foundation": "^7.0"
     },
     "require-dev": {

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/ai-schema": "@dev",
-        "waaseyaa/access": "@dev"
+        "waaseyaa/ai-schema": "^1.1",
+        "waaseyaa/access": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-pipeline/composer.json
+++ b/packages/ai-pipeline/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/queue": "@dev",
-        "waaseyaa/ai-vector": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/queue": "^1.1",
+        "waaseyaa/ai-vector": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-schema/composer.json
+++ b/packages/ai-schema/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev"
+        "waaseyaa/entity": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-vector/composer.json
+++ b/packages/ai-vector/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/queue": "@dev",
-        "waaseyaa/api": "@dev",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/workflows": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/queue": "^1.1",
+        "waaseyaa/api": "^1.1",
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/workflows": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/foundation": "@dev",
-        "waaseyaa/routing": "@dev",
-        "waaseyaa/access": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/foundation": "^1.1",
+        "waaseyaa/routing": "^1.1",
+        "waaseyaa/access": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/config": "@dev",
-        "waaseyaa/cache": "@dev",
-        "waaseyaa/user": "@dev",
-        "waaseyaa/access": "@dev",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/config": "^1.1",
+        "waaseyaa/cache": "^1.1",
+        "waaseyaa/user": "^1.1",
+        "waaseyaa/access": "^1.1",
         "symfony/console": "^7.0"
     },
     "require-dev": {

--- a/packages/entity-storage/composer.json
+++ b/packages/entity-storage/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/field": "@dev",
-        "waaseyaa/cache": "@dev",
-        "waaseyaa/database-legacy": "@dev",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/field": "^1.1",
+        "waaseyaa/cache": "^1.1",
+        "waaseyaa/database-legacy": "^1.1",
         "symfony/event-dispatcher": "^7.3"
     },
     "require-dev": {

--- a/packages/entity/composer.json
+++ b/packages/entity/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/typed-data": "@dev",
-        "waaseyaa/plugin": "@dev",
-        "waaseyaa/cache": "@dev",
-        "waaseyaa/config": "@dev",
-        "waaseyaa/foundation": "@dev",
-        "waaseyaa/validation": "@dev",
+        "waaseyaa/typed-data": "^1.1",
+        "waaseyaa/plugin": "^1.1",
+        "waaseyaa/cache": "^1.1",
+        "waaseyaa/config": "^1.1",
+        "waaseyaa/foundation": "^1.1",
+        "waaseyaa/validation": "^1.1",
         "symfony/event-dispatcher": "^7.3",
         "symfony/uid": "^7.3",
         "symfony/validator": "^7.3"

--- a/packages/field/composer.json
+++ b/packages/field/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/plugin": "@dev",
-        "waaseyaa/typed-data": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/plugin": "^1.1",
+        "waaseyaa/typed-data": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -11,7 +11,7 @@
         "symfony/http-foundation": "^7.0",
         "symfony/messenger": "^7.0",
         "symfony/uid": "^7.0",
-        "waaseyaa/queue": "@dev"
+        "waaseyaa/queue": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/mail/composer.json
+++ b/packages/mail/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=8.4",
-        "waaseyaa/foundation": "@dev"
+        "waaseyaa/foundation": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -22,15 +22,15 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/ai-schema": "@dev",
-        "waaseyaa/ai-agent": "@dev",
-        "waaseyaa/routing": "@dev",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/cache": "@dev",
-        "waaseyaa/api": "@dev",
-        "waaseyaa/ai-vector": "@dev",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/workflows": "@dev"
+        "waaseyaa/ai-schema": "^1.1",
+        "waaseyaa/ai-agent": "^1.1",
+        "waaseyaa/routing": "^1.1",
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/cache": "^1.1",
+        "waaseyaa/api": "^1.1",
+        "waaseyaa/ai-vector": "^1.1",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/workflows": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/media/composer.json
+++ b/packages/media/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev"
+        "waaseyaa/entity": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/menu/composer.json
+++ b/packages/menu/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev"
+        "waaseyaa/entity": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/node/composer.json
+++ b/packages/node/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/access": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/access": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/note/composer.json
+++ b/packages/note/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/access": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/access": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/path/composer.json
+++ b/packages/path/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev"
+        "waaseyaa/entity": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/relationship/composer.json
+++ b/packages/relationship/composer.json
@@ -10,10 +10,10 @@
     },
     "require": {
         "php": ">=8.3",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/database-legacy": "@dev",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/workflows": "@dev"
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/database-legacy": "^1.1",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/workflows": "^1.1"
     },
     "extra": {
         "waaseyaa": {

--- a/packages/routing/composer.json
+++ b/packages/routing/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/i18n": "@dev",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/i18n": "^1.1",
         "symfony/routing": "^7.3"
     },
     "require-dev": {

--- a/packages/ssr/composer.json
+++ b/packages/ssr/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=8.4",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/cache": "@dev",
-        "waaseyaa/config": "@dev",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/field": "@dev",
-        "waaseyaa/routing": "@dev",
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/cache": "^1.1",
+        "waaseyaa/config": "^1.1",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/field": "^1.1",
+        "waaseyaa/routing": "^1.1",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/packages/state/composer.json
+++ b/packages/state/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.3",
-        "waaseyaa/database-legacy": "@dev"
+        "waaseyaa/database-legacy": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/taxonomy/composer.json
+++ b/packages/taxonomy/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/access": "@dev"
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/access": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/foundation": "@dev",
+        "waaseyaa/entity": "^1.1",
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/foundation": "^1.1",
         "symfony/http-foundation": "^7.0"
     },
     "require-dev": {

--- a/packages/validation/composer.json
+++ b/packages/validation/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/typed-data": "@dev",
+        "waaseyaa/typed-data": "^1.1",
         "symfony/validator": "^7.3"
     },
     "require-dev": {

--- a/packages/workflows/composer.json
+++ b/packages/workflows/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/entity": "@dev"
+        "waaseyaa/access": "^1.1",
+        "waaseyaa/entity": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"


### PR DESCRIPTION
## Summary

Normalizes all `waaseyaa/*` `@dev` constraints to `^1.1` across 26 packages in preparation for full Packagist publishing rollout (Decision Point #3 approved — PR #396).

- **26 packages normalized** (14 unchanged — no internal waaseyaa/* deps)
- **0 `@dev` constraints remaining** across all 40 packages
- **40/40 packages pass** `composer validate`

## Affected packages

`access`, `ai-agent`, `ai-pipeline`, `ai-schema`, `ai-vector`, `api`, `cli`, `entity-storage`, `entity`, `field`, `foundation`, `mail`, `mcp`, `media`, `menu`, `node`, `note`, `path`, `relationship`, `routing`, `ssr`, `state`, `taxonomy`, `user`, `validation`, `workflows`

## What this unblocks

With `@dev` removed, each package's `composer.json` is valid for Packagist publishing. The next step is the full `splitsh-lite` split + mirror push for all 37 remaining packages.

## Test plan

- [ ] `grep -r '"@dev"' packages/*/composer.json` — expected: no output
- [ ] `composer validate packages/*/composer.json --no-check-lock` — expected: all valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)