### PR TITLE
test(#677): extract shared test doubles for Relationship package

### DIFF
--- a/packages/relationship/tests/Fixtures/FixedResultEntityQuery.php
+++ b/packages/relationship/tests/Fixtures/FixedResultEntityQuery.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Relationship\Tests\Fixtures;
+
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+
+/**
+ * Returns preconfigured result sets on successive execute() calls.
+ *
+ * Usage:
+ *   new FixedResultEntityQuery([[1, 2], [3, 4]])
+ *   // First execute() returns [1, 2], second returns [3, 4], subsequent return []
+ *
+ * @internal Test double for Relationship package tests.
+ */
+class FixedResultEntityQuery implements EntityQueryInterface
+{
+    private int $callCount = 0;
+
+    /** @param list<array<int|string>> $resultSets Each element is one execute() result */
+    public function __construct(private readonly array $resultSets) {}
+
+    public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
+    public function exists(string $field): static { return $this; }
+    public function notExists(string $field): static { return $this; }
+    public function sort(string $field, string $direction = 'ASC'): static { return $this; }
+    public function range(int $offset, int $limit): static { return $this; }
+    public function count(): static { return $this; }
+    public function accessCheck(bool $check = true): static { return $this; }
+
+    public function execute(): array
+    {
+        $index = $this->callCount++;
+
+        return $this->resultSets[$index] ?? [];
+    }
+}

--- a/packages/relationship/tests/Fixtures/NullEntityQuery.php
+++ b/packages/relationship/tests/Fixtures/NullEntityQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Relationship\Tests\Fixtures;
+
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+
+/**
+ * No-op EntityQuery — all chainable methods return $this, execute() returns [].
+ *
+ * @internal Test double for Relationship package tests.
+ */
+class NullEntityQuery implements EntityQueryInterface
+{
+    public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
+    public function exists(string $field): static { return $this; }
+    public function notExists(string $field): static { return $this; }
+    public function sort(string $field, string $direction = 'ASC'): static { return $this; }
+    public function range(int $offset, int $limit): static { return $this; }
+    public function count(): static { return $this; }
+    public function accessCheck(bool $check = true): static { return $this; }
+    public function execute(): array { return []; }
+}

--- a/packages/relationship/tests/Fixtures/StubEntityStorage.php
+++ b/packages/relationship/tests/Fixtures/StubEntityStorage.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Relationship\Tests\Fixtures;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+/**
+ * Configurable entity storage stub.
+ *
+ * @internal Test double for Relationship package tests.
+ */
+class StubEntityStorage implements EntityStorageInterface
+{
+    private readonly \Closure $loadHandler;
+
+    /**
+     * @param ?\Closure(int|string): ?EntityInterface $loadHandler Controls load() behavior.
+     *        Default: returns a minimal stub entity for any ID.
+     * @param ?EntityQueryInterface $query Returned by getQuery(). Default: NullEntityQuery.
+     * @param string $entityTypeId Returned by getEntityTypeId().
+     */
+    public function __construct(
+        ?\Closure $loadHandler = null,
+        private readonly ?EntityQueryInterface $query = null,
+        private readonly string $entityTypeId = 'node',
+    ) {
+        $this->loadHandler = $loadHandler ?? static function (int|string $id): EntityInterface {
+            return new class ($id) implements EntityInterface {
+                public function __construct(private readonly int|string $id) {}
+                public function id(): int|string|null { return $this->id; }
+                public function uuid(): string { return ''; }
+                public function label(): string { return 'test'; }
+                public function getEntityTypeId(): string { return 'node'; }
+                public function bundle(): string { return 'default'; }
+                public function isNew(): bool { return false; }
+                public function get(string $name): mixed { return null; }
+                public function set(string $name, mixed $value): static { return $this; }
+                public function toArray(): array { return []; }
+                public function language(): string { return 'en'; }
+            };
+        };
+    }
+
+    public function load(int|string $id): ?EntityInterface
+    {
+        return ($this->loadHandler)($id);
+    }
+
+    public function getQuery(): EntityQueryInterface
+    {
+        return $this->query ?? new NullEntityQuery();
+    }
+
+    public function getEntityTypeId(): string
+    {
+        return $this->entityTypeId;
+    }
+
+    public function create(array $values = []): EntityInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function loadByKey(string $key, mixed $value): ?EntityInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function loadMultiple(array $ids = []): array
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function save(EntityInterface $entity): int
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function delete(array $entities): void
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+}

--- a/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
+++ b/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Relationship\Tests\Fixtures;
+
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+/**
+ * Configurable EntityTypeManager stub.
+ *
+ * @internal Test double for Relationship package tests.
+ */
+class StubEntityTypeManager implements EntityTypeManagerInterface
+{
+    /**
+     * @param list<string> $knownTypes Entity type IDs that hasDefinition() returns true for.
+     * @param ?EntityStorageInterface $storage Returned by getStorage(). Default: new StubEntityStorage().
+     * @param ?\Closure(string): bool $hasDefinitionOverride Overrides hasDefinition() when set.
+     */
+    public function __construct(
+        private readonly array $knownTypes = [],
+        private readonly ?EntityStorageInterface $storage = null,
+        private readonly ?\Closure $hasDefinitionOverride = null,
+    ) {}
+
+    public function getDefinition(string $entityTypeId): EntityTypeInterface
+    {
+        return new class ($entityTypeId) implements EntityTypeInterface {
+            public function __construct(private readonly string $id) {}
+            public function id(): string { return $this->id; }
+            public function getLabel(): string { return $this->id; }
+            public function getClass(): string { return ''; }
+            public function getStorageClass(): string { return ''; }
+            public function getKeys(): array { return ['id' => 'id', 'uuid' => 'uuid']; }
+            public function isRevisionable(): bool { return false; }
+            public function getRevisionDefault(): bool { return false; }
+            public function isTranslatable(): bool { return false; }
+            public function getBundleEntityType(): ?string { return null; }
+            public function getConstraints(): array { return []; }
+            public function getFieldDefinitions(): array { return []; }
+            public function getGroup(): ?string { return null; }
+            public function getDescription(): ?string { return null; }
+        };
+    }
+
+    public function hasDefinition(string $entityTypeId): bool
+    {
+        if ($this->hasDefinitionOverride !== null) {
+            return ($this->hasDefinitionOverride)($entityTypeId);
+        }
+
+        return in_array($entityTypeId, $this->knownTypes, true);
+    }
+
+    public function getStorage(string $entityTypeId): EntityStorageInterface
+    {
+        return $this->storage ?? new StubEntityStorage();
+    }
+
+    public function getDefinitions(): array
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function registerEntityType(EntityTypeInterface $type): void
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function registerCoreEntityType(EntityTypeInterface $type): void
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+}

--- a/packages/relationship/tests/Unit/RelationshipDeleteGuardListenerTest.php
+++ b/packages/relationship/tests/Unit/RelationshipDeleteGuardListenerTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\EntityInterface;
-use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Event\EntityEvent;
-use Waaseyaa\Entity\Storage\EntityQueryInterface;
-use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Relationship\RelationshipDeleteGuardListener;
+use Waaseyaa\Relationship\Tests\Fixtures\FixedResultEntityQuery;
+use Waaseyaa\Relationship\Tests\Fixtures\StubEntityStorage;
+use Waaseyaa\Relationship\Tests\Fixtures\StubEntityTypeManager;
 
 #[CoversClass(RelationshipDeleteGuardListener::class)]
 final class RelationshipDeleteGuardListenerTest extends TestCase
@@ -22,7 +22,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function ignores_non_guarded_entity_types(): void
     {
         $entity = $this->makeEntity('taxonomy_term', 1);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: []);
+        $manager = $this->makeManager();
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         $this->expectNotToPerformAssertions();
@@ -33,7 +33,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function ignores_entities_with_null_id(): void
     {
         $entity = $this->makeEntity('node', null);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: []);
+        $manager = $this->makeManager();
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         $this->expectNotToPerformAssertions();
@@ -44,7 +44,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function allows_deletion_when_no_linked_relationships(): void
     {
         $entity = $this->makeEntity('node', 1);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: []);
+        $manager = $this->makeManager();
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         $this->expectNotToPerformAssertions();
@@ -55,7 +55,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function blocks_deletion_when_relationships_exist(): void
     {
         $entity = $this->makeEntity('node', 42);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: [10, 20, 30]);
+        $manager = $this->makeManager(outboundIds: [10, 20, 30]);
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         $this->expectException(\RuntimeException::class);
@@ -67,7 +67,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function exception_message_contains_sorted_relationship_ids(): void
     {
         $entity = $this->makeEntity('node', 5);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: [30, 10, 20]);
+        $manager = $this->makeManager(outboundIds: [30, 10, 20]);
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         try {
@@ -82,7 +82,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function defaults_to_guarding_node_entity_type(): void
     {
         $entity = $this->makeEntity('node', 1);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: [99]);
+        $manager = $this->makeManager(outboundIds: [99]);
         $listener = new RelationshipDeleteGuardListener($manager);
 
         $this->expectException(\RuntimeException::class);
@@ -93,7 +93,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function skips_when_relationship_type_not_defined(): void
     {
         $entity = $this->makeEntity('node', 1);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: [], hasRelationshipType: false);
+        $manager = $this->makeManager(hasRelationshipType: false);
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         $this->expectNotToPerformAssertions();
@@ -104,7 +104,7 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
     public function deduplicates_outbound_and_inbound_relationship_ids(): void
     {
         $entity = $this->makeEntity('node', 1);
-        $manager = new DeleteGuardStubEntityTypeManager(linkedIds: [5], inboundIds: [5]);
+        $manager = $this->makeManager(outboundIds: [5], inboundIds: [5]);
         $listener = new RelationshipDeleteGuardListener($manager, 'node');
 
         try {
@@ -114,6 +114,33 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
             $this->assertStringContainsString('[5]', $e->getMessage());
             $this->assertStringNotContainsString('5, 5', $e->getMessage());
         }
+    }
+
+    /**
+     * @param list<int|string> $outboundIds IDs returned for first query (outbound)
+     * @param list<int|string> $inboundIds  IDs returned for second query (inbound)
+     */
+    private function makeManager(
+        array $outboundIds = [],
+        array $inboundIds = [],
+        bool $hasRelationshipType = true,
+    ): EntityTypeManagerInterface {
+        $query = new FixedResultEntityQuery([$outboundIds, $inboundIds]);
+        $storage = new StubEntityStorage(
+            loadHandler: static fn () => null,
+            query: $query,
+            entityTypeId: 'relationship',
+        );
+
+        $hasDefinitionOverride = static function (string $typeId) use ($hasRelationshipType): bool {
+            return $typeId === 'relationship' ? $hasRelationshipType : true;
+        };
+
+        return new StubEntityTypeManager(
+            knownTypes: [],
+            storage: $storage,
+            hasDefinitionOverride: $hasDefinitionOverride,
+        );
     }
 
     private function makeEntity(string $entityTypeId, int|string|null $id): EntityInterface
@@ -145,107 +172,4 @@ final class RelationshipDeleteGuardListenerTest extends TestCase
             public function language(): string { return 'en'; }
         };
     }
