### PR TITLE
fix(#626): attach SessionInterface to Request, add requireSession() route option

### DIFF
--- a/packages/routing/src/AccessChecker.php
+++ b/packages/routing/src/AccessChecker.php
@@ -15,6 +15,7 @@ use Waaseyaa\Access\Gate\GateInterface;
  * Routes can declare access requirements via options:
  *   - '_public' => true — always allow access (no authentication required)
  *   - '_authenticated' => true — require a non-anonymous identity (returns 401 if not authenticated)
+ *   - '_session' => true|['key1','key2'] — require active session, optionally with specific keys
  *   - '_permission' => 'administer site' — require a specific permission
  *   - '_role' => 'administrator' — require a specific role (or comma-separated list)
  *   - '_gate' => ['ability' => 'config.export', 'subject' => null] — require a gate ability
@@ -57,6 +58,22 @@ final class AccessChecker
             $hasRequirement = true;
             if (!$account->isAuthenticated()) {
                 return AccessResult::unauthenticated('Authentication is required to access this resource.');
+            }
+        }
+
+        // Check _session option (requires active session, optionally with specific keys).
+        $sessionOption = $route->getOption('_session');
+        if ($sessionOption !== null) {
+            $hasRequirement = true;
+            if (session_status() !== \PHP_SESSION_ACTIVE) {
+                $result = $result->andIf(AccessResult::forbidden('An active session is required to access this resource.'));
+            } elseif (is_array($sessionOption)) {
+                foreach ($sessionOption as $key) {
+                    if (!isset($_SESSION[$key])) {
+                        $result = $result->andIf(AccessResult::forbidden(sprintf('Session key "%s" is required.', $key)));
+                        break;
+                    }
+                }
             }
         }
 

--- a/packages/routing/src/RouteBuilder.php
+++ b/packages/routing/src/RouteBuilder.php
@@ -109,6 +109,20 @@ final class RouteBuilder
     }
 
     /**
+     * Require an active PHP session (without requiring a Waaseyaa user account).
+     *
+     * Use for routes where guests/anonymous users need session state
+     * (e.g., chat nicknames, wizard progress) but don't need authentication.
+     *
+     * @param list<string> $requiredKeys Session keys that must be present.
+     */
+    public function requireSession(array $requiredKeys = []): self
+    {
+        $this->options['_session'] = $requiredKeys === [] ? true : $requiredKeys;
+        return $this;
+    }
+
+    /**
      * Allow all users (marks route as public).
      */
     public function allowAll(): self

--- a/packages/routing/tests/Unit/AccessCheckerTest.php
+++ b/packages/routing/tests/Unit/AccessCheckerTest.php
@@ -335,4 +335,57 @@ final class AccessCheckerTest extends TestCase
         // AND logic: public = allowed AND _permission = forbidden => forbidden
         $this->assertTrue($result->isForbidden());
     }
+
+    #[Test]
+    public function sessionOptionTrueAllowsWhenSessionActive(): void
+    {
+        // Start a session for this test
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+
+        $route = new Route('/chat');
+        $route->setOption('_session', true);
+
+        $account = $this->createMock(AccountInterface::class);
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function sessionOptionWithRequiredKeysAllowsWhenPresent(): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION['nickname'] = 'guest42';
+
+        $route = new Route('/chat');
+        $route->setOption('_session', ['nickname']);
+
+        $account = $this->createMock(AccountInterface::class);
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isAllowed());
+
+        unset($_SESSION['nickname']);
+    }
+
+    #[Test]
+    public function sessionOptionWithRequiredKeysDeniesWhenMissing(): void
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        unset($_SESSION['nickname']);
+
+        $route = new Route('/chat');
+        $route->setOption('_session', ['nickname']);
+
+        $account = $this->createMock(AccountInterface::class);
+        $result = $this->checker->check($route, $account);
+
+        $this->assertTrue($result->isForbidden());
+    }
 }

--- a/packages/routing/tests/Unit/RouteBuilderTest.php
+++ b/packages/routing/tests/Unit/RouteBuilderTest.php
@@ -210,4 +210,24 @@ final class RouteBuilderTest extends TestCase
         $this->assertSame('/path1', $route1->getPath());
         $this->assertSame('/path2', $route2->getPath());
     }
