### PR TITLE
fix(#443, #444): validate GraphQL filter operators and malformed entries

### DIFF
--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -216,12 +216,17 @@ final class EntityResolver
         if (isset($args['filter']) && is_array($args['filter'])) {
             foreach ($args['filter'] as $f) {
                 if (!is_array($f) || !isset($f['field'], $f['value'])) {
-                    continue;
+                    throw new UserError("Invalid filter: each entry must have 'field' and 'value' keys.");
+                }
+                $op = isset($f['operator']) ? strtoupper((string) $f['operator']) : '=';
+                $allowed = ['=', '!=', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN'];
+                if (!in_array($op, $allowed, true)) {
+                    throw new UserError("Invalid filter operator: '{$f['operator']}'");
                 }
                 $filters[] = new QueryFilter(
                     field: (string) $f['field'],
                     value: $f['value'],
-                    operator: isset($f['operator']) ? (string) $f['operator'] : '=',
+                    operator: $op,
                 );
             }
         }


### PR DESCRIPTION
## Summary
- Replaces silent `continue` on malformed filter entries with `UserError` throw (#443)
- Adds operator allowlist validation to prevent invalid/malicious operators (#444 — security fix)
- Normalizes operators to uppercase for consistency

## Test plan
- [ ] Run `./vendor/bin/phpunit --filter EntityResolver` — all pass
- [ ] Verify malformed filter throws UserError
- [ ] Verify invalid operator (e.g. `DROP`) throws UserError

Closes #443, closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)