### PR TITLE
fix(engagement): skip reaction type validation when no allowed list — Refs #701

### DIFF
--- a/packages/engagement/src/Reaction.php
+++ b/packages/engagement/src/Reaction.php
@@ -16,11 +16,9 @@ final class Reaction extends ContentEntityBase
         'label' => 'reaction_type',
     ];
 
-    public const array DEFAULT_REACTION_TYPES = ['like', 'love', 'celebrate'];
-
     /**
      * @param array<string, mixed> $values
-     * @param list<string>|null $allowedReactionTypes Custom allowed types (null = use defaults)
+     * @param list<string>|null $allowedReactionTypes Allowed types (null = accept any non-empty string)
      */
     public function __construct(array $values = [], ?array $allowedReactionTypes = null)
     {
@@ -30,10 +28,9 @@ final class Reaction extends ContentEntityBase
             }
         }
 
-        $allowed = $allowedReactionTypes ?? self::DEFAULT_REACTION_TYPES;
-        if (!in_array($values['reaction_type'], $allowed, true)) {
+        if ($allowedReactionTypes !== null && !in_array($values['reaction_type'], $allowedReactionTypes, true)) {
             throw new \InvalidArgumentException(
-                "Invalid reaction_type '{$values['reaction_type']}'. Allowed: " . implode(', ', $allowed),
+                "Invalid reaction_type '{$values['reaction_type']}'. Allowed: " . implode(', ', $allowedReactionTypes),
             );
         }
 

--- a/packages/engagement/tests/Unit/ReactionTest.php
+++ b/packages/engagement/tests/Unit/ReactionTest.php
@@ -44,16 +44,16 @@ final class ReactionTest extends TestCase
     }
 
     #[Test]
-    public function rejects_invalid_reaction_type_with_defaults(): void
+    public function accepts_any_type_when_no_allowed_list(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid reaction_type');
-        new Reaction([
+        $reaction = new Reaction([
             'user_id' => 1,
             'target_type' => 'post',
             'target_id' => 1,
-            'reaction_type' => 'invalid',
+            'reaction_type' => 'miigwech',
         ]);
+
+        $this->assertSame('miigwech', $reaction->get('reaction_type'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
When `allowedReactionTypes` is null (default), accept any non-empty string.
This allows `SqlEntityStorage::instantiateEntity()` to create Reaction
entities without passing the second constructor arg.

Apps configure allowed types explicitly via EngagementServiceProvider config.

## Test plan
- [x] All 19 engagement tests pass
- [x] `accepts_any_type_when_no_allowed_list` test added

Refs: #701