### PR TITLE
fix(#743): ensure storage/ dir exists for default SQLite path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ packages/admin/.nuxtrc
 packages/admin/.output/
 packages/admin/node_modules/
 
-# Storage (compiled artifacts)
-storage/
+# Storage (compiled artifacts, database files)
+storage/*
+!storage/.gitkeep
 
 # Environment
 .env

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-03-30 — ControllerDispatcher rate limiter addition reviewed, no spec changes needed -->
+<!-- Spec reviewed 2026-03-30 — DatabaseBootstrapper mkdir + ControllerDispatcher rate limiter reviewed, no spec changes needed -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 

--- a/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
+++ b/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
@@ -26,6 +26,12 @@ final class DatabaseBootstrapper
             $dbPath = getenv('WAASEYAA_DB') ?: $projectRoot . '/storage/waaseyaa.sqlite';
         }
 
+        // Ensure the parent directory exists so SQLite can create the file.
+        $dir = dirname($dbPath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o755, recursive: true);
+        }
+
         return $dbPath;
     }
 }

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/DatabaseBootstrapperTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/DatabaseBootstrapperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel\Bootstrap;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Foundation\Kernel\Bootstrap\DatabaseBootstrapper;
+
+#[CoversClass(DatabaseBootstrapper::class)]
+final class DatabaseBootstrapperTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/waaseyaa_test_' . uniqid();
+        mkdir($this->tempDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up temp files recursively.
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->tempDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+        rmdir($this->tempDir);
+    }
+
+    #[Test]
+    public function bootCreatesStorageDirectoryWhenMissing(): void
+    {
+        $projectRoot = $this->tempDir . '/project';
+        mkdir($projectRoot, 0o755, recursive: true);
+
+        // storage/ does not exist yet
+        $this->assertDirectoryDoesNotExist($projectRoot . '/storage');
+
+        $bootstrapper = new DatabaseBootstrapper();
+        $database = $bootstrapper->boot($projectRoot, []);
+
+        $this->assertInstanceOf(DatabaseInterface::class, $database);
+        $this->assertDirectoryExists($projectRoot . '/storage');
+    }
+
+    #[Test]
+    public function bootUsesConfigDatabasePathWhenProvided(): void
+    {
+        $dbPath = $this->tempDir . '/custom/my.sqlite';
+
+        // custom/ does not exist yet
+        $this->assertDirectoryDoesNotExist($this->tempDir . '/custom');
+
+        $bootstrapper = new DatabaseBootstrapper();
+        $database = $bootstrapper->boot($this->tempDir, ['database' => $dbPath]);
+
+        $this->assertInstanceOf(DatabaseInterface::class, $database);
+        $this->assertDirectoryExists($this->tempDir . '/custom');
+    }
+
+    #[Test]
+    public function bootUsesEnvVarOverDefault(): void
+    {
+        $dbPath = $this->tempDir . '/envdir/env.sqlite';
+        putenv('WAASEYAA_DB=' . $dbPath);
+
+        try {
+            $bootstrapper = new DatabaseBootstrapper();
+            $database = $bootstrapper->boot($this->tempDir, []);
+
+            $this->assertInstanceOf(DatabaseInterface::class, $database);
+            $this->assertDirectoryExists($this->tempDir . '/envdir');
+        } finally {
+            putenv('WAASEYAA_DB');
+        }
+    }
+
+    #[Test]
+    public function bootDefaultsToStorageWaaseyaaSqlite(): void
+    {
+        $projectRoot = $this->tempDir . '/project';
+        mkdir($projectRoot, 0o755, recursive: true);
+
+        // Ensure no env var interference.
+        putenv('WAASEYAA_DB');
+
+        $bootstrapper = new DatabaseBootstrapper();
+        $bootstrapper->boot($projectRoot, []);
+
+        // The default path creates storage/ under project root.
+        $this->assertDirectoryExists($projectRoot . '/storage');
+    }
+}


### PR DESCRIPTION
## Summary
- `DatabaseBootstrapper.resolvePath()` now creates the parent directory if missing
- `.gitignore` changed from `storage/` to `storage/*` + `!storage/.gitkeep` so fresh clones have the directory
- Added 4 unit tests for `DatabaseBootstrapper`

## Test plan
- [x] Unit tests: `./vendor/bin/phpunit packages/foundation/tests/Unit/Kernel/Bootstrap/DatabaseBootstrapperTest.php`
- [ ] Fresh clone: `bin/waaseyaa` creates `storage/waaseyaa.sqlite` without error
- [ ] Existing installs: no behavior change when `WAASEYAA_DB` is set

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)