### PR TITLE
feat(ssr): add flash messaging with Twig extension — Refs #697

### DIFF
--- a/packages/ssr/src/Flash/Flash.php
+++ b/packages/ssr/src/Flash/Flash.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Flash;
+
+final class Flash
+{
+    private static ?FlashMessageService $service = null;
+
+    public static function setService(FlashMessageService $service): void
+    {
+        self::$service = $service;
+    }
+
+    /** Reset for test isolation. */
+    public static function resetService(): void
+    {
+        self::$service = null;
+    }
+
+    public static function success(string $message): void
+    {
+        self::getService()->addSuccess($message);
+    }
+
+    public static function error(string $message): void
+    {
+        self::getService()->addError($message);
+    }
+
+    public static function info(string $message): void
+    {
+        self::getService()->addInfo($message);
+    }
+
+    private static function getService(): FlashMessageService
+    {
+        if (self::$service === null) {
+            self::$service = new FlashMessageService();
+        }
+
+        return self::$service;
+    }
+}

--- a/packages/ssr/src/Flash/FlashMessageService.php
+++ b/packages/ssr/src/Flash/FlashMessageService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Flash;
+
+final class FlashMessageService
+{
+    private const string SESSION_KEY = 'flash_messages';
+
+    public function addSuccess(string $message): void
+    {
+        $this->add('success', $message);
+    }
+
+    public function addError(string $message): void
+    {
+        $this->add('error', $message);
+    }
+
+    public function addInfo(string $message): void
+    {
+        $this->add('info', $message);
+    }
+
+    /**
+     * @return list<array{type: string, message: string}>
+     */
+    public function consumeAll(): array
+    {
+        if (!isset($_SESSION[self::SESSION_KEY]) || !is_array($_SESSION[self::SESSION_KEY])) {
+            return [];
+        }
+
+        $messages = $_SESSION[self::SESSION_KEY];
+        unset($_SESSION[self::SESSION_KEY]);
+
+        $allowedTypes = ['success', 'error', 'info'];
+
+        return array_values(array_filter($messages, static function (mixed $msg) use ($allowedTypes): bool {
+            return is_array($msg)
+                && isset($msg['type'], $msg['message'])
+                && is_string($msg['type'])
+                && is_string($msg['message'])
+                && $msg['message'] !== ''
+                && in_array($msg['type'], $allowedTypes, true);
+        }));
+    }
+
+    private function add(string $type, string $message): void
+    {
+        if (!isset($_SESSION[self::SESSION_KEY]) || !is_array($_SESSION[self::SESSION_KEY])) {
+            $_SESSION[self::SESSION_KEY] = [];
+        }
+
+        $_SESSION[self::SESSION_KEY][] = ['type' => $type, 'message' => $message];
+    }
+}

--- a/packages/ssr/src/SsrServiceProvider.php
+++ b/packages/ssr/src/SsrServiceProvider.php
@@ -6,6 +6,9 @@ namespace Waaseyaa\SSR;
 
 use Twig\Environment;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\SSR\Flash\Flash;
+use Waaseyaa\SSR\Flash\FlashMessageService;
+use Waaseyaa\SSR\Twig\FlashTwigExtension;
 
 final class SsrServiceProvider extends ServiceProvider
 {
@@ -26,6 +29,12 @@ final class SsrServiceProvider extends ServiceProvider
         self::$twigEnvironment = ThemeServiceProvider::getTwigEnvironment()
             ?? self::createTwigEnvironment($this->projectRoot, $this->config);
         self::$formatterRegistry = new FieldFormatterRegistry($this->manifestFormatters);
+
+        $flashService = new FlashMessageService();
+        Flash::setService($flashService);
+        if (self::$twigEnvironment !== null) {
+            self::$twigEnvironment->addExtension(new FlashTwigExtension($flashService));
+        }
     }
 
     public static function getTwigEnvironment(): ?Environment

