### PR TITLE
fix(#428): remove last admin-bridge reference

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -100,7 +100,7 @@ packages/validation/*|packages/typed-data/*|packages/testing/*|packages/mail/*)
 
   # Admin SPA
   case "$file" in
-    packages/admin/*|packages/admin-bridge/*)
+    packages/admin/*)
       specs="$specs docs/specs/admin-spa.md" ;;
   esac
 


### PR DESCRIPTION
## Summary
- Removes stale `packages/admin-bridge/*` pattern from `tools/drift-detector.sh`
- The admin-bridge package directory was already deleted in prior work

## Test plan
- [ ] `grep -r admin-bridge packages/ tools/ bin/` returns no active code references

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)