### PR TITLE
exec(conformance)(M10): Batch D4 — support-surface & verification-consumer alignment

### DIFF
--- a/packages/api/tests/Unit/ApiServiceProviderTest.php
+++ b/packages/api/tests/Unit/ApiServiceProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Api\ApiServiceProvider;
+use Waaseyaa\Api\Tests\Fixtures\TestEntity;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(ApiServiceProvider::class)]
+final class ApiServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function registers_json_api_routes_through_the_package_service_provider(): void
+    {
+        $entityTypeManager = new EntityTypeManager(new EventDispatcher());
+        $entityTypeManager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: TestEntity::class,
+        ));
+
+        $router = new WaaseyaaRouter();
+        (new ApiServiceProvider())->routes($router, $entityTypeManager);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('api.article.index'));
+        $this->assertNotNull($routes->get('api.article.show'));
+        $this->assertNotNull($routes->get('api.discovery'));
+    }
+
+    #[Test]
+    public function does_not_register_routes_without_an_entity_type_manager(): void
+    {
+        $router = new WaaseyaaRouter();
+
+        (new ApiServiceProvider())->routes($router, null);
+
+        $this->assertCount(0, $router->getRouteCollection());
+    }
+}

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
@@ -44,6 +44,7 @@ final class HttpKernelTest extends TestCase
         $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_http_test_' . uniqid();
         mkdir($this->projectRoot . '/config', 0755, true);
         mkdir($this->projectRoot . '/storage', 0755, true);
+        mkdir($this->projectRoot . '/vendor/composer', 0755, true);
         file_put_contents($this->projectRoot . '/config/waaseyaa.php', "<?php return ['database' => ':memory:'];");
         file_put_contents(
             $this->projectRoot . '/config/entity-types.php',
@@ -236,6 +237,64 @@ final class HttpKernelTest extends TestCase
         $this->assertNotNull($routes->get('public.home'));
         $this->assertNotNull($routes->get('public.page'));
         $this->assertTrue((bool) $routes->get('public.home')?->getOption('_render'));
+    }
+
+    #[Test]
+    public function booted_kernel_routes_include_provider_owned_request_surfaces(): void
+    {
+        $this->writeInstalledPackageProviders([
+            'waaseyaa/api' => ['Waaseyaa\\Api\\ApiServiceProvider'],
+            'waaseyaa/graphql' => ['Waaseyaa\\GraphQL\\GraphQlServiceProvider'],
+            'waaseyaa/user' => ['Waaseyaa\\User\\UserServiceProvider'],
+        ]);
+
+        $kernel = new HttpKernel($this->projectRoot);
+
+        $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
+        $boot->setAccessible(true);
+        $boot->invoke($kernel);
+
+        $entityTypeManagerProperty = new \ReflectionProperty(AbstractKernel::class, 'entityTypeManager');
+        $entityTypeManagerProperty->setAccessible(true);
+        $entityTypeManager = $entityTypeManagerProperty->getValue($kernel);
+
+        $providersProperty = new \ReflectionProperty(AbstractKernel::class, 'providers');
+        $providersProperty->setAccessible(true);
+        $providers = $providersProperty->getValue($kernel);
+
+        $router = new \Waaseyaa\Routing\WaaseyaaRouter(new \Symfony\Component\Routing\RequestContext('', 'GET'));
+        (new BuiltinRouteRegistrar($entityTypeManager, $providers))->register($router);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('api.discovery'));
+        $this->assertNotNull($routes->get('graphql.endpoint'));
+        $this->assertNotNull($routes->get('api.user.me'));
+        $this->assertNotNull($routes->get('api.auth.login'));
+        $this->assertNotNull($routes->get('api.auth.logout'));
+    }
+
+    /**
+     * @param array<string, list<string>> $providersByPackage
+     */
+    private function writeInstalledPackageProviders(array $providersByPackage): void
+    {
+        $packages = [];
+
+        foreach ($providersByPackage as $packageName => $providers) {
+            $packages[] = [
+                'name' => $packageName,
+                'extra' => [
+                    'waaseyaa' => [
+                        'providers' => $providers,
+                    ],
+                ],
+            ];
+        }
+
+        file_put_contents(
+            $this->projectRoot . '/vendor/composer/installed.json',
+            json_encode(['packages' => $packages], JSON_THROW_ON_ERROR),
+        );
     }
 
     #[Test]

