### PR TITLE
feat(#647): add json field type with typed accessor

### DIFF
--- a/packages/entity-storage/src/SqlEntityStorage.php
+++ b/packages/entity-storage/src/SqlEntityStorage.php
@@ -298,6 +298,19 @@ final class SqlEntityStorage implements EntityStorageInterface
             $row = array_merge($row, $extra);
         }
 
+        // Decode json field values from JSON strings back to arrays.
+        $jsonFields = $this->getJsonFieldNames();
+        foreach ($jsonFields as $fieldName => $_) {
+            if (isset($row[$fieldName]) && is_string($row[$fieldName])) {
+                try {
+                    $row[$fieldName] = json_decode($row[$fieldName], associative: true, depth: 512, flags: \JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    $this->logger->warning(sprintf('Corrupt JSON in field "%s" for %s entity %s: %s', $fieldName, $this->tableName, $row[$this->idKey] ?? '?', $e->getMessage()));
+                    $row[$fieldName] = null;
+                }
+            }
+        }
+
         /** @var EntityInterface $entity */
         $entity = $this->instantiateEntity($class, $row);
 
@@ -351,6 +364,7 @@ final class SqlEntityStorage implements EntityStorageInterface
      *
      * Values whose keys match actual table columns are stored directly.
      * All other values are JSON-encoded into the _data column.
+     * Fields with type 'json' are JSON-encoded before storage.
      *
      * @param array<string, mixed> $values
      * @return array<string, mixed>
@@ -358,6 +372,7 @@ final class SqlEntityStorage implements EntityStorageInterface
     private function splitForStorage(array $values): array
     {
         $schema = $this->database->schema();
+        $jsonFields = $this->getJsonFieldNames();
         $dbValues = [];
         $extraData = [];
 
@@ -366,6 +381,10 @@ final class SqlEntityStorage implements EntityStorageInterface
                 continue;
             }
             if ($this->columnExists($key, $schema)) {
+                // Encode json field values that are arrays/objects to JSON strings.
+                if (isset($jsonFields[$key]) && !is_string($value) && $value !== null) {
+                    $value = json_encode($value, \JSON_THROW_ON_ERROR);
+                }
                 $dbValues[$key] = $value;
             } else {
                 $extraData[$key] = $value;
@@ -399,6 +418,30 @@ final class SqlEntityStorage implements EntityStorageInterface
                 $entity->set('changed', $now);
             }
         }
