### PR TITLE
feat(admin): add packaging config, CI workflow, and bootstrap JSON schema

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -15,6 +15,10 @@ on:
       - 'packages/admin-bridge/**'
       - '.github/workflows/admin.yml'
 
+concurrency:
+  group: admin-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   contracts:
     name: admin/contracts
@@ -68,10 +72,12 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
+        if: hashFiles('packages/admin-bridge/composer.json') != ''
         run: composer install --no-interaction --no-progress --prefer-dist
         working-directory: .
 
       - name: Run PHP payload tests
+        if: hashFiles('packages/admin-bridge/composer.json') != ''
         run: ./vendor/bin/phpunit packages/admin-bridge/tests/
         working-directory: .
 

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -3,13 +3,16 @@ name: Admin SPA
 on:
   push:
     branches: [main]
+    tags: ['v*']
     paths:
       - 'packages/admin/**'
+      - 'packages/admin-bridge/**'
       - '.github/workflows/admin.yml'
   pull_request:
     branches: [main]
     paths:
       - 'packages/admin/**'
+      - 'packages/admin-bridge/**'
       - '.github/workflows/admin.yml'
 
 jobs:
@@ -57,6 +60,20 @@ jobs:
 
       - name: Run Vitest contract tests
         run: npx vitest run --reporter=verbose
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+        working-directory: .
+
+      - name: Run PHP payload tests
+        run: ./vendor/bin/phpunit packages/admin-bridge/tests/
+        working-directory: .
 
       - name: Upload contracts build
         uses: actions/upload-artifact@v4
@@ -116,3 +133,69 @@ jobs:
 
       - name: Run Playwright integration tests
         run: cd packages/admin && npx playwright test
