### PR TITLE
exec(conformance)(M10): Batch D2 — route/console/provider realignment

### DIFF
--- a/packages/admin/app/adapters/AdminSurfaceTransportAdapter.ts
+++ b/packages/admin/app/adapters/AdminSurfaceTransportAdapter.ts
@@ -1,29 +1,11 @@
 import type { TransportAdapter, ListQuery, ListResult, EntityResource } from '../contracts/transport'
 import { TransportError } from '../contracts/transport'
 import type { EntitySchema } from '../contracts/schema'
-
-/**
- * Surface API response envelope.
- */
-interface SurfaceResult<T> {
-  ok: boolean
-  data?: T
-  error?: { status: number; title: string; detail?: string; source?: Record<string, string> }
-  meta?: Record<string, unknown>
-}
-
-interface SurfaceEntity {
-  type: string
-  id: string
-  attributes: Record<string, unknown>
-}
-
-interface SurfaceListResult {
-  entities: SurfaceEntity[]
-  total: number
-  offset: number
-  limit: number
-}
+import type {
+  AdminSurfaceEntity as SurfaceEntity,
+  AdminSurfaceListResult as SurfaceListResult,
+  AdminSurfaceResult as SurfaceResult,
+} from '../../../admin-surface/contract/types'
 
 /**
  * Transport adapter that talks to the /admin/surface/* endpoints.

--- a/packages/admin/app/contracts/auth.ts
+++ b/packages/admin/app/contracts/auth.ts
@@ -1,3 +1,5 @@
+import type { AdminSurfaceAccount, AdminSurfaceTenant } from '../../../admin-surface/contract/types'
+
 export interface AuthAdapter {
   getSession(): Promise<AdminSession | null>
   refreshSession?(): Promise<AdminSession | null>
@@ -11,16 +13,10 @@ export interface AdminSession {
   features?: Record<string, boolean>
 }
 
-export interface AdminAccount {
-  id: string
-  name: string
-  email?: string
+export type AdminAccount = AdminSurfaceAccount & {
   emailVerified?: boolean
-  roles: string[]
 }
 
-export interface AdminTenant {
-  id: string
-  name: string
+export type AdminTenant = AdminSurfaceTenant & {
   scopingStrategy: 'server' | 'header'
 }

--- a/packages/admin/app/contracts/catalog.ts
+++ b/packages/admin/app/contracts/catalog.ts
@@ -1,18 +1,6 @@
-export interface CatalogEntry {
-  id: string
-  label: string
-  description?: string
-  keys?: Record<string, string>
-  group?: string
-  disabled?: boolean
-  capabilities: CatalogCapabilities
-}
+import type {
+  AdminSurfaceCatalogEntry as CatalogEntry,
+  AdminSurfaceCapabilities as CatalogCapabilities,
+} from '../../../admin-surface/contract/types'
 
-export interface CatalogCapabilities {
-  list: boolean
-  get: boolean
-  create: boolean
-  update: boolean
-  delete: boolean
-  schema: boolean
-}
+export type { CatalogEntry, CatalogCapabilities }

--- a/packages/admin/app/plugins/admin.ts
+++ b/packages/admin/app/plugins/admin.ts
@@ -2,30 +2,11 @@ import { SessionAuthAdapter } from '../adapters/SessionAuthAdapter'
 import { AdminSurfaceTransportAdapter } from '../adapters/AdminSurfaceTransportAdapter'
 import type { AdminRuntime, AdminAuthConfig } from '../contracts/runtime'
 import type { CatalogEntry } from '../contracts/catalog'
-
-interface SurfaceSession {
-  account: { id: string; name: string; email?: string; roles: string[] }
-  tenant: { id: string; name: string }
-  policies: string[]
-  features?: Record<string, boolean>
-}
-
-interface SurfaceCatalogEntry {
-  id: string
-  label: string
-  description?: string
-  group?: string
-  disabled?: boolean
-  fields: unknown[]
-  actions: unknown[]
-  capabilities: { list: boolean; get: boolean; create: boolean; update: boolean; delete: boolean; schema: boolean }
-}
-
-interface SurfaceResult<T> {
-  ok: boolean
-  data?: T
-  error?: { status: number; title: string; detail?: string }
-}
+import type {
+  AdminSurfaceCatalogEntry as SurfaceCatalogEntry,
+  AdminSurfaceResult as SurfaceResult,
+  AdminSurfaceSession as SurfaceSession,
+} from '../../../admin-surface/contract/types'
 
 export default defineNuxtPlugin(async (): Promise<{ provide: { admin: AdminRuntime | null } }> => {
   const config = useRuntimeConfig()

--- a/packages/admin/tests/unit/adapters/AdminSurfaceTransportAdapter.test.ts
+++ b/packages/admin/tests/unit/adapters/AdminSurfaceTransportAdapter.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AdminSurfaceTransportAdapter } from '~/adapters/AdminSurfaceTransportAdapter'
+
+describe('AdminSurfaceTransportAdapter', () => {
+  it('normalizes surface list responses into transport resources', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        data: {
+          entities: [
+            {
+              type: 'user',
+              id: '42',
+              attributes: { name: 'Admin' },
+            },
+          ],
+          total: 1,
+          offset: 0,
+          limit: 25,
+        },
+      }),
+    })
+
+    const adapter = new AdminSurfaceTransportAdapter('/admin/_surface', fetchFn as typeof fetch)
+    const result = await adapter.list('user', {
+      page: { offset: 0, limit: 25 },
+      sort: 'name',
+    })
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/admin/_surface/user?page%5Boffset%5D=0&page%5Blimit%5D=25&sort=name',
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+      }),
+    )
+    expect(result.data).toEqual([
+      {
+        type: 'user',
+        id: '42',
+        attributes: { name: 'Admin' },
+      },
+    ])
+    expect(result.meta).toEqual({ total: 1, offset: 0, limit: 25 })
+  })
+
+  it('throws a transport error for failed surface responses', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        ok: false,
+        error: {
+          status: 403,
+          title: 'Forbidden',
+          detail: 'Denied',
+        },
+      }),
+    })
+
+    const adapter = new AdminSurfaceTransportAdapter('/admin/_surface', fetchFn as typeof fetch)
+
+    await expect(adapter.get('user', '42')).rejects.toMatchObject({
+      status: 403,
+      title: 'Forbidden',
+      detail: 'Denied',
+    })
+  })
+})

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -65,6 +65,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\Api\\ApiServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/api/src/ApiServiceProvider.php
+++ b/packages/api/src/ApiServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api;
+
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class ApiServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        if ($entityTypeManager === null) {
+            return;
+        }
+
+        (new JsonApiRouteProvider($entityTypeManager))->registerRoutes($router);
+    }
+}

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -62,6 +62,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\CLI\\CliServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/cli/src/CliCommandRegistry.php
+++ b/packages/cli/src/CliCommandRegistry.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\Access\PermissionHandler;
+use Waaseyaa\AI\Vector\SemanticIndexWarmer;
+use Waaseyaa\Cache\CacheFactory;
+use Waaseyaa\CLI\Command\AboutCommand;
+use Waaseyaa\CLI\Command\AuditLogCommand;
+use Waaseyaa\CLI\Command\BundleScaffoldCommand;
+use Waaseyaa\CLI\Command\CacheClearCommand;
+use Waaseyaa\CLI\Command\ConfigExportCommand;
+use Waaseyaa\CLI\Command\ConfigImportCommand;
+use Waaseyaa\CLI\Command\DebugContextCommand;
+use Waaseyaa\CLI\Command\EntityCreateCommand;
+use Waaseyaa\CLI\Command\EntityListCommand;
+use Waaseyaa\CLI\Command\EntityTypeListCommand;
+use Waaseyaa\CLI\Command\EventListCommand;
+use Waaseyaa\CLI\Command\ExtensionScaffoldCommand;
+use Waaseyaa\CLI\Command\FixtureGenerateCommand;
+use Waaseyaa\CLI\Command\FixturePackRefreshCommand;
+use Waaseyaa\CLI\Command\FixtureScaffoldCommand;
+use Waaseyaa\CLI\Command\HealthCheckCommand;
+use Waaseyaa\CLI\Command\HealthReportCommand;
+use Waaseyaa\CLI\Command\IngestDashboardCommand;
+use Waaseyaa\CLI\Command\IngestRunCommand;
+use Waaseyaa\CLI\Command\InstallCommand;
+use Waaseyaa\CLI\Command\Make\MakeEntityCommand;
+use Waaseyaa\CLI\Command\Make\MakeJobCommand;
+use Waaseyaa\CLI\Command\Make\MakeListenerCommand;
+use Waaseyaa\CLI\Command\Make\MakeMigrationCommand;
+use Waaseyaa\CLI\Command\Make\MakePolicyCommand;
+use Waaseyaa\CLI\Command\Make\MakeProviderCommand;
+use Waaseyaa\CLI\Command\Make\MakeTestCommand;
+use Waaseyaa\CLI\Command\MakeEntityTypeCommand;
+use Waaseyaa\CLI\Command\MakePluginCommand;
+use Waaseyaa\CLI\Command\MigrateCommand;
+use Waaseyaa\CLI\Command\MigrateDefaultsCommand;
+use Waaseyaa\CLI\Command\MigrateRollbackCommand;
+use Waaseyaa\CLI\Command\MigrateStatusCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeClearCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeConfigCommand;
+use Waaseyaa\CLI\Command\Optimize\OptimizeManifestCommand;
+use Waaseyaa\CLI\Command\Perf\PerformanceBaselineCommand;
+use Waaseyaa\CLI\Command\Perf\PerformanceCompareCommand;
+use Waaseyaa\CLI\Command\PermissionListCommand;
+use Waaseyaa\CLI\Command\RelationshipTypeScaffoldCommand;
+use Waaseyaa\CLI\Command\RouteListCommand;
+use Waaseyaa\CLI\Command\SchemaCheckCommand;
+use Waaseyaa\CLI\Command\SchemaListCommand;
+use Waaseyaa\CLI\Command\SemanticRefreshCommand;
+use Waaseyaa\CLI\Command\SemanticWarmCommand;
+use Waaseyaa\CLI\Command\ServeCommand;
+use Waaseyaa\CLI\Command\SyncRulesCommand;
+use Waaseyaa\CLI\Command\Telescope\TelescopeClearCommand;
+use Waaseyaa\CLI\Command\Telescope\TelescopeListCommand;
+use Waaseyaa\CLI\Command\Telescope\TelescopePruneCommand;
+use Waaseyaa\CLI\Command\TypeDisableCommand;
+use Waaseyaa\CLI\Command\TypeEnableCommand;
+use Waaseyaa\CLI\Command\UserCreateCommand;
+use Waaseyaa\CLI\Command\UserRoleCommand;
+use Waaseyaa\CLI\Command\WaaseyaaVersionCommand;
+use Waaseyaa\CLI\Command\WorkflowScaffoldCommand;
+use Waaseyaa\Config\Cache\ConfigCacheCompiler;
+use Waaseyaa\Config\ConfigManager;
+use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+use Waaseyaa\Entity\EntityTypeIdNormalizer;
+use Waaseyaa\Entity\EntityTypeLifecycleManager;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Diagnostic\HealthCheckerInterface;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Migration\Migrator;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class CliCommandRegistry
+{
+    /**
+     * @param array<string, mixed> $config
+     * @return list<\Symfony\Component\Console\Command\Command>
+     */
+    public function coreCommands(
+        string $projectRoot,
+        array $config,
+        PackageManifest $manifest,
+        EventDispatcherInterface $dispatcher,
+        EntityTypeManager $entityTypeManager,
+        EntityTypeLifecycleManager $lifecycleManager,
+        EntityAuditLogger $entityAuditLogger,
+        DatabaseInterface $database,
+        ConfigManager $configManager,
+        CacheFactory $cacheFactory,
+        WaaseyaaRouter $router,
+        PermissionHandler $permissionHandler,
+        PackageManifestCompiler $manifestCompiler,
+        DefaultsSchemaRegistry $schemaRegistry,
+        HealthCheckerInterface $healthChecker,
+        EntityTypeIdNormalizer $typeIdNormalizer,
+        ?SemanticIndexWarmer $semanticWarmer,
+        \PDO $pdo,
+    ): array {
+        return [
+            new InstallCommand($entityTypeManager, $configManager),
+            new CacheClearCommand($cacheFactory),
+            new ConfigExportCommand($configManager),
+            new ConfigImportCommand($configManager),
+            new DebugContextCommand(),
+            new EntityCreateCommand($entityTypeManager),
+            new EntityListCommand($entityTypeManager),
+            new UserCreateCommand($entityTypeManager),
+            new UserRoleCommand($entityTypeManager),
+            new MakePluginCommand(),
+            new MigrateDefaultsCommand(
+                $entityTypeManager,
+                $lifecycleManager,
+                $entityAuditLogger,
+                $projectRoot,
+                $typeIdNormalizer,
+            ),
+            new MakeEntityTypeCommand(),
+            new MakeEntityCommand(),
+            new MakeJobCommand(),
+            new MakeListenerCommand(),
+            new MakeMigrationCommand($projectRoot, $manifest),
+            new MakePolicyCommand(),
+            new MakeProviderCommand(),
+            new MakeTestCommand(),
+            new ServeCommand(),
+            new AboutCommand(info: [
+                'name' => 'Waaseyaa',
+                'version' => (static function (): string {
+                    $pkg = \Composer\InstalledVersions::getRootPackage();
+                    return $pkg['pretty_version'];
+                })(),
+                'php' => PHP_VERSION,
+                'environment' => getenv('APP_ENV') ?: 'production',
+            ]),
+            new EntityTypeListCommand($entityTypeManager),
+            new TypeDisableCommand($entityTypeManager, $lifecycleManager, $typeIdNormalizer),
+            new TypeEnableCommand($entityTypeManager, $lifecycleManager, $typeIdNormalizer),
+            new AuditLogCommand($lifecycleManager, $entityAuditLogger),
+            new EventListCommand($dispatcher),
+            new RouteListCommand($router),
+            new SchemaListCommand($schemaRegistry),
+            new SchemaCheckCommand($healthChecker),
+            new HealthCheckCommand($healthChecker),
+            new HealthReportCommand($healthChecker, $projectRoot),
+            new PermissionListCommand($permissionHandler),
+            ...($semanticWarmer !== null ? [
+                new SemanticWarmCommand($semanticWarmer),
+                new SemanticRefreshCommand($semanticWarmer),
+            ] : []),
+            new FixtureScaffoldCommand(),
+            new FixtureGenerateCommand(),
+            new FixturePackRefreshCommand(),
+            new IngestDashboardCommand(),
+            new IngestRunCommand(),
+            new BundleScaffoldCommand(),
+            new RelationshipTypeScaffoldCommand(),
+            new WorkflowScaffoldCommand(),
+            new ExtensionScaffoldCommand(),
+            new OptimizeCommand(),
+            new OptimizeManifestCommand($manifestCompiler),
+            new OptimizeConfigCommand(new ConfigCacheCompiler(
+                $configManager->getActiveStorage(),
+                $projectRoot . '/storage/framework/config.php',
+            )),
+            new OptimizeClearCommand($projectRoot . '/storage'),
+            new PerformanceBaselineCommand(),
+            new PerformanceCompareCommand(),
+            new TelescopeClearCommand(),
+            new TelescopeListCommand(),
+            new TelescopePruneCommand(),
+            new SyncRulesCommand(
+                $projectRoot . '/vendor/waaseyaa/foundation/.claude/rules',
+                $projectRoot . '/.claude/rules',
+            ),
+            new WaaseyaaVersionCommand($projectRoot),
+        ];
+    }
+
+    /**
+     * @param \Closure(): array<string, array<string, \Waaseyaa\Foundation\Migration\Migration>> $migrationsProvider
+     * @return list<\Symfony\Component\Console\Command\Command>
+     */
+    public function migrationCommands(Migrator $migrator, \Closure $migrationsProvider): array
+    {
+        return [
+            new MigrateCommand($migrator, $migrationsProvider),
+            new MigrateRollbackCommand($migrator, $migrationsProvider),
+            new MigrateStatusCommand($migrator, $migrationsProvider),
+        ];
+    }
+}

