### PR TITLE
feat(#468, #469): CSRF JSON exemption and Node GraphQL field definitions

### DIFF
--- a/docs/superpowers/plans/2026-03-17-csrf-json-and-node-graphql-fields.md
+++ b/docs/superpowers/plans/2026-03-17-csrf-json-and-node-graphql-fields.md
@@ -1,0 +1,266 @@
+# CSRF JSON Exemption (#468) & Node GraphQL Fields (#469) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two framework blockers preventing Claudriel's GraphQL adoption: CSRF rejecting `application/json` POSTs, and Node's content fields missing from GraphQL schema.
+
+**Architecture:** Two independent fixes. #468 adds `application/json` to CSRF exempt content types and marks the GraphQL route as CSRF-exempt. #469 adds missing `title`, `type`, `slug` field definitions to `NodeServiceProvider` and fixes the `uid` entity reference format.
+
+**Tech Stack:** PHP 8.3, PHPUnit 10.5, Symfony HttpFoundation, webonyx/graphql-php
+
+**Spec:** `docs/superpowers/specs/2026-03-17-csrf-json-and-node-graphql-fields-design.md`
+
+---
+
+### Task 1: CSRF exempts `application/json` (#468)
+
+**Files:**
+- Modify: `packages/user/src/Middleware/CsrfMiddleware.php:22`
+- Modify: `packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php`
+
+- [ ] **Step 1: Write the failing test — `application/json` POST bypasses CSRF**
+
+Add to `CsrfMiddlewareTest.php` after the `postWithJsonApiContentTypeSkipsCsrf` test:
+
+```php
+#[Test]
+public function postWithJsonContentTypeSkipsCsrf(): void
+{
+    $_SESSION['_csrf_token'] = 'valid-token';
+
+    $request = Request::create('/graphql', 'POST', [], [], [], [], '{"query":"{ nodeList { items { id } } }"}');
+    $request->headers->set('Content-Type', 'application/json');
+    $response = $this->middleware->process($request, $this->passthrough);
+
+    $this->assertSame(200, $response->getStatusCode());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter postWithJsonContentTypeSkipsCsrf`
+Expected: FAIL — `application/json` is not in the exempt list, returns 403.
+
+- [ ] **Step 3: Add `application/json` to exempt content types**
+
+In `CsrfMiddleware.php` line 22, change:
+```php
+private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json'];
+```
+To:
+```php
+private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json', 'application/json'];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter postWithJsonContentTypeSkipsCsrf`
+Expected: PASS
+
+- [ ] **Step 5: Run full CSRF test suite**
+
+Run: `./vendor/bin/phpunit --filter CsrfMiddlewareTest`
+Expected: All tests pass (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/user/src/Middleware/CsrfMiddleware.php packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
+git commit -m "fix(#468): exempt application/json from CSRF validation"
+```
+
+---
+
+### Task 2: GraphQL route CSRF exemption (#468)
+
+**Files:**
+- Modify: `packages/graphql/src/GraphQlRouteProvider.php:22`
+
+- [ ] **Step 1: Add `->csrfExempt()` to GraphQL route**
+
+In `GraphQlRouteProvider.php`, add `->csrfExempt()` after `->allowAll()`:
+
+```php
+RouteBuilder::create('/graphql')
+    ->controller('graphql.endpoint')
+    ->allowAll()
+    ->csrfExempt()
+    ->methods('GET', 'POST')
+    ->build(),
+```
+
+- [ ] **Step 2: Run GraphQL tests to verify no regressions**
+
+Run: `./vendor/bin/phpunit --filter GraphQl`
+Expected: All GraphQL tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/graphql/src/GraphQlRouteProvider.php
+git commit -m "fix(#468): mark GraphQL route as CSRF-exempt"
+```
+
+---
+
+### Task 3: Add missing Node field definitions (#469)
+
+**Files:**
+- Modify: `packages/node/src/NodeServiceProvider.php:20-61`
+- Modify: `packages/node/tests/Unit/NodeServiceProviderTest.php`
+
+- [ ] **Step 1: Write the failing test — Node has title, type, slug field definitions**
+
+Update the existing `node_entity_type_has_field_definitions` test in `NodeServiceProviderTest.php`:
+
+```php
+#[Test]
+public function node_entity_type_has_field_definitions(): void
+{
+    $provider = new NodeServiceProvider();
+    $provider->register();
+
+    $fields = $provider->getEntityTypes()[0]->getFieldDefinitions();
+
+    // Content fields
+    $this->assertArrayHasKey('title', $fields);
+    $this->assertSame('string', $fields['title']['type']);
+    $this->assertTrue($fields['title']['required']);
+
+    $this->assertArrayHasKey('type', $fields);
+    $this->assertSame('string', $fields['type']['type']);
+    $this->assertTrue($fields['type']['readOnly']);
+
+    $this->assertArrayHasKey('slug', $fields);
+    $this->assertSame('string', $fields['slug']['type']);
+
+    // System fields
+    $this->assertArrayHasKey('status', $fields);
+    $this->assertArrayHasKey('promote', $fields);
+    $this->assertArrayHasKey('sticky', $fields);
+    $this->assertArrayHasKey('uid', $fields);
+    $this->assertArrayHasKey('created', $fields);
+    $this->assertArrayHasKey('changed', $fields);
+
+    // uid reference uses top-level target_entity_type_id
+    $this->assertSame('entity_reference', $fields['uid']['type']);
+    $this->assertSame('user', $fields['uid']['target_entity_type_id']);
+    $this->assertArrayNotHasKey('settings', $fields['uid']);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit --filter node_entity_type_has_field_definitions`
+Expected: FAIL — `title`, `type`, `slug` keys missing; `uid` lacks `target_entity_type_id`.
+
+- [ ] **Step 3: Add field definitions and fix uid reference**
+
+In `NodeServiceProvider.php`, update the `fieldDefinitions` array. Add `title`, `type`, `slug` at the top; fix `uid` to use `target_entity_type_id`:
+
+```php
+fieldDefinitions: [
+    'title' => [
+        'type' => 'string',
+        'label' => 'Title',
+        'description' => 'The title of the content.',
+        'required' => true,
+        'weight' => 0,
+    ],
+    'type' => [
+        'type' => 'string',
+        'label' => 'Content type',
+        'description' => 'The bundle (content type) machine name.',
+        'required' => true,
+        'readOnly' => true,
+        'weight' => 1,
+    ],
+    'slug' => [
+        'type' => 'string',
+        'label' => 'URL slug',
+        'description' => 'The URL-safe identifier for the content.',
+        'required' => true,
+        'weight' => 2,
+    ],
+    'status' => [
+        'type' => 'boolean',
+        'label' => 'Published',
+        'description' => 'Whether the content is published.',
+        'weight' => 10,
+        'default' => 1,
+    ],
+    'promote' => [
+        'type' => 'boolean',
+        'label' => 'Promoted to front page',
+        'description' => 'Whether the content is promoted to the front page.',
+        'weight' => 11,
+        'default' => 0,
+    ],
+    'sticky' => [
+        'type' => 'boolean',
+        'label' => 'Sticky at top of lists',
+        'description' => 'Whether the content is sticky at the top of lists.',
+        'weight' => 12,
+        'default' => 0,
+    ],
+    'uid' => [
+        'type' => 'entity_reference',
+        'label' => 'Author',
+        'description' => 'The user who authored this content.',
+        'target_entity_type_id' => 'user',
+        'weight' => 20,
+    ],
+    'created' => [
+        'type' => 'timestamp',
+        'label' => 'Authored on',
+        'description' => 'The date and time the content was created.',
+        'weight' => 30,
+    ],
+    'changed' => [
+        'type' => 'timestamp',
+        'label' => 'Last updated',
+        'description' => 'The date and time the content was last updated.',
+        'weight' => 31,
+    ],
+],
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit --filter node_entity_type_has_field_definitions`
+Expected: PASS
+
+- [ ] **Step 5: Run full Node test suite**
+
+Run: `./vendor/bin/phpunit --filter NodeServiceProvider`
+Expected: All 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/node/src/NodeServiceProvider.php packages/node/tests/Unit/NodeServiceProviderTest.php
+git commit -m "fix(#469): add title, type, slug field definitions to Node and fix uid reference"
+```
+
+---
+
+### Task 4: Verify GraphQL schema exposes Node fields (#469)
+
+**Files:**
+- Read-only verification against existing test infrastructure
+
+- [ ] **Step 1: Run existing GraphQL schema tests**
+
+Run: `./vendor/bin/phpunit --filter SchemaValidationTest`
+Expected: All tests pass. These tests use a synthetic `article` entity type that already declares `title` — they confirm the pipeline works. With Node now declaring `title`/`type`/`slug`, the same pipeline will expose them.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `./vendor/bin/phpunit --configuration phpunit.xml.dist`
+Expected: All tests pass, no regressions.
+
+- [ ] **Step 3: Verify `type` is excluded from mutation inputs**
+
+The existing `updateInputTypeExcludesReadOnlyFields` test in `SchemaValidationTest.php` (line 289) confirms the `readOnly` → excluded-from-inputs pipeline works. With `type` marked `readOnly: true`, it will be excluded from `NodeCreateInput` and `NodeUpdateInput` automatically.
+
+No additional test needed — the existing generic test covers this behavior.

--- a/docs/superpowers/specs/2026-03-17-csrf-json-and-node-graphql-fields-design.md
+++ b/docs/superpowers/specs/2026-03-17-csrf-json-and-node-graphql-fields-design.md
@@ -1,0 +1,99 @@
+# CSRF JSON Exemption (#468) & Node GraphQL Field Definitions (#469)
+
+**Date:** 2026-03-17
+**Issues:** #468, #469
+**Status:** Approved
+
+## Problem
+
+Two framework blockers prevent Claudriel's GraphQL adoption:
+
+1. **#468 — CSRF blocks `application/json` POST**: The CSRF middleware only exempts `application/vnd.api+json`. GraphQL endpoints send `application/json`, which triggers CSRF validation and returns 403.
+
+2. **#469 — `_data` blob fields not in GraphQL schema**: Node's `title`, `type`, and `slug` fields are stored in the `_data` JSON blob but not declared in `fieldDefinitions`. Since `EntityTypeBuilder::buildOutputFields()` only iterates `getFieldDefinitions()`, these fields are invisible to GraphQL. Additionally, the `uid` entity reference uses `settings.target_type` instead of the top-level `target_entity_type_id` that `EntityTypeBuilder` expects, so it doesn't resolve as a reference.
+
+## Architectural Decision
+
+**#469 fix location: Entity type declarations (Option A), not schema builder introspection (Option B).**
+
+Rationale:
+- Entity types are the source of truth for field schema, validation, GraphQL exposure, and access control
+- GraphQL should not know about `_data`, SQL columns, or storage internals
+- Undeclared fields in `_data` are a bug in the entity type, not in GraphQL
+- Automatic introspection would create unpredictable schemas dependent on content
+
+## Changes
+
+### #468 — CsrfMiddleware + GraphQlRouteProvider
+
+#### `packages/user/src/Middleware/CsrfMiddleware.php`
+
+Add `'application/json'` to `CSRF_EXEMPT_CONTENT_TYPES`:
+
+```php
+private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json', 'application/json'];
+```
+
+**Rationale:** Browsers cannot submit `application/json` from HTML forms. Same security reasoning as the existing `application/vnd.api+json` exemption.
+
+#### `packages/graphql/src/GraphQlRouteProvider.php`
+
+Add `->csrfExempt()` to the `/graphql` route:
+
+```php
+RouteBuilder::create('/graphql')
+    ->controller('graphql.endpoint')
+    ->allowAll()
+    ->csrfExempt()
+    ->methods('GET', 'POST')
+    ->build(),
+```
+
+**Rationale:** Belt-and-suspenders. GraphQL always uses JSON, so this ensures no regressions if content-type negotiation changes.
+
+### #469 — NodeServiceProvider field definitions
+
+#### `packages/node/src/NodeServiceProvider.php`
+
+Add three missing field definitions and fix the `uid` reference:
+
+| Field | Type | Required | ReadOnly | Notes |
+|-------|------|----------|----------|-------|
+| `title` | string | yes | no | Label key — node's display name |
+| `type` | string | yes | yes | Bundle key — set at creation, not editable. `readOnly` excludes it from GraphQL mutation inputs (correct behavior). |
+| `slug` | string | yes | no | URL-safe identifier |
+
+Fix `uid` reference — replace `settings.target_type` with top-level `target_entity_type_id` (remove the orphaned `settings` key entirely):
+
+```php
+// Before:
+'settings' => ['target_type' => 'user']
+
+// After:
+'target_entity_type_id' => 'user'
+```
+
+This aligns with `EntityTypeBuilder`'s lookup at lines 116-118 which checks `target_entity_type_id` or `targetEntityTypeId` at the top level of the field definition.
+
+#### Fields NOT included
+
+`summary` and `image` are deferred until Node bundles are formalized. They are not consistently present across all nodes today.
+
+## Test Plan
+
+### Unit tests
+- `NodeServiceProviderTest` — verify all field definitions are registered (title, type, slug, uid with correct reference format)
+
+### Integration tests
+- GraphQL schema test: confirm `title`, `type`, `slug` appear on the Node output type
+- GraphQL schema test: confirm `uid` resolves as a User entity reference, not a raw scalar
+- CSRF test: confirm `application/json` POST requests bypass CSRF validation
+- CSRF test: confirm the GraphQL route is CSRF-exempt via route option
+
+## Files Modified
+
+- `packages/user/src/Middleware/CsrfMiddleware.php`
+- `packages/graphql/src/GraphQlRouteProvider.php`
+- `packages/node/src/NodeServiceProvider.php`
+- `packages/node/tests/Unit/NodeServiceProviderTest.php` (updated)
+- New integration test file for GraphQL schema field coverage

--- a/packages/graphql/src/GraphQlRouteProvider.php
+++ b/packages/graphql/src/GraphQlRouteProvider.php
@@ -20,6 +20,7 @@ final class GraphQlRouteProvider
                 ->controller('graphql.endpoint')
                 ->allowAll()
                 ->methods('GET', 'POST')
+                ->csrfExempt()
                 ->build(),
         );
     }

--- a/packages/node/src/NodeServiceProvider.php
+++ b/packages/node/src/NodeServiceProvider.php
@@ -18,6 +18,28 @@ final class NodeServiceProvider extends ServiceProvider
             keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
             group: 'content',
             fieldDefinitions: [
+                'title' => [
+                    'type' => 'string',
+                    'label' => 'Title',
+                    'description' => 'The title of the content.',
+                    'required' => true,
+                    'weight' => 0,
+                ],
+                'type' => [
+                    'type' => 'string',
+                    'label' => 'Content type',
+                    'description' => 'The bundle (content type) of this node.',
+                    'required' => true,
+                    'readOnly' => true,
+                    'weight' => 1,
+                ],
+                'slug' => [
+                    'type' => 'string',
+                    'label' => 'Slug',
+                    'description' => 'The URL-friendly identifier for this content.',
+                    'required' => true,
+                    'weight' => 2,
+                ],
                 'status' => [
                     'type' => 'boolean',
                     'label' => 'Published',
@@ -43,7 +65,7 @@ final class NodeServiceProvider extends ServiceProvider
                     'type' => 'entity_reference',
                     'label' => 'Author',
                     'description' => 'The user who authored this content.',
-                    'settings' => ['target_type' => 'user'],
+                    'target_entity_type_id' => 'user',
                     'weight' => 20,
                 ],
                 'created' => [

--- a/packages/node/tests/Unit/NodeServiceProviderTest.php
+++ b/packages/node/tests/Unit/NodeServiceProviderTest.php
@@ -37,10 +37,27 @@ final class NodeServiceProviderTest extends TestCase
 
         $fields = $provider->getEntityTypes()[0]->getFieldDefinitions();
 
+        $this->assertArrayHasKey('title', $fields);
+        $this->assertSame('string', $fields['title']['type']);
+        $this->assertTrue($fields['title']['required']);
+
+        $this->assertArrayHasKey('type', $fields);
+        $this->assertSame('string', $fields['type']['type']);
+        $this->assertTrue($fields['type']['required']);
+        $this->assertTrue($fields['type']['readOnly']);
+
+        $this->assertArrayHasKey('slug', $fields);
+        $this->assertSame('string', $fields['slug']['type']);
+        $this->assertTrue($fields['slug']['required']);
+
         $this->assertArrayHasKey('status', $fields);
         $this->assertArrayHasKey('promote', $fields);
         $this->assertArrayHasKey('sticky', $fields);
+
         $this->assertArrayHasKey('uid', $fields);
+        $this->assertSame('user', $fields['uid']['target_entity_type_id']);
+        $this->assertArrayNotHasKey('settings', $fields['uid']);
+
         $this->assertArrayHasKey('created', $fields);
         $this->assertArrayHasKey('changed', $fields);
     }

--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -19,7 +19,7 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
     private const TOKEN_FIELD_NAME = '_csrf_token';
     private const TOKEN_HEADER_NAME = 'X-CSRF-Token';
     private const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
-    private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json'];
+    private const CSRF_EXEMPT_CONTENT_TYPES = ['application/vnd.api+json', 'application/json'];
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {

--- a/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
@@ -250,4 +250,16 @@ final class CsrfMiddlewareTest extends TestCase
 
         $this->assertSame(403, $response->getStatusCode());
     }
+
+    #[Test]
+    public function postWithJsonContentTypeSkipsCsrf(): void
+    {
+        $_SESSION['_csrf_token'] = 'valid-token';
+
+        $request = Request::create('/graphql', 'POST', [], [], [], [], '{"query":"{ nodes { id } }"}');
+        $request->headers->set('Content-Type', 'application/json');
+        $response = $this->middleware->process($request, $this->passthrough);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Closes #468
Closes #469

## Summary

- Add `application/json` to CSRF-exempt content types so GraphQL mutations over standard JSON aren't blocked by the CSRF middleware
- Add `->csrfExempt()` to the `/graphql` route for defense-in-depth
- Register `title` (string, required), `type` (string, required, readOnly), and `slug` (string, required) field definitions on the Node entity type for GraphQL schema generation
- Migrate `uid` entity reference from `settings.target_type` to top-level `target_entity_type_id`

## Test plan

- [x] `./vendor/bin/phpunit --filter CsrfMiddlewareTest` — 18 tests, 23 assertions
- [x] `./vendor/bin/phpunit --filter NodeServiceProviderTest` — 3 tests, 24 assertions
- [x] `./vendor/bin/phpunit --filter GraphQl` — 21 tests, 109 assertions

## Checklist

- [x] `Closes #N` above references the issue this PR resolves
- [x] The issue is assigned to a milestone
- [x] PR title includes the issue number (e.g. `feat(#42): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)