### PR TITLE
feat(#432): add static per-process GraphQL schema caching

### DIFF
--- a/packages/graphql/src/Schema/SchemaFactory.php
+++ b/packages/graphql/src/Schema/SchemaFactory.php
@@ -33,6 +33,9 @@ final class SchemaFactory
     /** @var array<string, array{args?: array<string, mixed>, resolve?: callable}> */
     private array $mutationOverrides = [];
 
+    /** @var array<string, Schema> Static per-process cache keyed by entity type ID hash. */
+    private static array $schemaCache = [];
+
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly EntityResolver $entityResolver,
@@ -55,8 +58,29 @@ final class SchemaFactory
         return $clone;
     }
 
+    /**
+     * Reset the static schema cache.
+     *
+     * Useful in testing or when entity type definitions change at runtime.
+     */
+    public static function resetCache(): void
+    {
+        self::$schemaCache = [];
+    }
+
     public function build(): Schema
     {
+        $definitions = $this->entityTypeManager->getDefinitions();
+        $typeIds = array_map(fn($def) => $def->id(), $definitions);
+        sort($typeIds);
+        $overrideKeys = array_keys($this->mutationOverrides);
+        sort($overrideKeys);
+        $cacheKey = hash('xxh128', implode(',', $typeIds) . '|' . implode(',', $overrideKeys));
+
+        if (isset(self::$schemaCache[$cacheKey])) {
+            return self::$schemaCache[$cacheKey];
+        }
+
         $registry = new TypeRegistry();
         $fieldTypeMapper = new FieldTypeMapper();
         $entityTypeBuilder = new EntityTypeBuilder(
@@ -64,8 +88,6 @@ final class SchemaFactory
             fieldTypeMapper: $fieldTypeMapper,
             referenceLoader: $this->referenceLoader,
         );
-
-        $definitions = $this->entityTypeManager->getDefinitions();
 
         // Pre-register all ObjectTypes so entity_reference field type callables
         // can resolve targets even for types not yet processed in the loop below.
@@ -155,7 +177,10 @@ final class SchemaFactory
             ]));
         }
 
-        return new Schema($config);
+        $schema = new Schema($config);
+        self::$schemaCache[$cacheKey] = $schema;
+
+        return $schema;
     }
 
     /**

--- a/packages/graphql/tests/Unit/SchemaFactoryTest.php
+++ b/packages/graphql/tests/Unit/SchemaFactoryTest.php
@@ -29,6 +29,8 @@ final class SchemaFactoryTest extends TestCase
 
     protected function setUp(): void
     {
+        SchemaFactory::resetCache();
+
         $this->entityTypeManager = new EntityTypeManager(new EventDispatcher());
 
         $articleType = new EntityType(
@@ -155,6 +157,80 @@ final class SchemaFactoryTest extends TestCase
         self::assertSame('ArticleListResult', $listType->name);
         self::assertTrue($listType->hasField('items'));
         self::assertTrue($listType->hasField('total'));
+    }
+
+    #[Test]
+    public function buildReturnsCachedSchemaOnSecondCall(): void
+    {
+        $guard = new GraphQlAccessGuard($this->accessHandler, $this->account);
+        $referenceLoader = new ReferenceLoader($this->entityTypeManager, $guard);
+        $entityResolver = new EntityResolver($this->entityTypeManager, $guard);
+
+        $factory = new SchemaFactory(
+            entityTypeManager: $this->entityTypeManager,
+            entityResolver: $entityResolver,
+            referenceLoader: $referenceLoader,
+        );
+
+        $schema1 = $factory->build();
+        $schema2 = $factory->build();
+
+        self::assertSame($schema1, $schema2, 'Second build() call should return the same cached instance');
+    }
+
+    #[Test]
+    public function resetCacheInvalidatesStaticCache(): void
+    {
+        $guard = new GraphQlAccessGuard($this->accessHandler, $this->account);
+        $referenceLoader = new ReferenceLoader($this->entityTypeManager, $guard);
+        $entityResolver = new EntityResolver($this->entityTypeManager, $guard);
+
+        $factory = new SchemaFactory(
+            entityTypeManager: $this->entityTypeManager,
+            entityResolver: $entityResolver,
+            referenceLoader: $referenceLoader,
+        );
+
+        $schema1 = $factory->build();
+
+        SchemaFactory::resetCache();
+
+        $schema2 = $factory->build();
+
+        self::assertNotSame($schema1, $schema2, 'After resetCache(), build() should return a new instance');
+    }
+
+    #[Test]
+    public function cacheKeyIncludesEntityTypeIds(): void
+    {
+        $guard = new GraphQlAccessGuard($this->accessHandler, $this->account);
+        $referenceLoader = new ReferenceLoader($this->entityTypeManager, $guard);
+        $entityResolver = new EntityResolver($this->entityTypeManager, $guard);
+
+        $factory = new SchemaFactory(
+            entityTypeManager: $this->entityTypeManager,
+            entityResolver: $entityResolver,
+            referenceLoader: $referenceLoader,
+        );
+
+        $schema1 = $factory->build();
+
+        // Register a new entity type — changes the definitions
+        $pageType = new EntityType(
+            id: 'page',
+            label: 'Page',
+            class: EntityBase::class,
+            keys: ['id' => 'id'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer'],
+                'title' => ['type' => 'string'],
+            ],
+        );
+        $this->entityTypeManager->registerCoreEntityType($pageType);
+
+        $schema2 = $factory->build();
+
+        self::assertNotSame($schema1, $schema2, 'Different entity type definitions should produce a new schema');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Caches built schema in a static property keyed by xxh128 hash of entity type IDs
- Subsequent `build()` calls return cached instance, avoiding full reconstruction
- `resetCache()` method for test isolation
- 3 new tests: cache hit, cache invalidation, cache key includes entity types

## Test plan
- [ ] `./vendor/bin/phpunit --filter SchemaFactory` — all 8 tests pass
- [ ] Verify second `build()` returns `assertSame` instance

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)