### PR TITLE
feat(#437,#438,#439,#440): GraphQL schema validation and input type improvements

### DIFF
--- a/docs/superpowers/plans/2026-03-16-claudriel-graphql-adoption.md
+++ b/docs/superpowers/plans/2026-03-16-claudriel-graphql-adoption.md
@@ -1,0 +1,730 @@
+# Claudriel GraphQL Adoption — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate Claudriel's frontend data-loading from JSON:API to GraphQL for Commitments + People, eliminating in-memory filtering and multi-roundtrip patterns.
+
+**Architecture:** Schema-first migration — validate Waaseyaa's auto-generated GraphQL schema supports Claudriel's query needs, fix gaps in the framework, then incrementally migrate frontend composables and retire custom controllers.
+
+**Tech Stack:** PHP 8.3+ (Waaseyaa GraphQL package, webonyx/graphql-php), TypeScript (Nuxt 3 composables), PHPUnit 10.5
+
+**Design spec:** `docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md`
+
+---
+
+## Chunk 1: Waaseyaa Schema Validation (framework repo)
+
+All tasks in this chunk are in the `waaseyaa/framework` repo, milestone v1.3 (#24).
+
+### Task 1: Schema validation test harness ([#437](https://github.com/waaseyaa/framework/issues/437))
+
+**Files:**
+- Create: `packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+
+- [ ] **Step 1: Write the schema introspection test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\GraphQL\Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\GraphQL\Schema\SchemaFactory;
+use Waaseyaa\GraphQL\Resolver\EntityResolver;
+use Waaseyaa\GraphQL\Resolver\ReferenceLoader;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\Type;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[CoversClass(SchemaFactory::class)]
+final class SchemaValidationTest extends TestCase
+{
+    private function buildSchema(array $entityTypes): \GraphQL\Type\Schema
+    {
+        $manager = new EntityTypeManager(new EventDispatcher());
+        foreach ($entityTypes as $et) {
+            $manager->addDefinition($et);
+        }
+
+        $resolver = $this->createMock(EntityResolver::class);
+        $referenceLoader = $this->createMock(ReferenceLoader::class);
+
+        $factory = new SchemaFactory($manager, $resolver, $referenceLoader);
+        return $factory->build();
+    }
+
+    #[Test]
+    public function queryFieldsAreGeneratedForEntityType(): void
+    {
+        $schema = $this->buildSchema([
+            new EntityType(
+                id: 'article',
+                label: 'Article',
+                entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+                entityClass: \stdClass::class,
+                fieldDefinitions: [
+                    'aid' => ['type' => 'integer'],
+                    'uuid' => ['type' => 'string'],
+                    'title' => ['type' => 'string', 'required' => true],
+                    'score' => ['type' => 'float'],
+                ],
+            ),
+        ]);
+
+        $queryType = $schema->getQueryType();
+        $this->assertNotNull($queryType);
+        $this->assertTrue($queryType->hasField('article'), 'Missing single query field');
+        $this->assertTrue($queryType->hasField('articleList'), 'Missing list query field');
+
+        // Single query accepts id: ID!
+        $articleField = $queryType->getField('article');
+        $idArg = $articleField->getArg('id');
+        $this->assertInstanceOf(NonNull::class, $idArg->getType());
+
+        // List query accepts filter, sort, offset, limit
+        $listField = $queryType->getField('articleList');
+        $this->assertNotNull($listField->getArg('filter'));
+        $this->assertNotNull($listField->getArg('sort'));
+        $this->assertNotNull($listField->getArg('offset'));
+        $this->assertNotNull($listField->getArg('limit'));
+    }
+
+    #[Test]
+    public function listResultTypeHasItemsAndTotal(): void
+    {
+        $schema = $this->buildSchema([
+            new EntityType(
+                id: 'article',
+                label: 'Article',
+                entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+                entityClass: \stdClass::class,
+                fieldDefinitions: [
+                    'aid' => ['type' => 'integer'],
+                    'uuid' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                ],
+            ),
+        ]);
+
+        $listResultType = $schema->getType('ArticleListResult');
+        $this->assertInstanceOf(ObjectType::class, $listResultType);
+        $this->assertTrue($listResultType->hasField('items'));
+        $this->assertTrue($listResultType->hasField('total'));
+    }
+
+    #[Test]
+    public function mutationFieldsAreGenerated(): void
+    {
+        $schema = $this->buildSchema([
+            new EntityType(
+                id: 'article',
+                label: 'Article',
+                entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+                entityClass: \stdClass::class,
+                fieldDefinitions: [
+                    'aid' => ['type' => 'integer'],
+                    'uuid' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                ],
+            ),
+        ]);
+
+        $mutationType = $schema->getMutationType();
+        $this->assertNotNull($mutationType);
+        $this->assertTrue($mutationType->hasField('createArticle'));
+        $this->assertTrue($mutationType->hasField('updateArticle'));
+        $this->assertTrue($mutationType->hasField('deleteArticle'));
+    }
+
+    #[Test]
+    public function fieldTypesMapCorrectly(): void
+    {
+        $schema = $this->buildSchema([
+            new EntityType(
+                id: 'article',
+                label: 'Article',
+                entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+                entityClass: \stdClass::class,
+                fieldDefinitions: [
+                    'aid' => ['type' => 'integer'],
+                    'uuid' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                    'score' => ['type' => 'float'],
+                    'active' => ['type' => 'boolean'],
+                ],
+            ),
+        ]);
+
+        $articleType = $schema->getType('Article');
+        $this->assertInstanceOf(ObjectType::class, $articleType);
+
+        // score should map to Float
+        $scoreField = $articleType->getField('score');
+        $this->assertSame('Float', $scoreField->getType()->name ?? $scoreField->getType()->toString());
+
+        // active should map to Boolean
+        $activeField = $articleType->getField('active');
+        $this->assertSame('Boolean', $activeField->getType()->name ?? $activeField->getType()->toString());
+    }
+
+    #[Test]
+    public function filterInputTypeHasCorrectStructure(): void
+    {
+        $schema = $this->buildSchema([
+            new EntityType(
+                id: 'article',
+                label: 'Article',
+                entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+                entityClass: \stdClass::class,
+                fieldDefinitions: [
+                    'aid' => ['type' => 'integer'],
+                    'uuid' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                ],
+            ),
+        ]);
+
+        $filterType = $schema->getType('FilterInput');
+        $this->assertInstanceOf(InputObjectType::class, $filterType);
+        $this->assertTrue($filterType->hasField('field'));
+        $this->assertTrue($filterType->hasField('value'));
+        $this->assertTrue($filterType->hasField('operator'));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+Expected: All tests PASS (these test the existing working implementation)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+git commit -m "feat(#437): add GraphQL schema validation test harness"
+```
+
+---
+
+### Task 2: Validate filter/sort on _data blob fields ([#438](https://github.com/waaseyaa/framework/issues/438))
+
+**Files:**
+- Modify: `packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+- Possibly modify: `packages/graphql/src/Resolver/EntityResolver.php` or `packages/api/src/Query/QueryApplier.php`
+
+- [ ] **Step 1: Write test for filtering on a schema column**
+
+Add a test method to `SchemaValidationTest` that creates an entity with a schema column, executes a GraphQL query with a filter, and confirms results are filtered correctly. This requires an integration test with real storage.
+
+- [ ] **Step 2: Write test for filtering on a _data blob field**
+
+Add a test that filters on a field stored in `_data` and documents the behavior — does it silently return no results, throw, or work?
+
+- [ ] **Step 3: Run tests, document findings**
+
+Run: `./vendor/bin/phpunit packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+
+If `_data` filtering doesn't work (expected), add inline documentation to `EntityResolver` or the GraphQL package README explaining the limitation and migration path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#438): validate and document _data blob filter/sort limitations"
+```
+
+---
+
+### Task 3: Separate create/update input types ([#439](https://github.com/waaseyaa/framework/issues/439))
+
+**Files:**
+- Modify: `packages/graphql/src/Schema/EntityTypeBuilder.php`
+- Modify: `packages/graphql/src/Schema/SchemaFactory.php`
+- Modify: `packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+
+- [ ] **Step 1: Write failing test for separate input types**
+
+```php
+#[Test]
+public function createAndUpdateInputTypesAreSeparate(): void
+{
+    $schema = $this->buildSchema([
+        new EntityType(
+            id: 'article',
+            label: 'Article',
+            entityKeys: ['id' => 'aid', 'uuid' => 'uuid'],
+            entityClass: \stdClass::class,
+            fieldDefinitions: [
+                'aid' => ['type' => 'integer'],
+                'uuid' => ['type' => 'string'],
+                'title' => ['type' => 'string', 'required' => true],
+                'body' => ['type' => 'string'],
+            ],
+        ),
+    ]);
+
+    $createInput = $schema->getType('ArticleCreateInput');
+    $updateInput = $schema->getType('ArticleUpdateInput');
+
+    $this->assertInstanceOf(InputObjectType::class, $createInput);
+    $this->assertInstanceOf(InputObjectType::class, $updateInput);
+
+    // Create input: required fields are NonNull
+    $createTitle = $createInput->getField('title');
+    $this->assertInstanceOf(NonNull::class, $createTitle->getType());
+
+    // Update input: all fields nullable
+    $updateTitle = $updateInput->getField('title');
+    $this->assertNotInstanceOf(NonNull::class, $updateTitle->getType());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter createAndUpdateInputTypesAreSeparate`
+Expected: FAIL (currently generates single `ArticleInput`)
+
+- [ ] **Step 3: Implement separate input types**
+
+In `EntityTypeBuilder`, add `buildCreateInputType()` and `buildUpdateInputType()` methods. The create version wraps required fields with `NonNull`, the update version makes all fields nullable. Update `SchemaFactory` to use `buildCreateInputType()` for `create{Type}` mutations and `buildUpdateInputType()` for `update{Type}` mutations.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(#439): separate create/update GraphQL input types for PATCH semantics"
+```
+
+---
+
+### Task 4: Validate pagination arguments ([#440](https://github.com/waaseyaa/framework/issues/440))
+
+**Files:**
+- Modify: `packages/graphql/tests/Unit/Schema/SchemaValidationTest.php`
+- Possibly modify: `packages/graphql/src/Resolver/EntityResolver.php`
+
+- [ ] **Step 1: Write test for pagination argument types**
+
+```php
+#[Test]
+public function listQueryHasPaginationArguments(): void
+{
+    $schema = $this->buildSchema([/* ... */]);
+
+    $listField = $schema->getQueryType()->getField('articleList');
+
+    $limitArg = $listField->getArg('limit');
+    $this->assertSame('Int', $limitArg->getType()->name ?? $limitArg->getType()->toString());
+
+    $offsetArg = $listField->getArg('offset');
+    $this->assertSame('Int', $offsetArg->getType()->name ?? $offsetArg->getType()->toString());
+}
+```
+
+- [ ] **Step 2: Write test for default behavior when omitted**
+
+Test that resolveList with no limit/offset returns results (and ideally has a sensible max).
+
+- [ ] **Step 3: Add default max limit if missing**
+
+If `EntityResolver::resolveList()` has no max limit, add a default (e.g., 100) to prevent unbounded queries.
+
+- [ ] **Step 4: Run tests, commit**
+
+```bash
+git commit -m "feat(#440): validate pagination arguments and add default max limit"
+```
+
+---
+
+### Task 5: Tag v0.1.0-alpha.10 ([#441](https://github.com/waaseyaa/framework/issues/441))
+
+- [ ] **Step 1: Verify all validation issues are resolved**
+
+Run: `./vendor/bin/phpunit packages/graphql/tests/`
+Expected: All PASS
+
+- [ ] **Step 2: Tag and push**
+
+```bash
+git tag v0.1.0-alpha.10
+git push origin v0.1.0-alpha.10
+```
+
+- [ ] **Step 3: Verify Packagist picks up the release**
+
+Check that all `waaseyaa/*` packages show alpha.10 on Packagist.
+
+---
+
+## Chunk 2: Claudriel Schema Validation (claudriel repo)
+
+All tasks in this chunk are in the `jonesrussell/claudriel` repo, milestone v1.5 (#16).
+
+### Task 6: Bump Waaseyaa to alpha.10 ([#170](https://github.com/jonesrussell/claudriel/issues/170))
+
+**Files:**
+- Modify: `composer.json`
+
+- [ ] **Step 1: Update composer.json**
+
+Bump all `waaseyaa/*` version constraints to `^0.1.0-alpha.10`. Add `waaseyaa/graphql` as a new dependency.
+
+- [ ] **Step 2: Install and verify**
+
+```bash
+composer update waaseyaa/*
+```
+
+- [ ] **Step 3: Boot dev server and test /graphql endpoint**
+
+```bash
+php -S localhost:8080 public/index.php &
+curl -s http://localhost:8080/graphql -H 'Content-Type: application/json' -d '{"query":"{ __schema { queryType { name } } }"}'
+```
+
+Expected: Returns schema introspection data with Claudriel entity types.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#170): bump Waaseyaa to alpha.10, add waaseyaa/graphql"
+```
+
+---
+
+### Task 7: Schema contract test ([#171](https://github.com/jonesrussell/claudriel/issues/171))
+
+**Files:**
+- Create: `tests/Integration/GraphQL/SchemaContractTest.php`
+
+- [ ] **Step 1: Write contract test**
+
+Boot Claudriel's kernel, generate the GraphQL schema, assert the Commitment and Person types exist with expected fields, queries, mutations, and argument structures. Use the pattern from Waaseyaa's `SchemaValidationTest` but with Claudriel's actual entity types.
+
+- [ ] **Step 2: Run test**
+
+```bash
+./vendor/bin/phpunit tests/Integration/GraphQL/SchemaContractTest.php
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(#171): add GraphQL schema contract test for Commitment + Person"
+```
+
+---
+
+### Task 8: Validate field definitions ([#172](https://github.com/jonesrussell/claudriel/issues/172))
+
+**Files:**
+- Possibly modify: `src/Entity/Commitment.php` or entity type registration
+- Possibly modify: `src/Schema/` (if schema handlers exist)
+
+- [ ] **Step 1: Check if tenant_id, last_interaction_at, confidence are schema columns**
+
+Inspect Claudriel's entity type definitions and schema handlers. If any of these fields are stored in `_data` blob, promote them to real schema columns.
+
+- [ ] **Step 2: Run schema contract test to verify**
+
+```bash
+./vendor/bin/phpunit tests/Integration/GraphQL/SchemaContractTest.php
+```
+
+- [ ] **Step 3: Test filtering and sorting end-to-end**
+
+Write a quick integration test that inserts test data, then queries via GraphQL with `tenant_id` filter and `last_interaction_at` sort to confirm SQL-level operations work.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#172): validate and fix field definitions for GraphQL compatibility"
+```
+
+---
+
+## Chunk 3: Claudriel Frontend Migration (claudriel repo)
+
+### Task 9: graphqlFetch() helper + gql tag ([#173](https://github.com/jonesrussell/claudriel/issues/173))
+
+**Files:**
+- Create: `frontend/admin/app/utils/gql.ts`
+- Create: `frontend/admin/app/utils/graphqlFetch.ts`
+- Create: `frontend/admin/app/utils/__tests__/graphqlFetch.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { graphqlFetch, GraphQlError } from '../graphqlFetch';
+
+describe('graphqlFetch', () => {
+  it('returns typed data on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ data: { article: { id: '1', title: 'Test' } } }),
+    });
+
+    const result = await graphqlFetch<{ article: { id: string; title: string } }>(
+      '{ article(id: "1") { id title } }'
+    );
+
+    expect(result.article.title).toBe('Test');
+  });
+
+  it('throws GraphQlError on errors', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ errors: [{ message: 'Not found' }] }),
+    });
+
+    await expect(graphqlFetch('{ bad }')).rejects.toThrow(GraphQlError);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd frontend/admin && npm test -- --run utils/__tests__/graphqlFetch.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+Create `gql.ts` and `graphqlFetch.ts` as specified in the design spec (Section 4).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd frontend/admin && npm test -- --run utils/__tests__/graphqlFetch.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(#173): add graphqlFetch helper and gql template tag"
+```
+
+---
+
+### Task 10: useCommitmentsQuery() composable ([#174](https://github.com/jonesrussell/claudriel/issues/174))
+
+**Files:**
+- Create: `frontend/admin/app/composables/useCommitmentsQuery.ts`
+- Create: `frontend/admin/app/composables/__tests__/useCommitmentsQuery.test.ts`
+- Create: `frontend/admin/app/types/commitment.ts` (TypeScript interface)
+
+- [ ] **Step 1: Define Commitment TypeScript interface**
+
+```typescript
+export interface Commitment {
+  uuid: string;
+  title: string;
+  status: string;
+  confidence: number;
+  due_date: string | null;
+  person_uuid: string | null;
+  source: string;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Test that the composable calls `graphqlFetch` with the correct query string and filter variables.
+
+- [ ] **Step 3: Implement the composable**
+
+```typescript
+import { gql } from '~/utils/gql';
+import { graphqlFetch } from '~/utils/graphqlFetch';
+import type { Commitment } from '~/types/commitment';
+
+interface ListResult<T> { items: T[]; total: number; }
+
+const COMMITMENTS_LIST_QUERY = gql`
+  query CommitmentsList($status: String, $tenantId: String) {
+    commitmentList(
+      filter: [
+        { field: "status", value: $status }
+        { field: "tenant_id", value: $tenantId }
+      ]
+      sort: "-updated_at"
+      limit: 50
+    ) {
+      items {
+        uuid title status confidence due_date
+        person_uuid source created_at updated_at
+      }
+      total
+    }
+  }
+`;
+
+export function useCommitmentsQuery(filter: { status?: string; tenantId?: string }) {
+  return useAsyncData('commitments', () =>
+    graphqlFetch<{ commitmentList: ListResult<Commitment> }>(COMMITMENTS_LIST_QUERY, filter)
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd frontend/admin && npm test -- --run composables/__tests__/useCommitmentsQuery.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(#174): add useCommitmentsQuery GraphQL composable"
+```
+
+---
+
+### Task 11: usePeopleQuery() composable ([#175](https://github.com/jonesrussell/claudriel/issues/175))
+
+**Files:**
+- Create: `frontend/admin/app/composables/usePeopleQuery.ts`
+- Create: `frontend/admin/app/composables/__tests__/usePeopleQuery.test.ts`
+- Create: `frontend/admin/app/types/person.ts`
+
+- [ ] **Step 1: Define Person TypeScript interface**
+
+```typescript
+export interface Person {
+  uuid: string;
+  name: string;
+  email: string;
+  tier: string;
+  source: string;
+  latest_summary: string | null;
+  last_interaction_at: string | null;
+  last_inbox_category: string | null;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Same pattern as Task 10 but for `usePeopleQuery`.
+
+- [ ] **Step 3: Implement the composable**
+
+Same pattern as Task 10 with the People query from the design spec.
+
+- [ ] **Step 4: Run test, commit**
+
+```bash
+git commit -m "feat(#175): add usePeopleQuery GraphQL composable"
+```
+
+---
+
+## Chunk 4: Component Migration & Controller Cleanup (claudriel repo)
+
+### Task 12: Migrate Commitment components ([#176](https://github.com/jonesrussell/claudriel/issues/176))
+
+**Files:**
+- Modify: All components that call `useEntity('commitment')`
+
+- [ ] **Step 1: Find all commitment adapter calls**
+
+```bash
+grep -r "useEntity.*commitment" frontend/admin/app/
+```
+
+- [ ] **Step 2: Replace each with useCommitmentsQuery()**
+
+For list calls: replace with `useCommitmentsQuery()`.
+For single-entity, create, update, delete: use `graphqlFetch()` directly with the appropriate query/mutation.
+
+- [ ] **Step 3: Smoke test**
+
+Boot dev server, verify commitment list, detail view, create, edit, delete all work correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#176): migrate commitment components to GraphQL"
+```
+
+---
+
+### Task 13: Migrate People components ([#177](https://github.com/jonesrussell/claudriel/issues/177))
+
+Same pattern as Task 12 but for `useEntity('person')` calls.
+
+- [ ] **Step 1: Find all people adapter calls**
+- [ ] **Step 2: Replace with usePeopleQuery()**
+- [ ] **Step 3: Smoke test**
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#177): migrate people components to GraphQL"
+```
+
+---
+
+### Task 14: Deprecate controllers ([#178](https://github.com/jonesrussell/claudriel/issues/178), [#179](https://github.com/jonesrussell/claudriel/issues/179))
+
+**Files:**
+- Modify: `src/Controller/CommitmentApiController.php`
+- Modify: `src/Controller/PeopleApiController.php`
+
+- [ ] **Step 1: Verify no frontend code calls the old endpoints**
+
+```bash
+grep -r "/api/commitments\|/api/people" frontend/admin/app/
+```
+
+Expected: No matches (all migrated to GraphQL).
+
+- [ ] **Step 2: Add deprecation logging to both controllers**
+
+Add `error_log('Deprecated: /api/commitments — use /graphql endpoint instead');` at the top of each controller method.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(#178,#179): deprecate Commitment and People API controllers"
+```
+
+---
+
+### Task 15: Remove deprecated controllers ([#180](https://github.com/jonesrussell/claudriel/issues/180))
+
+**Files:**
+- Delete: `src/Controller/CommitmentApiController.php`
+- Delete: `src/Controller/PeopleApiController.php`
+- Modify: Route registration (remove `/api/commitments` and `/api/people` routes)
+
+- [ ] **Step 1: Confirm zero deprecation log entries**
+
+Check logs to verify no consumers remain.
+
+- [ ] **Step 2: Delete controllers and route registrations**
+- [ ] **Step 3: Run all tests**
+
+```bash
+./vendor/bin/phpunit
+cd frontend/admin && npm test
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(#180): remove deprecated Commitment and People controllers"
+```

--- a/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
+++ b/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
@@ -1,0 +1,247 @@
+# Claudriel GraphQL Adoption — Design Spec
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Scope:** Claudriel adopts client-side GraphQL for Commitments + People data paths
+**Follow-up:** Minoo server-side GraphQL adoption (separate spec)
+
+---
+
+## 1. Context & Motivation
+
+Waaseyaa v1.3 added a zero-config GraphQL layer that auto-generates full CRUD schema from entity types — queries, mutations, filtering, sorting, pagination, nested reference resolution with N+1 prevention, and field-level access control.
+
+Claudriel has accumulated architectural pain in its data-loading path:
+
+- Controllers load ALL entities into memory, filter with `array_filter()`, sort with `usort()`
+- No server-side pagination
+- Frontend makes separate roundtrips for commitments, people, schedule, workspaces
+- N+1 patterns everywhere when loading related entities
+
+GraphQL solves all of these in one stroke by pushing filtering/sorting/pagination to the database and enabling nested entity resolution in a single request.
+
+## 2. Strategy
+
+- **Claudriel:** Adopt GraphQL on the **client side** for performance + UX gains
+- **Migration approach:** Incremental, one data path at a time
+- **First target:** Commitments + People (highest complexity, most relationship joins, most painful today)
+- **Waaseyaa dependency:** Tag v0.1.0-alpha.10 including GraphQL package before Claudriel adopts
+- **GitHub-first:** All issues created with milestones before any code changes
+
+## 3. Target GraphQL Queries
+
+### Commitments list
+
+```graphql
+query CommitmentsList($status: String, $tenantId: String) {
+  commitmentList(
+    filter: { status: $status, tenant_id: $tenantId }
+    sort: { field: "updated_at", direction: DESC }
+    limit: 50
+  ) {
+    uuid, title, status, confidence, due_date
+    person_uuid, source, created_at, updated_at
+  }
+}
+```
+
+### Single commitment
+
+```graphql
+query Commitment($id: ID!) {
+  commitment(id: $id) {
+    uuid, title, status, confidence, due_date
+    source, tenant_id, created_at, updated_at
+    person_uuid
+  }
+}
+```
+
+### People list
+
+```graphql
+query PeopleList($tenantId: String, $tier: String) {
+  personList(
+    filter: { tenant_id: $tenantId, tier: $tier }
+    sort: { field: "last_interaction_at", direction: DESC }
+  ) {
+    uuid, name, email, tier, source
+    latest_summary, last_interaction_at, last_inbox_category
+  }
+}
+```
+
+### Mutations
+
+```graphql
+mutation CreateCommitment($input: CommitmentInput!) {
+  createCommitment(input: $input) {
+    uuid, title, status
+  }
+}
+
+mutation UpdateCommitment($id: ID!, $input: CommitmentInput!) {
+  updateCommitment(id: $id, input: $input) {
+    uuid, title, status, updated_at
+  }
+}
+
+mutation DeleteCommitment($id: ID!) {
+  deleteCommitment(id: $id)
+}
+```
+
+**Note:** `person_uuid` stays as a plain string for v1. Nested resolution (`commitment { person { name } }`) requires an `entity_reference` field definition — scoped as a future enhancement.
+
+## 4. Frontend Composable Architecture
+
+### Transport layer
+
+A thin `graphqlFetch()` helper alongside the existing JSON:API adapter:
+
+```typescript
+// app/utils/gql.ts
+export const gql = String.raw;
+
+// app/utils/graphqlFetch.ts
+export class GraphQlError extends Error {
+  constructor(public errors: Array<{ message: string; path?: string[] }>) {
+    super(errors.map(e => e.message).join(', '));
+  }
+}
+
+export async function graphqlFetch<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch('/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await response.json();
+  if (json.errors?.length) throw new GraphQlError(json.errors);
+  return json.data;
+}
+```
+
+### Composables per data path
+
+```typescript
+// app/composables/useCommitmentsQuery.ts
+export function useCommitmentsQuery(filter: { status?: string; tenantId?: string }) {
+  return useAsyncData('commitments', () =>
+    graphqlFetch<{ commitmentList: Commitment[] }>(COMMITMENTS_LIST_QUERY, filter)
+  );
+}
+
+// app/composables/usePeopleQuery.ts
+export function usePeopleQuery(filter: { tenantId?: string; tier?: string }) {
+  return useAsyncData('people', () =>
+    graphqlFetch<{ personList: Person[] }>(PEOPLE_LIST_QUERY, filter)
+  );
+}
+```
+
+### What changes in components
+
+Replace:
+```typescript
+useEntity('commitment').list({ status: 'active' })
+```
+
+With:
+```typescript
+useCommitmentsQuery({ status: 'active' })
+```
+
+One-line change per component. No template changes. No reactive state changes.
+
+### What stays as-is
+
+- `claudrielAdapter.ts` and `useEntity.ts` remain for non-migrated entity types (schedule, triage, chat, workspace)
+- JSON:API endpoints stay live during migration
+- No breaking changes
+
+### TypeScript interfaces
+
+Flat types mirroring GraphQL response fields — `Commitment`, `Person` defined once, shared across composables.
+
+## 5. Controller Simplification
+
+### Controllers fully replaceable by GraphQL
+
+- **CommitmentApiController** — pure CRUD + in-memory filtering/sorting. All logic moves to GraphQL resolvers.
+- **PeopleApiController** — pure CRUD + in-memory filtering/sorting. Same.
+
+### Controllers that stay (for now)
+
+- **ScheduleApiController** — has temporal query logic (`TemporalContextFactory`, `RelativeScheduleQueryService`) that requires custom GraphQL resolver work. Migrates in a future phase.
+
+### Cleanup sequence per entity type
+
+1. Frontend composable ships
+2. Validate GraphQL path works end-to-end
+3. Remove old adapter calls from components
+4. Deprecate controller routes (keep responding, log warnings)
+5. Remove controller + routes in a follow-up PR
+
+Rollback-safe: if GraphQL has issues, flip back to the adapter path.
+
+## 6. Schema Validation & Gap Analysis
+
+Seven items to validate before any Claudriel code changes:
+
+| # | Item | Risk | Notes |
+|---|------|------|-------|
+| 1 | `tenant_id` is filterable | HIGH | Must be a declared field, not a `_data` blob value |
+| 2 | `last_interaction_at` is sortable | HIGH | Must be a schema column for SQL-level sorting |
+| 3 | `confidence` maps to GraphQL Float | MEDIUM | Commitment must define it with a float field type |
+| 4 | Update input types have all-optional fields | MEDIUM | PATCH semantics require nullable inputs |
+| 5 | `person_uuid` as entity reference (future) | LOW | Not needed for v1, flag for later |
+| 6 | Tenant context as implicit filter (future) | LOW | Future enhancement, not a blocker |
+| 7 | Pagination arguments (`limit`/`offset`) exist as `Int` | LOW | Confirm on all `*List` queries with correct defaults |
+
+**Validation method:** PHPUnit integration test that boots the Claudriel kernel, generates the GraphQL schema, and asserts expected query/mutation fields exist with correct types. Becomes a regression guard for the schema contract.
+
+## 7. GitHub Issue Tree
+
+### Waaseyaa repo — milestone: v1.3 (GraphQL & Cleanup)
+
+| # | Issue | Depends on | Description |
+|---|-------|------------|-------------|
+| W1 | Schema validation test harness | — | Integration test that boots a test kernel, generates GraphQL schema, asserts field/type presence. Reusable for any app. |
+| W2 | Validate filter/sort on `_data` blob fields | W1 | Confirm whether `QueryApplier` can filter/sort on fields stored in `_data` vs schema columns. Document the limitation if not. |
+| W3 | Validate nullable input types for PATCH semantics | W1 | Confirm auto-generated mutation input types have all-optional fields for update operations. Fix if not. |
+| W4 | Validate pagination arguments on list queries | W1 | Confirm `limit`/`offset` exist as `Int` on all `*List` queries, with correct defaults when omitted. |
+| W5 | Tag v0.1.0-alpha.10 | W2, W3, W4 | Release including GraphQL package + any fixes from validation. |
+
+### Claudriel repo — new milestone: GraphQL Adoption
+
+| # | Issue | Depends on | Description |
+|---|-------|------------|-------------|
+| C1 | Bump Waaseyaa to alpha.10, add `waaseyaa/graphql` | W5 | Update composer.json, verify schema auto-generates for all Claudriel entity types. |
+| C2 | Schema contract test for Commitment + Person | C1 | PHPUnit test asserting expected queries, mutations, field types, filter/sort args exist in generated schema. |
+| C3 | Validate `tenant_id`, `last_interaction_at`, `confidence` field definitions | C2 | Confirm these are schema columns (not `_data` blob). Fix entity type definitions if needed. |
+| C4 | `graphqlFetch()` helper + `gql` tag | C1 | Add `app/utils/graphqlFetch.ts` and `app/utils/gql.ts`. Unit test the helper. |
+| C5 | `useCommitmentsQuery()` composable | C3, C4 | Replaces `useEntity('commitment').list()`. Typed response, filter params, `useAsyncData` integration. |
+| C6 | `usePeopleQuery()` composable | C3, C4 | Replaces `useEntity('person').list()`. Same pattern as C5. |
+| C7 | Migrate Commitment components to GraphQL | C5 | Replace adapter calls in commitment-related components with `useCommitmentsQuery()`. |
+| C8 | Migrate People components to GraphQL | C6 | Replace adapter calls in people-related components with `usePeopleQuery()`. |
+| C9 | Deprecate CommitmentApiController | C7 | Add deprecation logging, keep routes live. |
+| C10 | Deprecate PeopleApiController | C8 | Add deprecation logging, keep routes live. |
+| C11 | Remove deprecated controllers | C9, C10 | Delete controllers + routes after validation period. |
+
+### Dependency chain
+
+```
+W1 → W2,W3,W4 → W5 → C1 → C2 → C3 → C5,C6 → C7,C8 → C9,C10 → C11
+                  W5 → C1 → C4 ↗
+```
+
+## 8. Future Work (Out of Scope)
+
+- **Schedule migration:** Requires custom GraphQL resolvers for temporal query logic. Separate design.
+- **Nested entity resolution:** Commitment → Person requires `entity_reference` field definition in Waaseyaa.
+- **Tenant-aware context:** Implicit tenant scoping at the resolver level, removing explicit `tenant_id` filter params.
+- **Minoo adoption:** Server-side GraphQL for admin SPA and SSR controller simplification. Separate spec.

--- a/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
+++ b/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
@@ -118,6 +118,7 @@ mutation DeleteCommitment($id: ID!) {
 **Notes:**
 - `person_uuid` stays as a plain string for v1. Nested resolution (`commitment { person { name } }`) requires an `entity_reference` field definition — scoped as a future enhancement.
 - Input type names depend on entity type IDs. If Claudriel's entity type ID is `commitment`, the input type is `CommitmentInput`. Verify actual IDs during schema validation (C2).
+- Once W3 lands (separate create/update input types), mutation examples here will need updating to `CommitmentCreateInput` / `CommitmentUpdateInput`. The current examples assume a single shared input type.
 
 ## 4. Frontend Composable Architecture
 

--- a/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
+++ b/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
@@ -30,17 +30,33 @@ GraphQL solves all of these in one stroke by pushing filtering/sorting/paginatio
 
 ## 3. Target GraphQL Queries
 
+### Waaseyaa GraphQL conventions
+
+Before the queries: Waaseyaa's auto-generated GraphQL layer uses these conventions:
+
+- **Filter:** `[FilterInput!]` array where each element has `{ field: String!, value: String!, operator: String }` (operator defaults to `=`)
+- **Sort:** `String` using JSON:API convention — field name for ascending, `-` prefix for descending (e.g. `"-updated_at"`)
+- **List results:** Wrapped in `{Type}ListResult { items: [Type]!, total: Int! }`
+- **Delete results:** Returns `DeleteResult { deleted: Boolean! }`
+- **Input types:** Named `{PascalCase}Input`, generated from entity field definitions. Fields marked `required` in the entity type get `NonNull` wrappers.
+
 ### Commitments list
 
 ```graphql
 query CommitmentsList($status: String, $tenantId: String) {
   commitmentList(
-    filter: { status: $status, tenant_id: $tenantId }
-    sort: { field: "updated_at", direction: DESC }
+    filter: [
+      { field: "status", value: $status }
+      { field: "tenant_id", value: $tenantId }
+    ]
+    sort: "-updated_at"
     limit: 50
   ) {
-    uuid, title, status, confidence, due_date
-    person_uuid, source, created_at, updated_at
+    items {
+      uuid, title, status, confidence, due_date
+      person_uuid, source, created_at, updated_at
+    }
+    total
   }
 }
 ```
@@ -62,11 +78,17 @@ query Commitment($id: ID!) {
 ```graphql
 query PeopleList($tenantId: String, $tier: String) {
   personList(
-    filter: { tenant_id: $tenantId, tier: $tier }
-    sort: { field: "last_interaction_at", direction: DESC }
+    filter: [
+      { field: "tenant_id", value: $tenantId }
+      { field: "tier", value: $tier }
+    ]
+    sort: "-last_interaction_at"
   ) {
-    uuid, name, email, tier, source
-    latest_summary, last_interaction_at, last_inbox_category
+    items {
+      uuid, name, email, tier, source
+      latest_summary, last_interaction_at, last_inbox_category
+    }
+    total
   }
 }
 ```
@@ -87,11 +109,15 @@ mutation UpdateCommitment($id: ID!, $input: CommitmentInput!) {
 }
 
 mutation DeleteCommitment($id: ID!) {
-  deleteCommitment(id: $id)
+  deleteCommitment(id: $id) {
+    deleted
+  }
 }
 ```
 
-**Note:** `person_uuid` stays as a plain string for v1. Nested resolution (`commitment { person { name } }`) requires an `entity_reference` field definition — scoped as a future enhancement.
+**Notes:**
+- `person_uuid` stays as a plain string for v1. Nested resolution (`commitment { person { name } }`) requires an `entity_reference` field definition — scoped as a future enhancement.
+- Input type names depend on entity type IDs. If Claudriel's entity type ID is `commitment`, the input type is `CommitmentInput`. Verify actual IDs during schema validation (C2).
 
 ## 4. Frontend Composable Architecture
 
@@ -128,17 +154,23 @@ export async function graphqlFetch<T>(
 ### Composables per data path
 
 ```typescript
+// Shared list result shape matching Waaseyaa's {Type}ListResult
+interface ListResult<T> {
+  items: T[];
+  total: number;
+}
+
 // app/composables/useCommitmentsQuery.ts
 export function useCommitmentsQuery(filter: { status?: string; tenantId?: string }) {
   return useAsyncData('commitments', () =>
-    graphqlFetch<{ commitmentList: Commitment[] }>(COMMITMENTS_LIST_QUERY, filter)
+    graphqlFetch<{ commitmentList: ListResult<Commitment> }>(COMMITMENTS_LIST_QUERY, filter)
   );
 }
 
 // app/composables/usePeopleQuery.ts
 export function usePeopleQuery(filter: { tenantId?: string; tier?: string }) {
   return useAsyncData('people', () =>
-    graphqlFetch<{ personList: Person[] }>(PEOPLE_LIST_QUERY, filter)
+    graphqlFetch<{ personList: ListResult<Person> }>(PEOPLE_LIST_QUERY, filter)
   );
 }
 ```
@@ -190,17 +222,18 @@ Rollback-safe: if GraphQL has issues, flip back to the adapter path.
 
 ## 6. Schema Validation & Gap Analysis
 
-Seven items to validate before any Claudriel code changes:
+Eight items to validate before any Claudriel code changes:
 
 | # | Item | Risk | Notes |
 |---|------|------|-------|
-| 1 | `tenant_id` is filterable | HIGH | Must be a declared field, not a `_data` blob value |
-| 2 | `last_interaction_at` is sortable | HIGH | Must be a schema column for SQL-level sorting |
-| 3 | `confidence` maps to GraphQL Float | MEDIUM | Commitment must define it with a float field type |
-| 4 | Update input types have all-optional fields | MEDIUM | PATCH semantics require nullable inputs |
-| 5 | `person_uuid` as entity reference (future) | LOW | Not needed for v1, flag for later |
-| 6 | Tenant context as implicit filter (future) | LOW | Future enhancement, not a blocker |
-| 7 | Pagination arguments (`limit`/`offset`) exist as `Int` | LOW | Confirm on all `*List` queries with correct defaults |
+| 1 | `tenant_id` is filterable | HIGH | Must be a declared schema column, not a `_data` blob value. `QueryApplier` generates SQL `WHERE` clauses via `SqlEntityQuery::condition()` — fields in `_data` cannot be filtered at the SQL level. If stored in `_data`, requires schema migration to promote to a real column. |
+| 2 | `last_interaction_at` is sortable | HIGH | Same constraint — `QueryApplier` sorts at SQL level. Fields in `_data` blob are invisible to `ORDER BY`. Must be a schema column. |
+| 3 | `confidence` maps to GraphQL Float | MEDIUM | Commitment must define it with a float field type in its field definitions. |
+| 4 | Update input types support partial updates | HIGH | Waaseyaa's `buildInputFields()` wraps fields marked `required` in the entity type with `Type::nonNull()`. This means `updateCommitment(input: { title: "..." })` would fail if `title` is required — you can't omit it. Either Waaseyaa needs separate create/update input types, or Claudriel's required fields need review. This is a likely Waaseyaa change (W3). |
+| 5 | `person_uuid` as entity reference (future) | LOW | Not needed for v1, flag for later. |
+| 6 | Tenant context as implicit filter (future) | LOW | Future enhancement, not a blocker. |
+| 7 | Pagination arguments (`limit`/`offset`) exist as `Int` | LOW | Confirm on all `*List` queries with correct defaults when omitted. |
+| 8 | Partial GraphQL responses | LOW | GraphQL can return both `data` and `errors` simultaneously. The `graphqlFetch()` helper currently throws on any errors. Decide whether to support partial success or treat any error as total failure. |
 
 **Validation method:** PHPUnit integration test that boots the Claudriel kernel, generates the GraphQL schema, and asserts expected query/mutation fields exist with correct types. Becomes a regression guard for the schema contract.
 
@@ -212,7 +245,7 @@ Seven items to validate before any Claudriel code changes:
 |---|-------|------------|-------------|
 | W1 | Schema validation test harness | — | Integration test that boots a test kernel, generates GraphQL schema, asserts field/type presence. Reusable for any app. |
 | W2 | Validate filter/sort on `_data` blob fields | W1 | Confirm whether `QueryApplier` can filter/sort on fields stored in `_data` vs schema columns. Document the limitation if not. |
-| W3 | Validate nullable input types for PATCH semantics | W1 | Confirm auto-generated mutation input types have all-optional fields for update operations. Fix if not. |
+| W3 | Separate create/update input types for PATCH semantics | W1 | `buildInputFields()` wraps `required` fields with `NonNull`, breaking partial updates. Either generate separate `{Type}CreateInput` (with NonNull) and `{Type}UpdateInput` (all nullable), or make all input fields nullable and validate required-ness in the resolver. |
 | W4 | Validate pagination arguments on list queries | W1 | Confirm `limit`/`offset` exist as `Int` on all `*List` queries, with correct defaults when omitted. |
 | W5 | Tag v0.1.0-alpha.10 | W2, W3, W4 | Release including GraphQL package + any fixes from validation. |
 

--- a/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
+++ b/docs/superpowers/specs/2026-03-16-claudriel-graphql-adoption-design.md
@@ -240,37 +240,37 @@ Eight items to validate before any Claudriel code changes:
 
 ## 7. GitHub Issue Tree
 
-### Waaseyaa repo — milestone: v1.3 (GraphQL & Cleanup)
+### Waaseyaa repo — milestone: v1.3 (GraphQL & Cleanup), milestone #24
 
 | # | Issue | Depends on | Description |
 |---|-------|------------|-------------|
-| W1 | Schema validation test harness | — | Integration test that boots a test kernel, generates GraphQL schema, asserts field/type presence. Reusable for any app. |
-| W2 | Validate filter/sort on `_data` blob fields | W1 | Confirm whether `QueryApplier` can filter/sort on fields stored in `_data` vs schema columns. Document the limitation if not. |
-| W3 | Separate create/update input types for PATCH semantics | W1 | `buildInputFields()` wraps `required` fields with `NonNull`, breaking partial updates. Either generate separate `{Type}CreateInput` (with NonNull) and `{Type}UpdateInput` (all nullable), or make all input fields nullable and validate required-ness in the resolver. |
-| W4 | Validate pagination arguments on list queries | W1 | Confirm `limit`/`offset` exist as `Int` on all `*List` queries, with correct defaults when omitted. |
-| W5 | Tag v0.1.0-alpha.10 | W2, W3, W4 | Release including GraphQL package + any fixes from validation. |
+| W1 | [#437](https://github.com/waaseyaa/framework/issues/437) Schema validation test harness | — | Integration test that boots a test kernel, generates GraphQL schema, asserts field/type presence. Reusable for any app. |
+| W2 | [#438](https://github.com/waaseyaa/framework/issues/438) Validate filter/sort on `_data` blob fields | W1 | Confirm whether `QueryApplier` can filter/sort on fields stored in `_data` vs schema columns. Document the limitation if not. |
+| W3 | [#439](https://github.com/waaseyaa/framework/issues/439) Separate create/update input types for PATCH semantics | W1 | `buildInputFields()` wraps `required` fields with `NonNull`, breaking partial updates. Either generate separate `{Type}CreateInput` (with NonNull) and `{Type}UpdateInput` (all nullable), or make all input fields nullable and validate required-ness in the resolver. |
+| W4 | [#440](https://github.com/waaseyaa/framework/issues/440) Validate pagination arguments on list queries | W1 | Confirm `limit`/`offset` exist as `Int` on all `*List` queries, with correct defaults when omitted. |
+| W5 | [#441](https://github.com/waaseyaa/framework/issues/441) Tag v0.1.0-alpha.10 | W2, W3, W4 | Release including GraphQL package + any fixes from validation. |
 
-### Claudriel repo — new milestone: GraphQL Adoption
+### Claudriel repo — milestone: v1.5 GraphQL Adoption, milestone #16
 
 | # | Issue | Depends on | Description |
 |---|-------|------------|-------------|
-| C1 | Bump Waaseyaa to alpha.10, add `waaseyaa/graphql` | W5 | Update composer.json, verify schema auto-generates for all Claudriel entity types. |
-| C2 | Schema contract test for Commitment + Person | C1 | PHPUnit test asserting expected queries, mutations, field types, filter/sort args exist in generated schema. |
-| C3 | Validate `tenant_id`, `last_interaction_at`, `confidence` field definitions | C2 | Confirm these are schema columns (not `_data` blob). Fix entity type definitions if needed. |
-| C4 | `graphqlFetch()` helper + `gql` tag | C1 | Add `app/utils/graphqlFetch.ts` and `app/utils/gql.ts`. Unit test the helper. |
-| C5 | `useCommitmentsQuery()` composable | C3, C4 | Replaces `useEntity('commitment').list()`. Typed response, filter params, `useAsyncData` integration. |
-| C6 | `usePeopleQuery()` composable | C3, C4 | Replaces `useEntity('person').list()`. Same pattern as C5. |
-| C7 | Migrate Commitment components to GraphQL | C5 | Replace adapter calls in commitment-related components with `useCommitmentsQuery()`. |
-| C8 | Migrate People components to GraphQL | C6 | Replace adapter calls in people-related components with `usePeopleQuery()`. |
-| C9 | Deprecate CommitmentApiController | C7 | Add deprecation logging, keep routes live. |
-| C10 | Deprecate PeopleApiController | C8 | Add deprecation logging, keep routes live. |
-| C11 | Remove deprecated controllers | C9, C10 | Delete controllers + routes after validation period. |
+| C1 | [#170](https://github.com/jonesrussell/claudriel/issues/170) Bump Waaseyaa to alpha.10, add `waaseyaa/graphql` | W5 | Update composer.json, verify schema auto-generates for all Claudriel entity types. |
+| C2 | [#171](https://github.com/jonesrussell/claudriel/issues/171) Schema contract test for Commitment + Person | C1 | PHPUnit test asserting expected queries, mutations, field types, filter/sort args exist in generated schema. |
+| C3 | [#172](https://github.com/jonesrussell/claudriel/issues/172) Validate `tenant_id`, `last_interaction_at`, `confidence` field definitions | C2 | Confirm these are schema columns (not `_data` blob). Fix entity type definitions if needed. |
+| C4 | [#173](https://github.com/jonesrussell/claudriel/issues/173) `graphqlFetch()` helper + `gql` tag | C1 | Add `app/utils/graphqlFetch.ts` and `app/utils/gql.ts`. Unit test the helper. |
+| C5 | [#174](https://github.com/jonesrussell/claudriel/issues/174) `useCommitmentsQuery()` composable | C3, C4 | Replaces `useEntity('commitment').list()`. Typed response, filter params, `useAsyncData` integration. |
+| C6 | [#175](https://github.com/jonesrussell/claudriel/issues/175) `usePeopleQuery()` composable | C3, C4 | Replaces `useEntity('person').list()`. Same pattern as C5. |
+| C7 | [#176](https://github.com/jonesrussell/claudriel/issues/176) Migrate Commitment components to GraphQL | C5 | Replace adapter calls in commitment-related components with `useCommitmentsQuery()`. |
+| C8 | [#177](https://github.com/jonesrussell/claudriel/issues/177) Migrate People components to GraphQL | C6 | Replace adapter calls in people-related components with `usePeopleQuery()`. |
+| C9 | [#178](https://github.com/jonesrussell/claudriel/issues/178) Deprecate CommitmentApiController | C7 | Add deprecation logging, keep routes live. |
+| C10 | [#179](https://github.com/jonesrussell/claudriel/issues/179) Deprecate PeopleApiController | C8 | Add deprecation logging, keep routes live. |
+| C11 | [#180](https://github.com/jonesrussell/claudriel/issues/180) Remove deprecated controllers | C9, C10 | Delete controllers + routes after validation period. |
 
 ### Dependency chain
 
 ```
-W1 → W2,W3,W4 → W5 → C1 → C2 → C3 → C5,C6 → C7,C8 → C9,C10 → C11
-                  W5 → C1 → C4 ↗
+#437 → #438,#439,#440 → #441 → #170 → #171 → #172 → #174,#175 → #176,#177 → #178,#179 → #180
+                          #441 → #170 → #173 ↗
 ```
 
 ## 8. Future Work (Out of Scope)

--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -28,6 +28,16 @@ final class EntityResolver
     ) {}
 
     /**
+     * Resolve a list query with filter, sort, and pagination.
+     *
+     * **_data blob limitation:** Filters and sorts operate at the SQL query level
+     * via QueryApplier. Fields stored in the `_data` JSON blob column are NOT
+     * queryable at the SQL level — they exist only as serialized JSON and cannot
+     * participate in WHERE or ORDER BY clauses. For fields that need filtering or
+     * sorting in GraphQL (or JSON:API) queries, they must be promoted to real
+     * schema columns in the entity type's SqlSchemaHandler. This is an inherent
+     * limitation of the _data blob storage strategy, not a bug.
+     *
      * @param array<string, mixed> $args GraphQL list query arguments
      * @return array{items: list<array<string, mixed>>, total: int}
      */
@@ -194,6 +204,15 @@ final class EntityResolver
     }
 
     /**
+     * Parse GraphQL filter arguments into QueryFilter objects.
+     *
+     * **_data blob limitation:** These filters are applied as SQL WHERE conditions
+     * via QueryApplier. Only fields with dedicated schema columns (defined in
+     * SqlSchemaHandler) can be filtered. Fields stored in the `_data` JSON blob
+     * will produce SQL errors or empty results when used as filter targets.
+     * To make a field filterable, promote it to a real column in the entity
+     * type's schema definition.
+     *
      * @return list<QueryFilter>
      */
     private function parseFilters(array $args): array

--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -33,13 +33,10 @@ final class EntityResolver
     /**
      * Resolve a list query with filter, sort, and pagination.
      *
-     * **_data blob limitation:** Filters and sorts operate at the SQL query level
-     * via QueryApplier. Fields stored in the `_data` JSON blob column are NOT
-     * queryable at the SQL level — they exist only as serialized JSON and cannot
-     * participate in WHERE or ORDER BY clauses. For fields that need filtering or
-     * sorting in GraphQL (or JSON:API) queries, they must be promoted to real
-     * schema columns in the entity type's SqlSchemaHandler. This is an inherent
-     * limitation of the _data blob storage strategy, not a bug.
+     * **_data blob performance note:** Filters and sorts on fields stored in the
+     * `_data` JSON blob work via `json_extract()` fallback in SqlEntityQuery, but
+     * cannot use column indexes. For high-traffic query fields, promote them to
+     * dedicated schema columns in SqlSchemaHandler for indexed performance.
      *
      * @param array<string, mixed> $args GraphQL list query arguments
      * @return array{items: list<array<string, mixed>>, total: int}
@@ -209,12 +206,7 @@ final class EntityResolver
     /**
      * Parse GraphQL filter arguments into QueryFilter objects.
      *
-     * **_data blob limitation:** These filters are applied as SQL WHERE conditions
-     * via QueryApplier. Only fields with dedicated schema columns (defined in
-     * SqlSchemaHandler) can be filtered. Fields stored in the `_data` JSON blob
-     * will produce SQL errors or empty results when used as filter targets.
-     * To make a field filterable, promote it to a real column in the entity
-     * type's schema definition.
+     * @see self::resolveList() for _data blob query performance considerations.
      *
      * @return list<QueryFilter>
      */

--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -22,6 +22,9 @@ use Waaseyaa\GraphQL\Access\GraphQlAccessGuard;
  */
 final class EntityResolver
 {
+    private const DEFAULT_LIMIT = 50;
+    private const MAX_LIMIT = 100;
+
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly GraphQlAccessGuard $guard,
@@ -48,7 +51,7 @@ final class EntityResolver
         $filters = $this->parseFilters($args);
         $sorts = $this->parseSorts($args);
         $offset = isset($args['offset']) ? max(0, (int) $args['offset']) : 0;
-        $limit = isset($args['limit']) ? min(100, max(1, (int) $args['limit'])) : 50;
+        $limit = isset($args['limit']) ? min(self::MAX_LIMIT, max(1, (int) $args['limit'])) : self::DEFAULT_LIMIT;
 
         // Count query — filters only, no sorts/pagination, access deferred to post-fetch
         $countQuery = $storage->getQuery()->accessCheck(false);

--- a/packages/graphql/src/Schema/EntityTypeBuilder.php
+++ b/packages/graphql/src/Schema/EntityTypeBuilder.php
@@ -36,17 +36,6 @@ final class EntityTypeBuilder
         ]));
     }
 
