### PR TITLE
fix(engagement): remove dead DEFAULT_REACTION_TYPES reference

### DIFF
--- a/packages/engagement/src/EngagementServiceProvider.php
+++ b/packages/engagement/src/EngagementServiceProvider.php
@@ -11,8 +11,6 @@ final class EngagementServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $reactionTypes = $this->config['engagement']['reaction_types'] ?? Reaction::DEFAULT_REACTION_TYPES;
-
         $this->entityType(new EntityType(
             id: 'reaction',
             label: 'Reaction',


### PR DESCRIPTION
Fixes CI — the constant was removed from Reaction but the provider still referenced it.