### PR TITLE
exec(conformance)(M10): Batch D5+ — MCP domain cleanup

### DIFF
--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -147,6 +147,24 @@ final class PackageManifestCompilerTest extends TestCase
     }
 
     #[Test]
+    public function compile_includes_mcp_provider_in_repo_manifest(): void
+    {
+        $repoRoot = dirname(__DIR__, 5);
+        $compiler = new PackageManifestCompiler($repoRoot, $repoRoot . '/storage');
+
+        $manifest = $compiler->compile();
+
+        $this->assertContains('Waaseyaa\\Mcp\\McpServiceProvider', $manifest->providers);
+        $this->assertSame(
+            [
+                'surface' => 'implementation',
+                'activation' => 'provider',
+            ],
+            $manifest->packageDeclarations['waaseyaa/mcp'] ?? null,
+        );
+    }
+
+    #[Test]
     public function compile_reads_local_package_composer_metadata_when_installed_manifest_omits_waaseyaa_extra(): void
     {
         mkdir($this->tempDir . '/packages/foundation/src', 0o755, true);

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -93,6 +93,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\Mcp\\McpServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/mcp/src/McpServiceProvider.php
+++ b/packages/mcp/src/McpServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mcp;
+
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+final class McpServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+
+    public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
+    {
+        (new McpRouteProvider())->registerRoutes($router);
+    }
+}

--- a/packages/mcp/tests/Unit/McpServiceProviderTest.php
+++ b/packages/mcp/tests/Unit/McpServiceProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Mcp\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Mcp\McpServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(McpServiceProvider::class)]
+final class McpServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function registers_mcp_routes_through_the_package_service_provider(): void
+    {
+        $router = new WaaseyaaRouter();
+
+        (new McpServiceProvider())->routes($router);
+
+        $routes = $router->getRouteCollection();
+        $this->assertNotNull($routes->get('mcp.endpoint'));
+        $this->assertNotNull($routes->get('mcp.server_card'));
+    }
+}

--- a/tests/Integration/Phase11/McpEndpointSmokeTest.php
+++ b/tests/Integration/Phase11/McpEndpointSmokeTest.php
@@ -21,8 +21,8 @@ use Waaseyaa\Mcp\Auth\BearerTokenAuth;
 use Waaseyaa\Mcp\Bridge\ToolExecutorInterface;
 use Waaseyaa\Mcp\Bridge\ToolRegistryInterface;
 use Waaseyaa\Mcp\McpEndpoint;
-use Waaseyaa\Mcp\McpRouteProvider;
 use Waaseyaa\Mcp\McpServerCard;
+use Waaseyaa\Mcp\McpServiceProvider;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class McpEndpointSmokeTest extends TestCase
@@ -96,8 +96,7 @@ final class McpEndpointSmokeTest extends TestCase
 
         // --- Step 2: Route registration ---
         $router = new WaaseyaaRouter();
-        $routeProvider = new McpRouteProvider();
-        $routeProvider->registerRoutes($router);
+        (new McpServiceProvider())->routes($router);
 
         $routes = $router->getRouteCollection();
         $this->assertNotNull($routes->get('mcp.endpoint'));


### PR DESCRIPTION
This PR merges the rebuilt Batch D5+ execution work from commit 3562c569.

D5+ adds the MCP provider declaration, introduces McpServiceProvider, extends manifest coverage for MCP provider discovery, and routes the Phase11 MCP endpoint through the MCP package provider.

Verification:
- 37 PHPUnit tests passed with 142 assertions (known non-blocking coverage-driver warning)
- Diff is limited to Batch D5+ scope only.
- No protected upstream surfaces modified.
- No new audit surfaces introduced.

Governance references:
- Canonical model: #987
- Drift ledger: #991
- Execution baseline: #986
- Invariant protocol: #988
- M10 bootstrap: #993
