### PR TITLE
test(#540): enforce layer rules for 6 orphan packages

### DIFF
--- a/packages/foundation/tests/Unit/LayerDependencyTest.php
+++ b/packages/foundation/tests/Unit/LayerDependencyTest.php
@@ -13,14 +13,24 @@ final class LayerDependencyTest extends TestCase
 {
     /** Layer 1+ packages that Foundation must NOT depend on. */
     private const FORBIDDEN_DEPS = [
+        // Layer 1 — Core Data
         'waaseyaa/entity', 'waaseyaa/entity-storage', 'waaseyaa/access',
         'waaseyaa/user', 'waaseyaa/config', 'waaseyaa/field',
+        'waaseyaa/auth',
+        // Layer 2 — Content Types
         'waaseyaa/node', 'waaseyaa/taxonomy', 'waaseyaa/media',
         'waaseyaa/path', 'waaseyaa/menu', 'waaseyaa/note',
-        'waaseyaa/relationship', 'waaseyaa/workflows', 'waaseyaa/search',
+        'waaseyaa/relationship',
+        // Layer 3 — Services
+        'waaseyaa/workflows', 'waaseyaa/search',
+        'waaseyaa/billing', 'waaseyaa/github',
+        // Layer 4 — API
         'waaseyaa/api', 'waaseyaa/routing',
+        // Layer 5 — AI
         'waaseyaa/ai-schema', 'waaseyaa/ai-agent', 'waaseyaa/ai-pipeline', 'waaseyaa/ai-vector',
+        // Layer 6 — Interfaces
         'waaseyaa/cli', 'waaseyaa/admin', 'waaseyaa/mcp', 'waaseyaa/ssr',
+        'waaseyaa/deployer', 'waaseyaa/inertia',
     ];
 
     #[Test]

--- a/packages/validation/tests/Unit/LayerDependencyTest.php
+++ b/packages/validation/tests/Unit/LayerDependencyTest.php
@@ -18,12 +18,15 @@ final class LayerDependencyTest extends TestCase
      * Layer-1+ packages that validation must never require.
      */
     private const FORBIDDEN_PACKAGES = [
+        // Layer 1 — Core Data
         'waaseyaa/entity',
         'waaseyaa/entity-storage',
         'waaseyaa/access',
         'waaseyaa/user',
         'waaseyaa/config',
         'waaseyaa/field',
+        'waaseyaa/auth',
+        // Layer 2 — Content Types
         'waaseyaa/node',
         'waaseyaa/taxonomy',
         'waaseyaa/media',
@@ -31,20 +34,27 @@ final class LayerDependencyTest extends TestCase
         'waaseyaa/menu',
         'waaseyaa/note',
         'waaseyaa/relationship',
+        // Layer 3 — Services
         'waaseyaa/workflows',
         'waaseyaa/search',
+        'waaseyaa/billing',
+        'waaseyaa/github',
+        // Layer 4 — API
         'waaseyaa/api',
         'waaseyaa/routing',
+        // Layer 5 — AI
         'waaseyaa/ai-schema',
         'waaseyaa/ai-agent',
         'waaseyaa/ai-pipeline',
         'waaseyaa/ai-vector',
+        // Layer 6 — Interfaces
         'waaseyaa/cli',
         'waaseyaa/admin',
         'waaseyaa/mcp',
         'waaseyaa/ssr',
         'waaseyaa/telescope',
-
+        'waaseyaa/deployer',
+        'waaseyaa/inertia',
     ];
 
     #[Test]


### PR DESCRIPTION
## Summary
- Classifies 6 orphan packages into Waaseyaa's 7-layer architecture: `auth` (Layer 1), `billing`/`github` (Layer 3), `deployer`/`inertia` (Layer 6), `ingestion` (Layer 0 — peer, not forbidden)
- Adds 5 new entries to `FORBIDDEN_PACKAGES`/`FORBIDDEN_DEPS` constants in both `packages/validation/tests/Unit/LayerDependencyTest.php` and `packages/foundation/tests/Unit/LayerDependencyTest.php`
- Adds layer section comments for readability

## Test plan
- [x] `./vendor/bin/phpunit packages/validation/tests/Unit/LayerDependencyTest.php packages/foundation/tests/Unit/LayerDependencyTest.php` — 2 tests, 62 assertions, OK

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)