### PR TITLE
feat: normalize inter-package constraints to ^0.1 for initial public release

### DIFF
--- a/packages/access/composer.json
+++ b/packages/access/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/plugin": "^1.1",
-        "waaseyaa/foundation": "^1.1",
-        "waaseyaa/routing": "^1.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/plugin": "^0.1",
+        "waaseyaa/foundation": "^0.1",
+        "waaseyaa/routing": "^0.1",
         "symfony/http-foundation": "^7.0"
     },
     "require-dev": {

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/ai-schema": "^1.1",
-        "waaseyaa/access": "^1.1"
+        "waaseyaa/ai-schema": "^0.1",
+        "waaseyaa/access": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-pipeline/composer.json
+++ b/packages/ai-pipeline/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/queue": "^1.1",
-        "waaseyaa/ai-vector": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/queue": "^0.1",
+        "waaseyaa/ai-vector": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-schema/composer.json
+++ b/packages/ai-schema/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1"
+        "waaseyaa/entity": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/ai-vector/composer.json
+++ b/packages/ai-vector/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/queue": "^1.1",
-        "waaseyaa/api": "^1.1",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/workflows": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/queue": "^0.1",
+        "waaseyaa/api": "^0.1",
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/workflows": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/foundation": "^1.1",
-        "waaseyaa/routing": "^1.1",
-        "waaseyaa/access": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/foundation": "^0.1",
+        "waaseyaa/routing": "^0.1",
+        "waaseyaa/access": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/config": "^1.1",
-        "waaseyaa/cache": "^1.1",
-        "waaseyaa/user": "^1.1",
-        "waaseyaa/access": "^1.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/config": "^0.1",
+        "waaseyaa/cache": "^0.1",
+        "waaseyaa/user": "^0.1",
+        "waaseyaa/access": "^0.1",
         "symfony/console": "^7.0"
     },
     "require-dev": {

--- a/packages/entity-storage/composer.json
+++ b/packages/entity-storage/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/field": "^1.1",
-        "waaseyaa/cache": "^1.1",
-        "waaseyaa/database-legacy": "^1.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/field": "^0.1",
+        "waaseyaa/cache": "^0.1",
+        "waaseyaa/database-legacy": "^0.1",
         "symfony/event-dispatcher": "^7.3"
     },
     "require-dev": {

--- a/packages/entity/composer.json
+++ b/packages/entity/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/typed-data": "^1.1",
-        "waaseyaa/plugin": "^1.1",
-        "waaseyaa/cache": "^1.1",
-        "waaseyaa/config": "^1.1",
-        "waaseyaa/foundation": "^1.1",
-        "waaseyaa/validation": "^1.1",
+        "waaseyaa/typed-data": "^0.1",
+        "waaseyaa/plugin": "^0.1",
+        "waaseyaa/cache": "^0.1",
+        "waaseyaa/config": "^0.1",
+        "waaseyaa/foundation": "^0.1",
+        "waaseyaa/validation": "^0.1",
         "symfony/event-dispatcher": "^7.3",
         "symfony/uid": "^7.3",
         "symfony/validator": "^7.3"

--- a/packages/field/composer.json
+++ b/packages/field/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/plugin": "^1.1",
-        "waaseyaa/typed-data": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/plugin": "^0.1",
+        "waaseyaa/typed-data": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -11,7 +11,7 @@
         "symfony/http-foundation": "^7.0",
         "symfony/messenger": "^7.0",
         "symfony/uid": "^7.0",
-        "waaseyaa/queue": "^1.1"
+        "waaseyaa/queue": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/mail/composer.json
+++ b/packages/mail/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=8.4",
-        "waaseyaa/foundation": "^1.1"
+        "waaseyaa/foundation": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -22,15 +22,15 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/ai-schema": "^1.1",
-        "waaseyaa/ai-agent": "^1.1",
-        "waaseyaa/routing": "^1.1",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/cache": "^1.1",
-        "waaseyaa/api": "^1.1",
-        "waaseyaa/ai-vector": "^1.1",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/workflows": "^1.1"
+        "waaseyaa/ai-schema": "^0.1",
+        "waaseyaa/ai-agent": "^0.1",
+        "waaseyaa/routing": "^0.1",
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/cache": "^0.1",
+        "waaseyaa/api": "^0.1",
+        "waaseyaa/ai-vector": "^0.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/workflows": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/media/composer.json
+++ b/packages/media/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1"
+        "waaseyaa/entity": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/menu/composer.json
+++ b/packages/menu/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1"
+        "waaseyaa/entity": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/node/composer.json
+++ b/packages/node/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/access": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/access": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/note/composer.json
+++ b/packages/note/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/access": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/access": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/path/composer.json
+++ b/packages/path/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1"
+        "waaseyaa/entity": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/relationship/composer.json
+++ b/packages/relationship/composer.json
@@ -10,10 +10,10 @@
     },
     "require": {
         "php": ">=8.3",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/database-legacy": "^1.1",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/workflows": "^1.1"
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/database-legacy": "^0.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/workflows": "^0.1"
     },
     "extra": {
         "waaseyaa": {

--- a/packages/routing/composer.json
+++ b/packages/routing/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/i18n": "^1.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/i18n": "^0.1",
         "symfony/routing": "^7.3"
     },
     "require-dev": {

--- a/packages/ssr/composer.json
+++ b/packages/ssr/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=8.4",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/cache": "^1.1",
-        "waaseyaa/config": "^1.1",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/field": "^1.1",
-        "waaseyaa/routing": "^1.1",
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/cache": "^0.1",
+        "waaseyaa/config": "^0.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/field": "^0.1",
+        "waaseyaa/routing": "^0.1",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/packages/state/composer.json
+++ b/packages/state/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.3",
-        "waaseyaa/database-legacy": "^1.1"
+        "waaseyaa/database-legacy": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/taxonomy/composer.json
+++ b/packages/taxonomy/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/access": "^1.1"
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/access": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/entity": "^1.1",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/foundation": "^1.1",
+        "waaseyaa/entity": "^0.1",
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/foundation": "^0.1",
         "symfony/http-foundation": "^7.0"
     },
     "require-dev": {

--- a/packages/validation/composer.json
+++ b/packages/validation/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/typed-data": "^1.1",
+        "waaseyaa/typed-data": "^0.1",
         "symfony/validator": "^7.3"
     },
     "require-dev": {

--- a/packages/workflows/composer.json
+++ b/packages/workflows/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=8.3",
-        "waaseyaa/access": "^1.1",
-        "waaseyaa/entity": "^1.1"
+        "waaseyaa/access": "^0.1",
+        "waaseyaa/entity": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"


### PR DESCRIPTION
## Summary

- Replaces all `waaseyaa/*` `^1.1` and `@dev` constraints with `^0.1` across 26 packages
- Aligns inter-package dependency constraints with the `v0.1.0-alpha.1` release version
- All 40 packages pass `composer validate --no-check-lock`

## Context

Commit #397 normalized `@dev` → `^1.1`, but `v0.1.0-alpha.1` does not satisfy `^1.1` (`>=1.1.0 <2.0.0`). This PR corrects the constraint range to `^0.1` so that `v0.1.0-alpha.1` resolves correctly on Packagist.

## Note: 4 packages not in split.yml

`mail`, `note`, `relationship`, `search` are in the monorepo but absent from `.github/workflows/split.yml`. They will not be split or published when the monorepo tag is pushed. None are dependencies of `waaseyaa/full`, so the consumer install test is not affected — but they will be invisible on Packagist. Add them to `split.yml` if they should be published.

## Affected packages

access, ai-agent, ai-pipeline, ai-schema, ai-vector, api, cli, entity-storage, entity, field, foundation, mail, mcp, media, menu, node, note, path, relationship, routing, ssr, state, taxonomy, user, validation, workflows

## Test plan

- [ ] `composer validate --no-check-lock` passes for all 40 packages
- [ ] No `waaseyaa/*` constraints remain at `^1.1` or `@dev`
- [ ] After merge: push `v0.1.0-alpha.1` tag to monorepo → `split.yml` fires and mirrors get correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)