### PR TITLE
docs(#450-453): DBAL migration design

### DIFF
--- a/docs/plans/v1.4-dbal-database-design.md
+++ b/docs/plans/v1.4-dbal-database-design.md
@@ -1,0 +1,847 @@
+# v1.4 DBAL Migration Design
+
+Design document for migrating from `PdoDatabase` (waaseyaa/database-legacy) to Doctrine DBAL. Covers class design, entity storage migration path, kernel boot changes, and consumer app compatibility.
+
+**Issues:** #450, #451, #452, #453
+**Depends on:** [v1.4 PDO Dependency Audit](v1.4-pdo-dependency-audit.md)
+**Date:** 2026-03-18
+
+---
+
+## 1. DBALDatabase Class Design (#450)
+
+### 1.1 Contract: `DatabaseInterface`
+
+The new `DBALDatabase` must implement `DatabaseInterface`, which defines:
+
+```php
+interface DatabaseInterface
+{
+    public function select(string $table, string $alias = ''): SelectInterface;
+    public function insert(string $table): InsertInterface;
+    public function update(string $table): UpdateInterface;
+    public function delete(string $table): DeleteInterface;
+    public function schema(): SchemaInterface;
+    public function transaction(string $name = ''): TransactionInterface;
+    /** @return \Traversable */
+    public function query(string $sql, array $args = []): \Traversable;
+}
+```
+
+### 1.2 Class Signature
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Database;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+
+final class DBALDatabase implements DatabaseInterface
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {}
+
+    public static function createSqlite(string $path = ':memory:'): self
+    {
+        $connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => $path === ':memory:' ? null : $path,
+            'memory' => $path === ':memory:',
+        ]);
+
+        return new self($connection);
+    }
+
+    public function select(string $table, string $alias = ''): SelectInterface
+    {
+        return new Query\DBALSelect($this->connection, $table, $alias);
+    }
+
+    public function insert(string $table): InsertInterface
+    {
+        return new Query\DBALInsert($this->connection, $table);
+    }
+
+    public function update(string $table): UpdateInterface
+    {
+        return new Query\DBALUpdate($this->connection, $table);
+    }
+
+    public function delete(string $table): DeleteInterface
+    {
+        return new Query\DBALDelete($this->connection, $table);
+    }
+
+    public function schema(): SchemaInterface
+    {
+        return new Schema\DBALSchema($this->connection);
+    }
+
+    public function transaction(string $name = ''): TransactionInterface
+    {
+        return new DBALTransaction($this->connection);
+    }
+
+    public function query(string $sql, array $args = []): \Traversable
+    {
+        $result = $this->connection->executeQuery($sql, $args);
+
+        // Yield associative rows to match PdoDatabase behavior (FETCH_ASSOC).
+        while ($row = $result->fetchAssociative()) {
+            yield $row;
+        }
+    }
+
+    /**
+     * Returns the underlying DBAL Connection.
+     *
+     * This replaces PdoDatabase::getPdo(). Consumers that previously
+     * used raw PDO should migrate to DBAL's Connection API.
+     */
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+}
+```
+
+### 1.3 Method Mapping: PdoDatabase to DBALDatabase
+
+| PdoDatabase Method | DBALDatabase Equivalent | Notes |
+|---|---|---|
+| `__construct(\PDO $pdo)` | `__construct(Connection $connection)` | Accepts DBAL Connection instead of raw PDO |
+| `createSqlite(string $path)` | `createSqlite(string $path)` | Uses `DriverManager::getConnection()` with `pdo_sqlite` driver |
+| `select($table, $alias)` | `select($table, $alias)` | Returns `DBALSelect` instead of `PdoSelect` |
+| `insert($table)` | `insert($table)` | Returns `DBALInsert` instead of `PdoInsert` |
+| `update($table)` | `update($table)` | Returns `DBALUpdate` instead of `PdoUpdate` |
+| `delete($table)` | `delete($table)` | Returns `DBALDelete` instead of `PdoDelete` |
+| `schema()` | `schema()` | Returns `DBALSchema` using `SchemaManager` instead of raw PRAGMA |
+| `transaction($name)` | `transaction($name)` | Returns `DBALTransaction` wrapping `Connection::beginTransaction()` |
+| `query($sql, $args)` | `query($sql, $args)` | Uses `Connection::executeQuery()` + `fetchAssociative()` generator |
+| `getPdo(): \PDO` | `getConnection(): Connection` | **Breaking change**: returns DBAL Connection, not raw PDO |
+
+### 1.4 Query Builder Mapping
+
+Each legacy query builder class maps to a DBAL-backed equivalent that preserves the same fluent interface (`SelectInterface`, `InsertInterface`, `UpdateInterface`, `DeleteInterface`).
+
+#### DBALSelect
+
+```php
+final class DBALSelect implements SelectInterface
+{
+    private QueryBuilder $qb;
+
+    public function __construct(Connection $connection, string $table, string $alias = '')
+    {
+        $this->qb = $connection->createQueryBuilder();
+        $effectiveAlias = $alias !== '' ? $alias : $table;
+        $this->qb->from($table, $effectiveAlias);
+    }
+
+    public function fields(string $tableAlias, array $fields = []): static
+    {
+        if (empty($fields)) {
+            $this->qb->addSelect($tableAlias . '.*');
+        } else {
+            foreach ($fields as $field) {
+                $this->qb->addSelect($tableAlias . '.' . $field);
+            }
+        }
+        return $this;
+    }
+
+    public function condition(string $field, mixed $value, string $operator = '='): static
+    {
+        $operator = strtoupper($operator);
+
+        if ($operator === 'IS NULL') {
+            $this->qb->andWhere($field . ' IS NULL');
+        } elseif ($operator === 'IS NOT NULL') {
+            $this->qb->andWhere($field . ' IS NOT NULL');
+        } elseif ($operator === 'IN' || $operator === 'NOT IN') {
+            $placeholder = $this->qb->createNamedParameter(
+                $value,
+                Connection::PARAM_STR_ARRAY,
+            );
+            $this->qb->andWhere($field . ' ' . $operator . ' (' . $placeholder . ')');
+        } elseif ($operator === 'LIKE') {
+            $placeholder = $this->qb->createNamedParameter($value);
+            $this->qb->andWhere($field . ' LIKE ' . $placeholder . " ESCAPE '\\'");
+        } else {
+            $placeholder = $this->qb->createNamedParameter($value);
+            $this->qb->andWhere($field . ' ' . $operator . ' ' . $placeholder);
+        }
+
+        return $this;
+    }
+
+    public function orderBy(string $field, string $direction = 'ASC'): static
+    {
+        $this->qb->addOrderBy($field, $direction);
+        return $this;
+    }
+
+    public function range(int $offset, int $limit): static
+    {
+        $this->qb->setFirstResult($offset)->setMaxResults($limit);
+        return $this;
+    }
+
+    public function countQuery(): static
+    {
+        $this->qb->select('COUNT(*) AS count');
+        return $this;
+    }
+
+    public function execute(): \Traversable
+    {
+        $result = $this->qb->executeQuery();
+        while ($row = $result->fetchAssociative()) {
+            yield $row;
+        }
+    }
+
+    // join(), leftJoin(), isNull(), isNotNull(), addField()
+    // follow the same pattern using $this->qb->...
+}
+```
+
+**Key behavior: `fetchAssociative()` confirmation.** DBAL's `fetchAssociative()` returns `array<string, mixed>`, which matches `PDO::FETCH_ASSOC` exactly. Both return column-name-keyed associative arrays. No behavioral difference.
+
+#### DBALInsert
+
+```php
+final class DBALInsert implements InsertInterface
+{
+    private array $fields = [];
+    private array $valuesSets = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $table,
+    ) {}
+
+    public function fields(array $fields): static { /* same as PdoInsert */ }
+    public function values(array $values): static { /* same as PdoInsert */ }
+
+    public function execute(): int|string
+    {
+        // Infer fields from first value set if fields() was not called.
+        if (empty($this->fields) && !empty($this->valuesSets)) {
+            $first = $this->valuesSets[0];
+            if (array_is_list($first)) {
+                throw new \RuntimeException('Cannot infer field names from indexed array.');
+            }
+            $this->fields = array_keys($first);
+        }
+
+        foreach ($this->valuesSets as $values) {
+            $params = [];
+            foreach ($this->fields as $field) {
+                $params[$field] = is_array($values) && !array_is_list($values)
+                    ? ($values[$field] ?? null)
+                    : array_shift($values);
+            }
+            $this->connection->insert($this->table, $params);
+        }
+
+        return $this->connection->lastInsertId();
+    }
+}
+```
+
+#### DBALUpdate
+
+```php
+final class DBALUpdate implements UpdateInterface
+{
+    private array $fields = [];
+    private array $conditions = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $table,
+    ) {}
+
+    public function execute(): int
+    {
+        // Build criteria from conditions.
+        $criteria = [];
+        foreach ($this->conditions as $cond) {
+            $criteria[$cond['field']] = $cond['value'];
+        }
+
+        return $this->connection->update($this->table, $this->fields, $criteria);
+    }
+}
+```
+
+Note: `Connection::update()` only supports simple `=` conditions. For `IN`, `IS NULL`, `LIKE` operators in UPDATE conditions, fall back to `QueryBuilder`:
+
+```php
+public function execute(): int
+{
+    if ($this->hasComplexConditions()) {
+        $qb = $this->connection->createQueryBuilder()->update($this->table);
+        foreach ($this->fields as $col => $val) {
+            $qb->set($col, $qb->createNamedParameter($val));
+        }
+        $this->applyConditions($qb);
+        return $qb->executeStatement();
+    }
+
+    // Simple path: all conditions are '=' operators.
+    return $this->connection->update($this->table, $this->fields, $this->simpleCriteria());
+}
+```
+
+#### DBALDelete
+
+```php
+final class DBALDelete implements DeleteInterface
+{
+    private array $conditions = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $table,
+    ) {}
+
+    public function execute(): int
+    {
+        if ($this->hasComplexConditions()) {
+            $qb = $this->connection->createQueryBuilder()->delete($this->table);
+            $this->applyConditions($qb);
+            return $qb->executeStatement();
+        }
+
+        return $this->connection->delete($this->table, $this->simpleCriteria());
+    }
+}
+```
+
+### 1.5 DBALSchema
+
+Replace SQLite-specific `PRAGMA` and `sqlite_master` queries with DBAL's platform-agnostic `SchemaManager`.
+
+```php
+final class DBALSchema implements SchemaInterface
+{
+    private readonly AbstractSchemaManager $sm;
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+        $this->sm = $connection->createSchemaManager();
+    }
+
+    public function tableExists(string $table): bool
+    {
+        return $this->sm->tablesExist([$table]);
+    }
+
+    public function fieldExists(string $table, string $field): bool
+    {
+        if (!$this->tableExists($table)) {
+            return false;
+        }
+        $columns = $this->sm->listTableColumns($table);
+        return isset($columns[$field]);
+    }
+
+    public function createTable(string $name, array $spec): void
+    {
+        $schema = new \Doctrine\DBAL\Schema\Schema();
+        $table = $schema->createTable($name);
+
+        $primaryKey = $spec['primary key'] ?? [];
+
+        foreach ($spec['fields'] as $fieldName => $fieldSpec) {
+            $type = $this->mapFieldType($fieldSpec['type']);
+            $options = $this->mapFieldOptions($fieldSpec, $primaryKey, $fieldName);
+            $table->addColumn($fieldName, $type, $options);
+        }
+
+        if (!empty($primaryKey)) {
+            $table->setPrimaryKey($primaryKey);
+        }
+
+        if (!empty($spec['unique keys'])) {
+            foreach ($spec['unique keys'] as $keyName => $keyFields) {
+                $table->addUniqueIndex($keyFields, $keyName);
+            }
+        }
+
+        if (!empty($spec['indexes'])) {
+            foreach ($spec['indexes'] as $indexName => $indexFields) {
+                $table->addIndex($indexFields, $indexName);
+            }
+        }
+
+        $platform = $this->connection->getDatabasePlatform();
+        $queries = $schema->toSql($platform);
+        foreach ($queries as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+    }
+
+    public function addField(string $table, string $field, array $spec): void
+    {
+        $currentSchema = $this->sm->introspectSchema();
+        $newSchema = clone $currentSchema;
+
+        $tableObj = $newSchema->getTable($table);
+        $type = $this->mapFieldType($spec['type']);
+        $options = $this->mapFieldOptions($spec, [], $field);
+        $tableObj->addColumn($field, $type, $options);
+
+        $platform = $this->connection->getDatabasePlatform();
+        $diff = $this->sm->createComparator()
+            ->compareSchemas($currentSchema, $newSchema);
+        $queries = $platform->getAlterSchemaSQL($diff);
+        foreach ($queries as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+    }
+
+    // dropTable, dropField, addIndex, dropIndex, addUniqueKey, addPrimaryKey
+    // all follow the same schema-diff pattern.
+
+    private function mapFieldType(string $waaseyaaType): string
+    {
+        return match (strtolower($waaseyaaType)) {
+            'serial' => 'integer',  // DBAL handles autoincrement via options
+            'int', 'integer' => 'integer',
+            'varchar', 'text', 'string' => 'text',
+            'blob' => 'blob',
+            'float', 'real' => 'float',
+            'boolean', 'bool' => 'boolean',
+            default => 'text',
+        };
+    }
+
+    private function mapFieldOptions(array $spec, array $primaryKey, string $fieldName): array
+    {
+        $options = [];
+
+        if (strtolower($spec['type'] ?? '') === 'serial') {
+            $options['autoincrement'] = true;
+        }
+        if (isset($spec['not null'])) {
+            $options['notnull'] = (bool) $spec['not null'];
+        }
+        if (array_key_exists('default', $spec)) {
+            $options['default'] = $spec['default'];
+        }
+        if (isset($spec['length'])) {
+            $options['length'] = $spec['length'];
+        }
+
+        return $options;
+    }
+}
+```
+
+### 1.6 DBALTransaction
+
+```php
+final class DBALTransaction implements TransactionInterface
+{
+    private bool $active = true;
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+        $this->connection->beginTransaction();
+    }
+
+    public function commit(): void
+    {
+        if (!$this->active) {
+            throw new \RuntimeException('Transaction is no longer active.');
+        }
+        $this->connection->commit();
+        $this->active = false;
+    }
+
+    public function rollBack(): void
+    {
+        if (!$this->active) {
+            throw new \RuntimeException('Transaction is no longer active.');
+        }
+        $this->connection->rollBack();
+        $this->active = false;
+    }
+}
+```
+
+### 1.7 SQLite-Specific Behaviors
+
+#### LIKE Escaping
+
+`PdoSelect` passes LIKE patterns through without escape clause. `SqlEntityQuery` manually escapes `%` and `_` in values before passing to the condition. Under DBAL, we add `ESCAPE '\\'` to the LIKE clause (shown in `DBALSelect::condition()` above) to make escape sequences explicit and portable.
+
+#### Type Affinity
+
+SQLite uses type affinity (VARCHAR becomes TEXT, SERIAL becomes INTEGER). DBAL's SQLite platform handles this transparently via its type mapping. No custom handling needed.
+
+#### WAL Mode
+
+`PdoDatabase` does not set WAL mode. If WAL is desired, add it to `DBALDatabase::createSqlite()`:
+
+```php
+public static function createSqlite(string $path = ':memory:'): self
+{
+    $connection = DriverManager::getConnection([
+        'driver' => 'pdo_sqlite',
+        'path' => $path === ':memory:' ? null : $path,
+        'memory' => $path === ':memory:',
+    ]);
+
+    // Enable WAL mode for better concurrent read performance.
+    if ($path !== ':memory:') {
+        $connection->executeStatement('PRAGMA journal_mode = WAL');
+    }
+
+    return new self($connection);
+}
+```
+
+#### `createSqlite()` Static Factory
+
+The DBAL equivalent uses `DriverManager::getConnection()` with SQLite parameters. For `:memory:` databases (used heavily in tests), set `'memory' => true` and omit `path`. This is the DBAL-idiomatic way.
+
+### 1.8 The `_data` JSON Blob Under DBAL
+
+The `json_extract(_data, '$.field')` pattern is SQLite JSON1 extension specific. DBAL has no built-in JSON function abstraction.
+
+**Approach: raw SQL expression passthrough.**
+
+DBAL's `QueryBuilder` allows raw SQL expressions in `select()`, `where()`, and `orderBy()`. The `json_extract()` calls in `SqlEntityQuery` and `SqlStorageDriver` are already constructed as raw SQL strings (e.g., `"json_extract(_data, '$.field')"`), which are passed to `condition()` as the field parameter. This works with DBAL's `QueryBuilder::andWhere()` because the field string is interpolated directly into the SQL, not quoted as an identifier.
+
+No changes needed to the JSON blob pattern. The raw `json_extract()` expressions pass through DBAL's query builder unchanged, just as they pass through `PdoSelect` today.
+
+**Future consideration:** If multi-database support is needed, introduce a `JsonFieldExpression` abstraction that generates platform-specific SQL (`json_extract` for SQLite, `->` operator for PostgreSQL, `JSON_EXTRACT` for MySQL).
+
+### 1.9 `fetchAllAssociative()` Behavior Confirmation
+
+DBAL's `Result::fetchAssociative()` returns `array<string, mixed>|false`, identical to `PDO::fetch(PDO::FETCH_ASSOC)`. The key difference is that DBAL returns `false` on exhaustion rather than an empty array. Since all consumers iterate via `foreach` on the `\Traversable` returned by `execute()`, this is handled by the generator pattern (the `while ($row = $result->fetchAssociative())` loop in `DBALSelect::execute()` yields nothing when exhausted).
+
+---
+
+## 2. Entity Storage Migration Path (#451)
+
+### 2.1 Current Architecture
+
+```
+SqlEntityStorage  → DatabaseInterface → select(), insert(), update(), delete(), schema()
+SqlEntityQuery    → DatabaseInterface → select(), schema() (for json_extract resolution)
+SqlSchemaHandler  → DatabaseInterface → schema()
+SqlStorageDriver  → DatabaseInterface → select(), schema() (for json_extract resolution)
+UnitOfWork        → DatabaseInterface → transaction()
+EntityStorageFactory → DatabaseInterface → passed to created storages
+ConnectionResolverInterface → DatabaseInterface → returns connection
+```
+
+All entity storage classes depend on `DatabaseInterface` (the interface), never on `PdoDatabase` (the concrete class). This is the cleanest migration path in the codebase.
+
+### 2.2 Migration Strategy: Drop-In Replacement
+
+Because entity-storage depends only on `DatabaseInterface`, migration is a **direct replacement** with no adapter layer needed:
+
+1. Replace `PdoDatabase` with `DBALDatabase` at the injection point (AbstractKernel)
+2. Entity storage classes receive `DBALDatabase` as `DatabaseInterface` with zero code changes
+3. All query builder interactions go through `SelectInterface`, `InsertInterface`, etc.
+
+The new DBAL query builders (`DBALSelect`, `DBALInsert`, etc.) implement the same interfaces, so no entity storage code changes.
+
+### 2.3 Query Builder Class Mapping
+
+| Legacy Class | DBAL Replacement | Interface |
+|---|---|---|
+| `PdoSelect` | `DBALSelect` | `SelectInterface` |
+| `PdoInsert` | `DBALInsert` | `InsertInterface` |
+| `PdoUpdate` | `DBALUpdate` | `UpdateInterface` |
+| `PdoDelete` | `DBALDelete` | `DeleteInterface` |
+| `PdoSchema` | `DBALSchema` | `SchemaInterface` |
+| `PdoTransaction` | `DBALTransaction` | `TransactionInterface` |
+
+### 2.4 `splitForStorage()` / `mapRowToEntity()` JSON Blob Handling
+
+**`splitForStorage()`** calls `$this->database->schema()->fieldExists()` to determine which values go into real columns vs the `_data` JSON blob. Under DBAL, `DBALSchema::fieldExists()` uses `SchemaManager::listTableColumns()` instead of `PRAGMA table_info()`. The return value is the same (boolean), so `splitForStorage()` needs no changes.
+
+**`mapRowToEntity()`** reads `$row['_data']` and calls `json_decode()`. This is pure PHP, no database interaction. No changes needed.
+
+**`json_extract()` in queries:** Both `SqlEntityQuery` and `SqlStorageDriver` use `resolveField()` which generates `json_extract(_data, '$.field')` strings. These are passed as raw SQL expressions to `SelectInterface::condition()` and `SelectInterface::orderBy()`. DBAL's `QueryBuilder` passes these through as-is (it does not attempt to quote field expressions that contain parentheses). No changes needed.
+
+### 2.5 LIKE Wildcard Escaping Under DBAL
+
+`SqlEntityQuery` handles `CONTAINS` and `STARTS_WITH` operators by escaping `%` and `_` characters, then passing the result to `SelectInterface::condition()` with `LIKE` operator.
+
+The `DBALSelect::condition()` method (Section 1.4) adds `ESCAPE '\\'` to LIKE clauses, making the escape character explicit. This is the correct DBAL approach and matches the escaping done in `SqlEntityQuery`.
+
+No changes needed in `SqlEntityQuery`. The escaping logic stays in the query class; the LIKE clause generation moves to `DBALSelect`.
+
+### 2.6 Migration Order
+
+| Phase | Component | Change Required | Risk |
+|---|---|---|---|
+| 1 | `DBALDatabase` + all DBAL query builders | New classes, implement existing interfaces | Low (additive) |
+| 2 | `AbstractKernel::bootDatabase()` | Swap `PdoDatabase::createSqlite()` for `DBALDatabase::createSqlite()` | Medium (affects all downstream) |
+| 3 | `entity-storage` package | **No code changes** (uses `DatabaseInterface`) | None |
+| 4 | `state` package | **No code changes** (uses `DatabaseInterface`) | None |
+| 5 | `foundation` package | Update type hints from `PdoDatabase` to `DBALDatabase` or `DatabaseInterface` | Medium |
+| 6 | `relationship` package | Update from `PdoDatabase` to `DatabaseInterface` | Low |
+| 7 | `api` package | Migrate `BroadcastStorage` raw SQL to DBAL | Medium |
+| 8 | `cache`, `ai-vector`, `telescope` | Migrate raw `\PDO` to DBAL Connection | Medium |
+| 9 | Remove `database-legacy` package | Delete package, remove from composer.json | Low (after all refs removed) |
+
+**Phase 1-2 can be done in a single PR** (the DBAL classes + kernel swap).
+**Phase 3-4 require no PRs** (zero code changes).
+**Phase 5-8 are independent PRs** that can be done in parallel.
+**Phase 9 is the final cleanup PR** after all consumers are migrated.
+
+### 2.7 Test Strategy
+
+Entity storage tests create `PdoDatabase::createSqlite(':memory:')` directly. These must be updated to `DBALDatabase::createSqlite(':memory:')`. This is a mechanical find-and-replace across test files.
+
+All existing entity storage tests should pass without modification after the swap, since they test through `DatabaseInterface`.
+
+---
+
+## 3. Kernel DBAL Boot Path (#452)
+
+### 3.1 Current `bootDatabase()` and `bootMigrations()` Duplication
+
+The kernel currently creates **two separate database connections**:
+
+```php
+// bootDatabase() — line 95-98
+$this->database = PdoDatabase::createSqlite($this->resolveDatabasePath());
+
+// bootMigrations() — line 133-138
+$connection = DriverManager::getConnection([
+    'driver' => 'pdo_sqlite',
+    'path' => $this->resolveDatabasePath(),
+]);
+```
+
+This is wasteful. DBAL is already a dependency and already creates a connection for migrations. Unifying to a single DBAL connection eliminates the duplication.
+
+### 3.2 New `bootDatabase()` Implementation
+
+```php
+protected function bootDatabase(): void
+{
+    $this->database = DBALDatabase::createSqlite($this->resolveDatabasePath());
+}
+```
+
+One line change. The `DBALDatabase::createSqlite()` factory (Section 1.2) handles `DriverManager::getConnection()` internally.
+
+### 3.3 Updated `bootMigrations()` Using Shared Connection
+
+```php
+protected function bootMigrations(): void
+{
+    // Reuse the DBAL connection from bootDatabase() instead of creating a second one.
+    $connection = $this->database->getConnection();
+
+    $repository = new MigrationRepository($connection);
+    $repository->createTable();
+
+    $this->migrationLoader = new MigrationLoader($this->projectRoot, $this->manifest);
+    $this->migrator = new Migrator($connection, $repository);
+}
+```
+
+This eliminates the duplicate `DriverManager::getConnection()` call. The `Migrator` and `MigrationRepository` already expect a DBAL `Connection`, so they work directly with `DBALDatabase::getConnection()`.
+
+### 3.4 DBAL Connection Parameters for SQLite
+
+```php
+// For file-based databases:
+[
+    'driver' => 'pdo_sqlite',
+    'path' => '/path/to/waaseyaa.sqlite',
+]
+
+// For in-memory databases (tests):
+[
+    'driver' => 'pdo_sqlite',
+    'memory' => true,
+]
+```
+
+Optional parameters to consider:
+
+```php
+[
+    'driver' => 'pdo_sqlite',
+    'path' => $path,
+    'driverOptions' => [
+        // DBAL sets ERRMODE_EXCEPTION by default.
+        // WAL mode can be set via post-connect event or direct PRAGMA.
+    ],
+]
+```
+
+### 3.5 Property and Return Type Changes
+
+| Location | Current | New |
+|---|---|---|
+| `AbstractKernel::$database` | `PdoDatabase` | `DBALDatabase` |
+| `AbstractKernel::getDatabase()` | `return PdoDatabase` | `return DBALDatabase` |
+| `use` import | `use Waaseyaa\Database\PdoDatabase` | `use Waaseyaa\Database\DBALDatabase` |
+
+### 3.6 Removal Order
+
+| Step | What | Why This Order |
+|---|---|---|
+| 1 | Create `DBALDatabase` + query builder classes in `database-legacy` package | Additive, no breaks |
+| 2 | Update `AbstractKernel::bootDatabase()` to use `DBALDatabase` | Single instantiation point |
+| 3 | Update `AbstractKernel::bootMigrations()` to reuse shared connection | Eliminate duplication |
+| 4 | Update `AbstractKernel::$database` type and `getDatabase()` return type | Propagates new type |
+| 5 | Update `ServiceProvider::commands()` signature: `PdoDatabase` to `DBALDatabase` | Enables app migration |
+| 6 | Update `HealthChecker` constructor: `PdoDatabase` to `DBALDatabase` | Diagnostic system |
+| 7 | Update `ControllerDispatcher`: `PdoDatabase` to `DBALDatabase` | HTTP dispatch layer |
+| 8 | Update `BroadcastStorage`, `DiscoveryApiHandler`, `SsrPageHandler` | API/SSR layer |
+| 9 | Migrate raw `\PDO` consumers (cache, ai-vector, telescope) to DBAL Connection | Hardest, most isolated |
+| 10 | Remove `PdoDatabase`, `PdoSelect`, `PdoInsert`, etc. | Final cleanup |
+| 11 | Remove `database-legacy` package from monorepo | Package deletion |
+
+Steps 1-4 form a single atomic PR. Steps 5-8 can be separate PRs. Step 9 is independent per-package. Steps 10-11 are the final cleanup.
+
+### 3.7 Health Check and Schema Check Commands
+
+`HealthChecker` currently accepts `PdoDatabase` and calls `$this->database->query('SELECT 1', [])` for the connectivity check. Under `DBALDatabase`, this call works identically (the `query()` method signature is unchanged via `DatabaseInterface`).
+
+Schema drift detection in `HealthChecker::checkSchemaDrift()` uses raw PRAGMA queries via `$this->database->query('PRAGMA table_info(...)')`. Under DBAL, replace with:
+
+```php
+// Before (PdoDatabase):
+$result = $this->database->query('PRAGMA table_info(' . $table . ')');
+
+// After (DBALDatabase):
+$columns = $this->database->getConnection()
+    ->createSchemaManager()
+    ->listTableColumns($table);
+```
+
+This makes schema drift detection platform-agnostic.
+
+### 3.8 Rollback Strategy
+
+If the DBAL migration causes issues in production:
+
+1. **Immediate rollback:** Revert the kernel `bootDatabase()` change (one line) to restore `PdoDatabase::createSqlite()`
+2. **The `DBALDatabase` class can coexist** with `PdoDatabase` in the codebase indefinitely; it is additive
+3. **Consumer apps** that haven't migrated yet continue working with `PdoDatabase` until the type is removed
+4. **Database files are unchanged:** DBAL reads the same SQLite files as PDO. No data migration is needed. Rollback is instant.
+
+The coexistence period allows gradual migration: kernel switches first, then foundation consumers, then app consumers, then raw PDO consumers. At any point, reverting the kernel change restores the old behavior.
+
+---
+
+## 4. Compatibility Shim Decision (#453)
+
+### 4.1 Consumer App Usage Analysis
+
+**Claudriel** (1 src + 9 test imports):
+
+| File | Usage | Nature |
+|---|---|---|
+| `src/Provider/ClaudrielServiceProvider.php` | `PdoDatabase $database` in `commands()` override | Forced by base class signature |
+| 9 test files | `PdoDatabase::createSqlite(':memory:')` | Test database setup |
+
+The source file usage is **inherited from the base `ServiceProvider::commands()` signature**. When the base class changes, Claudriel's override must change to match. This is not an independent coupling; it is a consequence of the framework signature.
+
+The 9 test files call `PdoDatabase::createSqlite(':memory:')` directly. These are mechanical replacements.
+
+**Minoo** (1 src import):
+
+| File | Usage | Nature |
+|---|---|---|
+| `src/Provider/MailServiceProvider.php` | `\Waaseyaa\Database\PdoDatabase $database` inline type | Direct concrete reference in method signature |
+
+### 4.2 Decision: Hard Cut (No Shim)
+
+**Recommendation: No compatibility shim.** Direct migration for all consumers.
+
+**Rationale:**
+
+1. **Only 2 source files across 2 apps** reference `PdoDatabase` directly. Both are method signatures forced by the framework's base class. When `ServiceProvider::commands()` changes its signature, both apps must update regardless.
+
+2. **A deprecation shim adds complexity without value.** A shim would be a `PdoDatabase` class that wraps `DBALDatabase` and delegates all calls. This requires maintaining two code paths, doubles the surface area for bugs, and delays the inevitable migration by exactly one version cycle. For 2 source files, this is not worth it.
+
+3. **Test file updates are mechanical.** All 9 Claudriel test files do `PdoDatabase::createSqlite(':memory:')`. Replace with `DBALDatabase::createSqlite(':memory:')`. A single find-and-replace operation.
+
+4. **The migration is coordinated.** Waaseyaa, Claudriel, and Minoo are all managed by the same team. There is no third-party ecosystem that needs deprecation warnings and migration windows.
+
+5. **DBAL is already a dependency.** Both Claudriel and Minoo already have `doctrine/dbal` in their dependency tree (via `waaseyaa/foundation`). No new dependencies are introduced.
+
+### 4.3 Migration Checklist for Consumer Apps
+
+#### Claudriel
+
+```
+[ ] src/Provider/ClaudrielServiceProvider.php
+    - Change: PdoDatabase $database → DBALDatabase $database
+    - Change: use Waaseyaa\Database\PdoDatabase → use Waaseyaa\Database\DBALDatabase
+
+[ ] 9 test files (Feature/Governance, Feature/Platform, Feature/Audit, Feature/Ai)
+    - Change: PdoDatabase::createSqlite(':memory:') → DBALDatabase::createSqlite(':memory:')
+    - Change: use Waaseyaa\Database\PdoDatabase → use Waaseyaa\Database\DBALDatabase
+```
+
+#### Minoo
+
+```
+[ ] src/Provider/MailServiceProvider.php
+    - Change: \Waaseyaa\Database\PdoDatabase $database → \Waaseyaa\Database\DBALDatabase $database
+```
+
+### 4.4 Coordinated Release Plan
+
+1. **Waaseyaa v1.4.x release** includes `DBALDatabase` alongside `PdoDatabase` (both available). Kernel switches to `DBALDatabase`. `PdoDatabase` is marked `@deprecated`.
+2. **Claudriel and Minoo PRs** are created simultaneously, updating imports. These PRs depend on Waaseyaa v1.4.x.
+3. **Waaseyaa v1.5.0** removes `PdoDatabase` and the `database-legacy` package entirely.
+
+This gives a one-minor-version window where both classes exist, allowing consumer apps to update without a hard lockstep deployment requirement.
+
+### 4.5 If a Shim Were Needed (Rejected Option)
+
+For reference, if third-party consumers existed, the shim would look like:
+
+```php
+/**
+ * @deprecated Use DBALDatabase instead. Will be removed in v1.5.0.
+ */
+final class PdoDatabase implements DatabaseInterface
+{
+    private readonly DBALDatabase $inner;
+
+    public function __construct(\PDO $pdo)
+    {
+        trigger_error('PdoDatabase is deprecated. Use DBALDatabase.', E_USER_DEPRECATED);
+        // Wrap the PDO in a DBAL connection.
+        $connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'pdo' => $pdo,
+        ]);
+        $this->inner = new DBALDatabase($connection);
+    }
+
+    public static function createSqlite(string $path = ':memory:'): self { /* delegate */ }
+    public function select(...): SelectInterface { return $this->inner->select(...); }
+    // ... all methods delegate to $this->inner
+    public function getPdo(): \PDO { return $this->inner->getConnection()->getNativeConnection(); }
+}
+```
+
+This is explicitly **not recommended** for the reasons in Section 4.2.


### PR DESCRIPTION
## Summary

Comprehensive design document for the DBAL migration covering 4 issues:

- **#450**: DBALDatabase class design
- **#451**: Entity storage migration path — zero entity-storage code changes needed
- **#452**: Kernel boot path — 11-step removal order
- **#453**: Compatibility shim — hard cut, no shim

### Output
- `docs/plans/v1.4-dbal-database-design.md` (847 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)