+    }
+
+    /** @var array<string, true>|null Cached json field names for this entity type. */
+    private ?array $jsonFieldCache = null;
+
+    /**
+     * Returns field names whose type is 'json', keyed by name.
+     *
+     * @return array<string, true>
+     */
+    private function getJsonFieldNames(): array
+    {
+        if ($this->jsonFieldCache !== null) {
+            return $this->jsonFieldCache;
+        }
+
+        $this->jsonFieldCache = [];
+        foreach ($this->entityType->getFieldDefinitions() as $name => $def) {
+            if (($def['type'] ?? null) === 'json') {
+                $this->jsonFieldCache[$name] = true;
+            }
+        }
+
+        return $this->jsonFieldCache;
     }
 
     /**

--- a/packages/entity-storage/tests/Unit/SqlEntityStorageTest.php
+++ b/packages/entity-storage/tests/Unit/SqlEntityStorageTest.php
@@ -600,6 +600,43 @@ final class SqlEntityStorageTest extends TestCase
         $this->assertSame($entity->id(), $found->id());
     }
 
+    public function testJsonFieldRoundTrip(): void
+    {
+        $storage = $this->createStorageWithFields('json_test', [
+            'metadata' => ['type' => 'json'],
+        ]);
+
+        $entity = $storage->create([
+            'label' => 'JSON Test',
+            'bundle' => 'article',
+            'metadata' => ['tags' => ['php', 'waaseyaa'], 'version' => 2],
+        ]);
+        $storage->save($entity);
+
+        $loaded = $storage->load($entity->id());
+        $this->assertNotNull($loaded);
+        $this->assertIsArray($loaded->get('metadata'));
+        $this->assertSame(['tags' => ['php', 'waaseyaa'], 'version' => 2], $loaded->get('metadata'));
+    }
+
+    public function testJsonFieldNullRoundTrip(): void
+    {
+        $storage = $this->createStorageWithFields('json_null_test', [
+            'metadata' => ['type' => 'json'],
+        ]);
+
+        $entity = $storage->create([
+            'label' => 'JSON Null Test',
+            'bundle' => 'article',
+            'metadata' => null,
+        ]);
+        $storage->save($entity);
+
+        $loaded = $storage->load($entity->id());
+        $this->assertNotNull($loaded);
+        $this->assertNull($loaded->get('metadata'));
+    }
+
     public function testPreSaveMutationsArePersisted(): void
     {
         $this->eventDispatcher->addListener(

--- a/packages/field/src/Item/JsonItem.php
+++ b/packages/field/src/Item/JsonItem.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Field\Item;
+
+use Waaseyaa\Field\Attribute\FieldType;
+use Waaseyaa\Field\FieldItemBase;
+
+#[FieldType(
+    id: 'json',
+    label: 'JSON',
+    description: 'A field containing a JSON-encoded value.',
+    category: 'general',
+    defaultCardinality: 1,
+)]
+class JsonItem extends FieldItemBase
+{
+    public static function propertyDefinitions(): array
+    {
+        return [
+            'value' => 'string',
+        ];
+    }
+
+    public static function mainPropertyName(): string
+    {
+        return 'value';
+    }
+
+    public static function schema(): array
+    {
+        return [
+            'value' => ['type' => 'text'],
+        ];
+    }
+
+    public static function jsonSchema(): array
+    {
+        return ['type' => 'object'];
+    }
+}

--- a/packages/field/tests/Unit/Item/JsonItemTest.php
+++ b/packages/field/tests/Unit/Item/JsonItemTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Field\Tests\Unit\Item;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Field\Item\JsonItem;
+
+#[CoversClass(JsonItem::class)]
+final class JsonItemTest extends TestCase
+{
+    #[Test]
+    public function schemaReturnsTextColumn(): void
+    {
+        $schema = JsonItem::schema();
+
+        $this->assertSame(['value' => ['type' => 'text']], $schema);
+    }
+
+    #[Test]
+    public function defaultValueReturnsNull(): void
+    {
+        $this->assertNull(JsonItem::defaultValue());
+    }
+
+    #[Test]
+    public function defaultSettingsReturnsEmptyArray(): void
+    {
+        $this->assertSame([], JsonItem::defaultSettings());
+    }
+
+    #[Test]
+    public function jsonSchemaReturnsObjectType(): void
+    {
+        $schema = JsonItem::jsonSchema();
+
+        $this->assertSame(['type' => 'object'], $schema);
+    }
+
+    #[Test]
+    public function propertyDefinitionsReturnValueAsString(): void
+    {
+        $this->assertSame(['value' => 'string'], JsonItem::propertyDefinitions());
+    }
+
+    #[Test]
+    public function mainPropertyNameReturnsValue(): void
+    {
+        $this->assertSame('value', JsonItem::mainPropertyName());
+    }
+}

--- a/packages/graphql/src/Schema/FieldTypeMapper.php
+++ b/packages/graphql/src/Schema/FieldTypeMapper.php
@@ -31,7 +31,7 @@ final class FieldTypeMapper
     {
         $known = true;
         $type = match ($fieldType) {
-            'string', 'email', 'uri', 'timestamp', 'datetime', 'list_string' => Type::string(),
+            'string', 'email', 'uri', 'timestamp', 'datetime', 'list_string', 'json' => Type::string(),
             'integer' => Type::int(),
             'boolean' => Type::boolean(),
             'float', 'decimal' => Type::float(),
@@ -50,7 +50,7 @@ final class FieldTypeMapper
     public function toInputType(string $fieldType, bool $isMultiple): Type
     {
         $type = match ($fieldType) {
-            'string', 'email', 'uri', 'timestamp', 'datetime', 'list_string' => Type::string(),
+            'string', 'email', 'uri', 'timestamp', 'datetime', 'list_string', 'json' => Type::string(),
             'integer' => Type::int(),
             'boolean' => Type::boolean(),
             'float', 'decimal' => Type::float(),


### PR DESCRIPTION
## Summary
- Adds `JsonItem` field type (`packages/field/src/Item/JsonItem.php`) following existing `StringItem`/`IntegerItem` patterns
- Modifies `SqlEntityStorage` to transparently JSON-encode on save and JSON-decode on load for fields with `'type' => 'json'`
- Maps `json` to `Type::string()` in GraphQL `FieldTypeMapper` for both input and output types

Closes #647

## Test plan
- [x] `JsonItemTest` — schema, defaultValue, defaultSettings, jsonSchema, propertyDefinitions, mainPropertyName
- [x] `SqlEntityStorageTest::testJsonFieldRoundTrip` — save array, load back as PHP array
- [x] `SqlEntityStorageTest::testJsonFieldNullRoundTrip` — save null, load back as null
- [x] `packages/field/tests/` — 254 tests pass
- [x] `packages/entity-storage/tests/` — 182 tests pass
- [x] `composer cs-check` — no new violations
- [x] `composer phpstan` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)