### PR TITLE
tooling: remove admin typecheck from pre-push hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,9 +10,6 @@ pre-push:
   commands:
     spec-drift:
       run: tools/drift-detector.sh 5
-    typecheck:
-      glob: "packages/admin/**/*.{ts,vue}"
-      run: cd packages/admin && npx nuxi typecheck
     phpstan:
       glob: "*.php"
       run: composer phpstan


### PR DESCRIPTION
## Summary

This PR removes the admin `nuxi typecheck` step from the root `pre-push` lefthook configuration.

The change keeps `spec-drift` and `phpstan` in place while preventing repeated admin typecheck execution from surfacing as unrelated workflow noise during other branch work.

## Verification

- `git diff -- lefthook.yml`