+
+  adapters:
+    name: admin/adapters
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/admin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: packages/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Run adapter unit tests
+        run: npx vitest run tests/unit/adapters/
+
+  release:
+    name: admin/release
+    runs-on: ubuntu-latest
+    needs: [contracts, adapters, build]
+    if: startsWith(github.ref, 'refs/tags/v')
+    defaults:
+      run:
+        working-directory: packages/admin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: packages/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Contract freeze check
+        run: |
+          # Verify contracts/bootstrap.schema.json matches the tagged version
+          # Fail if contract files have uncommitted changes
+          git diff --exit-code contracts/
+
+      - name: Build contracts
+        run: npm run build:contracts
+
+      - name: Tarball integrity check
+        run: |
+          # Pack and verify tarball contents
+          npm pack --dry-run 2>&1 | tee /dev/stderr
+
+      - name: Build Admin SPA
+        run: npm run build
+
+      # TODO: Publish step — enable when npm registry is configured
+      # - name: Publish to npm
+      #   run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,0 +1,118 @@
+name: Admin SPA
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/admin/**'
+      - '.github/workflows/admin.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/admin/**'
+      - '.github/workflows/admin.yml'
+
+jobs:
+  contracts:
+    name: admin/contracts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/admin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: packages/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: TypeScript typecheck
+        run: npx nuxi typecheck
+
+      - name: Build contracts
+        run: npm run build:contracts
+
+      - name: Validate bootstrap JSON schema
+        run: |
+          npx --yes ajv-cli validate \
+            --spec=draft2020 \
+            --strict=false \
+            -s contracts/bootstrap.schema.json \
+            -d - <<'PAYLOAD'
+          {
+            "version": "1.0",
+            "auth": { "strategy": "redirect", "loginUrl": "/login" },
+            "account": { "id": "1", "name": "Admin", "roles": ["admin"] },
+            "tenant": { "id": "default", "name": "Test", "scopingStrategy": "server" },
+            "transport": { "strategy": "jsonapi", "apiPath": "/api" },
+            "entities": []
+          }
+          PAYLOAD
+
+      - name: Run Vitest contract tests
+        run: npx vitest run --reporter=verbose
+
+      - name: Upload contracts build
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: contracts-dist
+          path: packages/admin/dist/
+          retention-days: 14
+
+  build:
+    name: admin/build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/admin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: packages/admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build Admin SPA
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: admin-build
+          path: packages/admin/.output/
+          retention-days: 14
+
+  integration:
+    name: admin/integration
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: false  # Placeholder — enable when Playwright smoke tests with mock host are ready
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: packages/admin/package-lock.json
+
+      - name: Install dependencies and Playwright
+        run: cd packages/admin && npm install --no-audit --no-fund && npx playwright install --with-deps chromium
+
+      - name: Run Playwright integration tests
+        run: cd packages/admin && npx playwright test

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -2,14 +2,14 @@ name: Admin SPA
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'develop/*']
     tags: ['v*']
     paths:
       - 'packages/admin/**'
       - 'packages/admin-bridge/**'
       - '.github/workflows/admin.yml'
   pull_request:
-    branches: [main]
+    branches: [main, 'develop/*']
     paths:
       - 'packages/admin/**'
       - 'packages/admin-bridge/**'

--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -1,0 +1,37 @@
+name: Trigger Packagist Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Packagist package name (e.g. waaseyaa/waaseyaa)'
+        required: true
+        default: 'waaseyaa/waaseyaa'
+      repo_url:
+        description: 'GitHub repo URL for the package'
+        required: true
+        default: 'https://github.com/waaseyaa/waaseyaa'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Packagist crawl
+        env:
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+          PACKAGE: ${{ github.event.inputs.package }}
+          REPO_URL: ${{ github.event.inputs.repo_url }}
+        run: |
+          USERNAME="${PACKAGE%%/*}"
+          RESPONSE=$(curl -s -o /tmp/packagist-response.json -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"repository\":{\"url\":\"${REPO_URL}\"}}" \
+            "https://packagist.org/api/update-package?username=${USERNAME}&apiToken=${PACKAGIST_TOKEN}")
+          echo "HTTP status: $RESPONSE"
+          cat /tmp/packagist-response.json
+          if [ "$RESPONSE" != "202" ]; then
+            echo "::error::Packagist update failed with status $RESPONSE"
+            exit 1
+          fi
+          echo "Packagist update triggered successfully."

--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -3,6 +3,10 @@ name: Trigger Packagist Update
 on:
   workflow_dispatch:
     inputs:
+      packagist_username:
+        description: 'Packagist account username (owner of the API token)'
+        required: true
+        default: 'jonesrussell'
       package:
         description: 'Packagist package name (e.g. waaseyaa/waaseyaa)'
         required: true
@@ -19,10 +23,11 @@ jobs:
       - name: Trigger Packagist crawl
         env:
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+          PACKAGIST_USERNAME: ${{ github.event.inputs.packagist_username }}
           PACKAGE: ${{ github.event.inputs.package }}
           REPO_URL: ${{ github.event.inputs.repo_url }}
         run: |
-          USERNAME="${PACKAGE%%/*}"
+          USERNAME="${PACKAGIST_USERNAME}"
           RESPONSE=$(curl -s -o /tmp/packagist-response.json -w "%{http_code}" \
             -X POST \
             -H "Content-Type: application/json" \

--- a/packages/admin/contracts/bootstrap.schema.json
+++ b/packages/admin/contracts/bootstrap.schema.json
@@ -134,6 +134,10 @@
         "group": {
           "type": "string"
         },
+        "disabled": {
+          "type": "boolean",
+          "description": "If true, the entity type is visible but non-interactive in the admin UI"
+        },
         "capabilities": {
           "$ref": "#/$defs/CatalogCapabilities"
         }

--- a/packages/admin/contracts/bootstrap.schema.json
+++ b/packages/admin/contracts/bootstrap.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://waaseyaa.com/schemas/admin-bootstrap.json",
+  "title": "AdminBootstrap",
+  "description": "Bootstrap payload for the Waaseyaa admin SPA (window.__WAASEYAA_ADMIN__)",
+  "type": "object",
+  "required": ["version", "auth", "account", "tenant", "transport", "entities"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Contract version — must match ADMIN_CONTRACT_VERSION"
+    },
+    "auth": {
+      "$ref": "#/$defs/AdminAuthConfig"
+    },
+    "account": {
+      "$ref": "#/$defs/AdminAccount"
+    },
+    "tenant": {
+      "$ref": "#/$defs/AdminTenant"
+    },
+    "transport": {
+      "$ref": "#/$defs/AdminTransportConfig"
+    },
+    "entities": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/CatalogEntry"
+      },
+      "description": "Entity types available to the admin UI"
+    },
+    "features": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "description": "Optional feature flags"
+    }
+  },
+  "$defs": {
+    "AdminAuthConfig": {
+      "type": "object",
+      "required": ["strategy"],
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["redirect", "embedded"]
+        },
+        "loginUrl": {
+          "type": "string"
+        },
+        "loginEndpoint": {
+          "type": "string"
+        },
+        "logoutEndpoint": {
+          "type": "string"
+        }
+      }
+    },
+    "AdminAccount": {
+      "type": "object",
+      "required": ["id", "name", "roles"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AdminTenant": {
+      "type": "object",
+      "required": ["id", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scopingStrategy": {
+          "type": "string",
+          "enum": ["server", "header"],
+          "default": "server"
+        }
+      }
+    },
+    "AdminTransportConfig": {
+      "type": "object",
+      "required": ["strategy"],
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["jsonapi", "custom"]
+        },
+        "apiPath": {
+          "type": "string"
+        }
+      }
+    },
+    "CatalogEntry": {
+      "type": "object",
+      "required": ["id", "label", "capabilities"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "keys": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/CatalogCapabilities"
+        }
+      }
+    },
+    "CatalogCapabilities": {
+      "type": "object",
+      "required": ["list", "get", "create", "update", "delete", "schema"],
+      "additionalProperties": false,
+      "properties": {
+        "list": {
+          "type": "boolean"
+        },
+        "get": {
+          "type": "boolean"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "update": {
+          "type": "boolean"
+        },
+        "delete": {
+          "type": "boolean"
+        },
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,12 +1,30 @@
 {
     "name": "@waaseyaa/admin",
-    "version": "0.1.0",
-    "private": true,
+    "version": "1.0.0",
     "type": "module",
-    "description": "Schema-driven admin SPA for Waaseyaa (Nuxt 3 + Vue 3)",
+    "description": "Schema-driven admin SPA for Waaseyaa with pluggable host contracts",
+    "exports": {
+        ".": {
+            "types": "./dist/contracts/index.d.ts",
+            "import": "./dist/contracts/index.js"
+        },
+        "./adapters": {
+            "types": "./dist/adapters/index.d.ts",
+            "import": "./dist/adapters/index.js"
+        },
+        "./nuxt": "./"
+    },
+    "files": [
+        "dist/contracts/",
+        "dist/adapters/",
+        "app/",
+        "nuxt.config.ts",
+        "tsconfig.json"
+    ],
     "scripts": {
         "dev": "nuxt dev",
         "build": "nuxt build",
+        "build:contracts": "tsc -p tsconfig.contracts.json",
         "generate": "nuxt generate",
         "preview": "nuxt preview",
         "postinstall": "nuxt prepare",

--- a/packages/admin/tsconfig.contracts.json
+++ b/packages/admin/tsconfig.contracts.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "app",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["app/contracts/**/*.ts", "app/adapters/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Remove `"private": true` from package.json, add npm exports map for contracts/adapters/nuxt
- Create `tsconfig.contracts.json` for building contract type declarations
- Create `contracts/bootstrap.schema.json` (JSON Schema 2020-12) for cross-language validation of bootstrap payload
- Create `.github/workflows/admin.yml` with contracts, adapters, build, integration, and release jobs

## Test plan
- [x] JSON schema validates against bootstrap contract types
- [ ] Verify `npm run build:contracts` compiles to dist/ (requires contract source files from #402)
- [ ] Verify CI workflow triggers on packages/admin/** changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)