--- a/packages/graphql/tests/Unit/GraphQlServiceProviderTest.php
+++ b/packages/graphql/tests/Unit/GraphQlServiceProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\GraphQL\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\GraphQL\GraphQlServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(GraphQlServiceProvider::class)]
+final class GraphQlServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function registers_the_graphql_endpoint_through_the_package_service_provider(): void
+    {
+        $router = new WaaseyaaRouter();
+
+        (new GraphQlServiceProvider())->routes($router);
+
+        $route = $router->getRouteCollection()->get('graphql.endpoint');
+        $this->assertNotNull($route);
+        $this->assertSame('/graphql', $route->getPath());
+    }
+}

--- a/tests/Integration/Phase7/ApiRoutingIntegrationTest.php
+++ b/tests/Integration/Phase7/ApiRoutingIntegrationTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RequestContext;
+use Waaseyaa\Api\ApiServiceProvider;
 use Waaseyaa\Api\JsonApiController;
-use Waaseyaa\Api\JsonApiRouteProvider;
 use Waaseyaa\Api\ResourceSerializer;
 use Waaseyaa\Api\Tests\Fixtures\InMemoryEntityStorage;
 use Waaseyaa\Api\Tests\Fixtures\TestEntity;
@@ -22,7 +22,7 @@ use Waaseyaa\Routing\WaaseyaaRouter;
 /**
  * End-to-end: routes + API controller + entity storage integration tests.
  *
- * Exercises: waaseyaa/api (JsonApiRouteProvider, JsonApiController) with
+ * Exercises: waaseyaa/api (ApiServiceProvider, JsonApiController) with
  * waaseyaa/routing (WaaseyaaRouter, RouteBuilder) and waaseyaa/entity
  * (EntityTypeManager).
  */
@@ -55,10 +55,8 @@ final class ApiRoutingIntegrationTest extends TestCase
             ],
         ));
 
-        // Set up router with API routes.
-        $this->router = new WaaseyaaRouter(new RequestContext());
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($this->router);
+        // Set up router with API routes through the package-owned provider surface.
+        $this->router = $this->createApiRouter('GET');
 
         // Set up controller.
         $serializer = new ResourceSerializer($this->entityTypeManager);
