### PR TITLE
feat(graphql): auto-inject account_id and tenant_id on create mutations

### DIFF
--- a/packages/graphql/src/GraphQlEndpoint.php
+++ b/packages/graphql/src/GraphQlEndpoint.php
@@ -89,7 +89,7 @@ final class GraphQlEndpoint
             $guard,
             $this->maxDepth,
         );
-        $entityResolver = new EntityResolver($this->entityTypeManager, $guard);
+        $entityResolver = new EntityResolver($this->entityTypeManager, $guard, $this->account);
 
         $schemaFactory = new SchemaFactory(
             entityTypeManager: $this->entityTypeManager,

--- a/packages/graphql/src/Resolver/EntityResolver.php
+++ b/packages/graphql/src/Resolver/EntityResolver.php
@@ -9,6 +9,7 @@ use Waaseyaa\Api\Query\ParsedQuery;
 use Waaseyaa\Api\Query\QueryApplier;
 use Waaseyaa\Api\Query\QueryFilter;
 use Waaseyaa\Api\Query\QuerySort;
+use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\FieldableInterface;
@@ -32,6 +33,7 @@ final class EntityResolver
     public function __construct(
         private readonly EntityTypeManagerInterface $entityTypeManager,
         private readonly GraphQlAccessGuard $guard,
+        private readonly ?AccountInterface $account = null,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -127,6 +129,8 @@ final class EntityResolver
     public function resolveCreate(string $entityTypeId, array $input): array
     {
         $this->guard->assertCreateAccess($entityTypeId);
+
+        $input = $this->injectAccountContext($entityTypeId, $input);
 
         $storage = $this->entityTypeManager->getStorage($entityTypeId);
         $entity = $storage->create($input);
@@ -269,5 +273,35 @@ final class EntityResolver
         }
 
         return $sorts;
+    }
+
+    /**
+     * Auto-inject account_id and tenant_id from the authenticated account
+     * when the entity type defines those fields and the input omits them.
+     *
+     * @param array<string, mixed> $input
+     * @return array<string, mixed>
+     */
+    private function injectAccountContext(string $entityTypeId, array $input): array
+    {
+        if ($this->account === null || !$this->account->isAuthenticated()) {
+            return $input;
+        }
+
+        $definition = $this->entityTypeManager->getDefinition($entityTypeId);
+        $fieldDefinitions = $definition->getFieldDefinitions();
+
+        if (isset($fieldDefinitions['account_id']) && !isset($input['account_id'])) {
+            $input['account_id'] = (string) $this->account->id();
+        }
+
+        if (isset($fieldDefinitions['tenant_id']) && !isset($input['tenant_id'])) {
+            $tenantId = $this->account->getTenantId();
+            if ($tenantId !== null) {
+                $input['tenant_id'] = $tenantId;
+            }
+        }
+
+        return $input;
     }
 }


### PR DESCRIPTION
## Summary
- Add `AccountInterface` parameter to `EntityResolver` constructor
- `resolveCreate()` auto-populates `account_id` and `tenant_id` from the authenticated account when the entity type defines those fields and the mutation input omits them
- Prevents orphaned entities that are invisible to access policies after GraphQL creation

## Context
Claudriel's admin SPA creates workspaces via GraphQL mutations without sending `account_id`. The new workspace gets `account_id = null`, making it invisible to `WorkspaceAccessPolicy`, causing the response query to time out (jonesrussell/claudriel#557).

## Test plan
- [ ] All 93 graphql package tests pass
- [ ] Create workspace via GraphQL mutation without `account_id` in input — workspace gets auto-populated `account_id`
- [ ] Explicit `account_id` in input is preserved (not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)