### PR TITLE
feat(#438,#439,#440): GraphQL hardening — validation tests and operator fix

### DIFF
--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -219,7 +219,7 @@ final class EntityResolver
                     throw new UserError("Invalid filter: each entry must have 'field' and 'value' keys.");
                 }
                 $op = isset($f['operator']) ? strtoupper((string) $f['operator']) : '=';
-                $allowed = ['=', '!=', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN'];
+                $allowed = ['=', '!=', '<', '>', '<=', '>=', 'CONTAINS', 'STARTS_WITH'];
                 if (!in_array($op, $allowed, true)) {
                     throw new UserError("Invalid filter operator: '{$f['operator']}'");
                 }

--- a/tests/Integration/GraphQL/GraphQlDataBlobTest.php
+++ b/tests/Integration/GraphQL/GraphQlDataBlobTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\GraphQL;
+
+/**
+ * Tests filter and sort behavior on fields stored in the _data JSON blob (#438).
+ *
+ * SqlSchemaHandler creates dedicated columns only for entity keys (id, uuid,
+ * label, bundle, langcode). All other fields are stored in a _data TEXT column
+ * as JSON. SqlEntityQuery::resolveField() detects this at runtime via
+ * fieldExists() and wraps them in json_extract(_data, '$.fieldname').
+ *
+ * These queries work but cannot use column indexes. For high-traffic query
+ * fields, promote them to dedicated schema columns in SqlSchemaHandler.
+ */
+final class GraphQlDataBlobTest extends GraphQlIntegrationTestBase
+{
+    public function testFilterOnSchemaColumnWorks(): void
+    {
+        // 'title' is the label key → dedicated column.
+        $response = $this->query('
+            {
+                articleList(filter: [{ field: "title", value: "Hello" }]) {
+                    items { title }
+                    total
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['articleList']['items'];
+        $this->assertCount(1, $items);
+        $this->assertSame('Hello', $items[0]['title']);
+    }
+
+    public function testFilterOnDataBlobFieldWorks(): void
+    {
+        // 'body' is not an entity key → stored in _data blob.
+        // SqlEntityQuery uses json_extract(_data, '$.body') transparently.
+        $response = $this->query('
+            {
+                articleList(filter: [{ field: "body", value: "Content 1" }]) {
+                    items { title }
+                    total
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['articleList']['items'];
+        $this->assertCount(1, $items);
+        $this->assertSame('Hello', $items[0]['title']);
+    }
+
+    public function testSortOnSchemaColumnWorks(): void
+    {
+        // Sort by title (schema column) descending.
+        $response = $this->query('
+            {
+                articleList(sort: "-title") {
+                    items { title }
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['articleList']['items'];
+        // Only article 1 visible (article 2 denied). With one item, just verify it works.
+        $this->assertNotEmpty($items);
+    }
+
+    public function testSortOnDataBlobFieldWorks(): void
+    {
+        // Sort by body (_data field) ascending.
+        $response = $this->query('
+            {
+                articleList(sort: "body") {
+                    items { title }
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['articleList']['items'];
+        $this->assertNotEmpty($items);
+    }
+
+    public function testFilterOnDataBlobFieldWithContainsOperator(): void
+    {
+        // CONTAINS operator on a _data string field ('location' on organization).
+        // CONTAINS wraps value in %...% and uses LIKE internally via SqlEntityQuery.
+        $response = $this->query('
+            {
+                organizationList(filter: [{ field: "location", value: "YC", operator: "CONTAINS" }]) {
+                    items { name }
+                    total
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['organizationList']['items'];
+        $this->assertCount(1, $items);
+        $this->assertSame('Acme', $items[0]['name']);
+    }
+
+    public function testFilterOnNonExistentFieldReturnsEmpty(): void
+    {
+        // Filtering on a field that doesn't exist in the entity at all.
+        // json_extract(_data, '$.nonexistent') returns NULL → no match.
+        $response = $this->query('
+            {
+                articleList(filter: [{ field: "nonexistent", value: "anything" }]) {
+                    items { title }
+                    total
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $this->assertCount(0, $response['data']['articleList']['items']);
+    }
+
+    public function testSortOnDataBlobFieldWithMultipleEntities(): void
+    {
+        // Authors: Alice (secret=classified) and Bob (secret=redacted). Both visible.
+        // Sort by secret ascending → 'classified' before 'redacted'.
+        $response = $this->query('
+            {
+                authorList(sort: "secret") {
+                    items { name }
+                }
+            }
+        ');
+
+        $this->assertNoErrors($response);
+        $items = $response['data']['authorList']['items'];
+        $this->assertCount(2, $items);
+        // 'classified' < 'redacted' alphabetically.
+        $this->assertSame('Alice', $items[0]['name']);
+        $this->assertSame('Bob', $items[1]['name']);
+    }
+}

--- a/tests/Integration/GraphQL/GraphQlSchemaValidationTest.php
+++ b/tests/Integration/GraphQL/GraphQlSchemaValidationTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\GraphQL;
+
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\WrappingType;
+use Waaseyaa\GraphQL\Access\GraphQlAccessGuard;
+use Waaseyaa\GraphQL\Resolver\EntityResolver;
+use Waaseyaa\GraphQL\Resolver\ReferenceLoader;
+use Waaseyaa\GraphQL\Schema\SchemaFactory;
+
+/**
+ * Tests GraphQL schema generation: input type separation (#439)
+ * and pagination argument validation (#440).
+ */
+final class GraphQlSchemaValidationTest extends GraphQlIntegrationTestBase
+{
+    private \GraphQL\Type\Schema $schema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $guard = new GraphQlAccessGuard($this->accessHandler, $this->createAccount(1));
+        $referenceLoader = new ReferenceLoader($this->entityTypeManager, $guard, 3);
+        $entityResolver = new EntityResolver($this->entityTypeManager, $guard);
+
+        $factory = new SchemaFactory(
+            entityTypeManager: $this->entityTypeManager,
+            entityResolver: $entityResolver,
+            referenceLoader: $referenceLoader,
+        );
+        $this->schema = $factory->build();
+    }
+
+    // --- #439: Separate create/update input types ---
+
+    public function testCreateInputHasNonNullOnRequiredFields(): void
+    {
+        $createInput = $this->getType('ArticleCreateInput');
+        $this->assertInstanceOf(InputObjectType::class, $createInput);
+
+        /** @var InputObjectType $createInput */
+        $fields = $createInput->getFields();
+
+        // 'title' is required in entity definition.
+        $this->assertArrayHasKey('title', $fields);
+        $this->assertInstanceOf(NonNull::class, $fields['title']->getType());
+    }
+
+    public function testUpdateInputHasAllFieldsNullable(): void
+    {
+        $updateInput = $this->getType('ArticleUpdateInput');
+        $this->assertInstanceOf(InputObjectType::class, $updateInput);
+
+        /** @var InputObjectType $updateInput */
+        $fields = $updateInput->getFields();
+
+        // 'title' is required for create, but nullable for update (PATCH semantics).
+        $this->assertArrayHasKey('title', $fields);
+        $this->assertNotInstanceOf(
+            NonNull::class,
+            $fields['title']->getType(),
+            'Update input fields should be nullable for PATCH semantics',
+        );
+    }
+
+    public function testCreateInputExcludesIdAndUuid(): void
+    {
+        $createInput = $this->getType('ArticleCreateInput');
+        /** @var InputObjectType $createInput */
+        $fields = $createInput->getFields();
+
+        $this->assertArrayNotHasKey('id', $fields, 'id should be excluded from create input');
+        $this->assertArrayNotHasKey('uuid', $fields, 'uuid should be excluded from create input');
+    }
+
+    public function testUpdateInputExcludesIdAndUuid(): void
+    {
+        $updateInput = $this->getType('ArticleUpdateInput');
+        /** @var InputObjectType $updateInput */
+        $fields = $updateInput->getFields();
+
+        $this->assertArrayNotHasKey('id', $fields, 'id should be excluded from update input');
+        $this->assertArrayNotHasKey('uuid', $fields, 'uuid should be excluded from update input');
+    }
+
+    public function testCreateMutationUsesCreateInput(): void
+    {
+        $result = GraphQL::executeQuery($this->schema, '
+            { __schema { mutationType { fields { name args { name type { name kind ofType { name } } } } } } }
+        ');
+        $fields = $result->toArray()['data']['__schema']['mutationType']['fields'];
+
+        $createArticle = $this->findField($fields, 'createArticle');
+        $this->assertNotNull($createArticle);
+
+        $inputArg = $this->findArg($createArticle['args'], 'input');
+        $this->assertNotNull($inputArg);
+
+        // input arg should be NonNull wrapping ArticleCreateInput.
+        $this->assertSame('NON_NULL', $inputArg['type']['kind']);
+        $this->assertSame('ArticleCreateInput', $inputArg['type']['ofType']['name']);
+    }
+
+    public function testUpdateMutationUsesUpdateInput(): void
+    {
+        $result = GraphQL::executeQuery($this->schema, '
+            { __schema { mutationType { fields { name args { name type { name kind ofType { name } } } } } } }
+        ');
+        $fields = $result->toArray()['data']['__schema']['mutationType']['fields'];
+
+        $updateArticle = $this->findField($fields, 'updateArticle');
+        $this->assertNotNull($updateArticle);
+
+        $inputArg = $this->findArg($updateArticle['args'], 'input');
+        $this->assertNotNull($inputArg);
+
+        $this->assertSame('NON_NULL', $inputArg['type']['kind']);
+        $this->assertSame('ArticleUpdateInput', $inputArg['type']['ofType']['name']);
+    }
+
+    // --- #440: Pagination argument validation ---
+
+    public function testListQueryHasLimitAndOffsetArgs(): void
+    {
+        $result = GraphQL::executeQuery($this->schema, '
+            { __schema { queryType { fields { name args { name type { name kind } } } } } }
+        ');
+        $fields = $result->toArray()['data']['__schema']['queryType']['fields'];
+
+        $articleList = $this->findField($fields, 'articleList');
+        $this->assertNotNull($articleList, 'articleList query should exist');
+
+        $limitArg = $this->findArg($articleList['args'], 'limit');
+        $this->assertNotNull($limitArg, 'limit argument should exist');
+        $this->assertSame('Int', $limitArg['type']['name']);
+
+        $offsetArg = $this->findArg($articleList['args'], 'offset');
+        $this->assertNotNull($offsetArg, 'offset argument should exist');
+        $this->assertSame('Int', $offsetArg['type']['name']);
+    }
+
+    public function testDefaultLimitWhenOmitted(): void
+    {
+        // Seed enough articles to exceed default limit detection.
+        // Default is 50, max is 100. With 2 seeded + 50 new = 52 total.
+        for ($i = 0; $i < 50; $i++) {
+            $article = $this->storages['article']->create(['title' => "Bulk {$i}"]);
+            $this->storages['article']->save($article);
+        }
+
+        $response = $this->query('{ articleList { items { title } total } }');
+        $this->assertNoErrors($response);
+
+        $data = $response['data']['articleList'];
+        // total reflects all articles (unfiltered count).
+        $this->assertGreaterThan(50, $data['total']);
+        // items should be capped at default limit (50), minus access-denied article 2.
+        $this->assertLessThanOrEqual(50, count($data['items']));
+    }
+
+    public function testOffsetDefaultsToZero(): void
+    {
+        $response = $this->query('{ articleList(limit: 1) { items { id } total } }');
+        $this->assertNoErrors($response);
+
+        $data = $response['data']['articleList'];
+        // First item should be article 1 (offset defaults to 0).
+        $this->assertCount(1, $data['items']);
+        $this->assertSame('1', $data['items'][0]['id']);
+    }
+
+    public function testMaxLimitIsCapped(): void
+    {
+        // Request limit=999, should be capped to MAX_LIMIT (100).
+        $response = $this->query('{ articleList(limit: 999) { items { title } total } }');
+        $this->assertNoErrors($response);
+
+        // Should not error, limit is silently capped.
+        $this->assertLessThanOrEqual(100, count($response['data']['articleList']['items']));
+    }
+
+    public function testNegativeOffsetTreatedAsZero(): void
+    {
+        $response = $this->query('{ articleList(offset: -5, limit: 1) { items { id } total } }');
+        $this->assertNoErrors($response);
+
+        // Negative offset should be clamped to 0.
+        $this->assertCount(1, $response['data']['articleList']['items']);
+    }
+
+    // --- Helpers ---
+
+    private function getType(string $name): mixed
+    {
+        return $this->schema->getType($name);
+    }
+
+    private function findField(array $fields, string $name): ?array
+    {
+        foreach ($fields as $field) {
+            if ($field['name'] === $name) {
+                return $field;
+            }
+        }
+        return null;
+    }
+
+    private function findArg(array $args, string $name): ?array
+    {
+        foreach ($args as $arg) {
+            if ($arg['name'] === $name) {
+                return $arg;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- **#438**: 7 integration tests proving filter/sort on `_data` JSON blob fields works via `json_extract()`. Tests cover schema columns, blob fields, CONTAINS operator, nonexistent fields, and sort ordering.
- **#439**: 6 tests verifying `CreateInput` has `NonNull` on required fields while `UpdateInput` has all fields nullable (PATCH semantics). Tests confirm mutations reference correct input types and both exclude `id`/`uuid`.
- **#440**: 5 tests validating `limit`/`offset` args exist as `Int` on list queries, default limit (50), max limit cap (100), offset defaults to 0, negative offset clamped.
- **Fix**: Aligned `EntityResolver::parseFilters` allowed operators with `QueryFilter::VALID_OPERATORS` (`CONTAINS`/`STARTS_WITH` instead of `LIKE`/`NOT LIKE`/`IN`/`NOT IN`). The old operators passed GraphQL validation but threw at the `QueryFilter` constructor.

## Test plan
- [x] 30/30 GraphQL integration tests pass
- [x] 519/519 full integration suite passes (no regressions)
- [x] PHPStan level 5 clean on all new test files
- [ ] CI pipeline green

Closes #438, closes #439, closes #440