### PR TITLE
feat(oauth-provider): add foundation package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         { "type": "path", "url": "packages/scheduler" },
         { "type": "path", "url": "packages/notification" },
         { "type": "path", "url": "packages/http-client" },
-        { "type": "path", "url": "packages/messaging" }
+        { "type": "path", "url": "packages/messaging" },
+        { "type": "path", "url": "packages/oauth-provider" }
     ],
     "require": {
         "php": ">=8.4",
@@ -93,6 +94,7 @@
         "waaseyaa/node": "@dev",
         "waaseyaa/note": "@dev",
         "waaseyaa/notification": "@dev",
+        "waaseyaa/oauth-provider": "@dev",
         "waaseyaa/path": "@dev",
         "waaseyaa/plugin": "@dev",
         "waaseyaa/queue": "@dev",
@@ -118,6 +120,7 @@
     "autoload": {
         "psr-4": {
             "Waaseyaa\\GitHub\\": "packages/github/src/",
+            "Waaseyaa\\OAuthProvider\\": "packages/oauth-provider/src/",
             "Waaseyaa\\Engagement\\": "packages/engagement/src/"
         }
     },
@@ -167,6 +170,7 @@
             "Waaseyaa\\Auth\\Tests\\": "packages/auth/tests/",
             "Waaseyaa\\Billing\\Tests\\": "packages/billing/tests/",
             "Waaseyaa\\HttpClient\\Tests\\": "packages/http-client/tests/",
+            "Waaseyaa\\OAuthProvider\\Tests\\": "packages/oauth-provider/tests/",
             "Waaseyaa\\Engagement\\Tests\\": "packages/engagement/tests/",
             "Waaseyaa\\Tests\\": "tests/"
         }

--- a/packages/oauth-provider/composer.json
+++ b/packages/oauth-provider/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "waaseyaa/oauth-provider",
+    "description": "OAuth 2.0 provider abstraction for Waaseyaa applications",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.4",
+        "waaseyaa/http-client": "^0.1.0-alpha"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Waaseyaa\\OAuthProvider\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Waaseyaa\\OAuthProvider\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.1.x-dev"
+        }
+    }
+}

--- a/packages/oauth-provider/phpunit.xml
+++ b/packages/oauth-provider/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="../../vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/packages/oauth-provider/src/OAuthException.php
+++ b/packages/oauth-provider/src/OAuthException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final class OAuthException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly string $provider,
+        public readonly int $httpStatusCode = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/oauth-provider/src/OAuthProviderInterface.php
+++ b/packages/oauth-provider/src/OAuthProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+interface OAuthProviderInterface
+{
+    public function getName(): string;
+
+    /**
+     * @param array<string> $scopes
+     */
+    public function getAuthorizationUrl(array $scopes, string $state): string;
+
+    public function exchangeCode(string $code): OAuthToken;
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    public function refreshToken(string $refreshToken): OAuthToken;
+
+    public function getUserProfile(string $accessToken): OAuthUserProfile;
+}

