### PR TITLE
ci(drift): wire drift detection into Taskfile, lefthook, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
     branches: [main]
 
 jobs:
+  spec-drift:
+    name: spec-drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for stale specs
+        run: bash tools/drift-detector.sh 5
+
   ci-lint:
     name: ci/lint
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+tasks:
+  drift:check:
+    desc: "Check for spec drift (stale specs vs recent changes)"
+    cmds:
+      - tools/drift-detector.sh {{.CLI_ARGS | default "5"}}
+
+  lint:
+    desc: "Run PHP linting (PHPStan)"
+    cmds:
+      - vendor/bin/phpstan analyse --no-progress
+
+  test:
+    desc: "Run PHPUnit tests"
+    cmds:
+      - vendor/bin/phpunit
+
+  ci:
+    desc: "Run full CI pipeline (drift check, lint, test)"
+    cmds:
+      - task: drift:check
+      - task: lint
+      - task: test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-push:
+  commands:
+    spec-drift:
+      run: tools/drift-detector.sh 5

--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -1,172 +1,170 @@
 #!/usr/bin/env bash
 #
-# drift-detector.sh — Map recent git changes to subsystem specs that may need review.
+# drift-detector.sh — Detect stale specs by comparing git timestamps.
 #
 # Usage: tools/drift-detector.sh [N]
 #   N = number of recent commits to check (default: 5)
+#
+# Exit codes:
+#   0 = all specs up to date (or no specs affected)
+#   1 = one or more specs are stale or missing
 
 set -euo pipefail
 
 N="${1:-5}"
 
-# Verify we're in a git repo.
-if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-  echo "Error: not inside a git repository." >&2
+# Validate input
+if ! [[ "$N" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: num_commits must be a positive integer, got '$N'" >&2
   exit 1
 fi
 
-# Collect changed files.
-changed_files=$(git diff --name-only "HEAD~${N}..HEAD" 2>/dev/null) || {
-  echo "Error: could not compute diff for last ${N} commits." >&2
-  exit 1
-}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
 
-if [ -z "$changed_files" ]; then
-  echo "No files changed in last ${N} commits."
-  echo "All specs up to date."
+# Verify git history depth
+TOTAL_COMMITS=$(git rev-list --count HEAD 2>/dev/null || echo 0)
+if [ "$TOTAL_COMMITS" -eq 0 ]; then
+  echo "ERROR: No git history found. Is this a git repository?" >&2
+  exit 1
+fi
+
+if [ "$TOTAL_COMMITS" -lt "$N" ]; then
+  echo "WARNING: Only $TOTAL_COMMITS commits available (requested $N). Checking all." >&2
+  N=$((TOTAL_COMMITS - 1))
+  if [ "$N" -le 0 ]; then
+    CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)
+  else
+    CHANGED_FILES=$(git diff --name-only "HEAD~${N}..HEAD")
+  fi
+else
+  CHANGED_FILES=$(git diff --name-only "HEAD~${N}..HEAD")
+fi
+
+# Exclude files that don't affect spec accuracy
+CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -vE '(_test|Test)\.php$|\.claude/|composer\.lock$|CLAUDE\.md$|/vendor/|\.layers$|phpunit\.xml|phpstan\.neon' || true)
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No spec-affecting changes in last ${N} commits."
   exit 0
 fi
 
-echo "Checking files changed in last ${N} commits..."
+echo "=== Drift Detector ==="
+echo "Checking last ${N} commits for spec drift..."
 echo ""
 
-declare -A affected_specs
+# Mapping: directory pattern -> spec file
+declare -A PATTERN_TO_SPEC=(
+  ["packages/entity/"]="docs/specs/entity-system.md"
+  ["packages/entity-storage/"]="docs/specs/entity-system.md"
+  ["packages/field/"]="docs/specs/entity-system.md"
+  ["packages/config/"]="docs/specs/entity-system.md"
+  ["packages/access/"]="docs/specs/access-control.md"
+  ["packages/api/"]="docs/specs/api-layer.md"
+  ["packages/routing/"]="docs/specs/api-layer.md"
+  ["packages/foundation/"]="docs/specs/infrastructure.md"
+  ["packages/cache/"]="docs/specs/infrastructure.md"
+  ["packages/database-legacy/"]="docs/specs/infrastructure.md"
+  ["packages/plugin/"]="docs/specs/infrastructure.md"
+  ["packages/i18n/"]="docs/specs/infrastructure.md"
+  ["packages/queue/"]="docs/specs/infrastructure.md"
+  ["packages/state/"]="docs/specs/infrastructure.md"
+  ["packages/validation/"]="docs/specs/infrastructure.md"
+  ["packages/typed-data/"]="docs/specs/infrastructure.md"
+  ["packages/testing/"]="docs/specs/infrastructure.md"
+  ["packages/mail/"]="docs/specs/infrastructure.md"
+  ["packages/http-client/"]="docs/specs/infrastructure.md"
+  ["packages/admin/"]="docs/specs/admin-spa.md"
+  ["packages/note/"]="docs/specs/ingestion-defaults.md"
+  ["packages/relationship/"]="docs/specs/relationship-modeling.md"
+  ["packages/ai-"]="docs/specs/ai-integration.md"
+  ["packages/mcp/"]="docs/specs/mcp-endpoint.md"
+  ["packages/user/"]="docs/specs/access-control.md"
+  ["public/"]="docs/specs/middleware-pipeline.md"
+)
 
