### PR TITLE
fix(admin): use shared i18n on error page

### DIFF
--- a/packages/admin/app/error.vue
+++ b/packages/admin/app/error.vue
@@ -5,13 +5,7 @@ const props = defineProps<{
   error: NuxtError
 }>()
 
-const messages: Record<string, string> = {
-  error_page_title: 'Error',
-  error_not_found: 'Page not found',
-  error_generic: 'Something went wrong',
-  error_page_back: 'Go back',
-}
-const t = (key: string) => messages[key] ?? key
+const { t } = useLanguage()
 
 useHead({
   title: t('error_page_title'),
@@ -21,7 +15,7 @@ const message = computed(() => {
   if (props.error.statusCode === 404) {
     return t('error_not_found')
   }
-  return props.error.message || t('error_generic')
+  return props.error.message?.trim() || t('error_generic')
 })
 </script>
 

--- a/packages/admin/app/i18n/fr.json
+++ b/packages/admin/app/i18n/fr.json
@@ -23,6 +23,8 @@
   "next": "Suivant",
   "error_generic": "Une erreur est survenue.",
   "error_not_found": "Introuvable.",
+  "error_page_title": "Une erreur est survenue",
+  "error_page_back": "Retour au tableau de bord",
   "error_loading_schema": "Échec du chargement du schéma.",
   "error_loading_types": "Échec du chargement des types d'entité.",
   "error_loading_entities": "Échec du chargement des entités.",


### PR DESCRIPTION
## Summary
- switch `packages/admin/app/error.vue` to the shared `useLanguage()` translator
- remove hardcoded fallback strings so the page matches canonical i18n copy
- add the missing French error-page keys used by the shared translator

## Verification
- ran `cd packages/admin && npm run test:e2e -- e2e/error-page.spec.ts --project=chromium`
- translation mismatch is fixed, but the spec still fails earlier during admin bootstrap with `Admin contract version mismatch: expected 1.0, got undefined`

## Follow-up investigation
- pulled Playwright artifacts from run `23272892696`
- traces show the shared failures for #497, #498, #500, and #501 are environmental: Nuxt starts, but `/admin/surface/session` and `/admin/bootstrap` return `502 Bad Gateway` before mocked `/api/...` routes matter
- likely CI misconfiguration: the admin SPA proxies `/api/**` and `/admin/**` to `localhost:8081`, while the workflows start PHP on `127.0.0.1:8080`

Closes #499