### PR TITLE
fix(#471): migrate entity_reference fields to target_entity_type_id

### DIFF
--- a/packages/api/src/Schema/SchemaPresenter.php
+++ b/packages/api/src/Schema/SchemaPresenter.php
@@ -335,10 +335,15 @@ final class SchemaPresenter
                 $schema['maximum'] = $settings['max'];
             }
 
-            // Handle target_type for entity_reference fields.
+            // Handle target_type for entity_reference fields (legacy settings format).
             if (isset($settings['target_type'])) {
                 $schema['x-target-type'] = $settings['target_type'];
             }
+        }
+
+        // Handle top-level target_entity_type_id for entity_reference fields.
+        if (isset($definition['target_entity_type_id'])) {
+            $schema['x-target-type'] = $definition['target_entity_type_id'];
         }
 
         // Default value.

--- a/packages/api/tests/Unit/Controller/SchemaControllerTest.php
+++ b/packages/api/tests/Unit/Controller/SchemaControllerTest.php
@@ -138,7 +138,7 @@ final class SchemaControllerTest extends TestCase
                 'uid' => [
                     'type' => 'entity_reference',
                     'label' => 'Author',
-                    'settings' => ['target_type' => 'user'],
+                    'target_entity_type_id' => 'user',
                     'weight' => 20,
                 ],
             ],

--- a/packages/api/tests/Unit/Schema/SchemaPresenterTargetTypeTest.php
+++ b/packages/api/tests/Unit/Schema/SchemaPresenterTargetTypeTest.php
@@ -28,7 +28,7 @@ final class SchemaPresenterTargetTypeTest extends TestCase
             'author' => [
                 'type' => 'entity_reference',
                 'label' => 'Author',
-                'settings' => ['target_type' => 'user'],
+                'target_entity_type_id' => 'user',
             ],
         ]);
 

--- a/packages/entity/tests/Unit/EntityTypeTest.php
+++ b/packages/entity/tests/Unit/EntityTypeTest.php
@@ -117,7 +117,7 @@ class EntityTypeTest extends TestCase
             'uid' => [
                 'type' => 'entity_reference',
                 'label' => 'Author',
-                'settings' => ['target_type' => 'user'],
+                'target_entity_type_id' => 'user',
                 'weight' => 20,
             ],
         ];

--- a/packages/taxonomy/src/TaxonomyServiceProvider.php
+++ b/packages/taxonomy/src/TaxonomyServiceProvider.php
@@ -34,7 +34,7 @@ final class TaxonomyServiceProvider extends ServiceProvider
                     'type' => 'entity_reference',
                     'label' => 'Parent term',
                     'description' => 'The parent term for hierarchical vocabularies.',
-                    'settings' => ['target_type' => 'taxonomy_term'],
+                    'target_entity_type_id' => 'taxonomy_term',
                     'weight' => 15,
                 ],
                 'status' => [


### PR DESCRIPTION
## Summary
- Migrates all remaining `settings.target_type` to top-level `target_entity_type_id`
- Updates TaxonomyServiceProvider and 3 test fixtures
- Adds `target_entity_type_id` support in SchemaPresenter (with legacy fallback)

## Test plan
- [ ] `grep -r "settings.*target_type" packages/` returns only SchemaPresenter legacy fallback
- [ ] Run `./vendor/bin/phpunit` — all 4505 tests pass

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)