--- a/packages/cli/src/CliServiceProvider.php
+++ b/packages/cli/src/CliServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI;
+
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+final class CliServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+}

--- a/packages/cli/tests/Unit/CliCommandRegistryTest.php
+++ b/packages/cli/tests/Unit/CliCommandRegistryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\PermissionHandler;
+use Waaseyaa\CLI\CliCommandRegistry;
+use Waaseyaa\Cache\CacheConfiguration;
+use Waaseyaa\Cache\CacheFactory;
+use Waaseyaa\Config\ConfigManager;
+use Waaseyaa\Config\Storage\FileStorage;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeIdNormalizer;
+use Waaseyaa\Entity\EntityTypeLifecycleManager;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Audit\EntityAuditLogger;
+use Waaseyaa\Foundation\Diagnostic\BootDiagnosticReport;
+use Waaseyaa\Foundation\Diagnostic\HealthChecker;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Schema\DefaultsSchemaRegistry;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(CliCommandRegistry::class)]
+final class CliCommandRegistryTest extends TestCase
+{
+    #[Test]
+    public function core_commands_are_owned_by_the_cli_registry(): void
+    {
+        $projectRoot = sys_get_temp_dir() . '/waaseyaa_cli_registry_' . uniqid();
+        mkdir($projectRoot . '/config/active', 0755, true);
+        mkdir($projectRoot . '/config/sync', 0755, true);
+        mkdir($projectRoot . '/defaults', 0755, true);
+        mkdir($projectRoot . '/storage', 0755, true);
+
+        try {
+            $dispatcher = new EventDispatcher();
+            $entityTypeManager = new EntityTypeManager($dispatcher);
+            $entityTypeManager->registerEntityType(new EntityType(
+                id: 'node',
+                label: 'Node',
+                class: \stdClass::class,
+                keys: ['id' => 'id'],
+            ));
+
+            $database = DBALDatabase::createSqlite();
+            $activeStorage = new FileStorage($projectRoot . '/config/active');
+            $syncStorage = new FileStorage($projectRoot . '/config/sync');
+            $configManager = new ConfigManager($activeStorage, $syncStorage, $dispatcher);
+
+            assert($database instanceof DBALDatabase);
+            $pdo = $database->getConnection()->getNativeConnection();
+            assert($pdo instanceof \PDO);
+
+            $cacheFactory = new CacheFactory(new CacheConfiguration());
+            $router = new WaaseyaaRouter();
+            $registry = new CliCommandRegistry();
+            $commands = $registry->coreCommands(
+                projectRoot: $projectRoot,
+                config: [],
+                manifest: new PackageManifest(),
+                dispatcher: $dispatcher,
+                entityTypeManager: $entityTypeManager,
+                lifecycleManager: new EntityTypeLifecycleManager($projectRoot),
+                entityAuditLogger: new EntityAuditLogger($projectRoot),
+                database: $database,
+                configManager: $configManager,
+                cacheFactory: $cacheFactory,
+                router: $router,
+                permissionHandler: new PermissionHandler(),
+                manifestCompiler: new PackageManifestCompiler($projectRoot, $projectRoot . '/storage'),
+                schemaRegistry: new DefaultsSchemaRegistry($projectRoot . '/defaults'),
+                healthChecker: new HealthChecker(
+                    bootReport: new BootDiagnosticReport(
+                        registeredTypes: ['node' => true],
+                        disabledTypeIds: [],
+                        schemaCompatibility: [],
+                    ),
+                    database: $database,
+                    entityTypeManager: $entityTypeManager,
+                    projectRoot: $projectRoot,
+                ),
+                typeIdNormalizer: new EntityTypeIdNormalizer($entityTypeManager),
+                semanticWarmer: null,
+                pdo: $pdo,
+            );
+
+            $names = array_map(static fn($command): string => $command->getName() ?? '', $commands);
+
+            $this->assertContains('about', $names);
+            $this->assertContains('route:list', $names);
+            $this->assertContains('optimize:manifest', $names);
+            $this->assertContains('waaseyaa:version', $names);
+        } finally {
+            $items = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
+
+            foreach ($items as $item) {
+                $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+            }
+
+            rmdir($projectRoot);
+        }
+    }
+}