+
+    #[Test]
+    public function requireSessionSetsOptionTrue(): void
+    {
+        $route = RouteBuilder::create('/chat')
+            ->requireSession()
+            ->build();
+
+        $this->assertTrue($route->getOption('_session'));
+    }
+
+    #[Test]
+    public function requireSessionWithKeysSetsOptionArray(): void
+    {
+        $route = RouteBuilder::create('/chat')
+            ->requireSession(['nickname'])
+            ->build();
+
+        $this->assertSame(['nickname'], $route->getOption('_session'));
+    }
 }

--- a/packages/user/src/Middleware/SessionMiddleware.php
+++ b/packages/user/src/Middleware/SessionMiddleware.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\User\Middleware;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\User\Session\NativeSession;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
@@ -29,6 +30,13 @@ final class SessionMiddleware implements HttpMiddlewareInterface
     {
         if (session_status() !== \PHP_SESSION_ACTIVE && !$request->attributes->has('_session')) {
             session_start();
+        }
+
+        // Attach a session to the Request so controllers can use
+        // $request->getSession(). NativeSession reads/writes $_SESSION
+        // directly, preserving compatibility with AuthManager.
+        if (!$request->hasSession()) {
+            $request->setSession(new NativeSession());
         }
 
         $existingAccount = $request->attributes->get('_account');

--- a/packages/user/src/Session/NativeSession.php
+++ b/packages/user/src/Session/NativeSession.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Session;
+
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * Thin SessionInterface wrapper around PHP's native $_SESSION.
+ *
+ * Unlike Symfony's Session class which uses namespaced "bags",
+ * this reads and writes $_SESSION keys directly, preserving
+ * compatibility with code that uses raw $_SESSION (e.g. AuthManager).
+ */
+final class NativeSession implements SessionInterface
+{
+    public function start(): bool
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            return true;
+        }
+        return session_start();
+    }
+
+    public function getId(): string
+    {
+        return session_id();
+    }
+
+    public function setId(string $id): void
+    {
+        session_id($id);
+    }
+
+    public function getName(): string
+    {
+        return session_name();
+    }
+
+    public function setName(string $name): void
+    {
+        session_name($name);
+    }
+
+    public function invalidate(?int $lifetime = null): bool
+    {
+        $_SESSION = [];
+        return session_regenerate_id(true);
+    }
+
+    public function migrate(bool $destroy = false, ?int $lifetime = null): bool
+    {
+        return session_regenerate_id($destroy);
+    }
+
+    public function save(): void
+    {
+        session_write_close();
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($_SESSION[$name]);
+    }
+
+    public function get(string $name, mixed $default = null): mixed
+    {
+        return $_SESSION[$name] ?? $default;
+    }
+
+    public function set(string $name, mixed $value): void
+    {
+        $_SESSION[$name] = $value;
+    }
+
+    public function all(): array
+    {
+        return $_SESSION ?? [];
+    }
+
+    public function replace(array $attributes): void
+    {
+        foreach ($attributes as $key => $value) {
+            $_SESSION[$key] = $value;
+        }
+    }
+
+    public function remove(string $name): mixed
+    {
+        $value = $_SESSION[$name] ?? null;
+        unset($_SESSION[$name]);
+        return $value;
+    }
+
+    public function clear(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function isStarted(): bool
+    {
+        return session_status() === PHP_SESSION_ACTIVE;
+    }
+
+    public function registerBag(SessionBagInterface $bag): void
+    {
+        // No-op — we don't use bags
+    }
+
+    public function getBag(string $name): SessionBagInterface
+    {
+        throw new \RuntimeException("NativeSession does not support session bags. Use get()/set() directly.");
+    }
+
+    public function getMetadataBag(): \Symfony\Component\HttpFoundation\Session\Storage\MetadataBag
+    {
+        throw new \RuntimeException("NativeSession does not support MetadataBag.");
+    }
+}

--- a/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
@@ -15,6 +15,7 @@ use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\User\AnonymousUser;
 use Waaseyaa\User\DevAdminAccount;
 use Waaseyaa\User\Middleware\SessionMiddleware;
+use Waaseyaa\User\Session\NativeSession;
 use Waaseyaa\User\User;
 
 #[CoversClass(SessionMiddleware::class)]
@@ -300,5 +301,54 @@ final class SessionMiddlewareTest extends TestCase
         $middleware->process($request, $next);
 
         $this->assertSame($existing, $capturedAccount);