-    public function buildInputType(EntityTypeInterface $entityType): InputObjectType
-    {
-        $typeName = self::toPascalCase($entityType->id()) . 'Input';
-
-        /** @var InputObjectType */
-        return $this->registry->getOrCreate($typeName, fn(): InputObjectType => new InputObjectType([
-            'name' => $typeName,
-            'fields' => fn(): array => $this->buildInputFields($entityType),
-        ]));
-    }
-
     public function buildCreateInputType(EntityTypeInterface $entityType): InputObjectType
     {
         $typeName = self::toPascalCase($entityType->id()) . 'CreateInput';

--- a/packages/graphql/src/Schema/EntityTypeBuilder.php
+++ b/packages/graphql/src/Schema/EntityTypeBuilder.php
@@ -47,6 +47,28 @@ final class EntityTypeBuilder
         ]));
     }
 
+    public function buildCreateInputType(EntityTypeInterface $entityType): InputObjectType
+    {
+        $typeName = self::toPascalCase($entityType->id()) . 'CreateInput';
+
+        /** @var InputObjectType */
+        return $this->registry->getOrCreate($typeName, fn(): InputObjectType => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn(): array => $this->buildInputFields($entityType, forCreate: true),
+        ]));
+    }
+
+    public function buildUpdateInputType(EntityTypeInterface $entityType): InputObjectType
+    {
+        $typeName = self::toPascalCase($entityType->id()) . 'UpdateInput';
+
+        /** @var InputObjectType */
+        return $this->registry->getOrCreate($typeName, fn(): InputObjectType => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn(): array => $this->buildInputFields($entityType, forCreate: false),
+        ]));
+    }
+
     public function buildListResultType(EntityTypeInterface $entityType): ObjectType
     {
         $typeName = self::toPascalCase($entityType->id()) . 'ListResult';
@@ -179,7 +201,7 @@ final class EntityTypeBuilder
     /**
      * @return array<string, array<string, mixed>>
      */
-    private function buildInputFields(EntityTypeInterface $entityType): array
+    private function buildInputFields(EntityTypeInterface $entityType, bool $forCreate = true): array
     {
         $fields = [];
         $keys = $entityType->getKeys();
@@ -202,7 +224,7 @@ final class EntityTypeBuilder
             $isRequired = !empty($def['required']);
 
             $graphqlType = $this->fieldTypeMapper->toInputType($fieldType, $isMultiple);
-            if ($isRequired) {
+            if ($isRequired && $forCreate) {
                 $graphqlType = Type::nonNull($graphqlType);
             }
 

--- a/packages/graphql/src/Schema/SchemaFactory.php
+++ b/packages/graphql/src/Schema/SchemaFactory.php
@@ -62,7 +62,8 @@ final class SchemaFactory
 
             $objectType = $entityTypeBuilder->buildObjectType($entityType);
             $listResultType = $entityTypeBuilder->buildListResultType($entityType);
-            $inputType = $entityTypeBuilder->buildInputType($entityType);
+            $createInputType = $entityTypeBuilder->buildCreateInputType($entityType);
+            $updateInputType = $entityTypeBuilder->buildUpdateInputType($entityType);
 
             // Query: single entity by ID
             $queryFields[$camelCase] = [
@@ -89,7 +90,7 @@ final class SchemaFactory
             $mutationFields['create' . $pascalCase] = [
                 'type' => $objectType,
                 'args' => [
-                    'input' => Type::nonNull($inputType),
+                    'input' => Type::nonNull($createInputType),
                 ],
                 'resolve' => fn(mixed $root, array $args): array => $this->entityResolver->resolveCreate($typeId, $args['input']),
             ];
@@ -99,7 +100,7 @@ final class SchemaFactory
                 'type' => $objectType,
                 'args' => [
                     'id' => Type::nonNull(Type::id()),
-                    'input' => Type::nonNull($inputType),
+                    'input' => Type::nonNull($updateInputType),
                 ],
                 'resolve' => fn(mixed $root, array $args): array => $this->entityResolver->resolveUpdate($typeId, $args['id'], $args['input']),
             ];

--- a/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+++ b/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -29,7 +29,7 @@ use Waaseyaa\GraphQL\Schema\SchemaFactory;
  * These tests verify that SchemaFactory produces correct query fields,
  * mutation fields, type mappings, and input types for registered entity types.
  */
-#[CoversClass(SchemaFactory::class)]
+#[CoversNothing]
 final class SchemaValidationTest extends TestCase
 {
     private EntityTypeManager $entityTypeManager;

--- a/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+++ b/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
@@ -236,6 +236,45 @@ final class SchemaValidationTest extends TestCase
         self::assertSame('=', $operatorField->defaultValue);
     }
 
+    #[Test]
+    public function createAndUpdateInputTypesAreSeparate(): void
+    {
+        $schema = $this->buildSchema();
+
+        $mutationType = $schema->getMutationType();
+        $createField = $mutationType->getField('createArticle');
+        $updateField = $mutationType->getField('updateArticle');
+
+        // Get input types (unwrap NonNull)
+        $createInputType = $createField->getArg('input')->getType();
+        if ($createInputType instanceof NonNull) {
+            $createInputType = $createInputType->getWrappedType();
+        }
+        $updateInputType = $updateField->getArg('input')->getType();
+        if ($updateInputType instanceof NonNull) {
+            $updateInputType = $updateInputType->getWrappedType();
+        }
+
+        // They should be different types
+        self::assertInstanceOf(InputObjectType::class, $createInputType);
+        self::assertInstanceOf(InputObjectType::class, $updateInputType);
+        self::assertSame('ArticleCreateInput', $createInputType->name);
+        self::assertSame('ArticleUpdateInput', $updateInputType->name);
+
+        // Create input: required fields (title) are NonNull
+        $createTitle = $createInputType->getField('title');
+        self::assertInstanceOf(NonNull::class, $createTitle->getType());
+
+        // Update input: all fields nullable (PATCH semantics)
+        $updateTitle = $updateInputType->getField('title');
+        self::assertNotInstanceOf(NonNull::class, $updateTitle->getType());
+
+        // Both should have the same non-key, non-readOnly fields
+        $createFieldNames = array_keys($createInputType->getFields());
+        $updateFieldNames = array_keys($updateInputType->getFields());
+        self::assertSame($createFieldNames, $updateFieldNames);
+    }
+
     /**
      * Unwrap NonNull wrappers to get the named type.
      */

--- a/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+++ b/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\GraphQL\Tests\Unit\Schema;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Entity\EntityBase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\GraphQL\Access\GraphQlAccessGuard;
+use Waaseyaa\GraphQL\Resolver\EntityResolver;
+use Waaseyaa\GraphQL\Resolver\ReferenceLoader;
+use Waaseyaa\GraphQL\Schema\SchemaFactory;
+
+/**
+ * Validates the auto-generated GraphQL schema structure.
+ *
+ * These tests verify that SchemaFactory produces correct query fields,
+ * mutation fields, type mappings, and input types for registered entity types.
+ */
+#[CoversClass(SchemaFactory::class)]
+final class SchemaValidationTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+
+    protected function setUp(): void
+    {
+        $this->entityTypeManager = new EntityTypeManager(new EventDispatcher());
+
+        $articleType = new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: EntityBase::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer'],
+                'uuid' => ['type' => 'string'],
+                'title' => ['type' => 'string', 'required' => true],
+                'body' => ['type' => 'text'],
+                'status' => ['type' => 'boolean'],
+                'created' => ['type' => 'timestamp'],
+                'view_count' => ['type' => 'integer'],
+                'rating' => ['type' => 'float'],
+            ],
+        );
+        $this->entityTypeManager->registerCoreEntityType($articleType);
+    }
+
+    private function buildSchema(): \GraphQL\Type\Schema
+    {
+        $accessHandler = new EntityAccessHandler([]);
+        $account = $this->createStub(AccountInterface::class);
+        $guard = new GraphQlAccessGuard($accessHandler, $account);
+        $resolver = new EntityResolver($this->entityTypeManager, $guard);
+        $referenceLoader = new ReferenceLoader($this->entityTypeManager, $guard);
+        $factory = new SchemaFactory(
+            entityTypeManager: $this->entityTypeManager,
+            entityResolver: $resolver,
+            referenceLoader: $referenceLoader,
+        );
+
+        return $factory->build();
+    }
+
+    #[Test]
+    public function queryFieldsAreGeneratedForEntityType(): void
+    {
+        $schema = $this->buildSchema();
+        $queryType = $schema->getQueryType();
+
+        self::assertNotNull($queryType);
+
+        // Single query field
+        self::assertTrue($queryType->hasField('article'));
+        $singleField = $queryType->getField('article');
+        $singleArgs = $singleField->args;
+        $argNames = array_map(fn($a) => $a->name, $singleArgs);
+        self::assertContains('id', $argNames);
+
+        // The id arg should be NonNull(ID)
+        $idArg = $singleField->getArg('id');
+        self::assertNotNull($idArg);
+        $idArgType = $idArg->getType();
+        self::assertInstanceOf(NonNull::class, $idArgType);
+
+        // List query field
+        self::assertTrue($queryType->hasField('articleList'));
+        $listField = $queryType->getField('articleList');
+        $listArgNames = array_map(fn($a) => $a->name, $listField->args);
+        self::assertContains('filter', $listArgNames);
+        self::assertContains('sort', $listArgNames);
+        self::assertContains('offset', $listArgNames);
+        self::assertContains('limit', $listArgNames);
+    }
+
+    #[Test]
+    public function listResultTypeHasItemsAndTotal(): void
+    {
+        $schema = $this->buildSchema();
+        $queryType = $schema->getQueryType();
+        $listField = $queryType->getField('articleList');
+        $listType = $listField->getType();
+
+        self::assertInstanceOf(ObjectType::class, $listType);
+        self::assertSame('ArticleListResult', $listType->name);
+        self::assertTrue($listType->hasField('items'));
+        self::assertTrue($listType->hasField('total'));
+
+        // items should be a list type
+        $itemsField = $listType->getField('items');
+        $itemsType = $itemsField->getType();
+        self::assertInstanceOf(NonNull::class, $itemsType);
+        $innerList = $itemsType->getWrappedType();
+        self::assertInstanceOf(ListOfType::class, $innerList);
+
+        // total should be NonNull(Int)
+        $totalField = $listType->getField('total');
+        $totalType = $totalField->getType();
+        self::assertInstanceOf(NonNull::class, $totalType);
+        self::assertSame('Int', $totalType->getWrappedType()->name);
+    }
+
+    #[Test]
+    public function mutationFieldsAreGenerated(): void
+    {
+        $schema = $this->buildSchema();
+        $mutationType = $schema->getMutationType();
+
+        self::assertNotNull($mutationType);
+        self::assertTrue($mutationType->hasField('createArticle'));
+        self::assertTrue($mutationType->hasField('updateArticle'));
+        self::assertTrue($mutationType->hasField('deleteArticle'));
+
+        // createArticle should have an 'input' arg
+        $createField = $mutationType->getField('createArticle');
+        $inputArg = $createField->getArg('input');
+        self::assertNotNull($inputArg);
+        $inputArgType = $inputArg->getType();
+        self::assertInstanceOf(NonNull::class, $inputArgType);
+
+        // updateArticle should have 'id' and 'input' args
+        $updateField = $mutationType->getField('updateArticle');
+        self::assertNotNull($updateField->getArg('id'));
+        self::assertNotNull($updateField->getArg('input'));
+
+        // deleteArticle should have 'id' arg and return DeleteResult
+        $deleteField = $mutationType->getField('deleteArticle');
+        self::assertNotNull($deleteField->getArg('id'));
+        $deleteReturnType = $deleteField->getType();
+        self::assertInstanceOf(ObjectType::class, $deleteReturnType);
+        self::assertSame('DeleteResult', $deleteReturnType->name);
+    }
+
+    #[Test]
+    public function fieldTypesMapCorrectly(): void
+    {
+        $schema = $this->buildSchema();
+        $queryType = $schema->getQueryType();
+        $articleField = $queryType->getField('article');
+        $articleType = $articleField->getType();
+
+        self::assertInstanceOf(ObjectType::class, $articleType);
+
+        // integer → Int (using view_count, not id which is mapped to ID scalar)
+        $viewCountField = $articleType->getField('view_count');
+        self::assertSame('Int', $this->unwrapTypeName($viewCountField->getType()));
+
+        // float → Float
+        $ratingField = $articleType->getField('rating');
+        self::assertSame('Float', $this->unwrapTypeName($ratingField->getType()));
+
+        // boolean → Boolean
+        $statusField = $articleType->getField('status');
+        self::assertSame('Boolean', $this->unwrapTypeName($statusField->getType()));
+
+        // string → String
+        $titleField = $articleType->getField('title');
+        self::assertSame('String', $this->unwrapTypeName($titleField->getType()));
+
+        // timestamp → String
+        $createdField = $articleType->getField('created');
+        self::assertSame('String', $this->unwrapTypeName($createdField->getType()));
+    }
+
+    #[Test]
+    public function filterInputTypeHasCorrectStructure(): void
+    {
+        $schema = $this->buildSchema();
+        $queryType = $schema->getQueryType();
+        $listField = $queryType->getField('articleList');
+        $filterArg = $listField->getArg('filter');
+
+        self::assertNotNull($filterArg);
+
+        // filter arg type is [FilterInput!] — unwrap the list
+        $filterArgType = $filterArg->getType();
+        self::assertInstanceOf(ListOfType::class, $filterArgType);
+        $innerType = $filterArgType->getWrappedType();
+
+        // Unwrap NonNull wrapper
+        if ($innerType instanceof NonNull) {
+            $innerType = $innerType->getWrappedType();
+        }
+
+        self::assertInstanceOf(InputObjectType::class, $innerType);
+        self::assertSame('FilterInput', $innerType->name);
+
+        // Verify FilterInput fields
+        self::assertTrue($innerType->hasField('field'));
+        self::assertTrue($innerType->hasField('value'));
+        self::assertTrue($innerType->hasField('operator'));
+
+        // field and value are NonNull(String)
+        $fieldType = $innerType->getField('field')->getType();
+        self::assertInstanceOf(NonNull::class, $fieldType);
+        self::assertSame('String', $fieldType->getWrappedType()->name);
+
+        $valueType = $innerType->getField('value')->getType();
+        self::assertInstanceOf(NonNull::class, $valueType);
+        self::assertSame('String', $valueType->getWrappedType()->name);
+
+        // operator is optional String with default '='
+        $operatorField = $innerType->getField('operator');
+        self::assertSame('String', $this->unwrapTypeName($operatorField->getType()));
+        self::assertSame('=', $operatorField->defaultValue);
+    }
+
+    /**
+     * Unwrap NonNull wrappers to get the named type.
+     */
+    private function unwrapTypeName(Type $type): string
+    {
+        if ($type instanceof NonNull) {
+            $type = $type->getWrappedType();
+        }
+
+        return $type->name;
+    }
+}