--- a/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
+++ b/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Kernel;
 
-use Waaseyaa\Api\JsonApiRouteProvider;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
@@ -20,16 +19,21 @@ final class BuiltinRouteRegistrar
 {
     /**
      * @param list<ServiceProvider> $providers
+     * @param list<object> $routeProviders
      */
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly array $providers = [],
+        private readonly array $routeProviders = [],
     ) {}
 
     public function register(WaaseyaaRouter $router): void
     {
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        foreach ($this->routeProviders as $routeProvider) {
+            if (method_exists($routeProvider, 'registerRoutes')) {
+                $routeProvider->registerRoutes($router);
+            }
+        }
 
         $router->addRoute(
             'api.schema.show',
@@ -142,38 +146,6 @@ final class BuiltinRouteRegistrar
                 ->allowAll()
                 ->jsonApi()
                 ->methods('GET', 'POST')
-                ->build(),
-        );
-
-        if (class_exists(\Waaseyaa\GraphQL\GraphQlRouteProvider::class)) {
-            $graphQlRouteProvider = new \Waaseyaa\GraphQL\GraphQlRouteProvider();
-            $graphQlRouteProvider->registerRoutes($router);
-        }
-
-        $router->addRoute(
-            'api.user.me',
-            RouteBuilder::create('/api/user/me')
-                ->controller('user.me')
-                ->allowAll()
-                ->methods('GET')
-                ->build(),
-        );
-
-        $router->addRoute(
-            'api.auth.login',
-            RouteBuilder::create('/api/auth/login')
-                ->controller('auth.login')
-                ->allowAll()
-                ->methods('POST')
-                ->build(),
-        );
-
-        $router->addRoute(
-            'api.auth.logout',
-            RouteBuilder::create('/api/auth/logout')
-                ->controller('auth.logout')
-                ->allowAll()
-                ->methods('POST')
                 ->build(),
         );
 

--- a/packages/foundation/src/Kernel/ConsoleKernel.php
+++ b/packages/foundation/src/Kernel/ConsoleKernel.php
@@ -11,65 +11,10 @@ use Waaseyaa\AI\Vector\SqliteEmbeddingStorage;
 use Waaseyaa\Cache\Backend\DatabaseBackend;
 use Waaseyaa\Cache\CacheConfiguration;
 use Waaseyaa\Cache\CacheFactory;
-use Waaseyaa\CLI\Command\AboutCommand;
-use Waaseyaa\CLI\Command\AuditLogCommand;
-use Waaseyaa\CLI\Command\BundleScaffoldCommand;
-use Waaseyaa\CLI\Command\CacheClearCommand;
-use Waaseyaa\CLI\Command\ConfigExportCommand;
-use Waaseyaa\CLI\Command\ConfigImportCommand;
-use Waaseyaa\CLI\Command\DebugContextCommand;
-use Waaseyaa\CLI\Command\EntityCreateCommand;
-use Waaseyaa\CLI\Command\EntityListCommand;
-use Waaseyaa\CLI\Command\EntityTypeListCommand;
-use Waaseyaa\CLI\Command\EventListCommand;
-use Waaseyaa\CLI\Command\ExtensionScaffoldCommand;
-use Waaseyaa\CLI\Command\FixtureGenerateCommand;
-use Waaseyaa\CLI\Command\FixturePackRefreshCommand;
-use Waaseyaa\CLI\Command\FixtureScaffoldCommand;
-use Waaseyaa\CLI\Command\HealthCheckCommand;
-use Waaseyaa\CLI\Command\HealthReportCommand;
-use Waaseyaa\CLI\Command\IngestDashboardCommand;
-use Waaseyaa\CLI\Command\IngestRunCommand;
-use Waaseyaa\CLI\Command\InstallCommand;
-use Waaseyaa\CLI\Command\Make\MakeEntityCommand;
-use Waaseyaa\CLI\Command\Make\MakeJobCommand;
-use Waaseyaa\CLI\Command\Make\MakeListenerCommand;
-use Waaseyaa\CLI\Command\Make\MakeMigrationCommand;
-use Waaseyaa\CLI\Command\Make\MakePolicyCommand;
-use Waaseyaa\CLI\Command\Make\MakeProviderCommand;
-use Waaseyaa\CLI\Command\Make\MakeTestCommand;
-use Waaseyaa\CLI\Command\MakeEntityTypeCommand;
-use Waaseyaa\CLI\Command\MakePluginCommand;
-use Waaseyaa\CLI\Command\MigrateCommand;
-use Waaseyaa\CLI\Command\MigrateDefaultsCommand;
-use Waaseyaa\CLI\Command\MigrateRollbackCommand;
-use Waaseyaa\CLI\Command\MigrateStatusCommand;
-use Waaseyaa\CLI\Command\Optimize\OptimizeClearCommand;
-use Waaseyaa\CLI\Command\Optimize\OptimizeCommand;
-use Waaseyaa\CLI\Command\Optimize\OptimizeConfigCommand;
+use Waaseyaa\CLI\CliCommandRegistry;
 use Waaseyaa\CLI\Command\Optimize\OptimizeManifestCommand;
-use Waaseyaa\CLI\Command\Perf\PerformanceBaselineCommand;
-use Waaseyaa\CLI\Command\Perf\PerformanceCompareCommand;
-use Waaseyaa\CLI\Command\PermissionListCommand;
-use Waaseyaa\CLI\Command\RelationshipTypeScaffoldCommand;
-use Waaseyaa\CLI\Command\RouteListCommand;
-use Waaseyaa\CLI\Command\SchemaCheckCommand;
-use Waaseyaa\CLI\Command\SchemaListCommand;
-use Waaseyaa\CLI\Command\SemanticRefreshCommand;
-use Waaseyaa\CLI\Command\SemanticWarmCommand;
-use Waaseyaa\CLI\Command\ServeCommand;
-use Waaseyaa\CLI\Command\SyncRulesCommand;
-use Waaseyaa\CLI\Command\Telescope\TelescopeClearCommand;
-use Waaseyaa\CLI\Command\Telescope\TelescopeListCommand;
-use Waaseyaa\CLI\Command\Telescope\TelescopePruneCommand;
-use Waaseyaa\CLI\Command\TypeDisableCommand;
-use Waaseyaa\CLI\Command\TypeEnableCommand;
-use Waaseyaa\CLI\Command\UserCreateCommand;
-use Waaseyaa\CLI\Command\UserRoleCommand;
 use Waaseyaa\CLI\Command\WaaseyaaVersionCommand;
-use Waaseyaa\CLI\Command\WorkflowScaffoldCommand;
 use Waaseyaa\CLI\WaaseyaaApplication;
-use Waaseyaa\Config\Cache\ConfigCacheCompiler;
 use Waaseyaa\Config\ConfigManager;
 use Waaseyaa\Config\Storage\FileStorage;
 use Waaseyaa\Entity\EntityTypeIdNormalizer;
@@ -170,92 +115,31 @@ final class ConsoleKernel extends AbstractKernel
 
         $app = new WaaseyaaApplication();
         $app->setAutoExit(false);
+        $commandRegistry = new CliCommandRegistry();
 
-        $app->registerCommands([
-            new InstallCommand($this->entityTypeManager, $configManager),
-            new CacheClearCommand($cacheFactory),
-            new ConfigExportCommand($configManager),
-            new ConfigImportCommand($configManager),
-            new DebugContextCommand(),
-            new EntityCreateCommand($this->entityTypeManager),
-            new EntityListCommand($this->entityTypeManager),
-            new UserCreateCommand($this->entityTypeManager),
-            new UserRoleCommand($this->entityTypeManager),
-            new MakePluginCommand(),
-            new MigrateDefaultsCommand(
-                $this->entityTypeManager,
-                $this->lifecycleManager,
-                $this->entityAuditLogger,
-                $this->projectRoot,
-                $typeIdNormalizer,
-            ),
-            new MakeEntityTypeCommand(),
-            new MakeEntityCommand(),
-            new MakeJobCommand(),
-            new MakeListenerCommand(),
-            new MakeMigrationCommand($this->projectRoot, $this->manifest),
-            new MakePolicyCommand(),
-            new MakeProviderCommand(),
-            new MakeTestCommand(),
-            new ServeCommand(),
-            new AboutCommand(info: [
-                'name' => 'Waaseyaa',
-                'version' => (static function (): string {
-                    $pkg = \Composer\InstalledVersions::getRootPackage();
-                    return $pkg['pretty_version'];
-                })(),
-                'php' => PHP_VERSION,
-                'environment' => getenv('APP_ENV') ?: 'production',
-            ]),
-            new EntityTypeListCommand($this->entityTypeManager),
-            new TypeDisableCommand($this->entityTypeManager, $this->lifecycleManager, $typeIdNormalizer),
-            new TypeEnableCommand($this->entityTypeManager, $this->lifecycleManager, $typeIdNormalizer),
-            new AuditLogCommand($this->lifecycleManager, $this->entityAuditLogger),
-            new EventListCommand($this->dispatcher),
-            new RouteListCommand($router),
-            new SchemaListCommand($schemaRegistry),
-            new SchemaCheckCommand($healthChecker),
-            new HealthCheckCommand($healthChecker),
-            new HealthReportCommand($healthChecker, $this->projectRoot),
-            new PermissionListCommand($permissionHandler),
-            ...($semanticWarmer !== null ? [
-                new SemanticWarmCommand($semanticWarmer),
-                new SemanticRefreshCommand($semanticWarmer),
-            ] : []),
-            new FixtureScaffoldCommand(),
-            new FixtureGenerateCommand(),
-            new FixturePackRefreshCommand(),
-            new IngestDashboardCommand(),
-            new IngestRunCommand(),
-            new BundleScaffoldCommand(),
-            new RelationshipTypeScaffoldCommand(),
-            new WorkflowScaffoldCommand(),
-            new ExtensionScaffoldCommand(),
-            new OptimizeCommand(),
-            new OptimizeManifestCommand($manifestCompiler),
-            new OptimizeConfigCommand(new ConfigCacheCompiler(
-                $activeStorage,
-                $this->projectRoot . '/storage/framework/config.php',
-            )),
-            new OptimizeClearCommand($this->projectRoot . '/storage'),
-            new PerformanceBaselineCommand(),
-            new PerformanceCompareCommand(),
-            new TelescopeClearCommand(),
-            new TelescopeListCommand(),
-            new TelescopePruneCommand(),
-            new SyncRulesCommand(
-                $this->projectRoot . '/vendor/waaseyaa/foundation/.claude/rules',
-                $this->projectRoot . '/.claude/rules',
-            ),
-            new WaaseyaaVersionCommand($this->projectRoot),
-        ]);
+        $app->registerCommands($commandRegistry->coreCommands(
+            projectRoot: $this->projectRoot,
+            config: $this->config,
+            manifest: $this->manifest,
+            dispatcher: $this->dispatcher,
+            entityTypeManager: $this->entityTypeManager,
+            lifecycleManager: $this->lifecycleManager,
+            entityAuditLogger: $this->entityAuditLogger,
+            database: $this->database,
+            configManager: $configManager,
+            cacheFactory: $cacheFactory,
+            router: $router,
+            permissionHandler: $permissionHandler,
+            manifestCompiler: $manifestCompiler,
+            schemaRegistry: $schemaRegistry,
+            healthChecker: $healthChecker,
+            typeIdNormalizer: $typeIdNormalizer,
+            semanticWarmer: $semanticWarmer,
+            pdo: $pdo,
+        ));
 
         $migrationsProvider = fn() => $this->migrationLoader->loadAll();
-        $app->registerCommands([
-            new MigrateCommand($this->migrator, $migrationsProvider),
-            new MigrateRollbackCommand($this->migrator, $migrationsProvider),
-            new MigrateStatusCommand($this->migrator, $migrationsProvider),
-        ]);
+        $app->registerCommands($commandRegistry->migrationCommands($this->migrator, $migrationsProvider));
 
         foreach ($this->providers as $provider) {
             $pluginCommands = $provider->commands($this->entityTypeManager, $this->database, $this->dispatcher);

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -165,7 +165,13 @@ final class HttpKernel extends AbstractKernel
         // Router setup.
         $context = new RequestContext('', $method);
         $router = new WaaseyaaRouter($context);
-        $routeRegistrar = new BuiltinRouteRegistrar($this->entityTypeManager, $this->providers);
+        $routeProviders = [
+            new \Waaseyaa\Api\JsonApiRouteProvider($this->entityTypeManager),
+        ];
+        if (class_exists(\Waaseyaa\GraphQL\GraphQlRouteProvider::class)) {
+            $routeProviders[] = new \Waaseyaa\GraphQL\GraphQlRouteProvider();
+        }
+        $routeRegistrar = new BuiltinRouteRegistrar($this->entityTypeManager, $this->providers, $routeProviders);
         $routeRegistrar->register($router);
 
         // Strip language prefix before routing so /oj/communities matches /communities.

--- a/packages/foundation/tests/Unit/Kernel/BuiltinRouteRegistrarExternalRoutesTest.php
+++ b/packages/foundation/tests/Unit/Kernel/BuiltinRouteRegistrarExternalRoutesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Routing\RequestContext;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Kernel\BuiltinRouteRegistrar;
+use Waaseyaa\Routing\RouteBuilder;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(BuiltinRouteRegistrar::class)]
+final class BuiltinRouteRegistrarExternalRoutesTest extends TestCase
+{
+    #[Test]
+    public function registers_external_route_providers_before_public_pages(): void
+    {
+        $entityTypeManager = new EntityTypeManager(new EventDispatcher());
+        $router = new WaaseyaaRouter(new RequestContext('', 'GET'));
+        $registrar = new BuiltinRouteRegistrar(
+            entityTypeManager: $entityTypeManager,
+            providers: [],
+            routeProviders: [new class {
+                public function registerRoutes(WaaseyaaRouter $router): void
+                {
+                    $router->addRoute(
+                        'external.route',
+                        RouteBuilder::create('/external')
+                            ->controller('external.route')
+                            ->methods('GET')
+                            ->build(),
+                    );
+                }
+            }],
+        );
+
+        $registrar->register($router);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('external.route'));
+        $this->assertNotNull($routes->get('public.page'));
+    }
+}

