### PR TITLE
fix(#446): throw on missing entity reference target in GraphQL schema

### DIFF
--- a/packages/graphql/src/Schema/EntityTypeBuilder.php
+++ b/packages/graphql/src/Schema/EntityTypeBuilder.php
@@ -152,10 +152,13 @@ final class EntityTypeBuilder
         $getType = static function () use ($registry, $targetTypeName): Type {
             $type = $registry->get($targetTypeName);
             if ($type === null) {
-                error_log("GraphQL: target type '{$targetTypeName}' not found in registry, falling back to String");
+                throw new \RuntimeException(
+                    "GraphQL schema error: entity reference field targets type '{$targetTypeName}' "
+                    . "which is not registered."
+                );
             }
 
-            return $type ?? Type::string();
+            return $type;
         };
 
         return [


### PR DESCRIPTION
## Summary
- Replaces silent `error_log()` + `Type::string()` fallback with `RuntimeException`
- Schema build now fails fast with a clear error message when a target type is missing

## Test plan
- [ ] Run `./vendor/bin/phpunit --filter EntityTypeBuilder` — all pass
- [ ] Verify missing target type throws RuntimeException at schema build time

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)