### PR TITLE
exec(conformance)(M10): Batch D3 — fallback-path correction & semantic normalization

### DIFF
--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -29,6 +29,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\Foundation\\FoundationServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -51,7 +51,13 @@ final class PackageManifestCompiler
         $installedPath = $this->basePath . '/vendor/composer/installed.json';
         if (is_file($installedPath)) {
             $installed = json_decode(file_get_contents($installedPath), true, 512, JSON_THROW_ON_ERROR);
-            $packages = $installed['packages'] ?? $installed;
+            $packages = array_map(
+                fn(array $package): array => $this->hydrateInstalledPackageMetadata(
+                    package: $package,
+                    installedMetadataDir: dirname($installedPath),
+                ),
+                $installed['packages'] ?? $installed,
+            );
 
             foreach ($packages as $package) {
                 $extra = $package['extra']['waaseyaa'] ?? null;
@@ -165,6 +171,67 @@ final class PackageManifestCompiler
             policies: $policies,
             packageDeclarations: $packageDeclarations,
         );
+    }
+
+    /**
+     * Composer path repositories can leave installed.json without local extra metadata.
+     *
+     * When install-path is present, merge the on-disk package composer.json so the
+     * canonical provider/declaration model reflects the actual local package state.
+     *
+     * @param array<string, mixed> $package
+     * @return array<string, mixed>
+     */
+    private function hydrateInstalledPackageMetadata(array $package, string $installedMetadataDir): array
+    {
+        $installPath = $package['install-path'] ?? null;
+        if (!is_string($installPath) || $installPath === '') {
+            return $package;
+        }
+
+        $composerPath = $this->resolveInstalledPackageComposerPath($installPath, $installedMetadataDir);
+        if ($composerPath === null) {
+            return $package;
+        }
+
+        try {
+            $localComposer = json_decode(file_get_contents($composerPath), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable) {
+            return $package;
+        }
+
+        if (!is_array($localComposer)) {
+            return $package;
+        }
+
+        $localExtra = is_array($localComposer['extra'] ?? null) ? $localComposer['extra'] : [];
+        $installedExtra = is_array($package['extra'] ?? null) ? $package['extra'] : [];
+        $localAutoload = is_array($localComposer['autoload'] ?? null) ? $localComposer['autoload'] : [];
+        $installedAutoload = is_array($package['autoload'] ?? null) ? $package['autoload'] : [];
+
+        return array_replace($localComposer, $package, [
+            'name' => $package['name'] ?? $localComposer['name'] ?? null,
+            'type' => $package['type'] ?? $localComposer['type'] ?? 'library',
+            'autoload' => array_replace_recursive($localAutoload, $installedAutoload),
+            'extra' => array_replace_recursive($localExtra, $installedExtra),
+        ]);
+    }
+
+    private function resolveInstalledPackageComposerPath(string $installPath, string $installedMetadataDir): ?string
+    {
+        $candidatePaths = [
+            $installedMetadataDir . '/' . $installPath . '/composer.json',
+            $this->basePath . '/' . ltrim($installPath, './') . '/composer.json',
+        ];
+
+        foreach ($candidatePaths as $candidatePath) {
+            $resolved = realpath($candidatePath);
+            if ($resolved !== false && is_file($resolved)) {
+                return $resolved;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/packages/foundation/src/FoundationServiceProvider.php
+++ b/packages/foundation/src/FoundationServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation;
+
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+final class FoundationServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+}

--- a/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
+++ b/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
@@ -19,22 +19,14 @@ final class BuiltinRouteRegistrar
 {
     /**
      * @param list<ServiceProvider> $providers
-     * @param list<object> $routeProviders
      */
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
         private readonly array $providers = [],
-        private readonly array $routeProviders = [],
     ) {}
 
     public function register(WaaseyaaRouter $router): void
     {
-        foreach ($this->routeProviders as $routeProvider) {
-            if (method_exists($routeProvider, 'registerRoutes')) {
-                $routeProvider->registerRoutes($router);
-            }
-        }
-
         $router->addRoute(
             'api.schema.show',
             RouteBuilder::create('/api/schema/{entity_type}')

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -165,13 +165,7 @@ final class HttpKernel extends AbstractKernel
         // Router setup.
         $context = new RequestContext('', $method);
         $router = new WaaseyaaRouter($context);
-        $routeProviders = [
-            new \Waaseyaa\Api\JsonApiRouteProvider($this->entityTypeManager),
-        ];
-        if (class_exists(\Waaseyaa\GraphQL\GraphQlRouteProvider::class)) {
-            $routeProviders[] = new \Waaseyaa\GraphQL\GraphQlRouteProvider();
-        }
-        $routeRegistrar = new BuiltinRouteRegistrar($this->entityTypeManager, $this->providers, $routeProviders);
+        $routeRegistrar = new BuiltinRouteRegistrar($this->entityTypeManager, $this->providers);
         $routeRegistrar->register($router);
 
         // Strip language prefix before routing so /oj/communities matches /communities.

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -129,6 +129,73 @@ final class PackageManifestCompilerTest extends TestCase
     }
 
     #[Test]
+    public function compile_includes_foundation_provider_in_repo_manifest(): void
+    {
+        $repoRoot = dirname(__DIR__, 5);
+        $compiler = new PackageManifestCompiler($repoRoot, $repoRoot . '/storage');
+
+        $manifest = $compiler->compile();
+
+        $this->assertContains('Waaseyaa\\Foundation\\FoundationServiceProvider', $manifest->providers);
+        $this->assertSame(
+            [
+                'surface' => 'implementation',
+                'activation' => 'provider',
+            ],
+            $manifest->packageDeclarations['waaseyaa/foundation'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function compile_reads_local_package_composer_metadata_when_installed_manifest_omits_waaseyaa_extra(): void
+    {
+        mkdir($this->tempDir . '/packages/foundation/src', 0o755, true);
+
+        file_put_contents(
+            $this->tempDir . '/packages/foundation/composer.json',
+            json_encode([
+                'name' => 'waaseyaa/foundation',
+                'autoload' => [
+                    'psr-4' => ['Waaseyaa\\Foundation\\' => 'src/'],
+                ],
+                'extra' => [
+                    'waaseyaa' => [
+                        'providers' => ['Waaseyaa\\Foundation\\FoundationServiceProvider'],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+        );
+
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode([
+                'packages' => [
+                    [
+                        'name' => 'waaseyaa/foundation',
+                        'type' => 'library',
+                        'install-path' => '../../../packages/foundation',
+                        'autoload' => [
+                            'psr-4' => ['Waaseyaa\\Foundation\\' => 'src/'],
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $compiler = new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage');
+        $manifest = $compiler->compile();
+
+        $this->assertContains('Waaseyaa\\Foundation\\FoundationServiceProvider', $manifest->providers);
+        $this->assertSame(
+            [
+                'surface' => 'implementation',
+                'activation' => 'provider',
+            ],
+            $manifest->packageDeclarations['waaseyaa/foundation'] ?? null,
+        );
+    }
+
+    #[Test]
     public function compile_handles_missing_installed_json(): void
     {
         $storagePath = $this->tempDir . '/storage';

--- a/packages/foundation/tests/Unit/Kernel/BuiltinRouteRegistrarExternalRoutesTest.php
+++ b/packages/foundation/tests/Unit/Kernel/BuiltinRouteRegistrarExternalRoutesTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\RequestContext;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\Kernel\BuiltinRouteRegistrar;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
@@ -24,9 +25,10 @@ final class BuiltinRouteRegistrarExternalRoutesTest extends TestCase
         $router = new WaaseyaaRouter(new RequestContext('', 'GET'));
         $registrar = new BuiltinRouteRegistrar(
             entityTypeManager: $entityTypeManager,
-            providers: [],
-            routeProviders: [new class {
-                public function registerRoutes(WaaseyaaRouter $router): void
+            providers: [new class extends ServiceProvider {
+                public function register(): void {}
+
+                public function routes(WaaseyaaRouter $router, ?\Waaseyaa\Entity\EntityTypeManager $entityTypeManager = null): void
                 {
                     $router->addRoute(
                         'external.route',

--- a/packages/foundation/tests/Unit/Kernel/ProviderDrivenRouteRegistrationTest.php
+++ b/packages/foundation/tests/Unit/Kernel/ProviderDrivenRouteRegistrationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Routing\RequestContext;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistry;
+use Waaseyaa\Foundation\Kernel\BuiltinRouteRegistrar;
+use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class ProviderDrivenRouteRegistrationTest extends TestCase
+{
+    #[Test]
+    public function provider_declared_request_packages_register_routes_without_foundation_special_casing(): void
+    {
+        $repoRoot = dirname(__DIR__, 5);
+        $compiler = new PackageManifestCompiler($repoRoot, $repoRoot . '/storage');
+        $compiledManifest = $compiler->compile();
+
+        $providers = array_values(array_filter(
+            $compiledManifest->providers,
+            static fn(string $provider): bool => in_array($provider, [
+                'Waaseyaa\\Api\\ApiServiceProvider',
+                'Waaseyaa\\GraphQL\\GraphQlServiceProvider',
+            ], true),
+        ));
+
+        $manifest = new PackageManifest(
+            providers: $providers,
+            commands: [],
+            routes: [],
+            migrations: [],
+            fieldTypes: [],
+            formatters: [],
+            listeners: [],
+            middleware: [],
+            permissions: [],
+            policies: [],
+            packageDeclarations: $compiledManifest->packageDeclarations,
+        );
+
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+        $entityTypeManager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: \stdClass::class,
+            keys: ['id' => 'id'],
+        ));
+
+        $database = DBALDatabase::createSqlite();
+        $registry = new ProviderRegistry(new NullLogger());
+        $providerInstances = $registry->discoverAndRegister(
+            manifest: $manifest,
+            projectRoot: $repoRoot,
+            config: [],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+
+        $router = new WaaseyaaRouter(new RequestContext('', 'GET'));
+        $registrar = new BuiltinRouteRegistrar($entityTypeManager, $providerInstances);
+        $registrar->register($router);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('api.discovery'));
+        $this->assertNotNull($routes->get('graphql.endpoint'));
+    }
+}


### PR DESCRIPTION
This PR merges the rebuilt Batch D3 execution work from commit 9c3d21cf.

D3 corrects the provider fallback path, normalizes foundation provider declarations, removes residual API/GraphQL fallback handling, and adds the regression coverage that proves provider-driven route registration.

Verification:
- 25 PHPUnit tests passed with 45 assertions (known non-blocking coverage-driver warning)
- Diff is limited to Batch D3 scope only.
- No protected upstream surfaces modified.
- No new audit surfaces introduced.

Governance references:
- Canonical model: #987
- Drift ledger: #991
- Execution baseline: #986
- Invariant protocol: #988
- M10 bootstrap: #993
