### PR TITLE
fix: quote table names in DBAL query builders

### DIFF
--- a/packages/database-legacy/src/Query/DBALDelete.php
+++ b/packages/database-legacy/src/Query/DBALDelete.php
@@ -35,7 +35,7 @@ final class DBALDelete implements DeleteInterface
         }
 
         // Simple path: all conditions are '=' operators.
-        return $this->connection->delete($this->table, $this->simpleCriteria());
+        return $this->connection->delete($this->connection->quoteIdentifier($this->table), $this->simpleCriteria());
     }
 
     private function hasComplexConditions(): bool
@@ -64,7 +64,7 @@ final class DBALDelete implements DeleteInterface
 
     private function executeWithQueryBuilder(): int
     {
-        $qb = $this->connection->createQueryBuilder()->delete($this->table);
+        $qb = $this->connection->createQueryBuilder()->delete($this->connection->quoteIdentifier($this->table));
         $this->applyConditions($qb);
 
         return $qb->executeStatement();

--- a/packages/database-legacy/src/Query/DBALInsert.php
+++ b/packages/database-legacy/src/Query/DBALInsert.php
@@ -60,7 +60,7 @@ final class DBALInsert implements InsertInterface
                     $params[$field] = $values[$field] ?? null;
                 }
             }
-            $this->connection->insert($this->table, $params);
+            $this->connection->insert($this->connection->quoteIdentifier($this->table), $params);
         }
 
         return $this->connection->lastInsertId();

--- a/packages/database-legacy/src/Query/DBALSelect.php
+++ b/packages/database-legacy/src/Query/DBALSelect.php
@@ -26,7 +26,7 @@ final class DBALSelect implements SelectInterface
     ) {
         $this->qb = $connection->createQueryBuilder();
         $this->tableAlias = $alias !== '' ? $alias : $table;
-        $this->qb->from($table, $this->tableAlias);
+        $this->qb->from($connection->quoteIdentifier($table), $this->tableAlias);
     }
 
     public function fields(string $tableAlias, array $fields = []): static

--- a/packages/database-legacy/src/Query/DBALUpdate.php
+++ b/packages/database-legacy/src/Query/DBALUpdate.php
@@ -49,7 +49,7 @@ final class DBALUpdate implements UpdateInterface
         }
 
         // Simple path: all conditions are '=' operators.
-        return $this->connection->update($this->table, $this->fields, $this->simpleCriteria());
+        return $this->connection->update($this->connection->quoteIdentifier($this->table), $this->fields, $this->simpleCriteria());
     }
 
     private function hasComplexConditions(): bool
@@ -78,7 +78,7 @@ final class DBALUpdate implements UpdateInterface
 
     private function executeWithQueryBuilder(): int
     {
-        $qb = $this->connection->createQueryBuilder()->update($this->table);
+        $qb = $this->connection->createQueryBuilder()->update($this->connection->quoteIdentifier($this->table));
 
         foreach ($this->fields as $col => $val) {
             $qb->set($col, $qb->createNamedParameter($val));


### PR DESCRIPTION
## Summary
Tables named with SQL reserved words (e.g. `group` in Minoo) caused query failures. All DBAL query builders now use `quoteIdentifier()`.

## Test plan
- [x] 78 DBAL tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)