### PR TITLE
fix(access): resolve session account for GraphQL endpoint on allowAll routes

### DIFF
--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -572,10 +572,16 @@ final class ControllerDispatcher
                 })(),
 
                 $controller === 'graphql.endpoint' => (function () use ($method, $httpRequest, $account, $queryString): never {
+                    // Prefer the middleware-resolved session account over the
+                    // route-level $account, which is AnonymousUser on allowAll() routes.
+                    $resolvedAccount = $httpRequest->attributes->get('_account');
+                    $graphqlAccount = ($resolvedAccount instanceof \Waaseyaa\Access\AccountInterface && $resolvedAccount->isAuthenticated())
+                        ? $resolvedAccount
+                        : $account;
                     $endpoint = new \Waaseyaa\GraphQL\GraphQlEndpoint(
                         entityTypeManager: $this->entityTypeManager,
                         accessHandler: $this->accessHandler,
-                        account: $account,
+                        account: $graphqlAccount,
                     );
                     if ($this->graphqlMutationOverrides !== []) {
                         $endpoint = $endpoint->withMutationOverrides($this->graphqlMutationOverrides);


### PR DESCRIPTION
## Summary

- GraphQL endpoint on `allowAll()` routes always received `AnonymousUser` as the account, causing mutations from authenticated admin users to fail with "Access denied"
- Now prefers the middleware-resolved session account from `$httpRequest->attributes->get('_account')` when available
- Fixes jonesrussell/claudriel#470

## Test plan

- [x] All 93 GraphQL package tests pass
- [x] All 452 foundation package tests pass
- [x] All 663 Claudriel app tests pass
- [ ] Manual: verify admin SPA GraphQL mutations work with authenticated session

🤖 Generated with [Claude Code](https://claude.com/claude-code)