### PR TITLE
test(#579): add ValidationResult edge case tests

### DIFF
--- a/packages/ingestion/tests/Unit/ValidationResultTest.php
+++ b/packages/ingestion/tests/Unit/ValidationResultTest.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\Ingestion\Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Waaseyaa\Ingestion\ValidationResult;
 
 #[CoversClass(ValidationResult::class)]
@@ -26,5 +27,29 @@ final class ValidationResultTest extends TestCase
         $result = new ValidationResult(['Missing field: name']);
         $this->assertFalse($result->isValid());
         $this->assertCount(1, $result->errors);
+    }
+
+    #[Test]
+    public function multipleErrorsPreservedInOrder(): void
+    {
+        $errors = ['First error', 'Second error', 'Third error'];
+        $result = new ValidationResult($errors);
+        $this->assertFalse($result->isValid());
+        $this->assertSame($errors, $result->errors);
+    }
+
+    #[Test]
+    public function emptyStringErrorCountsAsInvalid(): void
+    {
+        $result = new ValidationResult(['']);
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->errors);
+    }
+
+    #[Test]
+    public function errorsPropertyIsReadonly(): void
+    {
+        $property = new ReflectionProperty(ValidationResult::class, 'errors');
+        $this->assertTrue($property->isReadOnly());
     }
 }


### PR DESCRIPTION
## Summary
- Add 3 edge case tests to `ValidationResultTest`: multiple errors preserved in order, empty string counts as invalid, errors property is readonly
- Part of #579 ingestion package test coverage improvements

## Test plan
- [x] `./vendor/bin/phpunit packages/ingestion/tests/Unit/ValidationResultTest.php` — 5 tests, 0 failures
- [x] `composer cs-check` — no violations in changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)