### PR TITLE
feat(foundation): APP_DEBUG and LOG_LEVEL config and env setup (#729)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,19 @@
 #
 APP_ENV=local
 
+# Debug mode: enables detailed error pages, debug toolbar, and debug headers.
+# MUST be false in production — the kernel refuses to boot if APP_DEBUG=true
+# when APP_ENV is not local/dev/development.
+# Default: false
+#
+APP_DEBUG=true
+
+# Minimum log level for the default log handler.
+# Values: debug, info, notice, warning, error, critical, alert, emergency
+# Default: warning
+#
+# LOG_LEVEL=warning
+
 # ── Local Admin Development ───────────────────────────────────────────────────
 # To run the admin SPA locally, THREE conditions must be met:
 #

--- a/composer.json
+++ b/composer.json
@@ -179,7 +179,7 @@
         "cs-fix": "php-cs-fixer fix",
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "APP_ENV=local WAASEYAA_DEV_FALLBACK_ACCOUNT=true PHP_CLI_SERVER_WORKERS=4 php -S localhost:8081 -t public & npm run dev --prefix packages/admin && kill $!"
+            "APP_ENV=local APP_DEBUG=true WAASEYAA_DEV_FALLBACK_ACCOUNT=true PHP_CLI_SERVER_WORKERS=4 php -S localhost:8081 -t public & npm run dev --prefix packages/admin && kill $!"
         ],
         "phpstan": "phpstan analyse --memory-limit=512M"
     },

--- a/config/waaseyaa.php
+++ b/config/waaseyaa.php
@@ -3,6 +3,18 @@
 declare(strict_types=1);
 
 return [
+    // Debug mode. Controls error detail display, debug toolbar, and debug headers.
+    // Override with APP_DEBUG env var. MUST be false in production.
+    'debug' => filter_var(getenv('APP_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN),
+
+    // Minimum log level for the default log handler.
+    // Override with LOG_LEVEL env var. Values: debug, info, notice, warning, error, critical, alert, emergency.
+    'log_level' => getenv('LOG_LEVEL') ?: 'warning',
+
+    // Application environment. Controls dev-only features (fallback account, CORS relaxation).
+    // Override with APP_ENV env var. Values: local, dev, development, staging, production.
+    'environment' => getenv('APP_ENV') ?: 'production',
+
     // SQLite database path. Null means "resolve in kernel":
     // WAASEYAA_DB env var -> {projectRoot}/storage/waaseyaa.sqlite fallback.
     // Set an explicit path here to override both.

--- a/skeleton/config/waaseyaa.php
+++ b/skeleton/config/waaseyaa.php
@@ -3,6 +3,18 @@
 declare(strict_types=1);
 
 return [
+    // Debug mode. Controls error detail display, debug toolbar, and debug headers.
+    // Override with APP_DEBUG env var. MUST be false in production.
+    'debug' => filter_var(getenv('APP_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN),
+
+    // Minimum log level for the default log handler.
+    // Override with LOG_LEVEL env var. Values: debug, info, notice, warning, error, critical, alert, emergency.
+    'log_level' => getenv('LOG_LEVEL') ?: 'warning',
+
+    // Application environment. Controls dev-only features (fallback account, CORS relaxation).
+    // Override with APP_ENV env var. Values: local, dev, development, staging, production.
+    'environment' => getenv('APP_ENV') ?: 'production',
+
     // SQLite database path. Null means "resolve in kernel":
     // WAASEYAA_DB env var -> {projectRoot}/storage/waaseyaa.sqlite fallback.
     // Set an explicit path here to override both.


### PR DESCRIPTION
## Summary

- Added `debug`, `log_level`, and `environment` config keys to `config/waaseyaa.php` and `skeleton/config/waaseyaa.php`, resolved from `APP_DEBUG`, `LOG_LEVEL`, and `APP_ENV` env vars with safe production defaults
- Added `APP_DEBUG=true` and `LOG_LEVEL` documentation to `.env.example`
- Added `APP_DEBUG=true` to the `composer dev` script so debug mode is automatic in local development

Closes #729. See `docs/specs/debugging-dx.md` for the full spec.

## Test plan

- [x] `phpstan` shows no new errors (10 pre-existing, none in changed files)
- [x] `phpunit` shows no regressions (same 12 errors + 3 failures as main branch)
- [x] Config files use existing `getenv() ?: default` and `filter_var(..., FILTER_VALIDATE_BOOLEAN)` patterns consistent with codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)