### PR TITLE
feat(user): add AuthMailer + wire all Batch 2 services — Refs #695, #702

### DIFF
--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -39,6 +39,14 @@
         {
             "type": "path",
             "url": "../queue"
+        },
+        {
+            "type": "path",
+            "url": "../mail"
+        },
+        {
+            "type": "path",
+            "url": "../ssr"
         }
     ],
     "require": {
@@ -46,7 +54,9 @@
         "waaseyaa/entity": "^0.1",
         "waaseyaa/access": "^0.1",
         "waaseyaa/foundation": "^0.1",
-        "symfony/http-foundation": "^7.0"
+        "waaseyaa/mail": "^0.1",
+        "symfony/http-foundation": "^7.0",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/user/src/AuthMailer.php
+++ b/packages/user/src/AuthMailer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User;
+
+use Twig\Environment;
+use Waaseyaa\Entity\FieldableInterface;
+use Waaseyaa\Mail\MailDriverInterface;
+use Waaseyaa\Mail\MailMessage;
+
+class AuthMailer
+{
+    public function __construct(
+        private readonly MailDriverInterface $driver,
+        private readonly Environment $twig,
+        private readonly string $baseUrl,
+        private readonly string $appName,
+    ) {}
+
+    public function isConfigured(): bool
+    {
+        return $this->driver->isConfigured();
+    }
+
+    public function sendPasswordReset(FieldableInterface $user, string $token): void
+    {
+        if (!$this->driver->isConfigured()) {
+            return;
+        }
+
+        $vars = [
+            'user_name' => $user->get('name'),
+            'reset_url' => $this->baseUrl . '/reset-password?token=' . $token,
+        ];
+
+        $html = $this->twig->render('email/password-reset.html.twig', $vars);
+        $text = $this->twig->render('email/password-reset.txt.twig', $vars);
+
+        $this->driver->send(new MailMessage(
+            from: '',
+            to: $user->get('mail'),
+            subject: "Reset your {$this->appName} password",
+            body: $text,
+            htmlBody: $html,
+        ));
+    }
+
+    public function sendEmailVerification(FieldableInterface $user, string $token): void
+    {
+        if (!$this->driver->isConfigured()) {
+            return;
+        }
+
+        $vars = [
+            'user_name' => $user->get('name'),
+            'verify_url' => $this->baseUrl . '/verify-email?token=' . $token,
+        ];
+
+        $html = $this->twig->render('email/email-verification.html.twig', $vars);
+        $text = $this->twig->render('email/email-verification.txt.twig', $vars);
+
+        $this->driver->send(new MailMessage(
+            from: '',
+            to: $user->get('mail'),
+            subject: "Verify your email for {$this->appName}",
+            body: $text,
+            htmlBody: $html,
+        ));
+    }
+
+    public function sendWelcome(FieldableInterface $user): void
+    {
+        if (!$this->driver->isConfigured()) {
+            return;
+        }
+
+        $vars = [
+            'user_name' => $user->get('name'),
+            'home_url' => $this->baseUrl,
+        ];
+
+        $html = $this->twig->render('email/welcome.html.twig', $vars);
+        $text = $this->twig->render('email/welcome.txt.twig', $vars);
+
+        $this->driver->send(new MailMessage(
+            from: '',
+            to: $user->get('mail'),
+            subject: "Welcome to {$this->appName}",
+            body: $text,
+            htmlBody: $html,
+        ));
+    }
+}

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Waaseyaa\User;
 
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Mail\MailDriverInterface;
 
 final class UserServiceProvider extends ServiceProvider
 {
@@ -37,6 +39,35 @@ final class UserServiceProvider extends ServiceProvider
                     'weight' => 20,
                 ],
             ],
+        ));
+
+        $this->entityType(new EntityType(
+            id: 'user_block',
+            label: 'User Block',
+            class: UserBlock::class,
+            keys: ['id' => 'ubid', 'uuid' => 'uuid', 'label' => 'blocker_id'],
+            group: 'user',
+            fieldDefinitions: [
+                'blocker_id' => ['type' => 'integer', 'label' => 'Blocker ID', 'weight' => 0],
+                'blocked_id' => ['type' => 'integer', 'label' => 'Blocked ID', 'weight' => 1],
+                'created_at' => ['type' => 'timestamp', 'label' => 'Created', 'weight' => 10],
+            ],
+        ));
+
+        $this->singleton(UserBlockService::class, fn () => new UserBlockService(
+            $this->resolve(EntityTypeManager::class),
+        ));
+
+        $this->singleton(PasswordResetTokenRepository::class, fn () => new PasswordResetTokenRepository(
+            $this->resolve(\PDO::class),
+        ));
+
+        $config = $this->config ?? [];
+        $this->singleton(AuthMailer::class, fn () => new AuthMailer(
+            driver: $this->resolve(MailDriverInterface::class),
+            twig: \Waaseyaa\SSR\SsrServiceProvider::getTwigEnvironment(),
+            baseUrl: $config['app']['url'] ?? '',
+            appName: $config['app']['name'] ?? 'Waaseyaa',
         ));
     }
 }

