### PR TITLE
fix(#800): lazy-resolve MailDriverInterface in AuthMailer

### DIFF
--- a/packages/user/src/AuthMailer.php
+++ b/packages/user/src/AuthMailer.php
@@ -11,21 +11,34 @@ use Waaseyaa\Mail\MailMessage;
 
 class AuthMailer
 {
+    private ?MailDriverInterface $resolvedDriver = null;
+
     public function __construct(
-        private readonly MailDriverInterface $driver,
+        private readonly MailDriverInterface|\Closure $driver,
         private readonly Environment $twig,
         private readonly string $baseUrl,
         private readonly string $appName,
     ) {}
 
+    private function driver(): MailDriverInterface
+    {
+        if ($this->resolvedDriver === null) {
+            $this->resolvedDriver = $this->driver instanceof \Closure
+                ? ($this->driver)()
+                : $this->driver;
+        }
+
+        return $this->resolvedDriver;
+    }
+
     public function isConfigured(): bool
     {
-        return $this->driver->isConfigured();
+        return $this->driver()->isConfigured();
     }
 
     public function sendPasswordReset(FieldableInterface $user, string $token): void
     {
-        if (!$this->driver->isConfigured()) {
+        if (!$this->driver()->isConfigured()) {
             return;
         }
 
@@ -37,7 +50,7 @@ class AuthMailer
         $html = $this->twig->render('email/password-reset.html.twig', $vars);
         $text = $this->twig->render('email/password-reset.txt.twig', $vars);
 
-        $this->driver->send(new MailMessage(
+        $this->driver()->send(new MailMessage(
             from: '',
             to: $user->get('mail'),
             subject: "Reset your {$this->appName} password",
@@ -48,7 +61,7 @@ class AuthMailer
 
     public function sendEmailVerification(FieldableInterface $user, string $token): void
     {
-        if (!$this->driver->isConfigured()) {
+        if (!$this->driver()->isConfigured()) {
             return;
         }
 
@@ -60,7 +73,7 @@ class AuthMailer
         $html = $this->twig->render('email/email-verification.html.twig', $vars);
         $text = $this->twig->render('email/email-verification.txt.twig', $vars);
 
-        $this->driver->send(new MailMessage(
+        $this->driver()->send(new MailMessage(
             from: '',
             to: $user->get('mail'),
             subject: "Verify your email for {$this->appName}",
@@ -71,7 +84,7 @@ class AuthMailer
 
     public function sendWelcome(FieldableInterface $user): void
     {
-        if (!$this->driver->isConfigured()) {
+        if (!$this->driver()->isConfigured()) {
             return;
         }
 
@@ -83,7 +96,7 @@ class AuthMailer
         $html = $this->twig->render('email/welcome.html.twig', $vars);
         $text = $this->twig->render('email/welcome.txt.twig', $vars);
 
-        $this->driver->send(new MailMessage(
+        $this->driver()->send(new MailMessage(
             from: '',
             to: $user->get('mail'),
             subject: "Welcome to {$this->appName}",

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -68,7 +68,7 @@ final class UserServiceProvider extends ServiceProvider
 
         $config = $this->config ?? [];
         $this->singleton(AuthMailer::class, fn() => new AuthMailer(
-            driver: $this->resolve(MailDriverInterface::class),
+            driver: fn() => $this->resolve(MailDriverInterface::class),
             twig: \Waaseyaa\SSR\SsrServiceProvider::getTwigEnvironment(),
             baseUrl: $config['app']['url'] ?? '',
             appName: $config['app']['name'] ?? 'Waaseyaa',

--- a/packages/user/tests/Unit/AuthMailerTest.php
+++ b/packages/user/tests/Unit/AuthMailerTest.php
@@ -107,6 +107,37 @@ final class AuthMailerTest extends TestCase
     }
 
     #[Test]
+    public function lazily_resolves_closure_driver_on_first_use(): void
+    {
+        $resolved = false;
+        $driver = new class($this) implements MailDriverInterface {
+            public function __construct(private readonly AuthMailerTest $test) {}
+            public function send(MailMessage $message): int
+            {
+                $this->test->sentMessages[] = $message;
+                return 202;
+            }
+            public function isConfigured(): bool { return true; }
+        };
+
+        $mailer = new AuthMailer(
+            driver: function () use (&$resolved, $driver): MailDriverInterface {
+                $resolved = true;
+                return $driver;
+            },
+            twig: $this->twig,
+            baseUrl: 'https://example.com',
+            appName: 'TestApp',
+        );
+
+        $this->assertFalse($resolved, 'Closure should not be resolved until first use');
+
+        $mailer->isConfigured();
+
+        $this->assertTrue($resolved, 'Closure should be resolved after first use');
+    }
+
+    #[Test]
     public function skips_sending_when_driver_not_configured(): void
     {
         $unconfigured = new class implements MailDriverInterface {


### PR DESCRIPTION
## Summary
- AuthMailer now accepts `MailDriverInterface|\Closure` constructor param
- Driver is resolved lazily on first use via `driver()` accessor
- UserServiceProvider passes a closure, eliminating boot-order dependency on MailServiceProvider
- Fixes boot crash when MailServiceProvider hasn't registered yet

Closes #800

## Test plan
- [x] New test verifies closure is not resolved until `isConfigured()` is called
- [x] Existing tests pass with concrete driver (backward-compatible)
- [x] `./vendor/bin/phpunit packages/user/tests/Unit/AuthMailerTest.php` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)