### PR TITLE
governance(M11): C17 — admin SPA runtime & composable drift remediation

### DIFF
--- a/packages/admin/tests/components/schema/SchemaForm.test.ts
+++ b/packages/admin/tests/components/schema/SchemaForm.test.ts
@@ -5,28 +5,28 @@ import { flushPromises } from '@vue/test-utils'
 import SchemaForm from '~/components/schema/SchemaForm.vue'
 import { userSchema } from '../../fixtures/schemas'
 
-// Register schema endpoints — transport POSTs to /_surface/{type}/action/schema
-registerEndpoint('/_surface/user/action/schema', {
+// Register schema endpoints — transport POSTs to /admin/_surface/{type}/action/schema
+registerEndpoint('/admin/_surface/user/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
 
-registerEndpoint('/_surface/user_create/action/schema', {
+registerEndpoint('/admin/_surface/user_create/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
 
-registerEndpoint('/_surface/user_create_err/action/schema', {
+registerEndpoint('/admin/_surface/user_create_err/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
 
-registerEndpoint('/_surface/user_edit/action/schema', {
+registerEndpoint('/admin/_surface/user_edit/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
 
-registerEndpoint('/_surface/user_edit_patch/action/schema', {
+registerEndpoint('/admin/_surface/user_edit_patch/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
@@ -59,7 +59,7 @@ const schemaWithDefaults = {
   },
 }
 
-registerEndpoint('/_surface/node_defaults/action/schema', {
+registerEndpoint('/admin/_surface/node_defaults/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: schemaWithDefaults }),
 })
@@ -71,7 +71,7 @@ beforeEach(() => {
 
 describe('SchemaForm loading and error states', () => {
   it('shows error state when schema fetch fails', async () => {
-    registerEndpoint('/_surface/user_err_state/action/schema', {
+    registerEndpoint('/admin/_surface/user_err_state/action/schema', {
       method: 'POST',
       handler: () => {
         throw createError({ statusCode: 404, statusMessage: 'Not Found' })
@@ -98,7 +98,7 @@ describe('SchemaForm loading and error states', () => {
 describe('SchemaForm submit — create mode (no entityId)', () => {
   it('emits saved event with resource on successful create', async () => {
     const resource = { type: 'user', id: '5', attributes: { name: 'alice' } }
-    registerEndpoint('/_surface/user_create/action/create', {
+    registerEndpoint('/admin/_surface/user_create/action/create', {
       method: 'POST',
       handler: () => ({
         ok: true,
@@ -134,7 +134,7 @@ describe('SchemaForm submit — create mode (no entityId)', () => {
   })
 
   it('emits error event when create fails', async () => {
-    registerEndpoint('/_surface/user_create_err/action/create', {
+    registerEndpoint('/admin/_surface/user_create_err/action/create', {
       method: 'POST',
       handler: () => {
         throw createError({ statusCode: 422, statusMessage: 'Validation failed' })
@@ -154,7 +154,7 @@ describe('SchemaForm submit — create mode (no entityId)', () => {
 
 describe('SchemaForm submit — edit mode (with entityId)', () => {
   it('loads existing entity attributes into form', async () => {
-    registerEndpoint('/_surface/user_edit/3', {
+    registerEndpoint('/admin/_surface/user_edit/3', {
       method: 'GET',
       handler: () => ({
         ok: true,
@@ -179,11 +179,11 @@ describe('SchemaForm submit — edit mode (with entityId)', () => {
 
   it('emits saved event after PATCH when entityId is provided', async () => {
     const updated = { type: 'user', id: '3', attributes: { name: 'bob-updated' } }
-    registerEndpoint('/_surface/user_edit_patch/3', () => ({
+    registerEndpoint('/admin/_surface/user_edit_patch/3', () => ({
       ok: true,
       data: { type: 'user', id: '3', attributes: { name: 'bob' } },
     }))
-    registerEndpoint('/_surface/user_edit_patch/action/update', {
+    registerEndpoint('/admin/_surface/user_edit_patch/action/update', {
       method: 'POST',
       handler: () => ({
         ok: true,

--- a/packages/admin/tests/pages/dashboard.test.ts
+++ b/packages/admin/tests/pages/dashboard.test.ts
@@ -5,7 +5,7 @@ import Dashboard from '~/pages/index.vue'
 
 describe('Dashboard onboarding', () => {
   it('shows onboarding prompt when no content types exist', async () => {
-    registerEndpoint('/_surface/node_type', () => ({
+    registerEndpoint('/admin/_surface/node_type', () => ({
       ok: true,
       data: {
         entities: [],

--- a/packages/admin/tests/setup.ts
+++ b/packages/admin/tests/setup.ts
@@ -1,6 +1,6 @@
 // packages/admin/tests/setup.ts
-// Global test setup — provides mock /_surface/* endpoints for the admin plugin.
-// The admin plugin fetches /_surface/session then /_surface/catalog to build AdminRuntime.
+// Global test setup — provides mock /admin/_surface/* endpoints for the admin plugin.
+// The admin plugin fetches /admin/_surface/session then /admin/_surface/catalog to build AdminRuntime.
 // Individual tests can override $fetch or $admin as needed.
 import { vi } from 'vitest'
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
@@ -22,8 +22,8 @@ const catalogEntities = [
   { id: 'pipeline', label: 'Pipeline', capabilities: defaultCaps, fields: [], actions: [] },
 ]
 
-// /_surface/session — the admin plugin checks this first
-registerEndpoint('/_surface/session', () => ({
+// /admin/_surface/session — the admin plugin checks this first
+registerEndpoint('/admin/_surface/session', () => ({
   ok: true,
   data: {
     account: { id: '1', name: 'Admin', email: 'admin@example.com', roles: ['admin'] },
@@ -33,8 +33,8 @@ registerEndpoint('/_surface/session', () => ({
   },
 }))
 
-// /_surface/catalog — fetched after a successful session
-registerEndpoint('/_surface/catalog', () => ({
+// /admin/_surface/catalog — fetched after a successful session
+registerEndpoint('/admin/_surface/catalog', () => ({
   ok: true,
   data: {
     entities: catalogEntities,

--- a/packages/admin/tests/unit/composables/useEntity.test.ts
+++ b/packages/admin/tests/unit/composables/useEntity.test.ts
@@ -1,13 +1,13 @@
 // packages/admin/tests/unit/composables/useEntity.test.ts
 // The useEntity composable delegates to $admin.transport (AdminSurfaceTransportAdapter).
-// The transport calls /_surface/* endpoints with SurfaceResult<T> envelope { ok, data }.
+// The transport calls /admin/_surface/* endpoints with SurfaceResult<T> envelope { ok, data }.
 import { describe, it, expect, vi } from 'vitest'
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
 import { useEntity } from '~/composables/useEntity'
 
 describe('useEntity (adapter-backed)', () => {
   it('list delegates to transport and returns result', async () => {
-    registerEndpoint('/_surface/node', () => ({
+    registerEndpoint('/admin/_surface/node', () => ({
       ok: true,
       data: {
         entities: [{ type: 'node', id: '1', attributes: { title: 'Hello' } }],
@@ -23,7 +23,7 @@ describe('useEntity (adapter-backed)', () => {
   })
 
   it('get delegates to transport and returns resource', async () => {
-    registerEndpoint('/_surface/node/5', () => ({
+    registerEndpoint('/admin/_surface/node/5', () => ({
       ok: true,
       data: { type: 'node', id: '5', attributes: { title: 'Post' } },
     }))
@@ -34,7 +34,7 @@ describe('useEntity (adapter-backed)', () => {
   })
 
   it('create delegates to transport', async () => {
-    registerEndpoint('/_surface/node/action/create', {
+    registerEndpoint('/admin/_surface/node/action/create', {
       method: 'POST',
       handler: () => ({
         ok: true,

--- a/packages/admin/tests/unit/composables/useSchema.test.ts
+++ b/packages/admin/tests/unit/composables/useSchema.test.ts
@@ -1,24 +1,24 @@
 // packages/admin/tests/unit/composables/useSchema.test.ts
 // useSchema delegates to $admin.transport.schema() which calls
-// POST /_surface/{type}/action/schema and expects { ok: true, data: EntitySchema }.
+// POST /admin/_surface/{type}/action/schema and expects { ok: true, data: EntitySchema }.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
 import { userSchema } from '../../fixtures/schemas'
 
-// Register schema endpoints for tests — the transport POSTs to /_surface/{type}/action/schema
-registerEndpoint('/_surface/user/action/schema', {
+// Register schema endpoints for tests — the transport POSTs to /admin/_surface/{type}/action/schema
+registerEndpoint('/admin/_surface/user/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
-registerEndpoint('/_surface/user_fresh/action/schema', {
+registerEndpoint('/admin/_surface/user_fresh/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
-registerEndpoint('/_surface/user_cache/action/schema', {
+registerEndpoint('/admin/_surface/user_cache/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
-registerEndpoint('/_surface/user_invalidate/action/schema', {
+registerEndpoint('/admin/_surface/user_invalidate/action/schema', {
   method: 'POST',
   handler: () => ({ ok: true, data: userSchema }),
 })
@@ -78,7 +78,7 @@ describe('useSchema fetch and caching', () => {
   })
 
   it('sets error.value when schema fetch fails', async () => {
-    registerEndpoint('/_surface/user_error/action/schema', {
+    registerEndpoint('/admin/_surface/user_error/action/schema', {
       method: 'POST',
       handler: () => {
         throw createError({ statusCode: 500, statusMessage: 'Server Error' })


### PR DESCRIPTION
This PR remediates the admin SPA runtime and composable drift tracked in #1016.

The current runtime on `main` is treated as authoritative. The failing admin Vitest suite was still mocking legacy `/_surface/*` endpoints, while the admin runtime now boots against `/admin/_surface/*`. This PR aligns the admin test harness and affected composable/component tests with the actual runtime behavior on `main`.

Resolved drift:
- 29 Vitest failures
- 13 unhandled errors

Scope:
- aligned admin test setup with the current admin runtime bootstrap path
- updated stale composable and component test endpoint mocks to `/admin/_surface/*`
- preserved the shipped runtime behavior and converged the test suite to it

Verification:
- Vitest: 29 test files passed, 145 tests passed
- npm run build: passed
- PHP suite: 5,576 tests passed, 13,299 assertions
- Known non-blocking PHPUnit warning: `No code coverage driver available`

Runtime behavior and tests are now aligned.
No protected upstream surfaces modified.
No new audit surfaces introduced.
