### PR TITLE
feat(#475,#476,#477): cleanup/tooling — ingestion, provider scaffolding, deployer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         { "type": "path", "url": "packages/telescope" },
         { "type": "path", "url": "packages/full" },
         { "type": "path", "url": "packages/admin-surface" },
-        { "type": "path", "url": "packages/github" }
+        { "type": "path", "url": "packages/github" },
+        { "type": "path", "url": "packages/ingestion" }
     ],
     "require": {
         "php": ">=8.4",
@@ -70,6 +71,7 @@
         "waaseyaa/foundation": "@dev",
         "waaseyaa/github": "@dev",
         "waaseyaa/graphql": "@dev",
+        "waaseyaa/ingestion": "@dev",
         "waaseyaa/i18n": "@dev",
         "waaseyaa/mail": "@dev",
         "waaseyaa/mcp": "@dev",
@@ -123,6 +125,7 @@
             "Waaseyaa\\State\\Tests\\": "packages/state/tests/",
             "Waaseyaa\\Mcp\\Tests\\": "packages/mcp/tests/",
             "Waaseyaa\\GraphQL\\Tests\\": "packages/graphql/tests/",
+            "Waaseyaa\\Ingestion\\Tests\\": "packages/ingestion/tests/",
             "Waaseyaa\\Mail\\Tests\\": "packages/mail/tests/",
             "Waaseyaa\\Media\\Tests\\": "packages/media/tests/",
             "Waaseyaa\\Menu\\Tests\\": "packages/menu/tests/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0943ff3ab1eb161f1db0e5ed6aab146",
+    "content-hash": "a3e6487c84f1f117de6937f75b8eaef8",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -3473,7 +3473,7 @@
         },
         {
             "name": "waaseyaa/github",
-            "version": "dev-main",
+            "version": "dev-feat/batch-b-cleanup-475-476-477",
             "dist": {
                 "type": "path",
                 "url": "packages/github",
@@ -3582,6 +3582,44 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "waaseyaa/ingestion",
+            "version": "dev-main",
+            "dist": {
+                "type": "path",
+                "url": "packages/ingestion",
+                "reference": "938e80c2229b632b813d3aabf4b5e640ab7b286b"
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\Ingestion\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Waaseyaa\\Ingestion\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Payload validation and ingestion utilities for Waaseyaa applications",
             "transport-options": {
                 "relative": true
             }
@@ -7930,6 +7968,7 @@
         "waaseyaa/github": 20,
         "waaseyaa/graphql": 20,
         "waaseyaa/i18n": 20,
+        "waaseyaa/ingestion": 20,
         "waaseyaa/mail": 20,
         "waaseyaa/mcp": 20,
         "waaseyaa/media": 20,

--- a/packages/cli/src/Command/Make/MakeProviderCommand.php
+++ b/packages/cli/src/Command/Make/MakeProviderCommand.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\CLI\Command\Make;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
@@ -17,17 +18,39 @@ final class MakeProviderCommand extends AbstractMakeCommand
 {
     protected function configure(): void
     {
-        $this->addArgument('name', InputArgument::REQUIRED, 'The provider class name (e.g. "SitemapServiceProvider")');
+        $this->addArgument('name', InputArgument::REQUIRED, 'The provider class name (e.g. "Blog" or "BlogServiceProvider")');
+        $this->addOption('domain', 'd', InputOption::VALUE_NONE, 'Generate a domain provider with entity type registration boilerplate');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = $input->getArgument('name');
-        $className = $this->toPascalCase($name);
+        $isDomain = $input->getOption('domain');
 
-        $rendered = $this->renderStub('provider', [
-            'class' => $className,
-        ]);
+        // Normalize: "Blog" → "BlogServiceProvider", "BlogServiceProvider" → as-is.
+        $className = $this->toPascalCase($name);
+        if (!str_ends_with($className, 'ServiceProvider')) {
+            $className .= 'ServiceProvider';
+        }
+
+        // Extract domain name from class: "BlogServiceProvider" → "Blog".
+        $domain = str_replace('ServiceProvider', '', $className);
+
+        if ($isDomain) {
+            $entityTypeId = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $domain));
+            $rendered = $this->renderStub('provider-domain', [
+                'class' => $className,
+                'domain' => $domain,
+                'entity_namespace' => 'App\\Entity',
+                'entity_class' => $domain,
+                'entity_type_id' => $entityTypeId,
+                'entity_label' => $domain,
+            ]);
+        } else {
+            $rendered = $this->renderStub('provider', [
+                'class' => $className,
+            ]);
+        }
 
         $output->write($rendered);
 

--- a/packages/cli/stubs/provider-domain.stub
+++ b/packages/cli/stubs/provider-domain.stub
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider;
+
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use {{ entity_namespace }}\{{ entity_class }};
+
+/**
+ * Service provider for the {{ domain }} domain.
+ *
+ * Registers entity types, repositories, and services for this domain.
+ * Each domain should have its own provider to maintain clear boundaries.
+ */
+final class {{ class }} extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Register entity types for this domain.
+        $this->entityType(new EntityType(
+            id: '{{ entity_type_id }}',
+            label: '{{ entity_label }}',
+            class: {{ entity_class }}::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'label'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer'],
+                'uuid' => ['type' => 'string'],
+                'label' => ['type' => 'string', 'required' => true],
+                // Add field definitions here.
+            ],
+        ));
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/packages/cli/tests/Unit/Command/Make/MakeProviderCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Make/MakeProviderCommandTest.php
@@ -39,6 +39,41 @@ final class MakeProviderCommandTest extends TestCase
         $this->assertStringContainsString('class SitemapServiceProvider extends ServiceProvider', $output);
     }
 
+    #[Test]
+    public function it_appends_service_provider_suffix(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['name' => 'Blog']);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('class BlogServiceProvider extends ServiceProvider', $output);
+    }
+
+    #[Test]
+    public function it_generates_domain_provider_with_entity_boilerplate(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['name' => 'Blog', '--domain' => true]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('class BlogServiceProvider extends ServiceProvider', $output);
+        $this->assertStringContainsString("id: 'blog'", $output);
+        $this->assertStringContainsString("label: 'Blog'", $output);
+        $this->assertStringContainsString('fieldDefinitions:', $output);
+        $this->assertStringContainsString('Blog::class', $output);
+    }
+
+    #[Test]
+    public function domain_flag_converts_multi_word_to_snake_case(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['name' => 'UserProfile', '--domain' => true]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('class UserProfileServiceProvider extends ServiceProvider', $output);
+        $this->assertStringContainsString("id: 'user_profile'", $output);
+    }
+
     private function createTester(): CommandTester
     {
         $app = new Application();

--- a/packages/deployer/composer.json
+++ b/packages/deployer/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "waaseyaa/deployer",
+    "description": "Shared Deployer recipe for Waaseyaa applications",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.4",
+        "deployer/deployer": "^7.0"
+    },
+    "autoload": {
+        "files": ["recipe/waaseyaa.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.1.x-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/deployer/recipe/waaseyaa.php
+++ b/packages/deployer/recipe/waaseyaa.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Shared Deployer recipe for Waaseyaa applications.
+ *
+ * Provides common tasks for artifact-upload deploys where vendor is pre-built
+ * in CI and uploaded to the server (no composer on server).
+ *
+ * Usage in your app's deploy.php:
+ *
+ *   require 'recipe/common.php';
+ *   require __DIR__ . '/vendor/waaseyaa/deployer/recipe/waaseyaa.php';
+ *
+ *   set('application', 'myapp');
+ *   set('shared_files', ['.env', 'waaseyaa.sqlite']);
+ *   set('shared_dirs', ['storage']);
+ *   set('writable_dirs', ['storage']);
+ *
+ *   host('production')
+ *       ->setHostname('myapp.example.com')
+ *       ->set('remote_user', 'deployer')
+ *       ->set('deploy_path', '/home/deployer/myapp');
+ *
+ *   // Add app-specific tasks, then define the deploy flow:
+ *   task('deploy', [
+ *       ...waaseyaaDeploySteps(),
+ *       'myapp:migrate',        // your custom task
+ *       ...waaseyaaFinalizeSteps(),
+ *   ]);
+ */
+
+namespace Deployer;
+
+set('keep_releases', 5);
+set('allow_anonymous_stats', false);
+
+// ── Shared tasks ─────────────────────────────────────────────────────────────
+
+desc('Upload pre-built release artifact from CI');
+task('waaseyaa:upload', function (): void {
+    upload('.build/', '{{release_path}}/', [
+        'options' => ['--recursive', '--compress'],
+    ]);
+});
+
+desc('Clear Waaseyaa framework manifest cache');
+task('waaseyaa:clear-manifest', function (): void {
+    run('rm -f {{deploy_path}}/shared/storage/framework/packages.php 2>/dev/null '
+        . '|| echo "INVALIDATED" > {{deploy_path}}/shared/storage/framework/packages.php 2>/dev/null '
+        . '|| true');
+});
+
+desc('Reload PHP-FPM to pick up new release');
+task('waaseyaa:php-fpm-reload', function (): void {
+    run('sudo systemctl reload php8.4-fpm');
+});
+
+desc('Ensure shared runtime directories exist');
+task('waaseyaa:runtime-dirs', function (): void {
+    $sharedDirs = get('shared_dirs', ['storage']);
+    foreach ($sharedDirs as $dir) {
+        run("mkdir -p {{deploy_path}}/shared/{$dir}");
+    }
+});
+
+// ── Step helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Common deploy steps before app-specific tasks.
+ *
+ * @return list<string>
+ */
+function waaseyaaDeploySteps(): array
+{
+    return [
+        'deploy:info',
+        'deploy:setup',
+        'deploy:lock',
+        'deploy:release',
+        'waaseyaa:upload',
+        'waaseyaa:runtime-dirs',
+        'deploy:shared',
+        'deploy:writable',
+    ];
+}
+
+/**
+ * Common finalization steps after app-specific tasks.
+ *
+ * @return list<string>
+ */
+function waaseyaaFinalizeSteps(): array
+{
+    return [
+        'deploy:symlink',
+        'waaseyaa:clear-manifest',
+        'waaseyaa:php-fpm-reload',
+        'deploy:unlock',
+        'deploy:cleanup',
+    ];
+}
+
+after('deploy:failed', 'deploy:unlock');

--- a/packages/ingestion/composer.json
+++ b/packages/ingestion/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "waaseyaa/ingestion",
+    "description": "Payload validation and ingestion utilities for Waaseyaa applications",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Waaseyaa\\Ingestion\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Waaseyaa\\Ingestion\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.1.x-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/ingestion/src/EnvelopeValidator.php
+++ b/packages/ingestion/src/EnvelopeValidator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Ingestion;
+
+/**
+ * Base envelope validator with configurable required fields, versions, and entity types.
+ *
+ * Applications extend this to provide their supported versions, entity types,
+ * and entity-specific validation rules via validateEntityData().
+ */
+abstract class EnvelopeValidator implements PayloadValidatorInterface
+{
+    /**
+     * @return list<string> Supported payload versions (e.g. ['1.0']).
+     */
+    abstract protected function supportedVersions(): array;
+
+    /**
+     * @return list<string> Supported entity type IDs.
+     */
+    abstract protected function supportedEntityTypes(): array;
+
+    /**
+     * Validate entity-specific data after envelope checks pass.
+     *
+     * @param array<string, mixed> $data The envelope's 'data' field.
+     * @return list<string> Validation errors (empty = valid).
+     */
+    abstract protected function validateEntityData(string $entityType, array $data): array;
+
+    /**
+     * Required top-level envelope fields.
+     *
+     * Override to customize. Defaults match the standard ingest envelope.
+     *
+     * @return list<string>
+     */
+    protected function requiredFields(): array
+    {
+        return ['payload_id', 'version', 'source', 'snapshot_type', 'timestamp', 'entity_type', 'source_url', 'data'];
+    }
+
+    public function validate(array $envelope): ValidationResult
+    {
+        $errors = [];
+
+        foreach ($this->requiredFields() as $field) {
+            if (!array_key_exists($field, $envelope) || $envelope[$field] === '' || $envelope[$field] === null) {
+                $errors[] = sprintf('Missing required field: %s', $field);
+            }
+        }
+
+        if ($errors !== []) {
+            return new ValidationResult($errors);
+        }
+
+        if (!in_array($envelope['version'], $this->supportedVersions(), true)) {
+            $errors[] = sprintf('Unsupported version: %s', $envelope['version']);
+        }
+
+        if (!in_array($envelope['entity_type'], $this->supportedEntityTypes(), true)) {
+            $errors[] = sprintf('Unsupported entity type: %s', $envelope['entity_type']);
+        }
+
+        if (!is_array($envelope['data'])) {
+            $errors[] = 'Data field must be an array.';
+            return new ValidationResult($errors);
+        }
+
+        if ($errors === []) {
+            $errors = $this->validateEntityData((string) $envelope['entity_type'], $envelope['data']);
+        }
+
+        return new ValidationResult($errors);
+    }
+}

--- a/packages/ingestion/src/PayloadValidatorInterface.php
+++ b/packages/ingestion/src/PayloadValidatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Ingestion;
+
+/**
+ * Validates an ingest payload envelope.
+ *
+ * Implementations check required fields, version compatibility,
+ * entity type support, and entity-specific data constraints.
+ */
+interface PayloadValidatorInterface
+{
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    public function validate(array $envelope): ValidationResult;
+}

--- a/packages/ingestion/src/ValidationResult.php
+++ b/packages/ingestion/src/ValidationResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Ingestion;
+
+/**
+ * Immutable result of a payload validation.
+ *
+ * Contains a list of error messages (empty = valid).
+ */
+final readonly class ValidationResult
+{
+    /** @param list<string> $errors */
+    public function __construct(
+        public array $errors = [],
+    ) {}
+
+    public function isValid(): bool
+    {
+        return $this->errors === [];
+    }
+}

--- a/packages/ingestion/tests/Unit/EnvelopeValidatorTest.php
+++ b/packages/ingestion/tests/Unit/EnvelopeValidatorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Ingestion\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Ingestion\EnvelopeValidator;
+use Waaseyaa\Ingestion\ValidationResult;
+
+#[CoversClass(EnvelopeValidator::class)]
+final class EnvelopeValidatorTest extends TestCase
+{
+    private EnvelopeValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new class extends EnvelopeValidator {
+            protected function supportedVersions(): array
+            {
+                return ['1.0'];
+            }
+
+            protected function supportedEntityTypes(): array
+            {
+                return ['article', 'note'];
+            }
+
+            protected function validateEntityData(string $entityType, array $data): array
+            {
+                if ($entityType === 'article' && empty($data['title'])) {
+                    return ['Article requires title.'];
+                }
+                return [];
+            }
+        };
+    }
+
+    #[Test]
+    public function validEnvelopePasses(): void
+    {
+        $result = $this->validator->validate($this->envelope());
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function missingRequiredFieldFails(): void
+    {
+        $envelope = $this->envelope();
+        unset($envelope['version']);
+        $result = $this->validator->validate($envelope);
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('version', $result->errors[0]);
+    }
+
+    #[Test]
+    public function unsupportedVersionFails(): void
+    {
+        $envelope = $this->envelope(['version' => '99.0']);
+        $result = $this->validator->validate($envelope);
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Unsupported version', $result->errors[0]);
+    }
+
+    #[Test]
+    public function unsupportedEntityTypeFails(): void
+    {
+        $envelope = $this->envelope(['entity_type' => 'widget']);
+        $result = $this->validator->validate($envelope);
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Unsupported entity type', $result->errors[0]);
+    }
+
+    #[Test]
+    public function nonArrayDataFails(): void
+    {
+        $envelope = $this->envelope(['data' => 'not-an-array']);
+        $result = $this->validator->validate($envelope);
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Data field must be an array', $result->errors[0]);
+    }
+
+    #[Test]
+    public function entitySpecificValidationRuns(): void
+    {
+        $envelope = $this->envelope(['data' => ['body' => 'no title']]);
+        $result = $this->validator->validate($envelope);
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Article requires title', $result->errors[0]);
+    }
+
+    #[Test]
+    public function entityTypeWithNoExtraRulesPasses(): void
+    {
+        $envelope = $this->envelope(['entity_type' => 'note', 'data' => ['text' => 'hello']]);
+        $result = $this->validator->validate($envelope);
+        $this->assertTrue($result->isValid());
+    }
+
+    /** @param array<string, mixed> $overrides */
+    private function envelope(array $overrides = []): array
+    {
+        return array_merge([
+            'payload_id' => 'test-001',
+            'version' => '1.0',
+            'source' => 'test',
+            'snapshot_type' => 'full',
+            'timestamp' => '2026-01-01T00:00:00Z',
+            'entity_type' => 'article',
+            'source_url' => 'https://example.com/article/1',
+            'data' => ['title' => 'Test Article'],
+        ], $overrides);
+    }
+}

--- a/packages/ingestion/tests/Unit/ValidationResultTest.php
+++ b/packages/ingestion/tests/Unit/ValidationResultTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Ingestion\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Ingestion\ValidationResult;
+
+#[CoversClass(ValidationResult::class)]
+final class ValidationResultTest extends TestCase
+{
+    #[Test]
+    public function emptyErrorsIsValid(): void
+    {
+        $result = new ValidationResult();
+        $this->assertTrue($result->isValid());
+        $this->assertSame([], $result->errors);
+    }
+
+    #[Test]
+    public function withErrorsIsInvalid(): void
+    {
+        $result = new ValidationResult(['Missing field: name']);
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->errors);
+    }
+}


### PR DESCRIPTION
## Summary
- **#475**: New `waaseyaa/ingestion` package with `PayloadValidatorInterface`, `ValidationResult` value object, and `EnvelopeValidator` abstract base class. Apps extend `EnvelopeValidator` with their supported versions, entity types, and entity-specific validation rules.
- **#476**: Enhanced `make:provider` with `--domain` flag that generates a domain service provider with entity type registration boilerplate (`EntityType`, `fieldDefinitions`, entity class import). Auto-appends `ServiceProvider` suffix when omitted.
- **#477**: New `waaseyaa/deployer` package with shared Deployer recipe providing `waaseyaa:upload`, `waaseyaa:clear-manifest`, `waaseyaa:php-fpm-reload`, `waaseyaa:runtime-dirs` tasks plus `waaseyaaDeploySteps()`/`waaseyaaFinalizeSteps()` helpers for composing deploy flows.

## Test plan
- [x] 9/9 ingestion package unit tests pass
- [x] 5/5 MakeProviderCommand tests pass (2 existing + 3 new)
- [x] 4622/4622 full test suite passes (no regressions)
- [x] PHPStan level 5 clean on all new code
- [ ] CI pipeline green

Closes #475, closes #476, closes #477