### PR TITLE
fix(#797,#801): create useApi() composable and migrate admin SPA fetch calls

### DIFF
--- a/packages/admin/app/components/IngestSummaryWidget.vue
+++ b/packages/admin/app/components/IngestSummaryWidget.vue
@@ -2,10 +2,12 @@
 import { useLanguage } from '~/composables/useLanguage'
 import { useEntity, type JsonApiResource } from '~/composables/useEntity'
 import { useAdmin } from '~/composables/useAdmin'
+import { useApi } from '~/composables/useApi'
 
 const { t } = useLanguage()
 const { list } = useEntity()
 const { catalog } = useAdmin()
+const { apiFetch } = useApi()
 
 const counts = ref<Record<string, number>>({
   pending_review: 0,
@@ -64,7 +66,7 @@ onMounted(fetchCounts)
 
 async function fetchNcSyncStatus() {
   try {
-    const result = await $fetch<{ status: typeof ncSync.value }>('/api/admin/nc-sync-status')
+    const result = await apiFetch<{ status: typeof ncSync.value }>('/api/admin/nc-sync-status')
     ncSync.value = result.status ?? null
   } catch {
     ncSync.value = null

--- a/packages/admin/app/composables/useApi.ts
+++ b/packages/admin/app/composables/useApi.ts
@@ -1,0 +1,13 @@
+import type { FetchOptions } from 'ofetch'
+
+export function useApi() {
+  async function apiFetch<T>(path: string, options: FetchOptions = {}): Promise<T> {
+    return $fetch<T>(path, {
+      baseURL: '/',
+      credentials: 'include',
+      ...options,
+    })
+  }
+
+  return { apiFetch }
+}

--- a/packages/admin/app/composables/useAuth.ts
+++ b/packages/admin/app/composables/useAuth.ts
@@ -12,6 +12,7 @@ const STATE_KEY = 'waaseyaa.auth.user'
 const CHECKED_KEY = 'waaseyaa.auth.checked'
 
 export function useAuth() {
+  const { apiFetch } = useApi()
   const currentUser = useState<AdminAccount | null>(STATE_KEY, () => null)
   const authChecked = useState<boolean>(CHECKED_KEY, () => false)
   const isAuthenticated = computed(() => currentUser.value !== null)
@@ -19,9 +20,7 @@ export function useAuth() {
   async function checkAuth(): Promise<void> {
     if (authChecked.value) return
     try {
-      const res = await $fetch<{ data?: AdminAccount }>('/api/user/me', {
-        baseURL: '/',
-        credentials: 'include',
+      const res = await apiFetch<{ data?: AdminAccount }>('/api/user/me', {
         ignoreResponseError: true,
       })
       currentUser.value = res?.data?.id ? (res.data as AdminAccount) : null
@@ -33,14 +32,12 @@ export function useAuth() {
 
   async function login(username: string, password: string): Promise<LoginResult> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         data?: { id: string; name: string; email: string; roles: string[] }
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/login', {
         method: 'POST',
-        baseURL: '/',
         body: { username, password },
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -70,14 +67,12 @@ export function useAuth() {
     inviteToken?: string,
   ): Promise<LoginResult> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         data?: { id: string; name: string; email: string; roles: string[] }
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/register', {
         method: 'POST',
-        baseURL: '/',
         body: { name, email, password, ...(inviteToken ? { invite_token: inviteToken } : {}) },
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -102,14 +97,12 @@ export function useAuth() {
 
   async function forgotPassword(email: string): Promise<{ ok: boolean; message?: string; error?: string }> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         message?: string
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/forgot-password', {
         method: 'POST',
-        baseURL: '/',
         body: { email },
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -130,14 +123,12 @@ export function useAuth() {
     passwordConfirmation: string,
   ): Promise<{ ok: boolean; message?: string; error?: string }> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         message?: string
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/reset-password', {
         method: 'POST',
-        baseURL: '/',
         body: { token, password, password_confirmation: passwordConfirmation },
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -154,13 +145,11 @@ export function useAuth() {
 
   async function verifyEmail(token: string): Promise<{ ok: boolean; error?: string }> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/verify-email', {
         method: 'POST',
-        baseURL: '/',
         body: { token },
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -181,12 +170,10 @@ export function useAuth() {
 
   async function resendVerification(): Promise<{ ok: boolean; error?: string }> {
     try {
-      const res = await $fetch<{
+      const res = await apiFetch<{
         errors?: Array<{ status: string; title: string; detail?: string }>
       }>('/api/auth/resend-verification', {
         method: 'POST',
-        baseURL: '/',
-        credentials: 'include',
         ignoreResponseError: true,
       })
 
@@ -203,10 +190,8 @@ export function useAuth() {
 
   async function logout(): Promise<void> {
     try {
-      await $fetch('/api/auth/logout', {
+      await apiFetch('/api/auth/logout', {
         method: 'POST',
-        baseURL: '/',
-        credentials: 'include',
         ignoreResponseError: true,
       })
     } catch {

--- a/packages/admin/app/composables/useCodifiedContext.ts
+++ b/packages/admin/app/composables/useCodifiedContext.ts
@@ -32,6 +32,7 @@ export interface ValidationReport {
 }
 
 export function useCodifiedContext() {
+  const { apiFetch } = useApi()
   const sessions = ref<CodifiedContextSession[]>([])
   const currentSession = ref<CodifiedContextSession | null>(null)
   const events = ref<CodifiedContextEvent[]>([])
@@ -43,7 +44,7 @@ export function useCodifiedContext() {
     loading.value = true
     error.value = null
     try {
-      const response = await $fetch<{ data: CodifiedContextSession[] }>(
+      const response = await apiFetch<{ data: CodifiedContextSession[] }>(
         `/api/telescope/codified-context/sessions?limit=${limit}`,
       )
       sessions.value = response.data ?? []
@@ -58,7 +59,7 @@ export function useCodifiedContext() {
     loading.value = true
     error.value = null
     try {
-      const response = await $fetch<{ data: CodifiedContextSession }>(
+      const response = await apiFetch<{ data: CodifiedContextSession }>(
         `/api/telescope/codified-context/sessions/${id}`,
       )
       currentSession.value = response.data ?? null
@@ -73,7 +74,7 @@ export function useCodifiedContext() {
     loading.value = true
     error.value = null
     try {
-      const response = await $fetch<{ data: CodifiedContextEvent[] }>(
+      const response = await apiFetch<{ data: CodifiedContextEvent[] }>(
         `/api/telescope/codified-context/sessions/${id}/events`,
       )
       events.value = response.data ?? []
@@ -88,7 +89,7 @@ export function useCodifiedContext() {
     loading.value = true
     error.value = null
     try {
-      const response = await $fetch<{ data: ValidationReport }>(
+      const response = await apiFetch<{ data: ValidationReport }>(
         `/api/telescope/codified-context/sessions/${id}/validation`,
       )
       validationReport.value = response.data ?? null

--- a/packages/admin/app/pages/[entityType]/index.vue
+++ b/packages/admin/app/pages/[entityType]/index.vue
@@ -2,8 +2,10 @@
 import { useLanguage } from '~/composables/useLanguage'
 import { useSchema } from '~/composables/useSchema'
 import { useAdmin } from '~/composables/useAdmin'
+import { useApi } from '~/composables/useApi'
 
 const route = useRoute()
+const { apiFetch } = useApi()
 const { t, entityLabel: translateEntityLabel } = useLanguage()
 const { catalog, getEntity, hasCapability } = useAdmin()
 
@@ -43,7 +45,7 @@ async function disableType(force = false) {
   actionError.value = null
   try {
     const query = force ? '?force=1' : ''
-    await $fetch(`/api/entity-types/${entityType.value}/disable${query}`, { method: 'POST' })
+    await apiFetch(`/api/entity-types/${entityType.value}/disable${query}`, { method: 'POST' })
     localDisabledOverride.value = true
     showDisableConfirm.value = false
   } catch (e: any) {
@@ -59,7 +61,7 @@ async function enableType() {
   actionLoading.value = true
   actionError.value = null
   try {
-    await $fetch(`/api/entity-types/${entityType.value}/enable`, { method: 'POST' })
+    await apiFetch(`/api/entity-types/${entityType.value}/enable`, { method: 'POST' })
     localDisabledOverride.value = false
   } catch (e: any) {
     actionError.value = e?.data?.errors?.[0]?.detail ?? e?.message ?? t('error_generic')

--- a/packages/admin/app/plugins/admin.ts
+++ b/packages/admin/app/plugins/admin.ts
@@ -54,6 +54,7 @@ export default defineNuxtPlugin(async (): Promise<{ provide: { admin: AdminRunti
 
   try {
     const sessionRes = await $fetch<SurfaceResult<SurfaceSession>>(`${surfacePath}/session`, {
+      baseURL: '/',
       ignoreResponseError: true,
       credentials: 'include',
     })
@@ -62,6 +63,7 @@ export default defineNuxtPlugin(async (): Promise<{ provide: { admin: AdminRunti
       surfaceSession = sessionRes.data
 
       const catalogRes = await $fetch<SurfaceResult<{ entities: SurfaceCatalogEntry[] }>>(`${surfacePath}/catalog`, {
+        baseURL: '/',
         ignoreResponseError: true,
         credentials: 'include',
       })

--- a/packages/admin/tests/unit/composables/useApi.test.ts
+++ b/packages/admin/tests/unit/composables/useApi.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useApi } from '../../../app/composables/useApi'
+
+const mockFetch = vi.fn().mockResolvedValue({ data: 'test' })
+vi.stubGlobal('$fetch', mockFetch)
+
+describe('useApi', () => {
+  it('passes baseURL and credentials by default', async () => {
+    const { apiFetch } = useApi()
+    await apiFetch('/api/user/me')
+    expect(mockFetch).toHaveBeenCalledWith('/api/user/me', {
+      baseURL: '/',
+      credentials: 'include',
+    })
+  })
+
+  it('merges caller options', async () => {
+    const { apiFetch } = useApi()
+    await apiFetch('/api/auth/login', { method: 'POST', body: { user: 'a' } })
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/login', {
+      baseURL: '/',
+      credentials: 'include',
+      method: 'POST',
+      body: { user: 'a' },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Created `useApi()` composable that centralizes `baseURL: '/'` and `credentials: 'include'` for all admin SPA API calls
- Migrated 14 `$fetch` calls across `useAuth.ts` (8), `useCodifiedContext.ts` (4), and `[entityType]/index.vue` (2) to use `apiFetch`
- Added `baseURL: '/'` to 2 `$fetch` calls in `admin.ts` plugin (composables can't be used in plugins)

## Test plan
- [x] Unit tests for `useApi()` composable (2 tests passing)
- [x] Full admin test suite passes (28 files, 143 tests)

Closes #797, closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)