### PR TITLE
governance(M11): C18 — spec drift realignment

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,5 +1,7 @@
 # Access Control
 
+<!-- Spec reviewed 2026-04-01 - post-M10 provider-owned user/auth routes, manifest-discovered policy wiring, C18 drift remediation (#1017) -->
+
 Waaseyaa's access control system spans three packages: `packages/access/` (core primitives), `packages/routing/` (route-level checks), and `packages/user/` (session resolution, password reset). This document covers entity-level and route-level access. For field-level access, see `docs/specs/field-access.md`.
 
 ## Packages
@@ -8,7 +10,7 @@ Waaseyaa's access control system spans three packages: `packages/access/` (core 
 |---------|------|----------|
 | access | `packages/access/src/` | AccessPolicyInterface, AccessResult, AccessStatus, EntityAccessHandler, AccountInterface, FieldAccessPolicyInterface, PermissionHandler, Gate, EntityAccessGate, AuthorizationMiddleware |
 | routing | `packages/routing/src/` | AccessChecker (route-level access) |
-| user | `packages/user/src/Middleware/` | SessionMiddleware (account resolution) |
+| user | `packages/user/src/` | SessionMiddleware (account resolution), UserServiceProvider (package-owned user/auth routes) |
 
 ## Core Interfaces
 
@@ -172,7 +174,7 @@ For `checkFieldAccess()` and `filterFields()`, see `docs/specs/field-access.md`.
 
 ### Policy Registration
 
-Policies are passed to the constructor or added via `addPolicy()`. In `public/index.php`, the handler is created with an array of policy instances:
+Policies are passed to the constructor or added via `addPolicy()`. In the current post-M10 boot flow, `AccessPolicyRegistry` builds the handler from `PackageManifest::$policies`, while the kernel still exposes the resulting gate to `AccessChecker` during boot:
 
 ```php
 $accessHandler = new EntityAccessHandler([
@@ -452,12 +454,24 @@ Policies and permissions are discovered at build time via `PackageManifestCompil
 
 Layer discipline: Foundation (layer 0) uses string constants for attribute class names to avoid importing from higher layers. `ReflectionClass::getAttributes()` accepts string class names.
 
-## Auth Controllers (Phase 2)
+## User/Auth HTTP Surfaces (post-M10 package ownership)
 
-**Package:** `packages/auth/`
-**Registered by:** `AuthServiceProvider` — registers `AuthConfig`, `AuthTokenRepository`, and routes five controllers.
+**Packages:** `packages/auth/`, `packages/user/`
+**Registered by:** package service providers discovered from composer metadata. `UserServiceProvider` owns the foundational request surfaces `GET /api/user/me`, `POST /api/auth/login`, and `POST /api/auth/logout`; `AuthServiceProvider` continues to own registration, password-reset, and email-verification controllers.
 
 ### Endpoint Access Requirements
+
+#### UserServiceProvider-owned routes
+
+| Endpoint | Route option | Controller |
+|----------|-------------|------------|
+| `GET /api/user/me` | `_public: true` | `user.me` |
+| `POST /api/auth/login` | `_public: true` | `auth.login` |
+| `POST /api/auth/logout` | `_public: true` | `auth.logout` |
+
+These three request surfaces are registered by `packages/user/src/UserServiceProvider.php` as part of the package-owned route model introduced by M10.
+
+#### AuthServiceProvider-owned routes
 
 | Endpoint | Route option | Controller |
 |----------|-------------|------------|
@@ -547,9 +561,10 @@ packages/access/src/
 packages/routing/src/
     AccessChecker.php                - Route option access checks (_public, _authenticated, _session, _permission, _role, _gate)
 
-packages/user/src/Middleware/
-    SessionMiddleware.php            - Resolves AccountInterface from session
-    BearerAuthMiddleware.php         - JWT and API key authentication via Bearer tokens (priority: 40)
+packages/user/src/
+    Middleware/
+        SessionMiddleware.php        - Resolves AccountInterface from session
+        BearerAuthMiddleware.php     - JWT and API key authentication via Bearer tokens (priority: 40)
 
 public/index.php                     - Front controller; wires the pipeline
 ```

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,6 +1,6 @@
 # Admin SPA
 
-<!-- Spec reviewed 2026-03-31 — #814 baseUrl default /admin, surface proxy path fix, surfacePath prefix -->
+<!-- Spec reviewed 2026-04-01 - post-M10 admin surface bootstrap via /admin/_surface/*, contract re-exports, C17 test-harness alignment, C18 drift remediation (#1017) -->
 
 ## Package
 
@@ -35,7 +35,7 @@ routeRules: {
 },
 ```
 
-All `/api/*` requests and `/_surface/*` routes proxy to the PHP backend defined by `NUXT_BACKEND_URL`. The `/_surface/` path maps to `/admin/_surface/` on the backend. The default backend is `http://127.0.0.1:8080`, matching the repo's PHP dev server and CI workflows.
+All `/api/*` requests and `/admin/_surface/*` requests proxy directly to the PHP backend defined by `NUXT_BACKEND_URL`. The admin runtime no longer bootstraps through a bare `/_surface/` alias. The default backend is `http://127.0.0.1:8080`, matching the repo's PHP dev server and CI workflows.
 
 ### Base URL
 
@@ -70,7 +70,7 @@ function useApi(): {
 }
 ```
 
-**All `/api/*` calls must use `apiFetch`** — raw `$fetch` breaks when `app.baseURL` is set to a subpath like `/admin/`. Surface API calls (`/_surface/*`) are handled separately by the admin plugin, which builds the full path from `runtimeConfig.public.baseUrl` (e.g. `/admin/_surface/session`). The plugin uses `$fetch` with explicit `baseURL: '/'` since async Nuxt plugins can't call composables.
+**All `/api/*` calls must use `apiFetch`** — raw `$fetch` breaks when `app.baseURL` is set to a subpath like `/admin/`. Surface API calls are handled separately by the admin plugin, which builds the full path from `runtimeConfig.public.baseUrl` (for example `/admin/_surface/session` and `/admin/_surface/catalog`). The plugin uses `$fetch` with explicit `baseURL: '/'` since async Nuxt plugins can't call composables.
 
 ### useEntity (`packages/admin/app/composables/useEntity.ts`)
 
@@ -137,6 +137,18 @@ interface EntitySchema {
 - Module-level `Map<string, EntitySchema>` cache. Call `invalidate()` to clear a single type.
 - `sortedProperties(true)` filters out system `readOnly` fields (id, uuid) and hidden widgets, but keeps `x-access-restricted` fields (rendered as disabled inputs). Sorted by `x-weight` ascending.
 - `sortedProperties(false)` returns all properties sorted by weight.
+
+### Runtime Bootstrap (`packages/admin/app/plugins/admin.ts`)
+
+The root Nuxt plugin is the authoritative bootstrap for `$admin`. On non-public auth pages it:
+
+1. Reads `runtimeConfig.public.baseUrl` (default `/admin`) and derives a `surfacePath` such as `/admin/_surface`.
+2. Fetches `SurfaceResult<AdminSurfaceSession>` from `${surfacePath}/session`.
+3. Fetches `SurfaceResult<{ entities: AdminSurfaceCatalogEntry[] }>` from `${surfacePath}/catalog` after a successful session.
+4. Builds `AdminRuntime` from `SessionAuthAdapter`, `AdminSurfaceTransportAdapter`, the resolved account/tenant, and catalog entries re-exported from `packages/admin-surface/contract/types.ts`.
+5. Returns `{ provide: { admin: runtime } }`, or `{ provide: { admin: null } }` for public auth pages and unauthenticated redirects.
+
+This plugin is the source of truth for `$admin` injection and for composables that call `useAdmin()`.
 
 ### useLanguage (`packages/admin/app/composables/useLanguage.ts`)
 

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,8 +1,16 @@
 # API Layer
 
-Technical specification for the Waaseyaa JSON:API layer and routing system. This document covers the `packages/api/` and `packages/routing/` packages, which together provide RESTful CRUD endpoints, resource serialization, query parsing, JSON Schema presentation, route building, and access checking.
+<!-- Spec reviewed 2026-04-01 - post-M10 ApiServiceProvider route ownership, package-declared API surfaces, C18 drift remediation (#1017) -->
+
+Technical specification for the Waaseyaa JSON:API layer and routing system. This document covers the `packages/api/` and `packages/routing/` packages, which together provide RESTful CRUD endpoints, resource serialization, query parsing, JSON Schema presentation, route building, and access checking. The current post-M10 baseline uses package-owned service providers for API route registration: `packages/api/composer.json` declares `Waaseyaa\Api\ApiServiceProvider`, and that provider delegates CRUD route registration to `JsonApiRouteProvider` while foundation keeps only shared infrastructure endpoints.
 
 ## Packages
+
+### Package-owned route registration
+
+`Waaseyaa\Api\ApiServiceProvider` is declared in `packages/api/composer.json` under `extra.waaseyaa.providers`. Its `routes()` method is the authoritative entry point for JSON:API CRUD route registration and delegates to `JsonApiRouteProvider` when an `EntityTypeManager` is available.
+
+Foundation still owns the shared HTTP surfaces that are not entity-package specific, including `/api/schema/{entity_type}`, `/api/openapi.json`, `/api/entity-types`, discovery endpoints, broadcast, and the SSR catch-all.
 
 ### packages/api/
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-03-31 — DatabaseBootstrapper @mkdir suppression, CS fixes, GraphQL NamedType::name(), ConfigLoaderTest NullLogger injection, login session flush fix (#813) -->
+<!-- Spec reviewed 2026-04-01 - post-M10 package declarations, FoundationServiceProvider registration, provider-owned routes and CLI graph, C18 drift remediation (#1017) -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
@@ -1085,7 +1085,11 @@ public function boot(string $projectRoot): PackageManifest
 
 Instantiates `PackageManifestCompiler` with `storagePath: $projectRoot . '/storage'` and calls `load()` (cache-first, compile on miss).
 
-`storage/framework/packages.php` includes metadata key `_manifest_inputs_fp`: an `xxh128` digest of the raw contents of the project `composer.json` and `vendor/composer/installed.json`. When present and not equal to a freshly computed digest, `load()` discards the cache and recompiles (covers new/removed Composer packages and copied stale caches). Caches without `_manifest_inputs_fp` are still loaded so `StaleManifestException` can fire for missing provider classes before any rewrite. On every successful cache read, root `extra.waaseyaa` providers, commands, routes, and permissions are merged again from `composer.json` so a structurally valid cache cannot omit app-level declarations that match the current fingerprint.
+`storage/framework/packages.php` includes metadata key `_manifest_inputs_fp`: an `xxh128` digest of the raw contents of the project `composer.json` and `vendor/composer/installed.json`. When present and not equal to a freshly computed digest, `load()` discards the cache and recompiles (covers new/removed Composer packages and copied stale caches). Caches without `_manifest_inputs_fp` are still loaded so `StaleManifestException` can fire for missing provider classes before any rewrite.
+
+The compiled manifest now also carries `packageDeclarations`, derived from package-local `composer.json` metadata and merged installed-package metadata. This is the post-M10 baseline used to normalize provider ownership and to verify that declared provider classes still exist before the manifest is trusted.
+
+On every successful cache read, root `extra.waaseyaa` providers, commands, routes, and permissions are merged again from `composer.json` so a structurally valid cache cannot omit app-level declarations that match the current fingerprint.
 
 ### ProviderRegistry
 
@@ -1111,6 +1115,7 @@ Discovery and registration follows a multi-phase process:
 2. **Context injection**: Each provider receives kernel context via `setKernelContext($projectRoot, $config, $manifest->formatters)` and a kernel resolver closure via `setKernelResolver()`. The resolver provides cross-provider DI — it resolves `EntityTypeManager`, `DatabaseInterface`, `EventDispatcherInterface`, and any binding registered by previously-loaded providers.
 3. **Registration**: `register()` is called on each provider, allowing them to bind interfaces to implementations.
 4. **Entity type collection**: After all providers register, entity types from `$provider->getEntityTypes()` are registered with the `EntityTypeManager`. Registration failures are logged as errors but do not halt boot.
+5. **Provider-owned surfaces**: Route and command ownership stays with the package provider or package registry that declared it. Foundation now declares only its own baseline provider (`Waaseyaa\Foundation\FoundationServiceProvider`), while package-level providers such as `ApiServiceProvider`, `UserServiceProvider`, and `McpServiceProvider` own their respective HTTP surfaces.
 
 The method returns the full list of instantiated providers. Handles instantiation failures gracefully with error logging.
 
@@ -1135,11 +1140,11 @@ Reads `$manifest->policies` (keyed by class name → entity type list), instanti
 Kernel/
     AbstractKernel.php           -- boot orchestrator, delegates to Bootstrap/ classes
     HttpKernel.php               -- HTTP request handling, cache setup, CORS
-    ConsoleKernel.php            -- CLI command registration and execution
+    ConsoleKernel.php            -- CLI bootstrapping; delegates command graph assembly to `Waaseyaa\CLI\CliCommandRegistry`
     EnvLoader.php                -- .env file parser
     ConfigLoader.php             -- config/waaseyaa.php loader
     EventListenerRegistrar.php   -- registers cache invalidation listeners
-    BuiltinRouteRegistrar.php    -- registers built-in API routes
+    BuiltinRouteRegistrar.php    -- registers shared foundation-owned HTTP routes (schema, discovery, entity-types, SSR catch-all)
     Bootstrap/
         DatabaseBootstrapper.php     -- creates DBALDatabase connection
         ManifestBootstrapper.php     -- loads/compiles PackageManifest

--- a/docs/specs/mcp-endpoint.md
+++ b/docs/specs/mcp-endpoint.md
@@ -1,8 +1,10 @@
 # MCP Endpoint
 
+<!-- Spec reviewed 2026-04-01 - post-M10 McpServiceProvider registration and provider-owned MCP routes, C18 drift remediation (#1017) -->
+
 ## Overview
 
-The `waaseyaa/mcp` package exposes Waaseyaa's entity system as a remote MCP (Model Context Protocol) server over Streamable HTTP. External AI assistants (Claude Desktop, Cursor, etc.) and custom AI agents connect to a single `/mcp` endpoint to discover and invoke CRUD tools for all registered entity types. The package sits in Layer 6 (Interfaces) alongside CLI, SSR, and Admin.
+The `waaseyaa/mcp` package exposes Waaseyaa's entity system as a remote MCP (Model Context Protocol) server over Streamable HTTP. In the post-M10 baseline, package discovery loads `Waaseyaa\Mcp\McpServiceProvider` from `packages/mcp/composer.json`, and that provider owns MCP route registration. External AI assistants (Claude Desktop, Cursor, etc.) and custom AI agents connect to a single `/mcp` endpoint to discover and invoke CRUD tools for all registered entity types. The package sits in Layer 6 (Interfaces) alongside CLI, SSR, and Admin.
 
 ## Package
 
@@ -17,6 +19,7 @@ The `waaseyaa/mcp` package exposes Waaseyaa's entity system as a remote MCP (Mod
 | `src/McpEndpoint.php` | Thin HTTP handler: auth, JSON-RPC dispatch for `initialize`/`ping`/`tools/list`/`tools/call` via Bridge interfaces |
 | `src/McpController.php` | Rich tool controller: manifest, `tools/introspect`, `tools/call` dispatch to tool classes, read-cache orchestration |
 | `src/McpResponse.php` | Value object wrapping response body, status code, content type |
+| `src/McpServiceProvider.php` | Package-owned service provider that registers MCP routes via `McpRouteProvider` |
 | `src/McpRouteProvider.php` | Registers `/mcp` and `/.well-known/mcp.json` routes |
 | `src/McpServerCard.php` | Generates the `/.well-known/mcp.json` server card |
 | `src/Auth/McpAuthInterface.php` | Pluggable authentication contract |
@@ -31,6 +34,12 @@ The `waaseyaa/mcp` package exposes Waaseyaa's entity system as a remote MCP (Mod
 | `src/Tools/EditorialTools.php` | `editorial_transition`, `editorial_validate`, `editorial_publish`, `editorial_archive` implementations |
 | `src/Tools/EntityTools.php` | `get_entity`, `list_entity_types` implementations |
 | `src/Tools/TraversalTools.php` | `traverse_relationships`, `get_related_entities`, `get_knowledge_graph` implementations |
+
+## Package Discovery and Route Ownership
+
+`packages/mcp/composer.json` declares `Waaseyaa\Mcp\McpServiceProvider` in `extra.waaseyaa.providers`. During kernel boot, manifest discovery instantiates that provider and `McpServiceProvider::routes()` delegates directly to `McpRouteProvider`.
+
+This means MCP route ownership no longer depends on foundation fallback registration. The authoritative MCP HTTP surfaces are the provider-owned `/mcp` endpoint and `/.well-known/mcp.json` server card.
 
 ## McpEndpoint Class
 


### PR DESCRIPTION
This PR remediates the post-M10 spec drift tracked in #1017.

Updated specs:
- docs/specs/access-control.md
- docs/specs/admin-spa.md
- docs/specs/api-layer.md
- docs/specs/infrastructure.md
- docs/specs/mcp-endpoint.md

The implementation on `main` remains authoritative. This change realigns the stale specs to the current package-owned route model, provider declarations, admin surface bootstrap behavior, manifest discovery baseline, and MCP provider ownership established by M10 and the C17 remediation.

Specs now match the authoritative implementation on main.
All drift-detector checks pass.
No protected upstream surfaces modified.
No new audit surfaces introduced.

Verification:
- drift-detector: all green
- PHP suite: 5,576 tests passed, 13,299 assertions
- admin build: passed
- Vitest: 29 files passed, 145 tests passed
- Known non-blocking PHPUnit warning: `No code coverage driver available`