-}
-
-// ---------------------------------------------------------------------------
-// Test doubles
-// ---------------------------------------------------------------------------
-
-/** @internal */
-final class DeleteGuardStubEntityTypeManager implements EntityTypeManagerInterface
-{
-    /**
-     * @param list<int|string> $linkedIds IDs returned for outbound query
-     * @param list<int|string> $inboundIds IDs returned for inbound query (defaults to empty)
-     */
-    public function __construct(
-        private readonly array $linkedIds,
-        private readonly array $inboundIds = [],
-        private readonly bool $hasRelationshipType = true,
-    ) {}
-
-    public function getDefinition(string $entityTypeId): EntityTypeInterface
-    {
-        throw new \RuntimeException('Not needed in test.');
-    }
-
-    public function getDefinitions(): array { return []; }
-
-    public function hasDefinition(string $entityTypeId): bool
-    {
-        if ($entityTypeId === 'relationship') {
-            return $this->hasRelationshipType;
-        }
-
-        return true;
-    }
-
-    public function getStorage(string $entityTypeId): EntityStorageInterface
-    {
-        return new DeleteGuardStubStorage($this->linkedIds, $this->inboundIds);
-    }
-
-    public function registerEntityType(EntityTypeInterface $type): void {}
-
-    public function registerCoreEntityType(EntityTypeInterface $type): void {}
-}
-
-/** @internal */
-final class DeleteGuardStubStorage implements EntityStorageInterface
-{
-    private int $queryCallCount = 0;
-
-    /**
-     * @param list<int|string> $outboundIds
-     * @param list<int|string> $inboundIds
-     */
-    public function __construct(
-        private readonly array $outboundIds,
-        private readonly array $inboundIds = [],
-    ) {}
-
-    public function create(array $values = []): EntityInterface { throw new \RuntimeException('Not needed.'); }
-
-    public function load(int|string $id): ?EntityInterface { return null; }
-
-    public function loadByKey(string $key, mixed $value): ?EntityInterface { return null; }
-
-    public function loadMultiple(array $ids = []): array { return []; }
-
-    public function save(EntityInterface $entity): int { throw new \RuntimeException('Not needed.'); }
-
-    public function delete(array $entities): void {}
-
-    public function getEntityTypeId(): string { return 'relationship'; }
-
-    public function getQuery(): EntityQueryInterface
-    {
-        $this->queryCallCount++;
-        $ids = $this->queryCallCount <= 1 ? $this->outboundIds : $this->inboundIds;
-
-        return new DeleteGuardStubQuery($ids);
-    }
-}
-
-/** @internal */
-final class DeleteGuardStubQuery implements EntityQueryInterface
-{
-    /** @param list<int|string> $resultIds */
-    public function __construct(private readonly array $resultIds) {}
-
-    public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
-
-    public function exists(string $field): static { return $this; }
-
-    public function notExists(string $field): static { return $this; }
-
-    public function sort(string $field, string $direction = 'ASC'): static { return $this; }
-
-    public function range(int $offset, int $limit): static { return $this; }
-
-    public function count(): static { return $this; }
-
-    public function accessCheck(bool $check = true): static { return $this; }
-
-    public function execute(): array { return $this->resultIds; }
 }

