### PR TITLE
test(#639): add CLI tests for schedule:run and schedule:list commands

### DIFF
--- a/packages/cli/tests/Unit/Command/ScheduleListCommandTest.php
+++ b/packages/cli/tests/Unit/Command/ScheduleListCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\ScheduleListCommand;
+use Waaseyaa\Scheduler\ScheduledTask;
+use Waaseyaa\Scheduler\ScheduleInterface;
+
+#[CoversClass(ScheduleListCommand::class)]
+final class ScheduleListCommandTest extends TestCase
+{
+    #[Test]
+    public function lists_registered_tasks(): void
+    {
+        $schedule = $this->makeSchedule([
+            new ScheduledTask(
+                name: 'cache:clear',
+                expression: '0 * * * *',
+                command: static fn () => null,
+                description: 'Clear expired cache',
+            ),
+            new ScheduledTask(
+                name: 'report:generate',
+                expression: '0 0 * * *',
+                command: static fn () => null,
+                preventOverlap: true,
+            ),
+        ]);
+
+        $command = new ScheduleListCommand($schedule);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('2 scheduled task(s)', $display);
+        self::assertStringContainsString('cache:clear', $display);
+        self::assertStringContainsString('0 * * * *', $display);
+        self::assertStringContainsString('Clear expired cache', $display);
+        self::assertStringContainsString('report:generate', $display);
+        self::assertStringContainsString('[no-overlap]', $display);
+    }
+
+    #[Test]
+    public function shows_empty_message_when_no_tasks(): void
+    {
+        $schedule = $this->makeSchedule([]);
+
+        $command = new ScheduleListCommand($schedule);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('No scheduled tasks registered.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function returns_success_status_code(): void
+    {
+        $schedule = $this->makeSchedule([
+            new ScheduledTask(
+                name: 'heartbeat',
+                expression: '* * * * *',
+                command: static fn () => null,
+            ),
+        ]);
+
+        $command = new ScheduleListCommand($schedule);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @param list<ScheduledTask> $tasks
+     */
+    private function makeSchedule(array $tasks): ScheduleInterface
+    {
+        return new class ($tasks) implements ScheduleInterface {
+            /** @param list<ScheduledTask> $tasks */
+            public function __construct(private readonly array $tasks) {}
+
+            public function tasks(): array
+            {
+                return $this->tasks;
+            }
+
+            public function add(ScheduledTask $task): static
+            {
+                throw new \BadMethodCallException('Not implemented.');
+            }
+        };
+    }
+}

--- a/packages/cli/tests/Unit/Command/ScheduleRunCommandTest.php
+++ b/packages/cli/tests/Unit/Command/ScheduleRunCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\CLI\Command\ScheduleRunCommand;
+use Waaseyaa\Queue\QueueInterface;
+use Waaseyaa\Scheduler\Lock\InMemoryLock;
+use Waaseyaa\Scheduler\ScheduledTask;
+use Waaseyaa\Scheduler\ScheduleInterface;
+use Waaseyaa\Scheduler\ScheduleRunner;
+
+#[CoversClass(ScheduleRunCommand::class)]
+final class ScheduleRunCommandTest extends TestCase
+{
+    #[Test]
+    public function shows_executed_task_names(): void
+    {
+        $schedule = $this->makeSchedule([
+            new ScheduledTask(
+                name: 'cache:clear',
+                expression: '* * * * *',
+                command: static fn () => null,
+            ),
+            new ScheduledTask(
+                name: 'report:daily',
+                expression: '* * * * *',
+                command: static fn () => null,
+            ),
+        ]);
+
+        $runner = new ScheduleRunner($schedule, $this->makeQueue(), new InMemoryLock());
+        $command = new ScheduleRunCommand($runner);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('cache:clear', $display);
+        self::assertStringContainsString('report:daily', $display);
+        self::assertStringContainsString('Executed 2 scheduled tasks.', $display);
+    }
+
+    #[Test]
+    public function shows_no_tasks_due_message(): void
+    {
+        $schedule = $this->makeSchedule([]);
+
+        $runner = new ScheduleRunner($schedule, $this->makeQueue(), new InMemoryLock());
+        $command = new ScheduleRunCommand($runner);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('No scheduled tasks are due.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function shows_singular_label_for_one_task(): void
+    {
+        $schedule = $this->makeSchedule([
+            new ScheduledTask(
+                name: 'heartbeat',
+                expression: '* * * * *',
+                command: static fn () => null,
+            ),
+        ]);
+
+        $runner = new ScheduleRunner($schedule, $this->makeQueue(), new InMemoryLock());
+        $command = new ScheduleRunCommand($runner);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('Executed 1 scheduled task.', $tester->getDisplay());
+    }
+
+    /**
+     * @param list<ScheduledTask> $tasks
+     */
+    private function makeSchedule(array $tasks): ScheduleInterface
+    {
+        return new class ($tasks) implements ScheduleInterface {
+            /** @param list<ScheduledTask> $tasks */
+            public function __construct(private readonly array $tasks) {}
+
+            public function tasks(): array
+            {
+                return $this->tasks;
+            }
+
+            public function add(ScheduledTask $task): static
+            {
+                throw new \BadMethodCallException('Not implemented.');
+            }
+        };
+    }
+
+    private function makeQueue(): QueueInterface
+    {
+        return new class implements QueueInterface {
+            public function dispatch(object $message): void {}
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScheduleListCommandTest` (3 tests): verifies task listing output, empty schedule message, and success status code
- Add `ScheduleRunCommandTest` (3 tests): verifies executed task output, no-tasks-due message, and singular/plural label

## Test plan
- [x] `./vendor/bin/phpunit packages/cli/tests/` — all 6 new tests pass (18 assertions)
- [x] `composer cs-check` — no new violations
- [x] `composer phpstan` — no new errors (pre-existing ProviderRegistry warning unrelated)

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)