### PR TITLE
feat: wire GraphQL mutation overrides from service providers

### DIFF
--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -52,6 +52,8 @@ final class ControllerDispatcher
         private readonly string $projectRoot,
         /** @var array<string, mixed> */
         private readonly array $config,
+        /** @var array<string, array{args?: array<string, mixed>, resolve?: callable}> */
+        private readonly array $graphqlMutationOverrides = [],
     ) {}
 
     /**
@@ -535,6 +537,9 @@ final class ControllerDispatcher
                         accessHandler: $this->accessHandler,
                         account: $account,
                     );
+                    if ($this->graphqlMutationOverrides !== []) {
+                        $endpoint = $endpoint->withMutationOverrides($this->graphqlMutationOverrides);
+                    }
                     parse_str($queryString, $queryParams);
                     $result = $endpoint->handle($method, $httpRequest->getContent(), $queryParams);
                     ResponseSender::json($result['statusCode'], $result['body']);

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -212,6 +212,14 @@ final class HttpKernel extends AbstractKernel
             ResponseSender::json(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Account resolution failed.']]]);
         }
 
+        // Collect GraphQL mutation overrides from providers.
+        $gqlOverrides = [];
+        foreach ($this->providers as $provider) {
+            foreach ($provider->graphqlMutationOverrides() as $name => $override) {
+                $gqlOverrides[$name] = $override;
+            }
+        }
+
         // Dispatch.
         $controllerDispatcher = new ControllerDispatcher(
             entityTypeManager: $this->entityTypeManager,
@@ -223,6 +231,7 @@ final class HttpKernel extends AbstractKernel
             mcpReadCache: $this->mcpReadCache,
             projectRoot: $this->projectRoot,
             config: $this->config,
+            graphqlMutationOverrides: $gqlOverrides,
         );
         $controllerDispatcher->dispatch($method, $params, $httpRequest, $queryString, $broadcastStorage, $account);
     }

--- a/packages/foundation/src/ServiceProvider/ServiceProvider.php
+++ b/packages/foundation/src/ServiceProvider/ServiceProvider.php
@@ -46,6 +46,19 @@ abstract class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * Return GraphQL mutation overrides.
+     *
+     * Each key is a mutation name (e.g. 'updateScheduleEntry').
+     * Each value has optional 'args' (merged with defaults) and 'resolve' (replaces default).
+     *
+     * @return array<string, array{args?: array<string, mixed>, resolve?: callable}>
+     */
+    public function graphqlMutationOverrides(): array
+    {
+        return [];
+    }
+
+    /**
      * Return HTTP middleware instances to register with the kernel pipeline.
      *
      * Use #[AsMiddleware] on each class to set pipeline and priority.


### PR DESCRIPTION
## Summary

- Add `graphqlMutationOverrides()` to ServiceProvider
- HttpKernel collects overrides, passes to ControllerDispatcher
- ControllerDispatcher applies overrides to GraphQL endpoint

Completes: provider → kernel → dispatcher → endpoint → schema factory

Ref: jonesrussell/claudriel#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)