--- a/packages/relationship/tests/Unit/RelationshipPreSaveListenerTest.php
+++ b/packages/relationship/tests/Unit/RelationshipPreSaveListenerTest.php
@@ -8,14 +8,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\EntityInterface;
-use Waaseyaa\Entity\EntityTypeInterface;
-use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Event\EntityEvent;
-use Waaseyaa\Entity\Storage\EntityQueryInterface;
-use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Relationship\Relationship;
 use Waaseyaa\Relationship\RelationshipPreSaveListener;
 use Waaseyaa\Relationship\RelationshipValidator;
+use Waaseyaa\Relationship\Tests\Fixtures\StubEntityTypeManager;
 
 #[CoversClass(RelationshipPreSaveListener::class)]
 final class RelationshipPreSaveListenerTest extends TestCase
@@ -36,7 +33,7 @@ final class RelationshipPreSaveListenerTest extends TestCase
             public function language(): string { return 'en'; }
         };
 
-        $manager = new PreSaveStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $listener = new RelationshipPreSaveListener($validator);
 
@@ -58,7 +55,7 @@ final class RelationshipPreSaveListenerTest extends TestCase
             'weight' => '3.5',
         ]);
 
-        $manager = new PreSaveStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $listener = new RelationshipPreSaveListener($validator);
 