--- a/packages/ssr/src/Twig/FlashTwigExtension.php
+++ b/packages/ssr/src/Twig/FlashTwigExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use Waaseyaa\SSR\Flash\FlashMessageService;
+
+final class FlashTwigExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly FlashMessageService $flashService,
+    ) {}
+
+    /** @return TwigFunction[] */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('flash_messages', $this->flashMessages(...)),
+        ];
+    }
+
+    /**
+     * @return list<array{type: string, message: string}>
+     */
+    public function flashMessages(): array
+    {
+        return $this->flashService->consumeAll();
+    }
+}

--- a/packages/ssr/tests/Unit/Flash/FlashMessageServiceTest.php
+++ b/packages/ssr/tests/Unit/Flash/FlashMessageServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit\Flash;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\SSR\Flash\FlashMessageService;
+
+#[CoversClass(FlashMessageService::class)]
+final class FlashMessageServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    #[Test]
+    public function adds_and_consumes_success_message(): void
+    {
+        $service = new FlashMessageService();
+        $service->addSuccess('It worked');
+
+        $messages = $service->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('success', $messages[0]['type']);
+        $this->assertSame('It worked', $messages[0]['message']);
+    }
+
+    #[Test]
+    public function adds_and_consumes_error_message(): void
+    {
+        $service = new FlashMessageService();
+        $service->addError('Something broke');
+
+        $messages = $service->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('error', $messages[0]['type']);
+    }
+
+    #[Test]
+    public function adds_and_consumes_info_message(): void
+    {
+        $service = new FlashMessageService();
+        $service->addInfo('FYI');
+
+        $messages = $service->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('info', $messages[0]['type']);
+    }
+
+    #[Test]
+    public function consume_clears_messages(): void
+    {
+        $service = new FlashMessageService();
+        $service->addSuccess('First');
+        $service->consumeAll();
+
+        $this->assertSame([], $service->consumeAll());
+    }
+
+    #[Test]
+    public function returns_empty_array_when_no_messages(): void
+    {
+        $service = new FlashMessageService();
+        $this->assertSame([], $service->consumeAll());
+    }
+
+    #[Test]
+    public function filters_invalid_session_data(): void
+    {
+        $_SESSION['flash_messages'] = [
+            ['type' => 'success', 'message' => 'valid'],
+            'not an array',
+            ['type' => 'invalid_type', 'message' => 'bad type'],
+            ['type' => 'success', 'message' => ''],
+        ];
+
+        $service = new FlashMessageService();
+        $messages = $service->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('valid', $messages[0]['message']);
+    }
+}

--- a/packages/ssr/tests/Unit/Flash/FlashTest.php
+++ b/packages/ssr/tests/Unit/Flash/FlashTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit\Flash;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\SSR\Flash\Flash;
+use Waaseyaa\SSR\Flash\FlashMessageService;
+
+#[CoversClass(Flash::class)]
+final class FlashTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+        Flash::setService(new FlashMessageService());
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        Flash::resetService();
+    }
+
+    #[Test]
+    public function success_delegates_to_service(): void
+    {
+        Flash::success('Saved');
+        $messages = (new FlashMessageService())->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('success', $messages[0]['type']);
+    }
+
+    #[Test]
+    public function error_delegates_to_service(): void
+    {
+        Flash::error('Failed');
+        $messages = (new FlashMessageService())->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('error', $messages[0]['type']);
+    }
+
+    #[Test]
+    public function info_delegates_to_service(): void
+    {
+        Flash::info('Note');
+        $messages = (new FlashMessageService())->consumeAll();
+        $this->assertCount(1, $messages);
+        $this->assertSame('info', $messages[0]['type']);
+    }
+}


### PR DESCRIPTION
## Summary
- Add session-backed `FlashMessageService` with type-validated add/consume API (success, error, info)
- Add `Flash` static facade for convenient controller access
- Add `FlashTwigExtension` exposing `flash_messages()` function in templates
- Wire all three into `SsrServiceProvider::boot()`

## Test plan
- [x] 9 unit tests pass (6 for FlashMessageService, 3 for Flash facade)
- [x] Tests cover: add/consume per type, consume clears, empty state, invalid session data filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)