--- a/packages/graphql/composer.json
+++ b/packages/graphql/composer.json
@@ -42,6 +42,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\GraphQL\\GraphQlServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/graphql/src/GraphQlServiceProvider.php
+++ b/packages/graphql/src/GraphQlServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\GraphQL;
+
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class GraphQlServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        (new GraphQlRouteProvider())->registerRoutes($router);
+    }
+}

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -8,6 +8,8 @@ use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Mail\MailDriverInterface;
+use Waaseyaa\Routing\RouteBuilder;
+use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class UserServiceProvider extends ServiceProvider
 {
@@ -73,5 +75,35 @@ final class UserServiceProvider extends ServiceProvider
             baseUrl: $config['app']['url'] ?? '',
             appName: $config['app']['name'] ?? 'Waaseyaa',
         ));
+    }
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        $router->addRoute(
+            'api.user.me',
+            RouteBuilder::create('/api/user/me')
+                ->controller('user.me')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.auth.login',
+            RouteBuilder::create('/api/auth/login')
+                ->controller('auth.login')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.auth.logout',
+            RouteBuilder::create('/api/auth/logout')
+                ->controller('auth.logout')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
     }
 }

--- a/packages/user/tests/Unit/UserServiceProviderTest.php
+++ b/packages/user/tests/Unit/UserServiceProviderTest.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\User\Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\User\User;
 use Waaseyaa\User\UserServiceProvider;
 
