### PR TITLE
feat(#646): apply field defaults from EntityType on create()

### DIFF
--- a/packages/entity-storage/src/SqlEntityStorage.php
+++ b/packages/entity-storage/src/SqlEntityStorage.php
@@ -60,6 +60,12 @@ final class SqlEntityStorage implements EntityStorageInterface
 
     public function create(array $values = []): EntityInterface
     {
+        foreach ($this->entityType->getFieldDefinitions() as $name => $def) {
+            if (!array_key_exists($name, $values) && array_key_exists('default', $def)) {
+                $values[$name] = $def['default'];
+            }
+        }
+
         $class = $this->entityType->getClass();
         $entity = $this->instantiateEntity($class, $values);
 

--- a/packages/entity-storage/tests/Unit/SqlEntityStorageTest.php
+++ b/packages/entity-storage/tests/Unit/SqlEntityStorageTest.php
@@ -468,6 +468,29 @@ final class SqlEntityStorageTest extends TestCase
         $configStorage->save($entity);
     }
 
+    /** @param array<string, array<string, mixed>> $fieldDefinitions */
+    private function createStorageWithFields(string $id, array $fieldDefinitions): SqlEntityStorage
+    {
+        $entityType = new EntityType(
+            id: $id,
+            label: ucfirst($id),
+            class: TestStorageEntity::class,
+            keys: [
+                'id' => 'id',
+                'uuid' => 'uuid',
+                'bundle' => 'bundle',
+                'label' => 'label',
+                'langcode' => 'langcode',
+            ],
+            fieldDefinitions: $fieldDefinitions,
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $this->database);
+        $schemaHandler->ensureTable();
+
+        return new SqlEntityStorage($entityType, $this->database, $this->eventDispatcher);
+    }
+
     private function createConfigStorage(): SqlEntityStorage
     {
         $configType = new EntityType(
@@ -511,6 +534,39 @@ final class SqlEntityStorageTest extends TestCase
 
         $storage->save($entity);
         $this->assertGreaterThan(0, $factory->callCount, 'Custom event factory should be called during save');
+    }
+
+    public function testCreateAppliesFieldDefaults(): void
+    {
+        $storage = $this->createStorageWithFields('default_test', [
+            'status' => ['type' => 'integer', 'default' => 1],
+        ]);
+
+        $entity = $storage->create([]);
+
+        $this->assertSame(1, $entity->get('status'));
+    }
+
+    public function testCreateExplicitValuesOverrideDefaults(): void
+    {
+        $storage = $this->createStorageWithFields('override_test', [
+            'status' => ['type' => 'integer', 'default' => 1],
+        ]);
+
+        $entity = $storage->create(['status' => 0]);
+
+        $this->assertSame(0, $entity->get('status'));
+    }
+
+    public function testCreateSkipsFieldsWithoutDefaultKey(): void
+    {
+        $storage = $this->createStorageWithFields('nodefault_test', [
+            'title' => ['type' => 'string'],
+        ]);
+
+        $entity = $storage->create([]);
+
+        $this->assertNull($entity->get('title'));
     }
 
     public function testLoadByKeyReturnsEntityOnHit(): void


### PR DESCRIPTION
## Summary
- `SqlEntityStorage::create()` now merges `default` values from `EntityType::getFieldDefinitions()` into the values array before entity instantiation
- Explicit caller-provided values take precedence over defaults
- Uses `array_key_exists('default', $def)` to allow `null` as a valid default value

## Test plan
- [x] `testCreateAppliesFieldDefaults` — entity gets default `status = 1` when no value provided
- [x] `testCreateExplicitValuesOverrideDefaults` — explicit `status = 0` overrides default of `1`
- [x] `testCreateSkipsFieldsWithoutDefaultKey` — fields without a `default` key are not injected
- [x] All 180 entity-storage tests pass
- [x] No cs-check violations in changed files
- [x] Pre-existing phpstan error unrelated to this change

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)