@@ -77,7 +74,7 @@ final class RelationshipPreSaveListenerTest extends TestCase
             'directionality' => 'invalid',
         ]);
 
-        $manager = new PreSaveStubEntityTypeManager([]);
+        $manager = new StubEntityTypeManager([]);
         $validator = new RelationshipValidator($manager);
         $listener = new RelationshipPreSaveListener($validator);
 
@@ -85,98 +82,4 @@ final class RelationshipPreSaveListenerTest extends TestCase
         $this->expectExceptionMessage('Relationship validation failed');
         $listener(new EntityEvent($entity));
     }
-}
-
-// ---------------------------------------------------------------------------
-// Test doubles
-// ---------------------------------------------------------------------------
-
-/** @internal */
-final class PreSaveStubEntityTypeManager implements EntityTypeManagerInterface
-{
-    /** @param list<string> $knownTypes */
-    public function __construct(private readonly array $knownTypes) {}
-
-    public function getDefinition(string $entityTypeId): EntityTypeInterface
-    {
-        return new class($entityTypeId) implements EntityTypeInterface {
-            public function __construct(private readonly string $id) {}
-            public function id(): string { return $this->id; }
-            public function getLabel(): string { return $this->id; }
-            public function getClass(): string { return ''; }
-            public function getStorageClass(): string { return ''; }
-            public function getKeys(): array { return ['id' => 'id', 'uuid' => 'uuid']; }
-            public function isRevisionable(): bool { return false; }
-            public function getRevisionDefault(): bool { return false; }
-            public function isTranslatable(): bool { return false; }
-            public function getBundleEntityType(): ?string { return null; }
-            public function getConstraints(): array { return []; }
-            public function getFieldDefinitions(): array { return []; }
-            public function getGroup(): ?string { return null; }
-            public function getDescription(): ?string { return null; }
-        };
-    }
-
-    public function getDefinitions(): array { return []; }
-
-    public function hasDefinition(string $entityTypeId): bool
-    {
-        return in_array($entityTypeId, $this->knownTypes, true);
-    }
-
-    public function getStorage(string $entityTypeId): EntityStorageInterface
-    {
-        return new PreSaveStubEntityStorage();
-    }
-
-    public function registerEntityType(EntityTypeInterface $type): void {}
-    public function registerCoreEntityType(EntityTypeInterface $type): void {}
-}
-
-/** @internal */
-final class PreSaveStubEntityStorage implements EntityStorageInterface
-{
-    public function create(array $values = []): EntityInterface { throw new \RuntimeException('Not needed.'); }
-
-    public function load(int|string $id): ?EntityInterface
-    {
-        return new class($id) implements EntityInterface {
-            public function __construct(private readonly int|string $id) {}
-            public function id(): int|string|null { return $this->id; }
-            public function uuid(): string { return ''; }
-            public function label(): string { return 'test'; }
-            public function getEntityTypeId(): string { return 'node'; }
-            public function bundle(): string { return 'default'; }
-            public function isNew(): bool { return false; }
-            public function get(string $name): mixed { return null; }
-            public function set(string $name, mixed $value): static { return $this; }
-            public function toArray(): array { return []; }
-            public function language(): string { return 'en'; }
-        };
-    }
-
-    public function loadByKey(string $key, mixed $value): ?EntityInterface { return null; }
-    public function loadMultiple(array $ids = []): array { return []; }
-    public function save(EntityInterface $entity): int { throw new \RuntimeException('Not needed.'); }
-    public function delete(array $entities): void {}
-
-    public function getQuery(): EntityQueryInterface
-    {
-        return new PreSaveStubEntityQuery();
-    }
-
-    public function getEntityTypeId(): string { return 'node'; }
-}
-
-/** @internal */
-final class PreSaveStubEntityQuery implements EntityQueryInterface
-{
-    public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
-    public function exists(string $field): static { return $this; }
-    public function notExists(string $field): static { return $this; }
-    public function sort(string $field, string $direction = 'ASC'): static { return $this; }
-    public function range(int $offset, int $limit): static { return $this; }
-    public function count(): static { return $this; }
-    public function accessCheck(bool $check = true): static { return $this; }
-    public function execute(): array { return []; }
 }

