### PR TITLE
feat(#559,#560,#561): add framework logger contract, replace all error_log()

### DIFF
--- a/packages/access/src/Gate/EntityAccessGate.php
+++ b/packages/access/src/Gate/EntityAccessGate.php
@@ -7,6 +7,8 @@ namespace Waaseyaa\Access\Gate;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\EntityAccessHandler;
 use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
  * Adapter that bridges GateInterface to EntityAccessHandler.
@@ -18,15 +20,20 @@ use Waaseyaa\Entity\EntityInterface;
  */
 final class EntityAccessGate implements GateInterface
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityAccessHandler $handler,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function allows(string $ability, mixed $subject, ?object $user = null): bool
     {
         if (!$user instanceof AccountInterface) {
-            error_log(sprintf(
-                '[Waaseyaa] EntityAccessGate: expected AccountInterface, got %s for ability "%s".',
+            $this->logger->warning(sprintf(
+                'EntityAccessGate: expected AccountInterface, got %s for ability "%s".',
                 get_debug_type($user),
                 $ability,
             ));
@@ -37,8 +44,8 @@ final class EntityAccessGate implements GateInterface
             try {
                 return $this->handler->check($subject, $ability, $user)->isAllowed();
             } catch (\Throwable $e) {
-                error_log(sprintf(
-                    '[Waaseyaa] EntityAccessGate: policy check threw %s for ability "%s" on %s: %s',
+                $this->logger->error(sprintf(
+                    'EntityAccessGate: policy check threw %s for ability "%s" on %s: %s',
                     $e::class,
                     $ability,
                     $subject->getEntityTypeId(),
@@ -55,8 +62,8 @@ final class EntityAccessGate implements GateInterface
             try {
                 return $this->handler->checkCreateAccess($subject, '', $user)->isAllowed();
             } catch (\Throwable $e) {
-                error_log(sprintf(
-                    '[Waaseyaa] EntityAccessGate: create access check threw %s for ability "%s" on "%s": %s',
+                $this->logger->error(sprintf(
+                    'EntityAccessGate: create access check threw %s for ability "%s" on "%s": %s',
                     $e::class,
                     $ability,
                     $subject,
@@ -67,8 +74,8 @@ final class EntityAccessGate implements GateInterface
         }
 
         // This adapter only handles EntityInterface and string-typed create checks.
-        error_log(sprintf(
-            '[Waaseyaa] EntityAccessGate: unsupported subject type %s for ability "%s"; denying.',
+        $this->logger->warning(sprintf(
+            'EntityAccessGate: unsupported subject type %s for ability "%s"; denying.',
             get_debug_type($subject),
             $ability,
         ));

--- a/packages/access/src/Middleware/AuthorizationMiddleware.php
+++ b/packages/access/src/Middleware/AuthorizationMiddleware.php
@@ -12,6 +12,8 @@ use Symfony\Component\Routing\Route;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\ErrorPageRendererInterface;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\Routing\AccessChecker;
@@ -19,10 +21,15 @@ use Waaseyaa\Routing\AccessChecker;
 #[AsMiddleware(pipeline: 'http', priority: 10)]
 final class AuthorizationMiddleware implements HttpMiddlewareInterface
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly AccessChecker $accessChecker,
         private readonly ?ErrorPageRendererInterface $errorPageRenderer = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
@@ -36,7 +43,7 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
         $isRenderRoute = $this->isRenderRoute($route);
 
         if (!$account instanceof AccountInterface) {
-            error_log('[Waaseyaa] AuthorizationMiddleware: _account not set or invalid; denying access.');
+            $this->logger->warning('AuthorizationMiddleware: _account not set or invalid; denying access.');
 
             if ($isRenderRoute) {
                 return $this->renderError(403, 'Forbidden', 'No authenticated account available.', $request);

--- a/packages/ai-pipeline/src/EmbeddingPipeline.php
+++ b/packages/ai-pipeline/src/EmbeddingPipeline.php
@@ -8,9 +8,13 @@ use Waaseyaa\AI\Vector\EmbeddingProviderFactory;
 use Waaseyaa\AI\Vector\EmbeddingProviderInterface;
 use Waaseyaa\AI\Vector\EmbeddingStorageInterface;
 use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 final class EmbeddingPipeline
 {
+    private readonly LoggerInterface $logger;
+
     /**
      * @param array<string, mixed> $config
      */
@@ -18,7 +22,10 @@ final class EmbeddingPipeline
         private readonly EmbeddingStorageInterface $storage,
         private readonly array $config = [],
         private readonly ?EmbeddingProviderInterface $provider = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function processEntity(EntityInterface $entity): void
     {
@@ -29,7 +36,7 @@ final class EmbeddingPipeline
 
         $provider = $this->provider ?? $this->resolveProvider();
         if ($provider === null) {
-            error_log('[Waaseyaa] EmbeddingPipeline: no embedding provider configured; skipping.');
+            $this->logger->info('EmbeddingPipeline: no embedding provider configured; skipping.');
             return;
         }
 

--- a/packages/ai-vector/src/EntityEmbeddingListener.php
+++ b/packages/ai-vector/src/EntityEmbeddingListener.php
@@ -5,18 +5,25 @@ declare(strict_types=1);
 namespace Waaseyaa\AI\Vector;
 
 use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Queue\Message\GenericMessage;
 use Waaseyaa\Queue\QueueInterface;
 use Waaseyaa\Workflows\WorkflowVisibility;
 
 final class EntityEmbeddingListener
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly ?QueueInterface $queue = null,
         private readonly ?EmbeddingStorageInterface $storage = null,
         private readonly ?EmbeddingProviderInterface $embeddingProvider = null,
         private readonly WorkflowVisibility $workflowVisibility = new WorkflowVisibility(),
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function onPostSave(EntityEvent $event): void
     {
@@ -40,8 +47,8 @@ final class EntityEmbeddingListener
                 $vector = $this->embeddingProvider->embed($this->buildEmbeddingText($event));
                 $this->storage->store($entityType, $entityIdString, $vector);
             } catch (\Throwable $exception) {
-                error_log(sprintf(
-                    '[Waaseyaa] Embedding update failed for %s:%s: %s',
+                $this->logger->error(sprintf(
+                    'Embedding update failed for %s:%s: %s',
                     $entityType,
                     $entityIdString,
                     $exception->getMessage(),

--- a/packages/ai-vector/src/SearchController.php
+++ b/packages/ai-vector/src/SearchController.php
@@ -11,6 +11,8 @@ use Waaseyaa\Api\JsonApiError;
 use Waaseyaa\Api\ResourceSerializer;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Workflows\WorkflowVisibility;
 
 final class SearchController
@@ -22,6 +24,8 @@ final class SearchController
     private const float DEFAULT_SEMANTIC_WEIGHT = 1.0;
     private const float DEFAULT_GRAPH_WEIGHT = 0.001;
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly ResourceSerializer $serializer,
@@ -30,7 +34,10 @@ final class SearchController
         private readonly ?EntityAccessHandler $accessHandler = null,
         private readonly ?AccountInterface $account = null,
         private readonly WorkflowVisibility $workflowVisibility = new WorkflowVisibility(),
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function search(string $query, string $entityTypeId, int $limit = 10): JsonApiDocument
     {
@@ -258,8 +265,8 @@ final class SearchController
         try {
             $queryVector = $this->embeddingProvider?->embed($query) ?? [];
         } catch (\Throwable $exception) {
-            error_log(sprintf(
-                '[Waaseyaa] Semantic search provider error; falling back to keyword mode: %s',
+            $this->logger->warning(sprintf(
+                'Semantic search provider error; falling back to keyword mode: %s',
                 $exception->getMessage(),
             ));
             return ['ids' => [], 'scores' => [], 'fallback_reason' => 'embedding_provider_error'];

--- a/packages/ai-vector/src/SqliteEmbeddingStorage.php
+++ b/packages/ai-vector/src/SqliteEmbeddingStorage.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace Waaseyaa\AI\Vector;
 
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
+
 final class SqliteEmbeddingStorage implements EmbeddingStorageInterface
 {
     private bool $schemaReady = false;
+    private readonly LoggerInterface $logger;
 
     public function __construct(
         private readonly \PDO $pdo,
         private readonly string $table = 'embeddings',
+        ?LoggerInterface $logger = null,
     ) {
         $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function store(string $entityType, string $id, array $vector): void
@@ -71,8 +77,8 @@ final class SqliteEmbeddingStorage implements EmbeddingStorageInterface
         usort($results, static fn(array $a, array $b): int => $b['score'] <=> $a['score']);
 
         if ($dimensionMismatches > 0) {
-            error_log(sprintf(
-                '[Waaseyaa] Embedding dimension mismatch: skipped %d row(s) for entity type "%s".',
+            $this->logger->warning(sprintf(
+                'Embedding dimension mismatch: skipped %d row(s) for entity type "%s".',
                 $dimensionMismatches,
                 $entityType,
             ));

--- a/packages/ai-vector/tests/Unit/SqliteEmbeddingStorageTest.php
+++ b/packages/ai-vector/tests/Unit/SqliteEmbeddingStorageTest.php
@@ -63,27 +63,18 @@ final class SqliteEmbeddingStorageTest extends TestCase
     #[Test]
     public function logsDimensionMismatchForObservability(): void
     {
-        $logFile = tempnam(sys_get_temp_dir(), 'waaseyaa_ai_vector_log_');
-        $this->assertNotFalse($logFile);
-        if (!is_string($logFile)) {
-            return;
-        }
+        $lines = [];
+        $logger = new \Waaseyaa\Foundation\Log\ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+        $storage = new SqliteEmbeddingStorage($this->pdo, logger: $logger);
 
-        $previousLog = ini_get('error_log');
-        ini_set('error_log', $logFile);
+        $storage->store('node', '1', [1.0, 0.0, 0.0]);
+        $storage->store('node', '2', [0.5, 0.5]);
+        $storage->findSimilar([1.0, 0.0], 'node', 10);
 
-        try {
-            $this->storage->store('node', '1', [1.0, 0.0, 0.0]);
-            $this->storage->store('node', '2', [0.5, 0.5]);
-            $this->storage->findSimilar([1.0, 0.0], 'node', 10);
-
-            $logContents = file_get_contents($logFile);
-            $this->assertIsString($logContents);
-            $this->assertStringContainsString('Embedding dimension mismatch', $logContents);
-        } finally {
-            ini_set('error_log', is_string($previousLog) ? $previousLog : '');
-            @unlink($logFile);
-        }
+        $logContents = implode("\n", $lines);
+        $this->assertStringContainsString('Embedding dimension mismatch', $logContents);
     }
 
     #[Test]

--- a/packages/api/src/Controller/SchemaController.php
+++ b/packages/api/src/Controller/SchemaController.php
@@ -10,6 +10,8 @@ use Waaseyaa\Api\JsonApiDocument;
 use Waaseyaa\Api\JsonApiError;
 use Waaseyaa\Api\Schema\SchemaPresenter;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
  * Returns JSON Schema representations of entity types.
@@ -19,12 +21,17 @@ use Waaseyaa\Entity\EntityTypeManagerInterface;
  */
 final class SchemaController
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly SchemaPresenter $schemaPresenter,
         private readonly ?EntityAccessHandler $accessHandler = null,
         private readonly ?AccountInterface $account = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * GET /api/schema/{entity_type} — return JSON Schema for the given entity type.
@@ -46,8 +53,8 @@ final class SchemaController
             try {
                 $entity = new $class([]);
             } catch (\Throwable $e) {
-                error_log(sprintf(
-                    '[Waaseyaa] SchemaController: failed to create prototype entity for %s (%s): %s',
+                $this->logger->warning(sprintf(
+                    'SchemaController: failed to create prototype entity for %s (%s): %s',
                     $entityTypeId,
                     $class,
                     $e->getMessage(),

--- a/packages/cli/src/Command/HealthReportCommand.php
+++ b/packages/cli/src/Command/HealthReportCommand.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Waaseyaa\Foundation\Diagnostic\HealthCheckerInterface;
 use Waaseyaa\Foundation\Diagnostic\HealthCheckResult;
 use Waaseyaa\Foundation\Ingestion\IngestionLogger;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 #[AsCommand(
     name: 'health:report',
@@ -20,10 +22,14 @@ use Waaseyaa\Foundation\Ingestion\IngestionLogger;
 )]
 final class HealthReportCommand extends Command
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly HealthCheckerInterface $checker,
         private readonly string $projectRoot,
+        ?LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? new NullLogger();
         parent::__construct();
     }
 
@@ -144,7 +150,7 @@ final class HealthReportCommand extends Command
         try {
             $entries = $logger->read();
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] Failed to read ingestion log: %s', $e->getMessage()));
+            $this->logger->warning(sprintf('Failed to read ingestion log: %s', $e->getMessage()));
             return [];
         }
 

--- a/packages/config/src/Listener/ConfigCacheInvalidator.php
+++ b/packages/config/src/Listener/ConfigCacheInvalidator.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Waaseyaa\Config\Listener;
 
 use Waaseyaa\Config\Event\ConfigEvent;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 final class ConfigCacheInvalidator
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly string $cachePath,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function __invoke(ConfigEvent $event): void
     {
@@ -19,7 +26,7 @@ final class ConfigCacheInvalidator
                 unlink($this->cachePath);
             }
         } catch (\Throwable $e) {
-            error_log(sprintf('ConfigCacheInvalidator: failed to delete %s: %s', $this->cachePath, $e->getMessage()));
+            $this->logger->warning(sprintf('ConfigCacheInvalidator: failed to delete %s: %s', $this->cachePath, $e->getMessage()));
         }
     }
 }

--- a/packages/entity-storage/src/SqlEntityStorage.php
+++ b/packages/entity-storage/src/SqlEntityStorage.php
@@ -13,6 +13,8 @@ use Waaseyaa\Entity\Event\EntityEvent;
 use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\Entity\Storage\EntityQueryInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
  * SQL-based entity storage implementation.
@@ -36,15 +38,19 @@ final class SqlEntityStorage implements EntityStorageInterface
     /** @var array<string, bool> Column existence cache (column name => exists in table). */
     private array $columnCache = [];
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeInterface $entityType,
         private readonly DatabaseInterface $database,
         private readonly EventDispatcherInterface $eventDispatcher,
+        ?LoggerInterface $logger = null,
     ) {
         $this->tableName = $this->entityType->id();
         $keys = $this->entityType->getKeys();
         $this->idKey = $keys['id'] ?? 'id';
         $this->entityKeys = $keys;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function create(array $values = []): EntityInterface
@@ -259,7 +265,7 @@ final class SqlEntityStorage implements EntityStorageInterface
             try {
                 $extra = json_decode((string) $row['_data'], associative: true, flags: \JSON_THROW_ON_ERROR);
             } catch (\JsonException $e) {
-                error_log(sprintf('Corrupt _data JSON for %s entity %s: %s', $this->tableName, $row[$this->idKey] ?? '?', $e->getMessage()));
+                $this->logger->warning(sprintf('Corrupt _data JSON for %s entity %s: %s', $this->tableName, $row[$this->idKey] ?? '?', $e->getMessage()));
                 $extra = [];
             }
             unset($row['_data']);

--- a/packages/foundation/src/Diagnostic/DiagnosticEmitter.php
+++ b/packages/foundation/src/Diagnostic/DiagnosticEmitter.php
@@ -4,15 +4,24 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Diagnostic;
 
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
+
 /**
  * Emits structured diagnostic log entries for operator-facing error codes.
  *
- * Each call to emit() writes a single-line JSON object to error_log()
- * (following the project's no-psr/log convention) and returns the entry
- * for callers that need to inspect or re-throw it.
+ * Each call to emit() writes a single-line JSON object via LoggerInterface
+ * and returns the entry for callers that need to inspect or re-throw it.
  */
 final class DiagnosticEmitter
 {
+    private readonly LoggerInterface $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
     /**
      * @param array<string, mixed> $context
      */
@@ -20,7 +29,7 @@ final class DiagnosticEmitter
     {
         $entry = new DiagnosticEntry($code, $message, $context);
 
-        error_log(json_encode($entry->toArray(), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $this->logger->warning(json_encode($entry->toArray(), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
 
         return $entry;
     }

--- a/packages/foundation/src/Diagnostic/HealthChecker.php
+++ b/packages/foundation/src/Diagnostic/HealthChecker.php
@@ -9,6 +9,8 @@ use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\Foundation\Ingestion\IngestionLogger;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
  * Runs all operator health checks and returns structured results.
@@ -26,12 +28,17 @@ final class HealthChecker implements HealthCheckerInterface
     /** Maximum ingestion log entries before warning (roughly 10k entries). */
     private const int LOG_SIZE_WARN_THRESHOLD = 10000;
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly BootDiagnosticReport $bootReport,
         private readonly DatabaseInterface $database,
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly string $projectRoot,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /** @return list<HealthCheckResult> */
     public function runAll(): array
@@ -178,7 +185,7 @@ final class HealthChecker implements HealthCheckerInterface
 
             if (!$schema->tableExists($tableName)) {
                 // Table doesn't exist yet (lazy creation) — not drift, just uninitialized.
-                error_log(sprintf('[Waaseyaa] Schema drift: skipping %s — table %s does not exist (lazy creation)', $id, $tableName));
+                $this->logger->info(sprintf('Schema drift: skipping %s — table %s does not exist (lazy creation)', $id, $tableName));
                 continue;
             }
 

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -8,16 +8,23 @@ use Waaseyaa\Foundation\Attribute\AsEntityType;
 use Waaseyaa\Foundation\Attribute\AsFieldType;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Event\Attribute\Listener;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 final class PackageManifestCompiler
 {
     private const POLICY_ATTRIBUTE = 'Waaseyaa\\Access\\Gate\\PolicyAttribute';
     private const FORMATTER_ATTRIBUTE = 'Waaseyaa\\SSR\\Attribute\\AsFormatter';
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly string $basePath,
         private readonly string $storagePath,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * Compile the package manifest from composer metadata and attribute scanning.
@@ -93,7 +100,7 @@ final class PackageManifestCompiler
                     }
                 }
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Failed to read root composer.json: %s', $e->getMessage()));
+                $this->logger->warning(sprintf('Failed to read root composer.json: %s', $e->getMessage()));
             }
         }
 
@@ -273,8 +280,8 @@ final class PackageManifestCompiler
 
         if ($candidates === []) {
             // No classmap entries and no app classes — full PSR-4 fallback.
-            error_log(
-                '[Waaseyaa] PackageManifestCompiler: no discoverable classes found. '
+            $this->logger->warning(
+                'PackageManifestCompiler: no discoverable classes found. '
                 . 'Falling back to full PSR-4 directory scanning. '
                 . 'Run "composer dump-autoload --optimize" for faster, reliable discovery.',
             );
@@ -377,8 +384,8 @@ final class PackageManifestCompiler
         try {
             $psr4Map = require $psr4Path;
         } catch (\Throwable $e) {
-            error_log(
-                '[Waaseyaa] PackageManifestCompiler: failed to load PSR-4 map: ' . $e->getMessage(),
+            $this->logger->error(
+                'PackageManifestCompiler: failed to load PSR-4 map: ' . $e->getMessage(),
             );
             return [];
         }

--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -14,6 +14,8 @@ use Waaseyaa\AI\Vector\SearchController;
 use Waaseyaa\AI\Vector\SqliteEmbeddingStorage;
 use Waaseyaa\Api\Controller\BroadcastController;
 use Waaseyaa\Api\Controller\BroadcastStorage;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Api\Controller\SchemaController;
 use Waaseyaa\Api\Http\DiscoveryApiHandler;
 use Waaseyaa\Api\JsonApiController;
@@ -41,6 +43,8 @@ use Waaseyaa\User\Http\AuthController;
  */
 final class ControllerDispatcher
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly \Waaseyaa\Database\DatabaseInterface $database,
@@ -54,7 +58,10 @@ final class ControllerDispatcher
         private readonly array $config,
         /** @var array<string, array{args?: array<string, mixed>, resolve?: callable}> */
         private readonly array $graphqlMutationOverrides = [],
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * Dispatch the matched route to its controller.
@@ -244,7 +251,7 @@ final class ControllerDispatcher
                         try {
                             $messages = $broadcastStorage->poll($cursor, $channels);
                         } catch (\Throwable $e) {
-                            error_log(sprintf('[Waaseyaa] SSE poll error: %s', $e->getMessage()));
+                            $this->logger->error(sprintf('SSE poll error: %s', $e->getMessage()));
                             echo "event: error\ndata: " . json_encode(['message' => 'Broadcast poll failed'], JSON_THROW_ON_ERROR) . "\n\n";
                             if (ob_get_level() > 0) {
                                 ob_flush();
@@ -260,7 +267,7 @@ final class ControllerDispatcher
                                 $frame = "event: {$msg['event']}\ndata: " . json_encode($msg, JSON_THROW_ON_ERROR) . "\n\n";
                                 echo $frame;
                             } catch (\JsonException $e) {
-                                error_log(sprintf('[Waaseyaa] SSE json_encode error for event %s: %s', $msg['event'] ?? 'unknown', $e->getMessage()));
+                                $this->logger->error(sprintf('SSE json_encode error for event %s: %s', $msg['event'] ?? 'unknown', $e->getMessage()));
                             }
                         }
 
@@ -282,7 +289,7 @@ final class ControllerDispatcher
                             try {
                                 $broadcastStorage->prune(300);
                             } catch (\Throwable $e) {
-                                error_log(sprintf('[Waaseyaa] SSE prune error: %s', $e->getMessage()));
+                                $this->logger->warning(sprintf('SSE prune error: %s', $e->getMessage()));
                             }
                         }
 
@@ -702,12 +709,12 @@ final class ControllerDispatcher
                 })(),
 
                 default => (function () use ($controller): never {
-                    error_log(sprintf('[Waaseyaa] Unknown controller: %s', $controller));
+                    $this->logger->error(sprintf('Unknown controller: %s', $controller));
                     ResponseSender::json(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Unknown route handler.']]]);
                 })(),
             };
         } catch (\Throwable $e) {
-            error_log(sprintf("[Waaseyaa] Unhandled exception: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            $this->logger->critical(sprintf("Unhandled exception: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
             ResponseSender::json(500, [
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[
@@ -816,7 +823,7 @@ final class ControllerDispatcher
         try {
             $uploadedFile->move($targetDir, basename($relativePath));
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] Upload move failed: %s', $e->getMessage()));
+            $this->logger->error(sprintf('Upload move failed: %s', $e->getMessage()));
             ResponseSender::json(500, [
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[

--- a/packages/foundation/src/Http/CorsHandler.php
+++ b/packages/foundation/src/Http/CorsHandler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Http;
 
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
+
 /**
  * Handles CORS preflight and header resolution.
  *
@@ -13,13 +16,18 @@ namespace Waaseyaa\Foundation\Http;
  */
 final class CorsHandler
 {
+    private readonly LoggerInterface $logger;
+
     /**
      * @param list<string> $allowedOrigins
      */
     public function __construct(
         private readonly array $allowedOrigins = ['http://localhost:3000', 'http://127.0.0.1:3000'],
         private readonly bool $allowDevLocalhostPorts = false,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * @return list<string>
@@ -37,8 +45,8 @@ final class CorsHandler
         }
 
         if ($origin !== '') {
-            error_log(sprintf(
-                '[Waaseyaa] CORS: origin "%s" not in allowed list (%s). '
+            $this->logger->warning(sprintf(
+                'CORS: origin "%s" not in allowed list (%s). '
                 . 'If using Nuxt dev server on a non-standard port, update cors_origins in config/waaseyaa.php.',
                 $origin,
                 implode(', ', $this->allowedOrigins),

--- a/packages/foundation/src/Http/ResponseSender.php
+++ b/packages/foundation/src/Http/ResponseSender.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Http;
 
+use Waaseyaa\Foundation\Log\ErrorLogHandler;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+
 final class ResponseSender
 {
+    private static ?LoggerInterface $logger = null;
+
+    public static function setLogger(LoggerInterface $logger): void
+    {
+        self::$logger = $logger;
+    }
+
+    private static function logger(): LoggerInterface
+    {
+        return self::$logger ??= new ErrorLogHandler();
+    }
+
     /**
      * Send a JSON:API response and terminate.
      *
@@ -25,7 +40,7 @@ final class ResponseSender
         try {
             echo json_encode($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            error_log(sprintf('[Waaseyaa] JSON encoding failed in sendJson: %s', $e->getMessage()));
+            self::logger()->error(sprintf('JSON encoding failed in sendJson: %s', $e->getMessage()));
             echo '{"jsonapi":{"version":"1.1"},"errors":[{"status":"500","title":"Internal Server Error","detail":"Response encoding failed."}]}';
         }
         exit;

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -20,6 +20,8 @@ use Waaseyaa\Foundation\Diagnostic\DiagnosticCode;
 use Waaseyaa\Foundation\Diagnostic\DiagnosticEmitter;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Log\ErrorLogHandler;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Migration\MigrationLoader;
 use Waaseyaa\Foundation\Migration\MigrationRepository;
 use Waaseyaa\Foundation\Migration\Migrator;
@@ -49,10 +51,14 @@ abstract class AbstractKernel
 
     private ?KnowledgeToolingExtensionRunner $knowledgeExtensionRunner = null;
     private bool $booted = false;
+    protected readonly LoggerInterface $logger;
 
     public function __construct(
         protected readonly string $projectRoot,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new ErrorLogHandler();
+    }
 
     /**
      * Boot the kernel. Idempotent — safe to call multiple times.
@@ -148,13 +154,13 @@ abstract class AbstractKernel
         // Instantiate providers from manifest
         foreach ($this->manifest->providers as $providerClass) {
             if (!class_exists($providerClass)) {
-                error_log(sprintf('[Waaseyaa] Provider class not found: %s', $providerClass));
+                $this->logger->warning(sprintf('Provider class not found: %s', $providerClass));
                 continue;
             }
 
             $provider = new $providerClass();
             if (!$provider instanceof ServiceProvider) {
-                error_log(sprintf('[Waaseyaa] Class %s is not a ServiceProvider', $providerClass));
+                $this->logger->warning(sprintf('Class %s is not a ServiceProvider', $providerClass));
                 continue;
             }
 
@@ -192,8 +198,8 @@ abstract class AbstractKernel
                 try {
                     $this->entityTypeManager->registerEntityType($entityType);
                 } catch (\RuntimeException | \InvalidArgumentException $e) {
-                    error_log(sprintf(
-                        '[Waaseyaa] Failed to register entity type "%s" from %s: %s',
+                    $this->logger->error(sprintf(
+                        'Failed to register entity type "%s" from %s: %s',
                         $entityType->id(),
                         $provider::class,
                         $e->getMessage(),
@@ -210,8 +216,8 @@ abstract class AbstractKernel
 
         foreach ($types as $index => $typeData) {
             if (!$typeData instanceof \Waaseyaa\Entity\EntityTypeInterface) {
-                error_log(sprintf(
-                    '[Waaseyaa] config/entity-types.php item at index %s is not an EntityTypeInterface (got %s).',
+                $this->logger->warning(sprintf(
+                    'config/entity-types.php item at index %s is not an EntityTypeInterface (got %s).',
                     $index,
                     get_debug_type($typeData),
                 ));
@@ -221,8 +227,8 @@ abstract class AbstractKernel
             try {
                 $this->entityTypeManager->registerEntityType($typeData);
             } catch (\RuntimeException | \InvalidArgumentException $e) {
-                error_log(sprintf(
-                    '[Waaseyaa] Failed to register app entity type "%s": %s',
+                $this->logger->error(sprintf(
+                    'Failed to register app entity type "%s": %s',
                     $typeData->id(),
                     $e->getMessage(),
                 ));
@@ -281,8 +287,8 @@ abstract class AbstractKernel
         $policies = [];
         foreach ($this->manifest->policies as $class => $entityTypes) {
             if (!class_exists($class)) {
-                error_log(sprintf(
-                    '[Waaseyaa] Access policy class not found: %s (covering entity types: %s). '
+                $this->logger->warning(sprintf(
+                    'Access policy class not found: %s (covering entity types: %s). '
                     . 'Run "composer dump-autoload --optimize" to update the classmap.',
                     $class,
                     implode(', ', $entityTypes),
@@ -301,8 +307,8 @@ abstract class AbstractKernel
                     $policies[] = new $class();
                 }
             } catch (\Throwable $e) {
-                error_log(sprintf(
-                    '[Waaseyaa] Failed to instantiate access policy %s: %s',
+                $this->logger->error(sprintf(
+                    'Failed to instantiate access policy %s: %s',
                     $class,
                     $e->getMessage(),
                 ));
@@ -360,7 +366,7 @@ abstract class AbstractKernel
             $manager = new DefaultPluginManager($discovery);
             $this->knowledgeExtensionRunner = KnowledgeToolingExtensionRunner::fromPluginManager($manager);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] Failed to boot knowledge extension runner: %s', $e->getMessage()));
+            $this->logger->warning(sprintf('Failed to boot knowledge extension runner: %s', $e->getMessage()));
             $this->knowledgeExtensionRunner = new KnowledgeToolingExtensionRunner([]);
         }
     }

--- a/packages/foundation/src/Kernel/ConfigLoader.php
+++ b/packages/foundation/src/Kernel/ConfigLoader.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Kernel;
 
+use Waaseyaa\Foundation\Log\ErrorLogHandler;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+
 final class ConfigLoader
 {
+    private static ?LoggerInterface $logger = null;
+
+    public static function setLogger(LoggerInterface $logger): void
+    {
+        self::$logger = $logger;
+    }
+
+    private static function logger(): LoggerInterface
+    {
+        return self::$logger ??= new ErrorLogHandler();
+    }
+
     /**
      * Load configuration from a PHP file that returns an array.
      *
@@ -31,8 +46,8 @@ final class ConfigLoader
         }
 
         if (!is_array($data)) {
-            error_log(sprintf(
-                '[Waaseyaa] Config file %s did not return an array (got %s), treating as empty.',
+            self::logger()->warning(sprintf(
+                'Config file %s did not return an array (got %s), treating as empty.',
                 $path,
                 get_debug_type($data),
             ));

--- a/packages/foundation/src/Kernel/EventListenerRegistrar.php
+++ b/packages/foundation/src/Kernel/EventListenerRegistrar.php
@@ -6,6 +6,8 @@ namespace Waaseyaa\Foundation\Kernel;
 
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Waaseyaa\AI\Vector\EmbeddingProviderFactory;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\AI\Vector\EntityEmbeddingCleanupListener;
 use Waaseyaa\AI\Vector\EntityEmbeddingListener;
 use Waaseyaa\AI\Vector\SqliteEmbeddingStorage;
@@ -24,13 +26,19 @@ use Waaseyaa\SSR\RenderCache;
  */
 final class EventListenerRegistrar
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function registerBroadcastListeners(BroadcastStorage $broadcastStorage): void
     {
-        $this->dispatcher->addListener('waaseyaa.entity.post_save', function (object $event) use ($broadcastStorage): void {
+        $logger = $this->logger;
+        $this->dispatcher->addListener('waaseyaa.entity.post_save', static function (object $event) use ($broadcastStorage, $logger): void {
             try {
                 $entity = $event->entity;
                 $broadcastStorage->push(
@@ -39,11 +47,11 @@ final class EventListenerRegistrar
                     ['entityType' => $entity->getEntityTypeId(), 'id' => (string) ($entity->uuid() ?: $entity->id())],
                 );
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Failed to broadcast entity.saved: %s', $e->getMessage()));
+                $logger->warning(sprintf('Failed to broadcast entity.saved: %s', $e->getMessage()));
             }
         });
 
-        $this->dispatcher->addListener('waaseyaa.entity.post_delete', function (object $event) use ($broadcastStorage): void {
+        $this->dispatcher->addListener('waaseyaa.entity.post_delete', static function (object $event) use ($broadcastStorage, $logger): void {
             try {
                 $entity = $event->entity;
                 $broadcastStorage->push(
@@ -52,7 +60,7 @@ final class EventListenerRegistrar
                     ['entityType' => $entity->getEntityTypeId(), 'id' => (string) ($entity->uuid() ?: $entity->id())],
                 );
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Failed to broadcast entity.deleted: %s', $e->getMessage()));
+                $logger->warning(sprintf('Failed to broadcast entity.deleted: %s', $e->getMessage()));
             }
         });
     }
@@ -83,7 +91,8 @@ final class EventListenerRegistrar
 
     public function registerDiscoveryCacheListeners(CacheBackendInterface $cache): void
     {
-        $invalidate = static function (EntityEvent $event) use ($cache): void {
+        $logger = $this->logger;
+        $invalidate = static function (EntityEvent $event) use ($cache, $logger): void {
             try {
                 if ($cache instanceof TagAwareCacheInterface) {
                     $entityType = strtolower($event->entity->getEntityTypeId());
@@ -107,7 +116,7 @@ final class EventListenerRegistrar
 
                 $cache->deleteAll();
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Failed to clear discovery cache: %s', $e->getMessage()));
+                $logger->warning(sprintf('Failed to clear discovery cache: %s', $e->getMessage()));
             }
         };
 
@@ -121,7 +130,8 @@ final class EventListenerRegistrar
 
     public function registerMcpReadCacheListeners(CacheBackendInterface $cache): void
     {
-        $invalidate = static function (EntityEvent $event) use ($cache): void {
+        $logger = $this->logger;
+        $invalidate = static function (EntityEvent $event) use ($cache, $logger): void {
             try {
                 if ($cache instanceof TagAwareCacheInterface) {
                     $entityType = strtolower($event->entity->getEntityTypeId());
@@ -139,7 +149,7 @@ final class EventListenerRegistrar
 
                 $cache->deleteAll();
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Failed to clear MCP read cache: %s', $e->getMessage()));
+                $logger->warning(sprintf('Failed to clear MCP read cache: %s', $e->getMessage()));
             }
         };
 

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -56,7 +56,7 @@ final class HttpKernel extends AbstractKernel
         try {
             $this->boot();
         } catch (\Throwable $e) {
-            error_log(sprintf("[Waaseyaa] Boot failed: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            $this->logger->critical(sprintf("Boot failed: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
             ResponseSender::json(500, [
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Application failed to boot.']],
@@ -121,7 +121,7 @@ final class HttpKernel extends AbstractKernel
                         try {
                             return $provider->resolve($className);
                         } catch (\Throwable $e) {
-                            error_log(sprintf('[Waaseyaa] Failed to resolve %s: %s', $className, $e->getMessage()));
+                            $this->logger->error(sprintf('Failed to resolve %s: %s', $className, $e->getMessage()));
                             return null;
                         }
                     }
@@ -147,7 +147,7 @@ final class HttpKernel extends AbstractKernel
         } catch (\Symfony\Component\Routing\Exception\MethodNotAllowedException) {
             ResponseSender::json(405, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '405', 'title' => 'Method Not Allowed', 'detail' => "Method {$method} is not allowed for this route."]]]);
         } catch (\Throwable $e) {
-            error_log(sprintf("[Waaseyaa] Routing error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            $this->logger->critical(sprintf("Routing error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
             ResponseSender::json(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'A routing error occurred.']]]);
         }
 
@@ -204,7 +204,7 @@ final class HttpKernel extends AbstractKernel
                 },
             );
         } catch (\Throwable $e) {
-            error_log(sprintf("[Waaseyaa] Authorization pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            $this->logger->critical(sprintf("Authorization pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
             ResponseSender::json(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An authorization error occurred.']]]);
         }
 
@@ -215,7 +215,7 @@ final class HttpKernel extends AbstractKernel
 
         $account = $httpRequest->attributes->get('_account');
         if (!$account instanceof AccountInterface) {
-            error_log('[Waaseyaa] _account attribute missing or invalid after authorization pipeline.');
+            $this->logger->error('_account attribute missing or invalid after authorization pipeline.');
             ResponseSender::json(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Account resolution failed.']]]);
         }
 

--- a/packages/foundation/src/Log/CompositeLogger.php
+++ b/packages/foundation/src/Log/CompositeLogger.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+final class CompositeLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    /** @var list<LoggerInterface> */
+    private readonly array $loggers;
+
+    public function __construct(LoggerInterface ...$loggers)
+    {
+        $this->loggers = array_values($loggers);
+    }
+
+    public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+    {
+        foreach ($this->loggers as $logger) {
+            try {
+                $logger->log($level, $message, $context);
+            } catch (\Throwable) {
+                // Best-effort: one broken sink must not stop others.
+            }
+        }
+    }
+}

--- a/packages/foundation/src/Log/ErrorLogHandler.php
+++ b/packages/foundation/src/Log/ErrorLogHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+final class ErrorLogHandler implements LoggerInterface
+{
+    use LoggerTrait;
+
+    /** @var \Closure(string): void */
+    private readonly \Closure $writer;
+
+    /**
+     * @param ?\Closure(string): void $writer Custom writer for testing. Defaults to error_log().
+     */
+    public function __construct(?\Closure $writer = null)
+    {
+        $this->writer = $writer ?? static function (string $line): void {
+            error_log($line);
+        };
+    }
+
+    public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+    {
+        $line = sprintf('[%s] %s', $level->value, (string) $message);
+
+        if ($context !== []) {
+            $line .= ' ' . json_encode($context, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        }
+
+        ($this->writer)($line);
+    }
+}

--- a/packages/foundation/src/Log/FileLogger.php
+++ b/packages/foundation/src/Log/FileLogger.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+final class FileLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    private const array LEVEL_PRIORITY = [
+        'emergency' => 0,
+        'alert' => 1,
+        'critical' => 2,
+        'error' => 3,
+        'warning' => 4,
+        'notice' => 5,
+        'info' => 6,
+        'debug' => 7,
+    ];
+
+    public function __construct(
+        private readonly string $filePath,
+        private readonly LogLevel $minimumLevel = LogLevel::DEBUG,
+    ) {}
+
+    public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+    {
+        if (self::LEVEL_PRIORITY[$level->value] > self::LEVEL_PRIORITY[$this->minimumLevel->value]) {
+            return;
+        }
+
+        $timestamp = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        $line = sprintf('[%s] [%s] %s', $timestamp, $level->value, (string) $message);
+
+        if ($context !== []) {
+            $line .= ' ' . json_encode($context, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        }
+
+        file_put_contents($this->filePath, $line . "\n", FILE_APPEND | LOCK_EX);
+    }
+}

--- a/packages/foundation/src/Log/LogLevel.php
+++ b/packages/foundation/src/Log/LogLevel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+enum LogLevel: string
+{
+    case EMERGENCY = 'emergency';
+    case ALERT = 'alert';
+    case CRITICAL = 'critical';
+    case ERROR = 'error';
+    case WARNING = 'warning';
+    case NOTICE = 'notice';
+    case INFO = 'info';
+    case DEBUG = 'debug';
+}

--- a/packages/foundation/src/Log/LoggerInterface.php
+++ b/packages/foundation/src/Log/LoggerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+interface LoggerInterface
+{
+    public function emergency(string|\Stringable $message, array $context = []): void;
+
+    public function alert(string|\Stringable $message, array $context = []): void;
+
+    public function critical(string|\Stringable $message, array $context = []): void;
+
+    public function error(string|\Stringable $message, array $context = []): void;
+
+    public function warning(string|\Stringable $message, array $context = []): void;
+
+    public function notice(string|\Stringable $message, array $context = []): void;
+
+    public function info(string|\Stringable $message, array $context = []): void;
+
+    public function debug(string|\Stringable $message, array $context = []): void;
+
+    public function log(LogLevel $level, string|\Stringable $message, array $context = []): void;
+}

--- a/packages/foundation/src/Log/LoggerTrait.php
+++ b/packages/foundation/src/Log/LoggerTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+trait LoggerTrait
+{
+    public function emergency(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    public function alert(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    public function critical(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    public function error(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    public function warning(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    public function notice(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    public function info(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    public function debug(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    abstract public function log(LogLevel $level, string|\Stringable $message, array $context = []): void;
+}

--- a/packages/foundation/src/Log/NullLogger.php
+++ b/packages/foundation/src/Log/NullLogger.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log;
+
+final class NullLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+    {
+        // Intentionally discards all messages.
+    }
+}

--- a/packages/foundation/tests/Unit/Diagnostic/DiagnosticEmitterTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/DiagnosticEmitterTest.php
@@ -130,41 +130,34 @@ final class DiagnosticEmitterTest extends TestCase
     }
 
     #[Test]
-    public function emitWritesToErrorLog(): void
+    public function emitWritesToLogger(): void
     {
-        $emitter = new DiagnosticEmitter();
-
-        // Capture error_log output by redirecting to a temp file.
-        $logFile = sys_get_temp_dir() . '/waaseyaa_diag_test_' . uniqid() . '.log';
-        ini_set('error_log', $logFile);
+        $lines = [];
+        $logger = new \Waaseyaa\Foundation\Log\ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+        $emitter = new DiagnosticEmitter($logger);
 
         $emitter->emit(DiagnosticCode::NAMESPACE_RESERVED, 'core.foo blocked.', []);
 
-        ini_restore('error_log');
-
-        $contents = file_get_contents($logFile) ?: '';
-        @unlink($logFile);
-
+        $contents = implode("\n", $lines);
         $this->assertStringContainsString('NAMESPACE_RESERVED', $contents);
     }
 
     #[Test]
     public function emitLogLineIsValidJson(): void
     {
-        $emitter = new DiagnosticEmitter();
-
-        $logFile = sys_get_temp_dir() . '/waaseyaa_diag_test_' . uniqid() . '.log';
-        ini_set('error_log', $logFile);
+        $lines = [];
+        $logger = new \Waaseyaa\Foundation\Log\ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+        $emitter = new DiagnosticEmitter($logger);
 
         $emitter->emit(DiagnosticCode::DEFAULT_TYPE_DISABLED, 'All disabled.', ['count' => 2]);
 
-        ini_restore('error_log');
+        $raw = $lines[0] ?? '';
 
-        $raw = file_get_contents($logFile) ?: '';
-        @unlink($logFile);
-
-        // error_log prepends a timestamp like "[DD-Mon-YYYY HH:MM:SS UTC] ".
-        // Extract the JSON part after the first ']'.
+        // ErrorLogHandler formats as "[level] message". Extract the JSON part.
         $jsonStart = strpos($raw, '{');
         $this->assertNotFalse($jsonStart, 'Log line should contain a JSON object');
 

--- a/packages/foundation/tests/Unit/Log/CompositeLoggerTest.php
+++ b/packages/foundation/tests/Unit/Log/CompositeLoggerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\CompositeLogger;
+use Waaseyaa\Foundation\Log\ErrorLogHandler;
+use Waaseyaa\Foundation\Log\LogLevel;
+use Waaseyaa\Foundation\Log\NullLogger;
+
+#[CoversClass(CompositeLogger::class)]
+final class CompositeLoggerTest extends TestCase
+{
+    #[Test]
+    public function routes_to_multiple_loggers(): void
+    {
+        $linesA = [];
+        $linesB = [];
+
+        $loggerA = new ErrorLogHandler(static function (string $line) use (&$linesA): void {
+            $linesA[] = $line;
+        });
+        $loggerB = new ErrorLogHandler(static function (string $line) use (&$linesB): void {
+            $linesB[] = $line;
+        });
+
+        $composite = new CompositeLogger($loggerA, $loggerB);
+        $composite->error('test message');
+
+        $this->assertCount(1, $linesA);
+        $this->assertCount(1, $linesB);
+        $this->assertSame('[error] test message', $linesA[0]);
+        $this->assertSame('[error] test message', $linesB[0]);
+    }
+
+    #[Test]
+    public function continues_when_one_logger_throws(): void
+    {
+        $lines = [];
+
+        $brokenLogger = new class implements \Waaseyaa\Foundation\Log\LoggerInterface {
+            use \Waaseyaa\Foundation\Log\LoggerTrait;
+
+            public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+            {
+                throw new \RuntimeException('Broken sink');
+            }
+        };
+
+        $workingLogger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $composite = new CompositeLogger($brokenLogger, $workingLogger);
+        $composite->error('still delivered');
+
+        $this->assertCount(1, $lines);
+        $this->assertSame('[error] still delivered', $lines[0]);
+    }
+
+    #[Test]
+    public function works_with_no_loggers(): void
+    {
+        $composite = new CompositeLogger();
+        $composite->info('nothing happens');
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/packages/foundation/tests/Unit/Log/ErrorLogHandlerTest.php
+++ b/packages/foundation/tests/Unit/Log/ErrorLogHandlerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\ErrorLogHandler;
+use Waaseyaa\Foundation\Log\LogLevel;
+
+#[CoversClass(ErrorLogHandler::class)]
+final class ErrorLogHandlerTest extends TestCase
+{
+    #[Test]
+    public function formats_message_with_level(): void
+    {
+        $lines = [];
+        $logger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $logger->error('Something broke');
+
+        $this->assertCount(1, $lines);
+        $this->assertSame('[error] Something broke', $lines[0]);
+    }
+
+    #[Test]
+    public function includes_context_as_json(): void
+    {
+        $lines = [];
+        $logger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $logger->warning('Disk full', ['disk' => '/dev/sda1', 'usage' => 99]);
+
+        $this->assertCount(1, $lines);
+        $this->assertSame('[warning] Disk full {"disk":"/dev/sda1","usage":99}', $lines[0]);
+    }
+
+    #[Test]
+    public function omits_context_when_empty(): void
+    {
+        $lines = [];
+        $logger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $logger->info('All good');
+
+        $this->assertSame('[info] All good', $lines[0]);
+    }
+
+    #[Test]
+    public function delegates_convenience_methods_to_log(): void
+    {
+        $lines = [];
+        $logger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $logger->emergency('e');
+        $logger->alert('a');
+        $logger->critical('c');
+        $logger->error('err');
+        $logger->warning('w');
+        $logger->notice('n');
+        $logger->info('i');
+        $logger->debug('d');
+
+        $this->assertCount(8, $lines);
+        $this->assertStringStartsWith('[emergency]', $lines[0]);
+        $this->assertStringStartsWith('[alert]', $lines[1]);
+        $this->assertStringStartsWith('[critical]', $lines[2]);
+        $this->assertStringStartsWith('[error]', $lines[3]);
+        $this->assertStringStartsWith('[warning]', $lines[4]);
+        $this->assertStringStartsWith('[notice]', $lines[5]);
+        $this->assertStringStartsWith('[info]', $lines[6]);
+        $this->assertStringStartsWith('[debug]', $lines[7]);
+    }
+
+    #[Test]
+    public function accepts_stringable_message(): void
+    {
+        $lines = [];
+        $logger = new ErrorLogHandler(static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'stringable message';
+            }
+        };
+
+        $logger->log(LogLevel::INFO, $stringable);
+
+        $this->assertSame('[info] stringable message', $lines[0]);
+    }
+}

--- a/packages/foundation/tests/Unit/Log/FileLoggerTest.php
+++ b/packages/foundation/tests/Unit/Log/FileLoggerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\FileLogger;
+use Waaseyaa\Foundation\Log\LogLevel;
+
+#[CoversClass(FileLogger::class)]
+final class FileLoggerTest extends TestCase
+{
+    private string $logFile;
+
+    protected function setUp(): void
+    {
+        $this->logFile = sys_get_temp_dir() . '/waaseyaa_test_' . uniqid() . '.log';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->logFile)) {
+            unlink($this->logFile);
+        }
+    }
+
+    #[Test]
+    public function writes_formatted_line_with_timestamp(): void
+    {
+        $logger = new FileLogger($this->logFile);
+        $logger->error('Something failed');
+
+        $content = file_get_contents($this->logFile);
+        $this->assertIsString($content);
+        $this->assertMatchesRegularExpression(
+            '/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}\] \[error\] Something failed\n$/',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function includes_context_json(): void
+    {
+        $logger = new FileLogger($this->logFile);
+        $logger->warning('Low disk', ['percent' => 95]);
+
+        $content = file_get_contents($this->logFile);
+        $this->assertIsString($content);
+        $this->assertStringContainsString('[warning] Low disk {"percent":95}', $content);
+    }
+
+    #[Test]
+    public function respects_minimum_level_filter(): void
+    {
+        $logger = new FileLogger($this->logFile, minimumLevel: LogLevel::WARNING);
+
+        $logger->debug('ignored');
+        $logger->info('ignored');
+        $logger->notice('ignored');
+        $logger->warning('kept');
+        $logger->error('kept');
+
+        $content = file_get_contents($this->logFile);
+        $this->assertIsString($content);
+        $this->assertStringNotContainsString('ignored', $content);
+        $lines = array_filter(explode("\n", $content));
+        $this->assertCount(2, $lines);
+    }
+
+    #[Test]
+    public function appends_to_existing_file(): void
+    {
+        $logger = new FileLogger($this->logFile);
+        $logger->info('first');
+        $logger->info('second');
+
+        $content = file_get_contents($this->logFile);
+        $this->assertIsString($content);
+        $lines = array_filter(explode("\n", $content));
+        $this->assertCount(2, $lines);
+    }
+}

--- a/packages/foundation/tests/Unit/Log/NullLoggerTest.php
+++ b/packages/foundation/tests/Unit/Log/NullLoggerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\LogLevel;
+use Waaseyaa\Foundation\Log\NullLogger;
+
+#[CoversClass(NullLogger::class)]
+final class NullLoggerTest extends TestCase
+{
+    #[Test]
+    public function discards_all_messages_without_error(): void
+    {
+        $logger = new NullLogger();
+
+        // Should not throw or produce any side effects.
+        $logger->emergency('test');
+        $logger->alert('test');
+        $logger->critical('test');
+        $logger->error('test');
+        $logger->warning('test');
+        $logger->notice('test');
+        $logger->info('test');
+        $logger->debug('test');
+        $logger->log(LogLevel::ERROR, 'test', ['key' => 'value']);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function implements_logger_interface(): void
+    {
+        $logger = new NullLogger();
+
+        $this->assertInstanceOf(\Waaseyaa\Foundation\Log\LoggerInterface::class, $logger);
+    }
+}

--- a/packages/graphql/src/GraphQlEndpoint.php
+++ b/packages/graphql/src/GraphQlEndpoint.php
@@ -11,6 +11,8 @@ use GraphQL\Validator\Rules\DisableIntrospection;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\EntityAccessHandler;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\GraphQL\Access\GraphQlAccessGuard;
 use Waaseyaa\GraphQL\Resolver\EntityResolver;
 use Waaseyaa\GraphQL\Resolver\ReferenceLoader;
@@ -26,13 +28,17 @@ final class GraphQlEndpoint
 {
     /** @var array<string, array{args?: array<string, mixed>, resolve?: callable}> */
     private array $mutationOverrides = [];
+    private readonly LoggerInterface $logger;
 
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly EntityAccessHandler $accessHandler,
         private readonly AccountInterface $account,
         private readonly int $maxDepth = 3,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * Register mutation overrides (extra args, custom resolvers).
@@ -120,7 +126,7 @@ final class GraphQlEndpoint
                 'body' => $result->toArray(DebugFlag::NONE),
             ];
         } catch (\Exception $e) {
-            error_log('GraphQL execution error: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+            $this->logger->error('GraphQL execution error: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
 
             return [
                 'statusCode' => 500,

--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -12,6 +12,8 @@ use Waaseyaa\Api\Query\QuerySort;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\FieldableInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\GraphQL\Access\GraphQlAccessGuard;
 
 /**
@@ -25,10 +27,15 @@ final class EntityResolver
     private const DEFAULT_LIMIT = 50;
     private const MAX_LIMIT = 100;
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly GraphQlAccessGuard $guard,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * Resolve a list query with filter, sort, and pagination.
@@ -98,7 +105,7 @@ final class EntityResolver
             return null;
         }
         if (!$this->guard->canView($entity)) {
-            error_log("GraphQL: view access denied for {$entityTypeId}/{$id}");
+            $this->logger->info(sprintf('GraphQL: view access denied for %s/%s', $entityTypeId, (string) $id));
 
             return null;
         }

--- a/packages/graphql/src/Schema/FieldTypeMapper.php
+++ b/packages/graphql/src/Schema/FieldTypeMapper.php
@@ -7,6 +7,8 @@ namespace Waaseyaa\GraphQL\Schema;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
  * Maps Waaseyaa field types to GraphQL scalar/object types.
@@ -15,9 +17,15 @@ use GraphQL\Type\Definition\Type;
  */
 final class FieldTypeMapper
 {
+    private readonly LoggerInterface $logger;
     private ?ObjectType $textType = null;
     private ?InputObjectType $textInputType = null;
     private ?InputObjectType $entityReferenceInputType = null;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function toOutputType(string $fieldType, bool $isMultiple): Type
     {
@@ -30,7 +38,7 @@ final class FieldTypeMapper
             'text', 'text_long' => $this->getTextType(),
             default => (function () use ($fieldType, &$known): Type {
                 $known = false;
-                error_log("GraphQL: unknown field type '{$fieldType}', falling back to String");
+                $this->logger->warning(sprintf('GraphQL: unknown field type "%s", falling back to String', $fieldType));
 
                 return Type::string();
             })(),

--- a/packages/mcp/src/Cache/ReadCache.php
+++ b/packages/mcp/src/Cache/ReadCache.php
@@ -6,16 +6,22 @@ namespace Waaseyaa\Mcp\Cache;
 
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Cache\CacheBackendInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 final class ReadCache
 {
     private const string CONTRACT_VERSION = 'v1.0';
     private const int MAX_AGE = 120;
+    private readonly LoggerInterface $logger;
 
     public function __construct(
         private readonly AccountInterface $account,
         private readonly ?CacheBackendInterface $backend = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * @param array<string, mixed> $arguments
@@ -108,7 +114,7 @@ final class ReadCache
         try {
             $this->backend->set($cacheKey, $result, $expire, $tags);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] Failed to write MCP read cache: %s', $e->getMessage()));
+            $this->logger->warning(sprintf('Failed to write MCP read cache: %s', $e->getMessage()));
         }
     }
 

--- a/packages/search/src/EventSubscriber/SearchIndexSubscriber.php
+++ b/packages/search/src/EventSubscriber/SearchIndexSubscriber.php
@@ -7,14 +7,21 @@ namespace Waaseyaa\Search\EventSubscriber;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Waaseyaa\Entity\Event\EntityEvent;
 use Waaseyaa\Entity\Event\EntityEvents;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Search\SearchIndexableInterface;
 use Waaseyaa\Search\SearchIndexerInterface;
 
 final class SearchIndexSubscriber implements EventSubscriberInterface
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly SearchIndexerInterface $indexer,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public static function getSubscribedEvents(): array
     {
@@ -35,7 +42,7 @@ final class SearchIndexSubscriber implements EventSubscriberInterface
         try {
             $this->indexer->index($entity);
         } catch (\Throwable $e) {
-            error_log("Search indexing failed for {$entity->getSearchDocumentId()}: {$e->getMessage()}");
+            $this->logger->error(sprintf('Search indexing failed for %s: %s', $entity->getSearchDocumentId(), $e->getMessage()));
         }
     }
 
@@ -50,7 +57,7 @@ final class SearchIndexSubscriber implements EventSubscriberInterface
         try {
             $this->indexer->remove($entity->getSearchDocumentId());
         } catch (\Throwable $e) {
-            error_log("Search index removal failed for {$entity->getSearchDocumentId()}: {$e->getMessage()}");
+            $this->logger->error(sprintf('Search index removal failed for %s: %s', $entity->getSearchDocumentId(), $e->getMessage()));
         }
     }
 }

--- a/packages/search/src/Fts5/Fts5SearchProvider.php
+++ b/packages/search/src/Fts5/Fts5SearchProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Waaseyaa\Search\Fts5;
 
 use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Search\FacetBucket;
 use Waaseyaa\Search\SearchFacet;
 use Waaseyaa\Search\SearchFilters;
@@ -17,11 +19,15 @@ use Waaseyaa\Search\SearchResult;
 final class Fts5SearchProvider implements SearchProviderInterface
 {
     private const ALLOWED_SORT_COLUMNS = ['created_at', 'quality_score', 'entity_type', 'content_type'];
+    private readonly LoggerInterface $logger;
 
     public function __construct(
         private readonly DatabaseInterface $database,
         private readonly SearchIndexerInterface $indexer,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function search(SearchRequest $request): SearchResult
     {
@@ -99,7 +105,7 @@ final class Fts5SearchProvider implements SearchProviderInterface
         }
 
         if ($staleDetected) {
-            error_log('Search index contains stale documents. Run search:reindex to rebuild.');
+            $this->logger->warning('Search index contains stale documents. Run search:reindex to rebuild.');
         }
 
         // Facets — run on the full filtered result set (not just the page)

--- a/packages/ssr/src/SsrPageHandler.php
+++ b/packages/ssr/src/SsrPageHandler.php
@@ -19,6 +19,8 @@ use Waaseyaa\Relationship\RelationshipTraversalService;
 use Waaseyaa\Routing\Language\AcceptHeaderNegotiator;
 use Waaseyaa\Routing\Language\LanguageNegotiator;
 use Waaseyaa\Routing\Language\UrlPrefixNegotiator;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Workflows\EditorialVisibilityResolver;
 
 /**
@@ -33,6 +35,8 @@ final class SsrPageHandler
     private const string DISCOVERY_CONTRACT_VERSION = 'v1.0';
     private const string DISCOVERY_CONTRACT_STABILITY = 'stable';
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly DatabaseInterface $database,
@@ -45,7 +49,10 @@ final class SsrPageHandler
         private readonly ?object $manifest = null,
         /** @var (\Closure(string): ?object)|null */
         private readonly ?\Closure $serviceResolver = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * Render a page for the given path.
@@ -69,7 +76,7 @@ final class SsrPageHandler
             try {
                 $twig = SsrServiceProvider::createTwigEnvironment($this->projectRoot, $this->config);
             } catch (\Throwable $e) {
-                error_log(sprintf('[Waaseyaa] Twig environment initialization failed: %s', $e->getMessage()));
+                $this->logger->error(sprintf('Twig environment initialization failed: %s', $e->getMessage()));
                 return $this->jsonResult(500, [
                     'jsonapi' => ['version' => '1.1'],
                     'errors' => [[
@@ -215,7 +222,7 @@ final class SsrPageHandler
             $headers['Cache-Control'] = $cacheControlHeader;
             return $this->htmlResult($response->statusCode, $response->content, $headers);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] Render pipeline failed: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
+            $this->logger->error(sprintf('Render pipeline failed: %s in %s:%d', $e->getMessage(), $e->getFile(), $e->getLine()));
             return $this->jsonResult(500, [
                 'jsonapi' => ['version' => '1.1'],
                 'errors' => [[
@@ -261,8 +268,8 @@ final class SsrPageHandler
             $isRenderRoute = $route instanceof \Symfony\Component\Routing\Route
                 && $route->getOption('_render') === true;
             if (!$isRenderRoute) {
-                error_log(sprintf(
-                    '[Waaseyaa] Controller %s::%s returned SsrResponse on a non-render route. '
+                $this->logger->warning(sprintf(
+                    'Controller %s::%s returned SsrResponse on a non-render route. '
                     . 'Add ->render() to the RouteBuilder chain to fix SSR dispatch.',
                     $class,
                     $method,
@@ -445,7 +452,7 @@ final class SsrPageHandler
             ];
         } catch (\Throwable $e) {
             // Relationship navigation is additive and should not break render paths.
-            error_log(sprintf('[Waaseyaa] Relationship render context failed: %s', $e->getMessage()));
+            $this->logger->warning(sprintf('Relationship render context failed: %s', $e->getMessage()));
             return [];
         }
     }

--- a/packages/ssr/src/TwigErrorPageRenderer.php
+++ b/packages/ssr/src/TwigErrorPageRenderer.php
@@ -8,12 +8,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 use Waaseyaa\Access\ErrorPageRendererInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 
 final class TwigErrorPageRenderer implements ErrorPageRendererInterface
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly Environment $twig,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function render(int $statusCode, string $title, string $detail, Request $request): ?Response
     {
@@ -31,7 +38,7 @@ final class TwigErrorPageRenderer implements ErrorPageRendererInterface
                 'request_path' => $request->getPathInfo(),
             ]);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] TwigErrorPageRenderer failed for %s: %s', $template, $e->getMessage()));
+            $this->logger->error(sprintf('TwigErrorPageRenderer failed for %s: %s', $template, $e->getMessage()));
 
             return null;
         }

--- a/packages/user/src/Http/AuthController.php
+++ b/packages/user/src/Http/AuthController.php
@@ -6,6 +6,8 @@ namespace Waaseyaa\User\Http;
 
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\User\User;
 
 /**
@@ -13,6 +15,13 @@ use Waaseyaa\User\User;
  */
 final class AuthController
 {
+    private readonly LoggerInterface $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
     /**
      * Returns the current user's data or a 401 payload for anonymous users.
      *
@@ -22,7 +31,7 @@ final class AuthController
     {
         if (!$account->isAuthenticated()) {
             if (\PHP_SAPI === 'cli-server') {
-                error_log('[Waaseyaa] Admin endpoint returned 401. For local development, set APP_ENV=local and WAASEYAA_DEV_FALLBACK_ACCOUNT=true (or use `composer dev` which sets both automatically).');
+                $this->logger->info('Admin endpoint returned 401. For local development, set APP_ENV=local and WAASEYAA_DEV_FALLBACK_ACCOUNT=true (or use `composer dev` which sets both automatically).');
             }
 
             return [

--- a/packages/user/src/Middleware/BearerAuthMiddleware.php
+++ b/packages/user/src/Middleware/BearerAuthMiddleware.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\User\AnonymousUser;
@@ -16,6 +18,8 @@ use Waaseyaa\User\AnonymousUser;
 #[AsMiddleware(pipeline: 'http', priority: 40)]
 final class BearerAuthMiddleware implements HttpMiddlewareInterface
 {
+    private readonly LoggerInterface $logger;
+
     /**
      * @param array<string, int|string> $apiKeys Raw API key => user ID mapping.
      */
@@ -23,7 +27,10 @@ final class BearerAuthMiddleware implements HttpMiddlewareInterface
         private readonly EntityStorageInterface $userStorage,
         private readonly string $jwtSecret = '',
         private readonly array $apiKeys = [],
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
@@ -58,7 +65,7 @@ final class BearerAuthMiddleware implements HttpMiddlewareInterface
         try {
             $account = $this->userStorage->load($uid);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] BearerAuthMiddleware: failed to load user %s: %s', $uid, $e->getMessage()));
+            $this->logger->warning(sprintf('BearerAuthMiddleware: failed to load user %s: %s', $uid, $e->getMessage()));
             return null;
         }
 

--- a/packages/user/src/Middleware/SessionMiddleware.php
+++ b/packages/user/src/Middleware/SessionMiddleware.php
@@ -10,6 +10,8 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\User\Session\NativeSession;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\User\AnonymousUser;
@@ -17,6 +19,8 @@ use Waaseyaa\User\AnonymousUser;
 #[AsMiddleware(pipeline: 'http', priority: 30)]
 final class SessionMiddleware implements HttpMiddlewareInterface
 {
+    private readonly LoggerInterface $logger;
+
     /**
      * @param EntityStorageInterface $userStorage Storage for loading user entities.
      * @param AccountInterface|null $devFallback Account returned when no session UID exists. Intended for dev environments only.
@@ -24,7 +28,10 @@ final class SessionMiddleware implements HttpMiddlewareInterface
     public function __construct(
         private readonly EntityStorageInterface $userStorage,
         private readonly ?AccountInterface $devFallback = null,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
@@ -57,7 +64,7 @@ final class SessionMiddleware implements HttpMiddlewareInterface
 
         if ($uid === null) {
             if ($this->devFallback !== null) {
-                error_log('[Waaseyaa] SessionMiddleware: using dev fallback account (all permissions granted). This should only happen in development.');
+                $this->logger->info('SessionMiddleware: using dev fallback account (all permissions granted). This should only happen in development.');
                 return $this->devFallback;
             }
             return new AnonymousUser();
@@ -66,7 +73,7 @@ final class SessionMiddleware implements HttpMiddlewareInterface
         try {
             $user = $this->userStorage->load($uid);
         } catch (\Throwable $e) {
-            error_log(sprintf('[Waaseyaa] SessionMiddleware: failed to load user %s: %s', $uid, $e->getMessage()));
+            $this->logger->warning(sprintf('SessionMiddleware: failed to load user %s: %s', $uid, $e->getMessage()));
             return new AnonymousUser();
         }
 


### PR DESCRIPTION
## Summary
- **LoggerInterface + LogLevel enum + LoggerTrait** — PSR-3 compatible framework logging contract in `packages/foundation/src/Log/` (no psr/log dependency)
- **NullLogger, ErrorLogHandler, FileLogger, CompositeLogger** — four implementations covering tests, production fallback, file output, and multi-sink routing
- **Replaced all 50+ error_log() calls** across 33 source files in 15 packages with structured logger calls using nullable constructor injection (`?LoggerInterface $logger = null` + NullLogger fallback)

Closes #559, closes #560, closes #561

## Test plan
- [x] 4 new test files: NullLoggerTest, ErrorLogHandlerTest, FileLoggerTest, CompositeLoggerTest
- [x] Updated 2 existing tests (DiagnosticEmitterTest, SqliteEmbeddingStorageTest) to use injected loggers
- [x] `grep -rn "error_log(" packages/*/src/ --include="*.php"` returns only ErrorLogHandler.php
- [x] Full test suite: 4903 tests, 11908 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)