### PR TITLE
fix: quote table alias in DBALSelect for reserved words

### DIFF
--- a/packages/database-legacy/src/Query/DBALSelect.php
+++ b/packages/database-legacy/src/Query/DBALSelect.php
@@ -25,7 +25,8 @@ final class DBALSelect implements SelectInterface
         string $alias = '',
     ) {
         $this->qb = $connection->createQueryBuilder();
-        $this->tableAlias = $alias !== '' ? $alias : $table;
+        $rawAlias = $alias !== '' ? $alias : $table;
+        $this->tableAlias = $connection->quoteIdentifier($rawAlias);
         $this->qb->from($connection->quoteIdentifier($table), $this->tableAlias);
     }
 


### PR DESCRIPTION
Fixes SELECT group.* syntax error — alias must also be quoted when table name is a SQL reserved word.