### PR TITLE
feat(#464): add --package flag to make:migration command

### DIFF
--- a/packages/cli/src/Command/Make/MakeMigrationCommand.php
+++ b/packages/cli/src/Command/Make/MakeMigrationCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
 
 #[AsCommand(
     name: 'make:migration',
@@ -18,6 +19,7 @@ final class MakeMigrationCommand extends AbstractMakeCommand
 {
     public function __construct(
         private readonly string $projectRoot,
+        private readonly ?PackageManifest $manifest = null,
     ) {
         parent::__construct();
     }
@@ -27,7 +29,8 @@ final class MakeMigrationCommand extends AbstractMakeCommand
         $this
             ->addArgument('name', InputArgument::REQUIRED, 'The migration name (e.g. "create_comments_table")')
             ->addOption('create', null, InputOption::VALUE_REQUIRED, 'Table name to create')
-            ->addOption('table', null, InputOption::VALUE_REQUIRED, 'Existing table name to modify');
+            ->addOption('table', null, InputOption::VALUE_REQUIRED, 'Existing table name to modify')
+            ->addOption('package', null, InputOption::VALUE_REQUIRED, 'Package name to write migration to (e.g. "waaseyaa/node")');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -35,6 +38,7 @@ final class MakeMigrationCommand extends AbstractMakeCommand
         $name = $input->getArgument('name');
         $createTable = $input->getOption('create');
         $modifyTable = $input->getOption('table');
+        $package = $input->getOption('package');
 
         $table = $createTable ?? $modifyTable ?? $this->guessTableName($name);
 
@@ -45,7 +49,11 @@ final class MakeMigrationCommand extends AbstractMakeCommand
         $timestamp = date('Ymd_His');
         $filename = "{$timestamp}_{$name}.php";
 
-        $targetDir = $this->projectRoot . '/migrations';
+        $targetDir = $this->resolveMigrationDirectory($package, $output);
+        if ($targetDir === null) {
+            return self::FAILURE;
+        }
+
         if (!is_dir($targetDir)) {
             mkdir($targetDir, 0755, true);
         }
@@ -53,9 +61,32 @@ final class MakeMigrationCommand extends AbstractMakeCommand
         $targetPath = $targetDir . '/' . $filename;
         file_put_contents($targetPath, $rendered);
 
-        $output->writeln("Created: migrations/{$filename}");
+        $relativePath = str_starts_with($targetDir, $this->projectRoot)
+            ? substr($targetDir, strlen($this->projectRoot) + 1) . '/' . $filename
+            : $targetPath;
+        $output->writeln("Created: {$relativePath}");
 
         return self::SUCCESS;
+    }
+
+    private function resolveMigrationDirectory(?string $package, OutputInterface $output): ?string
+    {
+        if ($package === null) {
+            return $this->projectRoot . '/migrations';
+        }
+
+        if ($this->manifest === null) {
+            $output->writeln('<error>PackageManifest not available. Cannot resolve package migration directory.</error>');
+            return null;
+        }
+
+        $packageMigrations = $this->manifest->migrations;
+        if (!isset($packageMigrations[$package])) {
+            $output->writeln("<error>Package '{$package}' has no registered migration directory.</error>");
+            return null;
+        }
+
+        return $packageMigrations[$package];
     }
 
     /**

--- a/packages/cli/tests/Unit/Command/Make/MakeMigrationCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Make/MakeMigrationCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\CLI\Tests\Unit\Command\Make;
 
 use Waaseyaa\CLI\Command\Make\MakeMigrationCommand;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -83,6 +84,74 @@ final class MakeMigrationCommandTest extends TestCase
         $content = file_get_contents($files[0]);
         $this->assertStringContainsString('posts', $content);
         $this->assertStringContainsString('extends Migration', $content);
+    }
+
+    #[Test]
+    public function it_writes_to_package_migration_directory(): void
+    {
+        $packageMigDir = $this->tempDir . '/packages/node/migrations';
+        $manifest = new PackageManifest(
+            providers: [],
+            commands: [],
+            routes: [],
+            migrations: ['waaseyaa/node' => $packageMigDir],
+            fieldTypes: [],
+            listeners: [],
+            middleware: [],
+        );
+
+        $command = new MakeMigrationCommand($this->tempDir, $manifest);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'name' => 'add_body_field',
+            '--table' => 'node',
+            '--package' => 'waaseyaa/node',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryExists($packageMigDir);
+
+        $files = glob($packageMigDir . '/*.php');
+        $this->assertCount(1, $files);
+        $this->assertStringContainsString('add_body_field', $files[0]);
+    }
+
+    #[Test]
+    public function it_fails_for_unknown_package(): void
+    {
+        $manifest = new PackageManifest(
+            providers: [],
+            commands: [],
+            routes: [],
+            migrations: [],
+            fieldTypes: [],
+            listeners: [],
+            middleware: [],
+        );
+
+        $command = new MakeMigrationCommand($this->tempDir, $manifest);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'name' => 'test_migration',
+            '--package' => 'waaseyaa/nonexistent',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('no registered migration directory', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function it_fails_when_package_flag_used_without_manifest(): void
+    {
+        $command = new MakeMigrationCommand($this->tempDir);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'name' => 'test_migration',
+            '--package' => 'waaseyaa/node',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('PackageManifest not available', $tester->getDisplay());
     }
 
     private function createTester(): CommandTester

--- a/packages/foundation/src/Kernel/ConsoleKernel.php
+++ b/packages/foundation/src/Kernel/ConsoleKernel.php
@@ -171,7 +171,7 @@ final class ConsoleKernel extends AbstractKernel
             new MakeEntityCommand(),
             new MakeJobCommand(),
             new MakeListenerCommand(),
-            new MakeMigrationCommand($this->projectRoot),
+            new MakeMigrationCommand($this->projectRoot, $this->manifest),
             new MakePolicyCommand(),
             new MakeProviderCommand(),
             new MakeTestCommand(),


### PR DESCRIPTION
## Summary
- Adds `--package` option to `make:migration` command
- Resolves migration directory from `PackageManifest::$migrations`
- `PackageManifest` injected as optional constructor param (backward compatible)
- ConsoleKernel passes `$this->manifest` to the command
- 3 new tests: package write, unknown package error, missing manifest error

## Test plan
- [ ] `./vendor/bin/phpunit packages/cli/tests/Unit/Command/Make/MakeMigrationCommandTest.php` — 7 tests pass
- [ ] `bin/waaseyaa make:migration test_migration --package waaseyaa/node` writes to package dir

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)