### PR TITLE
fix(media): sort findByOwner() results by URI for deterministic ordering

### DIFF
--- a/packages/media/src/LocalFileRepository.php
+++ b/packages/media/src/LocalFileRepository.php
@@ -126,6 +126,8 @@ final class LocalFileRepository implements FileRepositoryInterface
             );
         }
 
+        usort($result, fn(File $a, File $b): int => strcmp($a->uri, $b->uri));
+
         return $result;
     }
 


### PR DESCRIPTION
## Summary
- `LocalFileRepository::findByOwner()` iterated the filesystem via `RecursiveDirectoryIterator`, returning results in unpredictable OS-dependent order
- Added `usort()` by URI before returning, making `testFindByOwnerReturnsMatchingFilesOnly` deterministic

## Test plan
- [x] `./vendor/bin/phpunit packages/media/tests/Unit/LocalFileRepositoryTest.php` — all 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)