### PR TITLE
fix(#497,#498,#500,#501): fix all failing Playwright E2E tests and enable CI

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -110,7 +110,6 @@ jobs:
     name: admin/integration
     runs-on: ubuntu-latest
     needs: [build]
-    if: false  # Placeholder — enable when Playwright smoke tests with mock host are ready
     steps:
       - uses: actions/checkout@v4
 
@@ -125,7 +124,7 @@ jobs:
         run: cd packages/admin && npm install --no-audit --no-fund && npx playwright install --with-deps chromium
 
       - name: Run Playwright integration tests
-        run: cd packages/admin && npx playwright test
+        run: cd packages/admin && npx playwright test --project=chromium
 
   adapters:
     name: admin/adapters
@@ -152,7 +151,7 @@ jobs:
   release:
     name: admin/release
     runs-on: ubuntu-latest
-    needs: [contracts, adapters, build]
+    needs: [contracts, adapters, build, integration]
     if: startsWith(github.ref, 'refs/tags/v')
     defaults:
       run:

--- a/packages/admin/app/adapters/AdminSurfaceTransportAdapter.ts
+++ b/packages/admin/app/adapters/AdminSurfaceTransportAdapter.ts
@@ -33,7 +33,7 @@ interface SurfaceListResult {
 export class AdminSurfaceTransportAdapter implements TransportAdapter {
   constructor(
     private readonly basePath: string,
-    private readonly fetchFn: typeof fetch = fetch,
+    private readonly fetchFn: typeof fetch = (...args) => fetch(...args),
   ) {}
 
   async list(type: string, query?: ListQuery): Promise<ListResult> {

--- a/packages/admin/app/pages/[entityType]/index.vue
+++ b/packages/admin/app/pages/[entityType]/index.vue
@@ -16,8 +16,21 @@ const actionError = ref<string | null>(null)
 const showDisableConfirm = ref(false)
 
 const isDefaultNote = computed(() => entityType.value === 'note')
-const typeDisabled = computed(() => typeInfo.value?.disabled ?? false)
-const enabledTypeCount = computed(() => catalog.filter((type) => !type.disabled).length)
+const localDisabledOverride = ref<boolean | null>(null)
+
+// Reset local override when navigating between entity types (Nuxt reuses the component)
+watch(entityType, () => {
+  localDisabledOverride.value = null
+})
+const typeDisabled = computed(() => localDisabledOverride.value ?? typeInfo.value?.disabled ?? false)
+const enabledTypeCount = computed(() => {
+  return catalog.filter((type) => {
+    if (type.id === entityType.value && localDisabledOverride.value !== null) {
+      return !localDisabledOverride.value
+    }
+    return !type.disabled
+  }).length
+})
 const showLifecycleControls = computed(() => isDefaultNote.value && typeInfo.value !== null)
 const showDisableWarning = computed(
   () => !typeDisabled.value && enabledTypeCount.value <= 1,
@@ -31,6 +44,7 @@ async function disableType(force = false) {
   try {
     const query = force ? '?force=1' : ''
     await $fetch(`/api/entity-types/${entityType.value}/disable${query}`, { method: 'POST' })
+    localDisabledOverride.value = true
     showDisableConfirm.value = false
   } catch (e: any) {
     actionError.value = e?.data?.errors?.[0]?.detail ?? e?.message ?? t('error_generic')
@@ -46,6 +60,7 @@ async function enableType() {
   actionError.value = null
   try {
     await $fetch(`/api/entity-types/${entityType.value}/enable`, { method: 'POST' })
+    localDisabledOverride.value = false
   } catch (e: any) {
     actionError.value = e?.data?.errors?.[0]?.detail ?? e?.message ?? t('error_generic')
   } finally {

--- a/packages/admin/app/plugins/admin.ts
+++ b/packages/admin/app/plugins/admin.ts
@@ -18,6 +18,7 @@ interface SurfaceCatalogEntry {
   id: string
   label: string
   group?: string
+  disabled?: boolean
   fields: unknown[]
   actions: unknown[]
   capabilities: { list: boolean; get: boolean; create: boolean; update: boolean; delete: boolean; schema: boolean }
@@ -64,6 +65,7 @@ export default defineNuxtPlugin(async (): Promise<{ provide: { admin: AdminRunti
       id: entry.id,
       label: entry.label,
       group: entry.group,
+      disabled: entry.disabled,
       capabilities: entry.capabilities,
     }))
 

--- a/packages/admin/e2e/dashboard.spec.ts
+++ b/packages/admin/e2e/dashboard.spec.ts
@@ -35,6 +35,13 @@ test.describe('Dashboard', () => {
   })
 
   test('shows onboarding prompt when no custom types exist', async ({ page }) => {
+    // Surface transport: GET /admin/surface/node_type
+    await page.route('**/admin/surface/node_type**', (route) =>
+      route.fulfill({
+        json: { ok: true, data: { entities: [], total: 0, offset: 0, limit: 25 } },
+      }),
+    )
+    // Legacy JSON API fallback
     await page.route('**/api/node_type**', (route) =>
       route.fulfill({
         json: { jsonapi: { version: '1.0' }, data: [], meta: { total: 0 }, links: {} },

--- a/packages/admin/e2e/error-page.spec.ts
+++ b/packages/admin/e2e/error-page.spec.ts
@@ -8,14 +8,17 @@ test.describe('Error page', () => {
   })
 
   test('shows branded 404 message on unknown route', async ({ page }) => {
-    await page.goto('/this-route-does-not-exist-404')
+    // Use a multi-segment path that doesn't match any dynamic route pattern
+    await page.goto('/no/such/deep/route')
     await expect(
       page.getByText("The page you're looking for doesn't exist."),
     ).toBeVisible()
   })
 
   test('shows "Back to dashboard" link', async ({ page }) => {
-    await page.goto('/this-route-does-not-exist-404')
+    // Use a 3+ segment path that doesn't match any dynamic route pattern
+    // (single-segment paths match [entityType] catch-all and show entity error state instead)
+    await page.goto('/no/such/deep/route')
     await expect(page.getByRole('link', { name: 'Back to dashboard' })).toBeVisible()
   })
 

--- a/packages/admin/e2e/fixtures/routes.ts
+++ b/packages/admin/e2e/fixtures/routes.ts
@@ -66,12 +66,27 @@ export async function mockEntityTypesRoute(page: Page) {
 
 export async function mockSchemaRoute(page: Page, entityType = 'user', schema?: EntitySchema) {
   const resolved = schema ?? (entityType === 'note' ? noteSchema : userSchema)
+  // Surface transport: POST /admin/surface/{type}/action/schema
+  await page.route(`**/admin/surface/${entityType}/action/schema`, (route) =>
+    route.fulfill({ json: { ok: true, data: resolved } }),
+  )
+  // Legacy JSON API fallback
   await page.route(`**/api/schema/${entityType}`, (route) =>
     route.fulfill({ json: { meta: { schema: resolved } } }),
   )
 }
 
 export async function mockEntityListRoute(page: Page, entityType = 'user') {
+  // Surface transport: GET /admin/surface/{type}
+  await page.route(`**/admin/surface/${entityType}`, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        json: { ok: true, data: { entities: [], total: 0, offset: 0, limit: 25 } },
+      })
+    }
+    return route.fallback()
+  })
+  // Legacy JSON API fallback
   await page.route(`**/api/${entityType}`, (route) =>
     route.fulfill({
       json: {
@@ -85,6 +100,13 @@ export async function mockEntityListRoute(page: Page, entityType = 'user') {
 }
 
 export async function mockEntityCreateRoute(page: Page, entityType = 'user') {
+  // Surface transport: POST /admin/surface/{type}/action/create
+  await page.route(`**/admin/surface/${entityType}/action/create`, (route) =>
+    route.fulfill({
+      json: { ok: true, data: { type: entityType, id: '99', attributes: {} } },
+    }),
+  )
+  // Legacy JSON API fallback
   await page.route(`**/api/${entityType}`, async (route) => {
     if (route.request().method() === 'POST') {
       await route.fulfill({
@@ -94,8 +116,6 @@ export async function mockEntityCreateRoute(page: Page, entityType = 'user') {
         },
       })
     } else {
-      // Fall through to other registered route handlers (e.g. mockEntityListRoute)
-      // rather than hitting the real server.
       await route.fallback()
     }
   })

--- a/packages/admin/e2e/telescope-codified-context.spec.ts
+++ b/packages/admin/e2e/telescope-codified-context.spec.ts
@@ -92,8 +92,10 @@ test.describe('Telescope: Codified Context', () => {
 
   test('shows severity badges with correct values', async ({ page }) => {
     await page.goto('/telescope/codified-context')
-    await expect(page.getByText('low')).toBeVisible()
-    await expect(page.getByText('high')).toBeVisible()
+    // Scope to main content to avoid matching sidebar nav items (e.g. "Workflows" contains "low")
+    const main = page.locator('main')
+    await expect(main.getByText('low', { exact: true })).toBeVisible()
+    await expect(main.getByText('high', { exact: true })).toBeVisible()
   })
 
   test('shows drift score in session list', async ({ page }) => {

--- a/packages/admin/e2e/type-lifecycle.spec.ts
+++ b/packages/admin/e2e/type-lifecycle.spec.ts
@@ -8,35 +8,41 @@ test.describe('Content type lifecycle', () => {
   })
 
   test('warns before disabling the last enabled type', async ({ page }) => {
-    let noteDisabled = false
+    // Override the catalog so note is the only enabled content type.
+    // The surface catalog route registered here takes precedence over the
+    // one from mockAdminBootstrapRoutes (Playwright runs handlers in LIFO order).
+    const lifecycleCatalog = [
+      { id: 'note', label: 'Note', group: 'content', fields: [], actions: [], capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true } },
+      { id: 'node', label: 'Content', group: 'content', disabled: true, fields: [], actions: [], capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true } },
+    ]
 
-    await page.route('**/api/entity-types', (route) =>
+    await page.route('**/admin/surface/catalog', (route) =>
+      route.fulfill({
+        json: { ok: true, data: { entities: lifecycleCatalog } },
+      }),
+    )
+
+    // Also override bootstrap entities for consistency
+    await page.route('**/admin/bootstrap', (route) =>
       route.fulfill({
         json: {
-          data: [
-            {
-              id: 'note',
-              label: 'Note',
-              keys: { id: 'id', label: 'title' },
-              group: 'content',
-              disabled: noteDisabled,
-            },
-            {
-              id: 'node',
-              label: 'Content',
-              keys: { id: 'id', label: 'title' },
-              group: 'content',
-              disabled: true,
-            },
-          ],
+          version: '1.0',
+          auth: { strategy: 'embedded', loginEndpoint: '/api/auth/login' },
+          account: { id: String(Number.MAX_SAFE_INTEGER), name: 'dev-admin', roles: ['admin'] },
+          tenant: { id: 'default', name: 'Waaseyaa', scopingStrategy: 'server' },
+          transport: { strategy: 'jsonapi', apiPath: '/api' },
+          entities: lifecycleCatalog.map(({ id, label, group, disabled, capabilities }) => ({
+            id, label, group, disabled, capabilities,
+          })),
+          features: {},
         },
       }),
     )
 
-    await page.route('**/api/entity-types/note/disable?force=1', (route) => {
-      noteDisabled = true
-      route.fulfill({ json: { data: { id: 'note', disabled: true } } })
-    })
+    // Mock the disable endpoint
+    await page.route('**/api/entity-types/note/disable*', (route) =>
+      route.fulfill({ json: { data: { id: 'note', disabled: true } } }),
+    )
 
     await mockSchemaRoute(page, 'note')
     await mockEntityListRoute(page, 'note')

--- a/packages/admin/tests/fixtures/entityTypes.ts
+++ b/packages/admin/tests/fixtures/entityTypes.ts
@@ -16,4 +16,5 @@ export const entityTypes: CatalogEntry[] = [
   { id: 'menu_link', label: 'Menu Link', keys: { id: 'id', label: 'title' }, capabilities: defaultCaps },
   { id: 'workflow', label: 'Workflow', keys: { id: 'id', label: 'label' }, capabilities: defaultCaps },
   { id: 'pipeline', label: 'Pipeline', keys: { id: 'id', label: 'label' }, capabilities: defaultCaps },
+  { id: 'note', label: 'Note', keys: { id: 'id', label: 'title' }, capabilities: defaultCaps },
 ]


### PR DESCRIPTION
## Summary

- **Fix `AdminSurfaceTransportAdapter` illegal invocation** — `fetch` was stored detached from `window`, breaking all surface transport calls (schema, list, create). Wrapped in arrow function to preserve binding.
- **Fix surface catalog mapping** — `disabled` property was dropped during surface→catalog mapping in admin plugin, preventing type lifecycle UI from working.
- **Add surface transport mocks to E2E fixtures** — route mocks only covered JSON API URLs (`/api/*`), not the surface transport URLs (`/admin/surface/*`) that the app actually uses.
- **Fix fragile test selectors** — telescope severity `getByText('low')` matched sidebar nav; error page test URL matched `[entityType]` catch-all; `note` missing from entity types fixture.
- **Track disable/enable state locally** — entity type page now updates UI immediately after disable/enable action, with navigation-safe reset.
- **Enable Playwright integration job in CI** — removed `if: false` placeholder, pinned to chromium, added as release gate dependency.

Closes #497, closes #498, closes #500, closes #501

## Test plan

- [x] Playwright E2E: 24/24 passed (chromium)
- [x] Vitest unit: 98/98 passed (20 files)
- [x] PHP tests: 2 pre-existing failures on clean main (unrelated GraphQL)
- [ ] CI integration job runs Playwright on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)