--- a/packages/user/tests/Unit/AuthMailerTest.php
+++ b/packages/user/tests/Unit/AuthMailerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\User\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Waaseyaa\Mail\MailDriverInterface;
+use Waaseyaa\Mail\MailMessage;
+use Waaseyaa\User\AuthMailer;
+use Waaseyaa\Entity\FieldableInterface;
+
+#[CoversClass(AuthMailer::class)]
+final class AuthMailerTest extends TestCase
+{
+    /** @var list<MailMessage> */
+    public array $sentMessages = [];
+    private MailDriverInterface $driver;
+    private Environment $twig;
+    private AuthMailer $mailer;
+
+    protected function setUp(): void
+    {
+        $this->sentMessages = [];
+
+        $this->driver = new class($this) implements MailDriverInterface {
+            public function __construct(private readonly AuthMailerTest $test) {}
+            public function send(MailMessage $message): int
+            {
+                $this->test->sentMessages[] = $message;
+                return 202;
+            }
+            public function isConfigured(): bool { return true; }
+        };
+
+        $this->twig = new Environment(new ArrayLoader([
+            'email/password-reset.html.twig' => '<p>Reset: {{ reset_url }}</p>',
+            'email/password-reset.txt.twig' => 'Reset: {{ reset_url }}',
+            'email/email-verification.html.twig' => '<p>Verify: {{ verify_url }}</p>',
+            'email/email-verification.txt.twig' => 'Verify: {{ verify_url }}',
+            'email/welcome.html.twig' => '<p>Welcome {{ user_name }}</p>',
+            'email/welcome.txt.twig' => 'Welcome {{ user_name }}',
+        ]));
+
+        $this->mailer = new AuthMailer(
+            driver: $this->driver,
+            twig: $this->twig,
+            baseUrl: 'https://example.com',
+            appName: 'TestApp',
+        );
+    }
+
+    #[Test]
+    public function sends_password_reset_email(): void
+    {
+        $user = $this->createMock(FieldableInterface::class);
+        $user->method('get')->willReturnMap([
+            ['name', 'Alice'],
+            ['mail', 'alice@example.com'],
+        ]);
+
+        $this->mailer->sendPasswordReset($user, 'abc123');
+
+        $this->assertCount(1, $this->sentMessages);
+        $msg = $this->sentMessages[0];
+        $this->assertSame('alice@example.com', $msg->to);
+        $this->assertSame('Reset your TestApp password', $msg->subject);
+        $this->assertStringContainsString('reset-password?token=abc123', $msg->htmlBody);
+    }
+
+    #[Test]
+    public function sends_email_verification(): void
+    {
+        $user = $this->createMock(FieldableInterface::class);
+        $user->method('get')->willReturnMap([
+            ['name', 'Bob'],
+            ['mail', 'bob@example.com'],
+        ]);
+
+        $this->mailer->sendEmailVerification($user, 'xyz789');
+
+        $this->assertCount(1, $this->sentMessages);
+        $msg = $this->sentMessages[0];
+        $this->assertSame('Verify your email for TestApp', $msg->subject);
+        $this->assertStringContainsString('verify-email?token=xyz789', $msg->htmlBody);
+    }
+
+    #[Test]
+    public function sends_welcome_email(): void
+    {
+        $user = $this->createMock(FieldableInterface::class);
+        $user->method('get')->willReturnMap([
+            ['name', 'Carol'],
+            ['mail', 'carol@example.com'],
+        ]);
+
+        $this->mailer->sendWelcome($user);
+
+        $this->assertCount(1, $this->sentMessages);
+        $msg = $this->sentMessages[0];
+        $this->assertSame('Welcome to TestApp', $msg->subject);
+        $this->assertStringContainsString('Welcome Carol', $msg->htmlBody);
+    }
+
+    #[Test]
+    public function skips_sending_when_driver_not_configured(): void
+    {
+        $unconfigured = new class implements MailDriverInterface {
+            public function send(MailMessage $message): int { return 202; }
+            public function isConfigured(): bool { return false; }
+        };
+
+        $mailer = new AuthMailer($unconfigured, $this->twig, 'https://example.com', 'App');
+        $user = $this->createMock(FieldableInterface::class);
+
+        $mailer->sendPasswordReset($user, 'token');
+        $this->assertCount(0, $this->sentMessages);
+    }
+}

--- a/packages/user/tests/Unit/UserServiceProviderTest.php
+++ b/packages/user/tests/Unit/UserServiceProviderTest.php
@@ -21,7 +21,7 @@ final class UserServiceProviderTest extends TestCase
 
         $entityTypes = $provider->getEntityTypes();
 
-        $this->assertCount(1, $entityTypes);
+        $this->assertCount(2, $entityTypes);
         $this->assertSame('user', $entityTypes[0]->id());
         $this->assertSame('User', $entityTypes[0]->getLabel());
         $this->assertSame(User::class, $entityTypes[0]->getClass());


### PR DESCRIPTION
## Summary
- AuthMailer with configurable app name (password reset, verification, welcome emails)
- UserServiceProvider wires: user_block entity, UserBlockService, PasswordResetTokenRepository, AuthMailer
- user composer.json adds waaseyaa/mail + twig dependencies
- Uses FieldableInterface instead of final User class for testability

Depends on: #711 (PasswordResetTokenRepository), #712 (UserBlock), #713 (mail package) — all merged.

## Test plan
- [x] All 160 user package tests pass

Refs: #695, #702