-map_file_to_specs() {
-  local file="$1"
-  local specs=""
+declare -A AFFECTED_SPECS=()
+declare -A SPEC_CHANGES=()
 
-  # Entity system
-  case "$file" in
-    packages/entity/*|packages/entity-storage/*|packages/field/*|packages/config/*)
-      specs="$specs docs/specs/entity-system.md" ;;
-  esac
-
-  # Access control
-  case "$file" in
-    packages/access/*|packages/user/src/Middleware/*)
-      specs="$specs docs/specs/access-control.md docs/specs/field-access.md" ;;
-  esac
-
-  # Field access (FieldAccess in access, Schema in api)
-  case "$file" in
-    packages/access/src/*FieldAccess*)
-      specs="$specs docs/specs/field-access.md" ;;
-  esac
-  case "$file" in
-    packages/api/src/*Schema*)
-      specs="$specs docs/specs/field-access.md" ;;
-  esac
-
-  # API layer
-  case "$file" in
-    packages/api/*|packages/routing/*)
-      specs="$specs docs/specs/api-layer.md" ;;
-  esac
-
-  # Infrastructure
-  case "$file" in
-    packages/foundation/*|packages/cache/*|packages/database-legacy/*|\
-packages/plugin/*|packages/i18n/*|packages/queue/*|packages/state/*|\
-packages/validation/*|packages/typed-data/*|packages/testing/*|packages/mail/*|\
-packages/http-client/*)
-      specs="$specs docs/specs/infrastructure.md" ;;
-  esac
-
-  # Ingestion
-  case "$file" in
-    packages/foundation/src/Ingestion/*)
-      specs="$specs docs/specs/ingestion-defaults.md" ;;
-  esac
-
-  # Package discovery
-  case "$file" in
-    packages/foundation/src/*Provider*)
-      specs="$specs docs/specs/package-discovery.md" ;;
-  esac
-  case "$file" in
-    packages/plugin/*)
-      specs="$specs docs/specs/package-discovery.md" ;;
-  esac
-
-  # Middleware pipeline
-  case "$file" in
-    public/index.php)
-      specs="$specs docs/specs/middleware-pipeline.md" ;;
-  esac
-  case "$file" in
-    packages/*/src/Middleware/*)
-      specs="$specs docs/specs/middleware-pipeline.md" ;;
-  esac
-
-  # Admin SPA
-  case "$file" in
-    packages/admin/*)
-      specs="$specs docs/specs/admin-spa.md" ;;
-  esac
-
-  # Note (ingestion-defaults)
-  case "$file" in
-    packages/note/*)
-      specs="$specs docs/specs/ingestion-defaults.md" ;;
-  esac
-
-  # Relationship modeling
-  case "$file" in
-    packages/relationship/*)
-      specs="$specs docs/specs/relationship-modeling.md" ;;
-  esac
-
-  # AI integration
-  case "$file" in
-    packages/ai-*/*)
-      specs="$specs docs/specs/ai-integration.md" ;;
-  esac
-
-  # MCP endpoint
-  case "$file" in
-    packages/mcp/*)
-      specs="$specs docs/specs/mcp-endpoint.md" ;;
-  esac
-
-  echo "$specs"
+record_spec() {
+  local spec="$1" file="$2"
+  AFFECTED_SPECS["$spec"]=1
+  SPEC_CHANGES["$spec"]="${SPEC_CHANGES[$spec]:-}  $file\n"
 }
 
-echo "Files changed -> Affected specs:"
-
 while IFS= read -r file; do
-  raw_specs=$(map_file_to_specs "$file")
-  if [ -z "$raw_specs" ]; then
-    continue
-  fi
+  [ -z "$file" ] && continue
 
-  # Deduplicate specs for this file.
-  declare -A seen_for_file
-  display_specs=""
-  for spec in $raw_specs; do
-    if [ -z "${seen_for_file[$spec]+x}" ]; then
-      seen_for_file[$spec]=1
-      affected_specs[$spec]=1
-      if [ -n "$display_specs" ]; then
-        display_specs="$display_specs, $spec"
-      else
-        display_specs="$spec"
-      fi
+  for pattern in "${!PATTERN_TO_SPEC[@]}"; do
+    if [[ "$file" == "$pattern"* ]]; then
+      record_spec "${PATTERN_TO_SPEC[$pattern]}" "$file"
     fi
   done
-  unset seen_for_file
 
-  echo "  $file -> $display_specs"
-done <<< "$changed_files"
+  # Secondary mappings: files that affect additional specs
+  case "$file" in
+    packages/access/src/*FieldAccess*|packages/api/src/*Schema*)
+      record_spec "docs/specs/field-access.md" "$file" ;;
+    packages/foundation/src/Ingestion/*)
+      record_spec "docs/specs/ingestion-defaults.md" "$file" ;;
+    packages/foundation/src/*Provider*|packages/plugin/*)
+      record_spec "docs/specs/package-discovery.md" "$file" ;;
+    packages/*/src/Middleware/*)
+      record_spec "docs/specs/middleware-pipeline.md" "$file"
+      ;;
+  esac
+done <<< "$CHANGED_FILES"
 
+if [ "${#AFFECTED_SPECS[@]}" -eq 0 ]; then
+  echo "No specs affected by recent changes."
+  exit 0
+fi
+
+echo "Affected specs:"
 echo ""
 
-count=${#affected_specs[@]}
-if [ "$count" -eq 0 ]; then
-  echo "All specs up to date."
+STALE_COUNT=0
+for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
+  spec_path="$REPO_ROOT/$spec"
+  if [ -f "$spec_path" ]; then
+    # Compare git commit timestamps: spec last touched vs service code last touched
+    spec_last_commit=$(git log -1 --format=%ct -- "$spec" 2>/dev/null)
+    spec_last_commit=${spec_last_commit:-0}
+
+    # Find the latest commit time for any matched service file
+    service_last_commit=0
+    for pattern in "${!PATTERN_TO_SPEC[@]}"; do
+      if [ "${PATTERN_TO_SPEC[$pattern]}" = "$spec" ]; then
+        pattern_commit=$(git log -1 --format=%ct -- "$pattern" ':!*/vendor/*' 2>/dev/null)
+        pattern_commit=${pattern_commit:-0}
+        if [ "$pattern_commit" -gt "$service_last_commit" ]; then
+          service_last_commit=$pattern_commit
+        fi
+      fi
+    done
+
+    if [ "$spec_last_commit" -lt "$service_last_commit" ]; then
+      echo "  STALE: $spec"
+      echo "    Fix: Review and update this spec to reflect recent changes"
+      STALE_COUNT=$((STALE_COUNT + 1))
+    else
+      echo "  OK: $spec"
+    fi
+  else
+    echo "  MISSING: $spec"
+    echo "    Fix: Create this spec file to document the package"
+    STALE_COUNT=$((STALE_COUNT + 1))
+  fi
+
+  echo "    Changed files:"
+  echo -e "${SPEC_CHANGES[$spec]}" | sort -u | grep -v '^[[:space:]]*$' | head -10 | sed 's/^/      /'
+done
+
+echo ""
+if [ $STALE_COUNT -gt 0 ]; then
+  echo "$STALE_COUNT spec(s) need review. Update specs before merging."
+  exit 1
 else
-  echo "$count spec(s) may need review:"
-  for spec in $(printf '%s\n' "${!affected_specs[@]}" | sort); do
-    echo "  - $spec"
-  done
+  echo "All affected specs are up to date."
+  exit 0
 fi


### PR DESCRIPTION
## Summary
- Enhanced `tools/drift-detector.sh` with git timestamp comparison, exit code enforcement (exits 1 on stale/missing specs), input validation, and exclusion filters for non-spec-affecting files (tests, composer.lock, config files)
- Created `Taskfile.yml` with `drift:check`, `lint`, `test`, and `ci` tasks matching North Cloud's production pattern
- Created `lefthook.yml` with pre-push spec-drift hook
- Added `spec-drift` job to `.github/workflows/ci.yml` as a lightweight first gate (no PHP setup needed)

## Test plan
- [x] `bash tools/drift-detector.sh 5` exits 0 when specs are current
- [x] `task drift:check` runs successfully via Taskfile
- [ ] CI workflow runs spec-drift job on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)