--- a/packages/oauth-provider/src/OAuthStateManager.php
+++ b/packages/oauth-provider/src/OAuthStateManager.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final class OAuthStateManager
+{
+    public function __construct(
+        private readonly int $ttlSeconds = 600,
+    ) {}
+
+    public function generate(SessionInterface $session): string
+    {
+        $state = bin2hex(random_bytes(32));
+        $session->set('_oauth_state', $state);
+        $session->set('_oauth_state_ts', time());
+
+        return $state;
+    }
+
+    public function validate(SessionInterface $session, string $state): bool
+    {
+        $storedState = $session->get('_oauth_state');
+        $storedTimestamp = $session->get('_oauth_state_ts');
+
+        if ($storedState === null || $storedTimestamp === null) {
+            return false;
+        }
+
+        $session->remove('_oauth_state');
+        $session->remove('_oauth_state_ts');
+
+        if (!\is_string($storedState) || !hash_equals($storedState, $state)) {
+            return false;
+        }
+
+        if (!\is_int($storedTimestamp) || (time() - $storedTimestamp) > $this->ttlSeconds) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/packages/oauth-provider/src/OAuthToken.php
+++ b/packages/oauth-provider/src/OAuthToken.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final readonly class OAuthToken
+{
+    /**
+     * @param array<string> $scopes
+     */
+    public function __construct(
+        public string $accessToken,
+        public ?string $refreshToken,
+        public ?\DateTimeImmutable $expiresAt,
+        public array $scopes,
+        public string $tokenType = 'Bearer',
+    ) {}
+
+    public function isExpired(): bool
+    {
+        if ($this->expiresAt === null) {
+            return false;
+        }
+
+        return $this->expiresAt < new \DateTimeImmutable();
+    }
+}

--- a/packages/oauth-provider/src/OAuthUserProfile.php
+++ b/packages/oauth-provider/src/OAuthUserProfile.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final readonly class OAuthUserProfile
+{
+    public function __construct(
+        public string $providerId,
+        public string $email,
+        public string $name,
+        public ?string $avatarUrl = null,
+    ) {}
+}

--- a/packages/oauth-provider/src/ProviderRegistry.php
+++ b/packages/oauth-provider/src/ProviderRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final class ProviderRegistry
+{
+    /** @var array<string, OAuthProviderInterface> */
+    private array $providers = [];
+
+    public function register(string $name, OAuthProviderInterface $provider): void
+    {
+        $this->providers[$name] = $provider;
+    }
+
+    public function get(string $name): OAuthProviderInterface
+    {
+        if (!isset($this->providers[$name])) {
+            throw new \InvalidArgumentException(sprintf('OAuth provider "%s" is not registered.', $name));
+        }
+
+        return $this->providers[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->providers[$name]);
+    }
+
+    /**
+     * @return array<string, OAuthProviderInterface>
+     */
+    public function all(): array
+    {
+        return $this->providers;
+    }
+}

--- a/packages/oauth-provider/src/SessionInterface.php
+++ b/packages/oauth-provider/src/SessionInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+interface SessionInterface
+{
+    public function get(string $key): mixed;
+
+    public function set(string $key, mixed $value): void;
+
+    public function remove(string $key): void;
+}

--- a/packages/oauth-provider/src/UnsupportedOperationException.php
+++ b/packages/oauth-provider/src/UnsupportedOperationException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider;
+
+final class UnsupportedOperationException extends \LogicException
+{
+    public function __construct(string $provider, string $operation)
+    {
+        parent::__construct(sprintf('Provider "%s" does not support %s.', $provider, $operation));
+    }
+}

--- a/packages/oauth-provider/tests/Unit/OAuthStateManagerTest.php
+++ b/packages/oauth-provider/tests/Unit/OAuthStateManagerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\OAuthProvider\OAuthStateManager;
+use Waaseyaa\OAuthProvider\SessionInterface;
+
+#[CoversClass(OAuthStateManager::class)]
+final class OAuthStateManagerTest extends TestCase
+{
+    public function testGenerateReturns64CharHexString(): void
+    {
+        $manager = new OAuthStateManager();
+        $session = new InMemorySession();
+
+        $state = $manager->generate($session);
+
+        self::assertSame(64, strlen($state));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $state);
+    }
+
+    public function testValidateReturnsTrueForValidState(): void
+    {
+        $manager = new OAuthStateManager();
+        $session = new InMemorySession();
+
+        $state = $manager->generate($session);
+
+        self::assertTrue($manager->validate($session, $state));
+    }
+
+    public function testValidateConsumesState(): void
+    {
+        $manager = new OAuthStateManager();
+        $session = new InMemorySession();
+
+        $state = $manager->generate($session);
+        $manager->validate($session, $state);
+
+        self::assertFalse($manager->validate($session, $state));
+    }
+
+    public function testValidateReturnsFalseForWrongState(): void
+    {
+        $manager = new OAuthStateManager();
+        $session = new InMemorySession();
+
+        $manager->generate($session);
+
+        self::assertFalse($manager->validate($session, 'wrong_state'));
+    }
+
+    public function testValidateReturnsFalseWhenNoStateInSession(): void
+    {
+        $manager = new OAuthStateManager();
+        $session = new InMemorySession();
+
+        self::assertFalse($manager->validate($session, 'any_state'));
+    }
+
+    public function testValidateReturnsFalseWhenExpired(): void
+    {
+        $manager = new OAuthStateManager(ttlSeconds: 0);
+        $session = new InMemorySession();
+
+        $state = $manager->generate($session);
+        sleep(1);
+
+        self::assertFalse($manager->validate($session, $state));
+    }
+}
+
+final class InMemorySession implements SessionInterface
+{
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    public function get(string $key): mixed
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+}

--- a/packages/oauth-provider/tests/Unit/OAuthTokenTest.php
+++ b/packages/oauth-provider/tests/Unit/OAuthTokenTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\OAuthProvider\OAuthToken;
+
+#[CoversClass(OAuthToken::class)]
+final class OAuthTokenTest extends TestCase
+{
+    public function testConstructorSetsAllFields(): void
+    {
+        $expiresAt = new \DateTimeImmutable('+1 hour');
+        $token = new OAuthToken(
+            accessToken: 'access_123',
+            refreshToken: 'refresh_456',
+            expiresAt: $expiresAt,
+            scopes: ['read', 'write'],
+            tokenType: 'Bearer',
+        );
+
+        self::assertSame('access_123', $token->accessToken);
+        self::assertSame('refresh_456', $token->refreshToken);
+        self::assertSame($expiresAt, $token->expiresAt);
+        self::assertSame(['read', 'write'], $token->scopes);
+        self::assertSame('Bearer', $token->tokenType);
+    }
+
+    public function testTokenTypeDefaultsToBearer(): void
+    {
+        $token = new OAuthToken(
+            accessToken: 'access_123',
+            refreshToken: null,
+            expiresAt: null,
+            scopes: [],
+        );
+
+        self::assertSame('Bearer', $token->tokenType);
+    }
+
+    public function testIsExpiredReturnsFalseWhenExpiresAtIsNull(): void
+    {
+        $token = new OAuthToken(
+            accessToken: 'access_123',
+            refreshToken: null,
+            expiresAt: null,
+            scopes: [],
+        );
+
+        self::assertFalse($token->isExpired());
+    }
+
+    public function testIsExpiredReturnsTrueForPastExpiry(): void
+    {
+        $token = new OAuthToken(
+            accessToken: 'access_123',
+            refreshToken: null,
+            expiresAt: new \DateTimeImmutable('-1 hour'),
+            scopes: [],
+        );
+
+        self::assertTrue($token->isExpired());
+    }
+
+    public function testIsExpiredReturnsFalseForFutureExpiry(): void
+    {
+        $token = new OAuthToken(
+            accessToken: 'access_123',
+            refreshToken: null,
+            expiresAt: new \DateTimeImmutable('+1 hour'),
+            scopes: [],
+        );
+
+        self::assertFalse($token->isExpired());
+    }
+}

--- a/packages/oauth-provider/tests/Unit/OAuthUserProfileTest.php
+++ b/packages/oauth-provider/tests/Unit/OAuthUserProfileTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\OAuthProvider\OAuthUserProfile;
+
+#[CoversClass(OAuthUserProfile::class)]
+final class OAuthUserProfileTest extends TestCase
+{
+    public function testConstructorSetsAllFields(): void
+    {
+        $profile = new OAuthUserProfile(
+            providerId: 'google_123',
+            email: 'user@example.com',
+            name: 'Test User',
+            avatarUrl: 'https://example.com/avatar.jpg',
+        );
+
+        self::assertSame('google_123', $profile->providerId);
+        self::assertSame('user@example.com', $profile->email);
+        self::assertSame('Test User', $profile->name);
+        self::assertSame('https://example.com/avatar.jpg', $profile->avatarUrl);
+    }
+
+    public function testAvatarUrlDefaultsToNull(): void
+    {
+        $profile = new OAuthUserProfile(
+            providerId: 'google_123',
+            email: 'user@example.com',
+            name: 'Test User',
+        );
+
+        self::assertNull($profile->avatarUrl);
+    }
+}

--- a/packages/oauth-provider/tests/Unit/ProviderRegistryTest.php
+++ b/packages/oauth-provider/tests/Unit/ProviderRegistryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\OAuthProvider\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\OAuthProvider\OAuthProviderInterface;
+use Waaseyaa\OAuthProvider\OAuthToken;
+use Waaseyaa\OAuthProvider\OAuthUserProfile;
+use Waaseyaa\OAuthProvider\ProviderRegistry;
+
+#[CoversClass(ProviderRegistry::class)]
+final class ProviderRegistryTest extends TestCase
+{
+    public function testRegisterAndGet(): void
+    {
+        $registry = new ProviderRegistry();
+        $provider = $this->createStub(OAuthProviderInterface::class);
+
+        $registry->register('google', $provider);
+
+        self::assertSame($provider, $registry->get('google'));
+    }
+
+    public function testGetThrowsForUnregisteredProvider(): void
+    {
+        $registry = new ProviderRegistry();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('OAuth provider "github" is not registered.');
+
+        $registry->get('github');
+    }
+
+    public function testHasReturnsTrueForRegisteredProvider(): void
+    {
+        $registry = new ProviderRegistry();
+        $provider = $this->createStub(OAuthProviderInterface::class);
+
+        $registry->register('google', $provider);
+
+        self::assertTrue($registry->has('google'));
+    }
+
+    public function testHasReturnsFalseForUnregisteredProvider(): void
+    {
+        $registry = new ProviderRegistry();
+
+        self::assertFalse($registry->has('google'));
+    }
+
+    public function testAllReturnsAllProviders(): void
+    {
+        $registry = new ProviderRegistry();
+        $google = $this->createStub(OAuthProviderInterface::class);
+        $github = $this->createStub(OAuthProviderInterface::class);
+
+        $registry->register('google', $google);
+        $registry->register('github', $github);
+
+        $all = $registry->all();
+
+        self::assertCount(2, $all);
+        self::assertSame($google, $all['google']);
+        self::assertSame($github, $all['github']);
+    }
+}


### PR DESCRIPTION
## Summary
- New `waaseyaa/oauth-provider` package with OAuth 2.0 provider abstractions
- Value objects: `OAuthToken` (with expiry check), `OAuthUserProfile`
- Interfaces: `OAuthProviderInterface`, `SessionInterface`
- Infrastructure: `OAuthStateManager` (CSRF state generation/validation with TTL), `ProviderRegistry`
- Exceptions: `OAuthException`, `UnsupportedOperationException`
- 18 unit tests, 29 assertions, PHPStan max level clean

## Test plan
- [x] `vendor/bin/phpunit packages/oauth-provider/tests/` — 18 tests pass
- [x] `vendor/bin/phpstan analyse packages/oauth-provider/src/ --level=max` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)