@@ -52,5 +53,19 @@ final class UserServiceProviderTest extends TestCase
         $this->assertSame('uid', $keys['id']);
         $this->assertSame('uuid', $keys['uuid']);
         $this->assertSame('name', $keys['label']);
+    }
+
+    #[Test]
+    public function registers_auth_routes_owned_by_the_user_domain(): void
+    {
+        $provider = new UserServiceProvider();
+        $router = new WaaseyaaRouter();
+
+        $provider->routes($router);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('api.user.me'));
+        $this->assertNotNull($routes->get('api.auth.login'));
+        $this->assertNotNull($routes->get('api.auth.logout'));
     }
 }


### PR DESCRIPTION
This PR merges the rebuilt Batch D2 execution work from commit 854801f9.

D2 realigns route, console, user, and admin provider surfaces, normalizes package declarations, and carries the regression coverage needed for the provider-owned runtime shape.

Verification:
- 20 PHPUnit tests passed with 54 assertions (known non-blocking coverage-driver warning)
- 7 Node adapter tests passed
- Diff is limited to Batch D2 scope only.
- No protected upstream surfaces modified.
- No new audit surfaces introduced.

Governance references:
- Canonical model: #987
- Drift ledger: #991
- Execution baseline: #986
- Invariant protocol: #988
- M10 bootstrap: #993
