### PR TITLE
feat(mail): add MailDriverInterface, SendGridDriver, MailServiceProvider — Refs #699

### DIFF
--- a/packages/mail/src/Driver/SendGridDriver.php
+++ b/packages/mail/src/Driver/SendGridDriver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mail\Driver;
+
+use SendGrid;
+use SendGrid\Mail\Mail;
+use Waaseyaa\Mail\MailDriverInterface;
+use Waaseyaa\Mail\MailMessage;
+
+final class SendGridDriver implements MailDriverInterface
+{
+    private SendGrid $client;
+
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $fromAddress,
+        private readonly string $fromName,
+    ) {
+        $this->client = new SendGrid($this->apiKey);
+    }
+
+    public function send(MailMessage $message): int
+    {
+        if (!$this->isConfigured()) {
+            throw new \RuntimeException('Mail driver is not configured.');
+        }
+
+        $email = new Mail();
+        $email->setFrom($message->from ?: $this->fromAddress, $message->fromName ?: $this->fromName);
+        $email->setSubject($message->subject);
+        $email->addTo($message->to);
+
+        if ($message->body !== '') {
+            $email->addContent('text/plain', $message->body);
+        }
+
+        if ($message->htmlBody !== '') {
+            $email->addContent('text/html', $message->htmlBody);
+        }
+
+        $response = $this->client->send($email);
+        $statusCode = $response->statusCode();
+
+        if ($statusCode >= 400) {
+            throw new \RuntimeException(sprintf(
+                'SendGrid returned HTTP %d: %s',
+                $statusCode,
+                $response->body(),
+            ));
+        }
+
+        return $statusCode;
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiKey !== '' && $this->fromAddress !== '';
+    }
+}

--- a/packages/mail/src/MailDriverInterface.php
+++ b/packages/mail/src/MailDriverInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mail;
+
+interface MailDriverInterface
+{
+    /**
+     * Send an email message.
+     *
+     * @return int HTTP status code (202 = accepted for SendGrid)
+     * @throws \RuntimeException on failure
+     */
+    public function send(MailMessage $message): int;
+
+    public function isConfigured(): bool;
+}

--- a/packages/mail/src/MailMessage.php
+++ b/packages/mail/src/MailMessage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mail;
+
+final class MailMessage
+{
+    public function __construct(
+        public readonly string $from,
+        public readonly string $to,
+        public readonly string $subject,
+        public readonly string $body,
+        public readonly string $htmlBody = '',
+        public readonly string $fromName = '',
+    ) {}
+}

--- a/packages/mail/tests/Unit/Driver/SendGridDriverTest.php
+++ b/packages/mail/tests/Unit/Driver/SendGridDriverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mail\Tests\Unit\Driver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Mail\Driver\SendGridDriver;
+use Waaseyaa\Mail\MailMessage;
+
+#[CoversClass(SendGridDriver::class)]
+final class SendGridDriverTest extends TestCase
+{
+    #[Test]
+    public function is_not_configured_with_empty_api_key(): void
+    {
+        $driver = new SendGridDriver('', 'from@example.com', 'App');
+        $this->assertFalse($driver->isConfigured());
+    }
+
+    #[Test]
+    public function is_not_configured_with_empty_from_address(): void
+    {
+        $driver = new SendGridDriver('key', '', 'App');
+        $this->assertFalse($driver->isConfigured());
+    }
+
+    #[Test]
+    public function is_configured_with_all_values(): void
+    {
+        $driver = new SendGridDriver('key', 'from@example.com', 'App');
+        $this->assertTrue($driver->isConfigured());
+    }
+
+    #[Test]
+    public function send_throws_when_not_configured(): void
+    {
+        $driver = new SendGridDriver('', '', '');
+        $msg = new MailMessage(
+            from: 'a@b.com',
+            to: 'c@d.com',
+            subject: 'Test',
+            body: 'Hello',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Mail driver is not configured');
+        $driver->send($msg);
+    }
+}

--- a/packages/mail/tests/Unit/MailMessageTest.php
+++ b/packages/mail/tests/Unit/MailMessageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mail\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Mail\MailMessage;
+
+#[CoversClass(MailMessage::class)]
+final class MailMessageTest extends TestCase
+{
+    #[Test]
+    public function creates_plain_text_message(): void
+    {
+        $msg = new MailMessage(
+            from: 'sender@example.com',
+            to: 'recipient@example.com',
+            subject: 'Test Subject',
+            body: 'Hello world',
+        );
+
+        $this->assertSame('sender@example.com', $msg->from);
+        $this->assertSame('recipient@example.com', $msg->to);
+        $this->assertSame('Test Subject', $msg->subject);
+        $this->assertSame('Hello world', $msg->body);
+        $this->assertSame('', $msg->htmlBody);
+        $this->assertSame('', $msg->fromName);
+    }
+
+    #[Test]
+    public function creates_html_message_with_from_name(): void
+    {
+        $msg = new MailMessage(
+            from: 'sender@example.com',
+            to: 'recipient@example.com',
+            subject: 'HTML Test',
+            body: 'Plain fallback',
+            htmlBody: '<h1>Hello</h1>',
+            fromName: 'Test App',
+        );
+
+        $this->assertSame('<h1>Hello</h1>', $msg->htmlBody);
+        $this->assertSame('Test App', $msg->fromName);
+    }
+}


### PR DESCRIPTION
## Summary
- `MailDriverInterface` with `send(MailMessage): int` and `isConfigured(): bool`
- `MailMessage` value object (from, to, subject, body, htmlBody, fromName)
- `SendGridDriver` implementing the interface
- `MailServiceProvider` with config-driven driver selection

Part of Batch 2 framework extraction from Minoo.

## Test plan
- [x] All mail package tests pass

Refs: #699