--- a/packages/relationship/tests/Unit/RelationshipValidatorTest.php
+++ b/packages/relationship/tests/Unit/RelationshipValidatorTest.php
@@ -7,19 +7,16 @@ namespace Waaseyaa\Relationship\Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Waaseyaa\Entity\EntityInterface;
-use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
-use Waaseyaa\Entity\Storage\EntityQueryInterface;
-use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\Relationship\RelationshipValidator;
+use Waaseyaa\Relationship\Tests\Fixtures\StubEntityTypeManager;
 
 #[CoversClass(RelationshipValidator::class)]
 final class RelationshipValidatorTest extends TestCase
 {
     private function makeValidator(?EntityTypeManagerInterface $manager = null): RelationshipValidator
     {
-        return new RelationshipValidator($manager ?? new ValidatorStubEntityTypeManager([]));
+        return new RelationshipValidator($manager ?? new StubEntityTypeManager([]));
     }
 
     // -----------------------------------------------------------------------
@@ -175,7 +172,7 @@ final class RelationshipValidatorTest extends TestCase
     #[Test]
     public function validate_accepts_valid_complete_entity(): void
     {
-        $manager = new ValidatorStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $errors = $validator->validate([
             'relationship_type' => 'references',
@@ -262,7 +259,7 @@ final class RelationshipValidatorTest extends TestCase
     #[Test]
     public function validate_accepts_confidence_in_range(): void
     {
-        $manager = new ValidatorStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $errors = $validator->validate([
             'relationship_type' => 'references',
@@ -304,7 +301,7 @@ final class RelationshipValidatorTest extends TestCase
     #[Test]
     public function validate_rejects_start_date_after_end_date(): void
     {
-        $manager = new ValidatorStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $errors = $validator->validate([
             'relationship_type' => 'references',
@@ -354,7 +351,7 @@ final class RelationshipValidatorTest extends TestCase
     #[Test]
     public function validate_rejects_unknown_entity_type(): void
     {
-        $manager = new ValidatorStubEntityTypeManager([]);
+        $manager = new StubEntityTypeManager([]);
         $validator = new RelationshipValidator($manager);
         $errors = $validator->validate([
             'relationship_type' => 'references',
@@ -405,7 +402,7 @@ final class RelationshipValidatorTest extends TestCase
     #[Test]
     public function assert_valid_does_not_throw_for_valid_entity(): void
     {
-        $manager = new ValidatorStubEntityTypeManager(['node']);
+        $manager = new StubEntityTypeManager(['node']);
         $validator = new RelationshipValidator($manager);
         $this->expectNotToPerformAssertions();
         $validator->assertValid([
@@ -427,102 +424,4 @@ final class RelationshipValidatorTest extends TestCase
         $this->expectExceptionMessage('Relationship validation failed');
         $validator->assertValid([]);
     }
-}
-
-// ---------------------------------------------------------------------------
-// Test doubles
-// ---------------------------------------------------------------------------
-
-/** @internal */
-final class ValidatorStubEntityTypeManager implements EntityTypeManagerInterface
-{
-    /** @param list<string> $knownTypes Entity types that "exist" with a loadable entity at ID "1" and "2" */
-    public function __construct(private readonly array $knownTypes) {}
-
-    public function getDefinition(string $entityTypeId): EntityTypeInterface
-    {
-        return new class($entityTypeId) implements EntityTypeInterface {
-            public function __construct(private readonly string $id) {}
-            public function id(): string { return $this->id; }
-            public function getLabel(): string { return $this->id; }
-            public function getClass(): string { return ''; }
-            public function getStorageClass(): string { return ''; }
-            public function getKeys(): array { return ['id' => 'id', 'uuid' => 'uuid']; }
-            public function isRevisionable(): bool { return false; }
-            public function getRevisionDefault(): bool { return false; }
-            public function isTranslatable(): bool { return false; }
-            public function getBundleEntityType(): ?string { return null; }
-            public function getConstraints(): array { return []; }
-            public function getFieldDefinitions(): array { return []; }
-            public function getGroup(): ?string { return null; }
-            public function getDescription(): ?string { return null; }
-        };
-    }
-
-    public function getDefinitions(): array { return []; }
-
-    public function hasDefinition(string $entityTypeId): bool
-    {
-        return in_array($entityTypeId, $this->knownTypes, true);
-    }
-
-    public function getStorage(string $entityTypeId): EntityStorageInterface
-    {
-        return new ValidatorStubEntityStorage();
-    }
-
-    public function registerEntityType(EntityTypeInterface $type): void {}
-    public function registerCoreEntityType(EntityTypeInterface $type): void {}
-}
-
-/** @internal */
-final class ValidatorStubEntityStorage implements EntityStorageInterface
-{
-    public function create(array $values = []): EntityInterface
-    {
-        throw new \RuntimeException('Not needed in test.');
-    }
-
-    public function load(int|string $id): ?EntityInterface
-    {
-        // All entities "exist" for validation tests
-        return new class($id) implements EntityInterface {
-            public function __construct(private readonly int|string $id) {}
-            public function id(): int|string|null { return $this->id; }
-            public function uuid(): string { return ''; }
-            public function label(): string { return 'test'; }
-            public function getEntityTypeId(): string { return 'node'; }
-            public function bundle(): string { return 'default'; }
-            public function isNew(): bool { return false; }
-            public function get(string $name): mixed { return null; }
-            public function set(string $name, mixed $value): static { return $this; }
-            public function toArray(): array { return []; }
-            public function language(): string { return 'en'; }
-        };
-    }
-
-    public function loadByKey(string $key, mixed $value): ?EntityInterface { return null; }
-    public function loadMultiple(array $ids = []): array { return []; }
-    public function save(EntityInterface $entity): int { throw new \RuntimeException('Not needed.'); }
-    public function delete(array $entities): void {}
-
-    public function getQuery(): EntityQueryInterface
-    {
-        return new ValidatorStubEntityQuery();
-    }
-
-    public function getEntityTypeId(): string { return 'node'; }
-}
-
-/** @internal */
-final class ValidatorStubEntityQuery implements EntityQueryInterface
-{
-    public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
-    public function exists(string $field): static { return $this; }
-    public function notExists(string $field): static { return $this; }
-    public function sort(string $field, string $direction = 'ASC'): static { return $this; }
-    public function range(int $offset, int $limit): static { return $this; }
-    public function count(): static { return $this; }
-    public function accessCheck(bool $check = true): static { return $this; }
-    public function execute(): array { return []; }
 }


### PR DESCRIPTION
## Summary
- Extract 4 shared fixture classes (`NullEntityQuery`, `FixedResultEntityQuery`, `StubEntityStorage`, `StubEntityTypeManager`) into `packages/relationship/tests/Fixtures/`
- Refactor 3 test files to use shared fixtures, removing 9 inline stub classes (~323 lines removed, ~276 added including the reusable fixtures)
- All 65 relationship tests pass with no regressions

## Test plan
- [x] `./vendor/bin/phpunit packages/relationship/tests/` — all 65 tests pass
- [x] `composer cs-check` — no new violations (pre-existing issues only)
- [x] `composer phpstan` — no new errors (pre-existing issue only)
- [x] No inline stub classes remain in refactored test files

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)