### PR TITLE
feat(user): add UserBlock entity, access policy, and block service — Refs #702

### DIFF
--- a/packages/user/src/UserBlock.php
+++ b/packages/user/src/UserBlock.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+final class UserBlock extends ContentEntityBase
+{
+    protected string $entityTypeId = 'user_block';
+
+    protected array $entityKeys = [
+        'id' => 'ubid',
+        'uuid' => 'uuid',
+        'label' => 'blocker_id',
+    ];
+
+    /** @param array<string, mixed> $values */
+    public function __construct(array $values = [])
+    {
+        foreach (['blocker_id', 'blocked_id'] as $field) {
+            if (!isset($values[$field])) {
+                throw new \InvalidArgumentException("Missing required field: {$field}");
+            }
+        }
+
+        if ((int) $values['blocker_id'] === (int) $values['blocked_id']) {
+            throw new \InvalidArgumentException('Cannot block yourself');
+        }
+
+        if (!array_key_exists('created_at', $values)) {
+            $values['created_at'] = time();
+        }
+
+        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+    }
+}

--- a/packages/user/src/UserBlockAccessPolicy.php
+++ b/packages/user/src/UserBlockAccessPolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+#[PolicyAttribute(entityType: 'user_block')]
+final class UserBlockAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'user_block';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $blockerId = $entity->get('blocker_id');
+
+        if ($blockerId !== null && (int) $blockerId === (int) $account->id()) {
+            return AccessResult::allowed('Blocker may manage own blocks.');
+        }
+
+        return AccessResult::neutral('Only the blocker may access this block.');
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->isAuthenticated()) {
+            return AccessResult::allowed('Authenticated users may create blocks.');
+        }
+
+        return AccessResult::neutral('Anonymous users cannot create blocks.');
+    }
+}

--- a/packages/user/src/UserBlockService.php
+++ b/packages/user/src/UserBlockService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User;
+
+use Waaseyaa\Entity\EntityTypeManager;
+
+final class UserBlockService
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {}
+
+    public function isBlocked(int $blockerId, int $blockedId): bool
+    {
+        $ids = $this->entityTypeManager->getStorage('user_block')
+            ->getQuery()
+            ->condition('blocker_id', $blockerId)
+            ->condition('blocked_id', $blockedId)
+            ->range(0, 1)
+            ->execute();
+
+        return $ids !== [];
+    }
+}

--- a/packages/user/tests/Unit/UserBlockAccessPolicyTest.php
+++ b/packages/user/tests/Unit/UserBlockAccessPolicyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\User\UserBlockAccessPolicy;
+
+#[CoversClass(UserBlockAccessPolicy::class)]
+final class UserBlockAccessPolicyTest extends TestCase
+{
+    private UserBlockAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new UserBlockAccessPolicy();
+    }
+
+    #[Test]
+    public function applies_to_user_block(): void
+    {
+        $this->assertTrue($this->policy->appliesTo('user_block'));
+        $this->assertFalse($this->policy->appliesTo('post'));
+    }
+
+    #[Test]
+    public function admin_is_always_allowed(): void
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('hasPermission')->with('administer content')->willReturn(true);
+
+        $entity = $this->createMock(EntityInterface::class);
+
+        $result = $this->policy->access($entity, 'view', $account);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function blocker_can_manage_own_blocks(): void
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('id')->willReturn(42);
+
+        $entity = $this->createMock(EntityInterface::class);
+        $entity->method('get')->with('blocker_id')->willReturn(42);
+
+        $result = $this->policy->access($entity, 'delete', $account);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function non_owner_is_neutral(): void
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('id')->willReturn(99);
+
+        $entity = $this->createMock(EntityInterface::class);
+        $entity->method('get')->with('blocker_id')->willReturn(42);
+
+        $result = $this->policy->access($entity, 'view', $account);
+        $this->assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function authenticated_can_create(): void
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('isAuthenticated')->willReturn(true);
+
+        $result = $this->policy->createAccess('user_block', 'user_block', $account);
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_cannot_create(): void
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('isAuthenticated')->willReturn(false);
+
+        $result = $this->policy->createAccess('user_block', 'user_block', $account);
+        $this->assertTrue($result->isNeutral());
+    }
+}

--- a/packages/user/tests/Unit/UserBlockServiceTest.php
+++ b/packages/user/tests/Unit/UserBlockServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\User\UserBlockService;
+
+#[CoversClass(UserBlockService::class)]
+final class UserBlockServiceTest extends TestCase
+{
+    #[Test]
+    public function returns_true_when_block_exists(): void
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('range')->willReturnSelf();
+        $query->method('execute')->willReturn([1]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getStorage')->with('user_block')->willReturn($storage);
+
+        $service = new UserBlockService($etm);
+        $this->assertTrue($service->isBlocked(42, 99));
+    }
+
+    #[Test]
+    public function returns_false_when_no_block(): void
+    {
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('condition')->willReturnSelf();
+        $query->method('range')->willReturnSelf();
+        $query->method('execute')->willReturn([]);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $etm = $this->createMock(EntityTypeManager::class);
+        $etm->method('getStorage')->with('user_block')->willReturn($storage);
+
+        $service = new UserBlockService($etm);
+        $this->assertFalse($service->isBlocked(42, 99));
+    }
+}

--- a/packages/user/tests/Unit/UserBlockTest.php
+++ b/packages/user/tests/Unit/UserBlockTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\User\UserBlock;
+
+#[CoversClass(UserBlock::class)]
+final class UserBlockTest extends TestCase
+{
+    #[Test]
+    public function creates_with_required_fields(): void
+    {
+        $block = new UserBlock(['blocker_id' => 1, 'blocked_id' => 2]);
+        $this->assertSame(1, (int) $block->get('blocker_id'));
+        $this->assertSame(2, (int) $block->get('blocked_id'));
+        $this->assertNotNull($block->get('created_at'));
+    }
+
+    #[Test]
+    public function uses_provided_created_at(): void
+    {
+        $block = new UserBlock(['blocker_id' => 1, 'blocked_id' => 2, 'created_at' => 1000]);
+        $this->assertSame(1000, (int) $block->get('created_at'));
+    }
+
+    #[Test]
+    public function requires_blocker_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('blocker_id');
+        new UserBlock(['blocked_id' => 2]);
+    }
+
+    #[Test]
+    public function requires_blocked_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('blocked_id');
+        new UserBlock(['blocker_id' => 1]);
+    }
+
+    #[Test]
+    public function rejects_self_block(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot block yourself');
+        new UserBlock(['blocker_id' => 1, 'blocked_id' => 1]);
+    }
+}


### PR DESCRIPTION
## Summary

- Added `UserBlock` content entity with constructor validation (required `blocker_id`/`blocked_id`, self-block rejection, auto `created_at`)
- Added `UserBlockAccessPolicy` with `#[PolicyAttribute(entityType: 'user_block')]` — admin full access, owner-based management, authenticated create
- Added `UserBlockService` with `isBlocked()` query method
- 13 unit tests covering all validation paths, access decisions, and service behavior

## Test plan

- [x] `UserBlockTest` — 5 tests: create, provided created_at, missing blocker_id, missing blocked_id, self-block rejection
- [x] `UserBlockAccessPolicyTest` — 6 tests: appliesTo, admin allowed, blocker owns, non-owner neutral, auth create, anon create
- [x] `UserBlockServiceTest` — 2 tests: block exists returns true, no block returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)