### PR TITLE
fix: pass EntityTypeManager to provider middleware() and graphqlMutationOverrides()

### DIFF
--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -174,7 +174,7 @@ final class HttpKernel extends AbstractKernel
 
         // Collect middleware contributed by service providers.
         foreach ($this->providers as $provider) {
-            foreach ($provider->middleware() as $mw) {
+            foreach ($provider->middleware($this->entityTypeManager) as $mw) {
                 $middlewares[] = $mw;
             }
         }
@@ -215,7 +215,7 @@ final class HttpKernel extends AbstractKernel
         // Collect GraphQL mutation overrides from providers.
         $gqlOverrides = [];
         foreach ($this->providers as $provider) {
-            foreach ($provider->graphqlMutationOverrides() as $name => $override) {
+            foreach ($provider->graphqlMutationOverrides($this->entityTypeManager) as $name => $override) {
                 $gqlOverrides[$name] = $override;
             }
         }

--- a/packages/foundation/src/ServiceProvider/ServiceProvider.php
+++ b/packages/foundation/src/ServiceProvider/ServiceProvider.php
@@ -53,7 +53,10 @@ abstract class ServiceProvider implements ServiceProviderInterface
      *
      * @return array<string, array{args?: array<string, mixed>, resolve?: callable}>
      */
-    public function graphqlMutationOverrides(): array
+    /**
+     * @return array<string, array{args?: array<string, mixed>, resolve?: callable}>
+     */
+    public function graphqlMutationOverrides(\Waaseyaa\Entity\EntityTypeManager $entityTypeManager): array
     {
         return [];
     }
@@ -65,7 +68,7 @@ abstract class ServiceProvider implements ServiceProviderInterface
      *
      * @return list<\Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface>
      */
-    public function middleware(): array
+    public function middleware(\Waaseyaa\Entity\EntityTypeManager $entityTypeManager): array
     {
         return [];
     }


### PR DESCRIPTION
Follows the commands() pattern. Fixes boot-time resolution crash.