--- a/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+++ b/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
@@ -265,14 +265,54 @@ final class SchemaValidationTest extends TestCase
         $createTitle = $createInputType->getField('title');
         self::assertInstanceOf(NonNull::class, $createTitle->getType());
 
+        // Create input: non-required fields remain nullable
+        $createBody = $createInputType->getField('body');
+        self::assertNotInstanceOf(NonNull::class, $createBody->getType());
+
         // Update input: all fields nullable (PATCH semantics)
         $updateTitle = $updateInputType->getField('title');
         self::assertNotInstanceOf(NonNull::class, $updateTitle->getType());
+
+        // Entity keys are excluded from both input types
+        self::assertFalse($createInputType->hasField('id'));
+        self::assertFalse($createInputType->hasField('uuid'));
+        self::assertFalse($updateInputType->hasField('id'));
+        self::assertFalse($updateInputType->hasField('uuid'));
 
         // Both should have the same non-key, non-readOnly fields
         $createFieldNames = array_keys($createInputType->getFields());
         $updateFieldNames = array_keys($updateInputType->getFields());
         self::assertSame($createFieldNames, $updateFieldNames);
+    }
+
+    #[Test]
+    public function updateInputTypeExcludesReadOnlyFields(): void
+    {
+        $this->entityTypeManager->registerCoreEntityType(new EntityType(
+            id: 'log_entry',
+            label: 'Log Entry',
+            class: EntityBase::class,
+            keys: ['id' => 'id'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer', 'readOnly' => true],
+                'message' => ['type' => 'string', 'required' => true],
+                'timestamp' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $schema = $this->buildSchema();
+        $mutationType = $schema->getMutationType();
+
+        // Update input should exclude readOnly fields
+        $updateField = $mutationType->getField('updateLogEntry');
+        $updateInputType = $updateField->getArg('input')->getType();
+        if ($updateInputType instanceof NonNull) {
+            $updateInputType = $updateInputType->getWrappedType();
+        }
+
+        self::assertInstanceOf(InputObjectType::class, $updateInputType);
+        self::assertTrue($updateInputType->hasField('message'));
+        self::assertFalse($updateInputType->hasField('timestamp'));
     }
 
     #[Test]
@@ -295,8 +335,8 @@ final class SchemaValidationTest extends TestCase
 
     /**
      * Documents that EntityResolver::resolveList() enforces pagination bounds:
-     * - Default limit: EntityResolver::DEFAULT_LIMIT (50)
-     * - Max limit: EntityResolver::MAX_LIMIT (100) — requests above are clamped
+     * - Default limit: EntityResolver::DEFAULT_LIMIT
+     * - Max limit: EntityResolver::MAX_LIMIT — requests above are clamped
      * - Min limit: 1 — zero or negative values are clamped to 1
      * - Min offset: 0 — negative offsets are clamped to 0
      *

--- a/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
+++ b/packages/graphql/tests/Unit/Schema/SchemaValidationTest.php
@@ -275,6 +275,46 @@ final class SchemaValidationTest extends TestCase
         self::assertSame($createFieldNames, $updateFieldNames);
     }
 
+    #[Test]
+    public function listQueryHasPaginationArguments(): void
+    {
+        $schema = $this->buildSchema();
+        $queryType = $schema->getQueryType();
+        $listField = $queryType->getField('articleList');
+
+        // limit should be Int
+        $limitArg = $listField->getArg('limit');
+        self::assertNotNull($limitArg);
+        self::assertSame('Int', $this->unwrapTypeName($limitArg->getType()));
+
+        // offset should be Int
+        $offsetArg = $listField->getArg('offset');
+        self::assertNotNull($offsetArg);
+        self::assertSame('Int', $this->unwrapTypeName($offsetArg->getType()));
+    }
+
+    /**
+     * Documents that EntityResolver::resolveList() enforces pagination bounds:
+     * - Default limit: EntityResolver::DEFAULT_LIMIT (50)
+     * - Max limit: EntityResolver::MAX_LIMIT (100) — requests above are clamped
+     * - Min limit: 1 — zero or negative values are clamped to 1
+     * - Min offset: 0 — negative offsets are clamped to 0
+     *
+     * These are enforced at the resolver level (not schema level) so that
+     * clients always get safe pagination regardless of the arguments passed.
+     */
+    #[Test]
+    public function paginationConstantsAreDefined(): void
+    {
+        $reflection = new \ReflectionClass(EntityResolver::class);
+
+        $defaultLimit = $reflection->getConstant('DEFAULT_LIMIT');
+        self::assertSame(50, $defaultLimit);
+
+        $maxLimit = $reflection->getConstant('MAX_LIMIT');
+        self::assertSame(100, $maxLimit);
+    }
+
     /**
      * Unwrap NonNull wrappers to get the named type.
      */


### PR DESCRIPTION
## Summary
- Add GraphQL schema validation test harness with 8 tests covering query/mutation fields, type mappings, filter structure, and pagination args (#437)
- Document _data blob filter/sort limitations in EntityResolver (#438)
- Split single input type into separate `CreateInput` (required fields NonNull) and `UpdateInput` (all nullable for PATCH semantics) (#439)
- Extract pagination limit constants (DEFAULT_LIMIT=50, MAX_LIMIT=100) from magic numbers (#440)

## Test Plan
- [x] All 20 GraphQL package tests pass (101 assertions)
- [x] Existing SchemaFactoryTest tests unaffected
- [x] Schema validation tests verify correct type generation
- [x] Create/update input type separation verified with dedicated test
- [x] Pagination arg types verified as Int

🤖 Generated with [Claude Code](https://claude.com/claude-code)