@@ -80,10 +78,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function indexRouteMatchesGetCollection(): void
     {
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $params = $router->match('/api/node');
 
@@ -94,10 +89,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function showRouteMatchesGetWithId(): void
     {
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $params = $router->match('/api/node/42');
 
@@ -109,10 +101,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function storeRouteMatchesPostCollection(): void
     {
-        $context = new RequestContext('', 'POST');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('POST');
 
         $params = $router->match('/api/node');
 
@@ -123,10 +112,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function updateRouteMatchesPatchWithId(): void
     {
-        $context = new RequestContext('', 'PATCH');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('PATCH');
 
         $params = $router->match('/api/node/7');
 
@@ -138,10 +124,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function destroyRouteMatchesDeleteWithId(): void
     {
-        $context = new RequestContext('', 'DELETE');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('DELETE');
 
         $params = $router->match('/api/node/3');
 
@@ -153,10 +136,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function routeParametersExtractEntityTypeAndId(): void
     {
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $params = $router->match('/api/node/123');
 
@@ -167,10 +147,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     #[Test]
     public function unmatchedPathThrowsResourceNotFound(): void
     {
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $this->expectException(ResourceNotFoundException::class);
         $router->match('/api/unknown_type');
@@ -188,10 +165,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         $this->nodeStorage->save($entity);
 
         // Step 2: Match a GET route for the entity.
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        $routeProvider = new JsonApiRouteProvider($this->entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $params = $router->match('/api/node/' . $entity->id());
 
@@ -217,9 +191,7 @@ final class ApiRoutingIntegrationTest extends TestCase
     public function fullCrudCycleThroughRouteMatching(): void
     {
         // POST: Create via route match.
-        $postContext = new RequestContext('', 'POST');
-        $postRouter = new WaaseyaaRouter($postContext);
-        (new JsonApiRouteProvider($this->entityTypeManager))->registerRoutes($postRouter);
+        $postRouter = $this->createApiRouter('POST');
 
         $postParams = $postRouter->match('/api/node');
         $this->assertSame('api.node.store', $postParams['_route']);
@@ -239,9 +211,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         $uuid = $createArray['data']['id'];
 
         // GET: Read via route match.
-        $getContext = new RequestContext('', 'GET');
-        $getRouter = new WaaseyaaRouter($getContext);
-        (new JsonApiRouteProvider($this->entityTypeManager))->registerRoutes($getRouter);
+        $getRouter = $this->createApiRouter('GET');
 
         $getParams = $getRouter->match('/api/node/1');
         $this->assertSame('api.node.show', $getParams['_route']);
@@ -250,9 +220,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         $this->assertSame(200, $showDoc->statusCode);
 
         // PATCH: Update via route match.
-        $patchContext = new RequestContext('', 'PATCH');
-        $patchRouter = new WaaseyaaRouter($patchContext);
-        (new JsonApiRouteProvider($this->entityTypeManager))->registerRoutes($patchRouter);
+        $patchRouter = $this->createApiRouter('PATCH');
 
         $patchParams = $patchRouter->match('/api/node/1');
         $this->assertSame('api.node.update', $patchParams['_route']);
@@ -269,9 +237,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         $this->assertSame(200, $updateDoc->statusCode);
 
         // DELETE: Destroy via route match.
-        $deleteContext = new RequestContext('', 'DELETE');
-        $deleteRouter = new WaaseyaaRouter($deleteContext);
-        (new JsonApiRouteProvider($this->entityTypeManager))->registerRoutes($deleteRouter);
+        $deleteRouter = $this->createApiRouter('DELETE');
 
         $deleteParams = $deleteRouter->match('/api/node/1');
         $this->assertSame('api.node.destroy', $deleteParams['_route']);
@@ -326,8 +292,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         ));
 
         $router = new WaaseyaaRouter(new RequestContext('', 'GET'));
-        $routeProvider = new JsonApiRouteProvider($entityTypeManager);
-        $routeProvider->registerRoutes($router);
+        (new ApiServiceProvider())->routes($router, $entityTypeManager);
 
         $routes = $router->getRouteCollection();
 
@@ -374,9 +339,7 @@ final class ApiRoutingIntegrationTest extends TestCase
         }
 
         // Match the index route.
-        $context = new RequestContext('', 'GET');
-        $router = new WaaseyaaRouter($context);
-        (new JsonApiRouteProvider($this->entityTypeManager))->registerRoutes($router);
+        $router = $this->createApiRouter('GET');
 
         $params = $router->match('/api/node');
         $this->assertSame('api.node.index', $params['_route']);
@@ -386,5 +349,13 @@ final class ApiRoutingIntegrationTest extends TestCase
         $this->assertSame(200, $doc->statusCode);
         $array = $doc->toArray();
         $this->assertCount(3, $array['data']);
+    }
+
+    private function createApiRouter(string $method): WaaseyaaRouter
+    {
+        $router = new WaaseyaaRouter(new RequestContext('', $method));
+        (new ApiServiceProvider())->routes($router, $this->entityTypeManager);
+
+        return $router;
     }
 }


### PR DESCRIPTION
This PR merges the rebuilt Batch D4 execution work from commit f8deba99.

D4 aligns the support-surface verification consumers with the canonical provider-owned runtime by updating the kernel harness, routing integration verification through ApiServiceProvider, and adding package-level provider coverage for API and GraphQL surfaces.

Verification:
- 59 PHPUnit tests passed with 167 assertions (known non-blocking coverage-driver warning)
- Diff is limited to Batch D4 scope only.
- No protected upstream surfaces modified.
- No new audit surfaces introduced.

Governance references:
- Canonical model: #987
- Drift ledger: #991
- Execution baseline: #986
- Invariant protocol: #988
- M10 bootstrap: #993
