### PR TITLE
feat(foundation): add LogLevel::severity() and fromName() (#729)

### DIFF
--- a/packages/foundation/src/Log/LogLevel.php
+++ b/packages/foundation/src/Log/LogLevel.php
@@ -14,4 +14,23 @@ enum LogLevel: string
     case NOTICE = 'notice';
     case INFO = 'info';
     case DEBUG = 'debug';
+
+    public function severity(): int
+    {
+        return match ($this) {
+            self::DEBUG => 0,
+            self::INFO => 1,
+            self::NOTICE => 2,
+            self::WARNING => 3,
+            self::ERROR => 4,
+            self::CRITICAL => 5,
+            self::ALERT => 6,
+            self::EMERGENCY => 7,
+        };
+    }
+
+    public static function fromName(string $name): ?self
+    {
+        return self::tryFrom(strtolower($name));
+    }
 }

--- a/packages/foundation/tests/Unit/Log/LogLevelSeverityTest.php
+++ b/packages/foundation/tests/Unit/Log/LogLevelSeverityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\LogLevel;
+
+#[CoversClass(LogLevel::class)]
+final class LogLevelSeverityTest extends TestCase
+{
+    #[Test]
+    public function emergency_is_highest_severity(): void
+    {
+        $this->assertGreaterThan(
+            LogLevel::ALERT->severity(),
+            LogLevel::EMERGENCY->severity(),
+        );
+    }
+
+    #[Test]
+    public function debug_is_lowest_severity(): void
+    {
+        $this->assertLessThan(
+            LogLevel::INFO->severity(),
+            LogLevel::DEBUG->severity(),
+        );
+    }
+
+    #[Test]
+    public function severity_ordering_matches_rfc_5424(): void
+    {
+        $expected = [
+            LogLevel::DEBUG,
+            LogLevel::INFO,
+            LogLevel::NOTICE,
+            LogLevel::WARNING,
+            LogLevel::ERROR,
+            LogLevel::CRITICAL,
+            LogLevel::ALERT,
+            LogLevel::EMERGENCY,
+        ];
+
+        for ($i = 1; $i < count($expected); $i++) {
+            $this->assertGreaterThan(
+                $expected[$i - 1]->severity(),
+                $expected[$i]->severity(),
+                sprintf('%s should be more severe than %s', $expected[$i]->value, $expected[$i - 1]->value),
+            );
+        }
+    }
+
+    #[Test]
+    public function from_name_resolves_valid_level(): void
+    {
+        $this->assertSame(LogLevel::WARNING, LogLevel::fromName('warning'));
+        $this->assertSame(LogLevel::DEBUG, LogLevel::fromName('DEBUG'));
+        $this->assertSame(LogLevel::ERROR, LogLevel::fromName('Error'));
+    }
+
+    #[Test]
+    public function from_name_returns_null_for_invalid_level(): void
+    {
+        $this->assertNull(LogLevel::fromName('invalid'));
+        $this->assertNull(LogLevel::fromName(''));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `LogLevel::severity(): int` method returning RFC 5424 numeric severity (DEBUG=0 through EMERGENCY=7) for level comparison
- Adds `LogLevel::fromName(string): ?self` case-insensitive factory method using `tryFrom(strtolower())`
- Adds `LogLevelSeverityTest` with 5 tests / 14 assertions covering ordering, boundary cases, and invalid input

Closes #729

See also: `docs/specs/debugging-dx.md`

## Test plan

- [x] `LogLevelSeverityTest` — all 5 tests pass (14 assertions)
- [x] Full `packages/foundation/tests/Unit/Log/` suite — all 19 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)