+    }
+
+    #[Test]
+    public function attaches_native_session_to_request(): void
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $middleware = new SessionMiddleware($storage);
+        $request = Request::create('/test');
+
+        $capturedSession = null;
+        $next = new class($capturedSession) implements HttpHandlerInterface {
+            public function __construct(private mixed &$ref) {}
+
+            public function handle(Request $request): Response
+            {
+                $this->ref = $request->hasSession() ? $request->getSession() : null;
+                return new Response('ok');
+            }
+        };
+
+        $middleware->process($request, $next);
+
+        $this->assertInstanceOf(NativeSession::class, $capturedSession);
+    }
+
+    #[Test]
+    public function does_not_replace_existing_session(): void
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $middleware = new SessionMiddleware($storage);
+        $request = Request::create('/test');
+
+        $existingSession = new NativeSession();
+        $request->setSession($existingSession);
+
+        $capturedSession = null;
+        $next = new class($capturedSession) implements HttpHandlerInterface {
+            public function __construct(private mixed &$ref) {}
+
+            public function handle(Request $request): Response
+            {
+                $this->ref = $request->getSession();
+                return new Response('ok');
+            }
+        };
+
+        $middleware->process($request, $next);
+
+        $this->assertSame($existingSession, $capturedSession);
     }
 }

--- a/packages/user/tests/Unit/Session/NativeSessionTest.php
+++ b/packages/user/tests/Unit/Session/NativeSessionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit\Session;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\User\Session\NativeSession;
+
+#[CoversClass(NativeSession::class)]
+final class NativeSessionTest extends TestCase
+{
+    private NativeSession $session;
+
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+        $this->session = new NativeSession();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    #[Test]
+    public function setAndGetValue(): void
+    {
+        $this->session->set('key', 'value');
+        $this->assertSame('value', $this->session->get('key'));
+    }
+
+    #[Test]
+    public function getReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('fallback', $this->session->get('missing', 'fallback'));
+    }
+
+    #[Test]
+    public function hasReturnsTrueForExistingKey(): void
+    {
+        $this->session->set('exists', true);
+        $this->assertTrue($this->session->has('exists'));
+    }
+
+    #[Test]
+    public function hasReturnsFalseForMissingKey(): void
+    {
+        $this->assertFalse($this->session->has('nope'));
+    }
+
+    #[Test]
+    public function removeReturnsValueAndUnsets(): void
+    {
+        $this->session->set('temp', 42);
+        $this->assertSame(42, $this->session->remove('temp'));
+        $this->assertFalse($this->session->has('temp'));
+    }
+
+    #[Test]
+    public function removeReturnsNullForMissingKey(): void
+    {
+        $this->assertNull($this->session->remove('missing'));
+    }
+
+    #[Test]
+    public function allReturnsSessionContents(): void
+    {
+        $this->session->set('a', 1);
+        $this->session->set('b', 2);
+        $this->assertSame(['a' => 1, 'b' => 2], $this->session->all());
+    }
+
+    #[Test]
+    public function clearEmptiesSession(): void
+    {
+        $this->session->set('key', 'value');
+        $this->session->clear();
+        $this->assertSame([], $this->session->all());
+    }
+
+    #[Test]
+    public function replaceMergesValues(): void
+    {
+        $this->session->set('keep', 'yes');
+        $this->session->replace(['new' => 'val', 'keep' => 'updated']);
+        $this->assertSame('updated', $this->session->get('keep'));
+        $this->assertSame('val', $this->session->get('new'));
+    }
+
+    #[Test]
+    public function getBagThrowsRuntimeException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->session->getBag('attributes');
+    }
+
+    #[Test]
+    public function getMetadataBagThrowsRuntimeException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->session->getMetadataBag();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NativeSession` — thin `SessionInterface` wrapper around `$_SESSION`, compatible with `AuthManager`'s raw `$_SESSION` usage
- `SessionMiddleware` now attaches `NativeSession` to Request so `$request->getSession()` works
- Add `RouteBuilder::requireSession(array $requiredKeys = [])` route option for session-bearing but unauthenticated routes
- `AccessChecker` evaluates `_session` option: checks active session + optional required keys

## Test plan
- [x] All 4,889 tests pass
- [x] NativeSession: get/set/has/remove/clear/replace/all (11 tests)
- [x] SessionMiddleware: attaches session, doesn't replace existing (2 new tests)
- [x] RouteBuilder: requireSession with and without keys (2 tests)
- [x] AccessChecker: session active, keys present, keys missing (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)