### PR TITLE
test(#1021): narrow admin fixture capability coverage

### DIFF
--- a/docs/governance/milestones/m12-e1-discovery.md
+++ b/docs/governance/milestones/m12-e1-discovery.md
@@ -204,7 +204,7 @@
     - 401 session bootstrap state fallback, missing catalog bootstrap state fallback, and unreachable surface API handling in the admin plugin
   - The original F9 gap is closed for the audited surfaces.
 
-### F10 — admin bootstrap test fixtures encode broad default capabilities that may mask navigation and action assumptions
+### F10 — capability fixtures were narrowed and the audited gaps are now closed
 - Classification: `test-gap`
 - Surfaces:
   - `packages/admin/tests/setup.ts`
@@ -212,9 +212,14 @@
   - `packages/admin/tests/components/layout/NavBuilder.test.ts`
   - `packages/admin/tests/pages/dashboard.test.ts`
 - Observation:
-  - Shared fixtures give most catalog entries a wide-open capability set and a uniform successful bootstrap.
-  - That keeps tests stable, but it also reduces pressure on capability-specific branches and empty/partial catalog behaviors.
-  - As a result, some admin surface assumptions are validated indirectly rather than explicitly.
+  - Follow-up work on 2026-04-02 replaced shared wide-open capability defaults with explicit per-entity capability fixtures.
+  - `NavBuilder` now uses capability-minimal test fixtures because navigation grouping and pipeline visibility are not capability-driven.
+  - `Dashboard` onboarding coverage now asserts the audited capability branches explicitly:
+    - `/node_type/create` when `node_type` is creatable
+    - fallback to the first create-capable entity type when it is not
+    - fallback to `/` when `note` is absent
+    - first-listable probe behavior when `node_type` is absent
+  - The original F10 masking gap is closed for the audited surfaces.
 
 ## Discovery Classification Summary
 
@@ -225,7 +230,6 @@
 - `component-invariant`
   - F5, F6, F7
 - `test-gap`
-  - F10
 - `spec-clarification`
   - F1
 

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -613,7 +613,8 @@ Test files live in `packages/admin/tests/`:
 - `tests/unit/composables/useAdmin.test.ts` — runtime-backed admin catalog access and missing-runtime invariant
 - `tests/unit/composables/useEntity.test.ts` — transport delegation and missing-runtime invariant
 - `tests/unit/composables/useSchema.test.ts` — schema caching/error handling and missing-runtime invariant
-- `tests/components/layout/NavBuilder.test.ts` — deterministic navigation rendering for empty and action-aware catalogs
+- `tests/components/layout/NavBuilder.test.ts` — deterministic navigation rendering for empty and action-aware catalogs using capability-minimal fixtures
+- `tests/pages/dashboard.test.ts` — onboarding prompt capability fallbacks (`node_type` create path, first create-capable fallback, root fallback when note is absent, first-listable probe when `node_type` is absent)
 
 Pattern: `mountSuspended()` from `@nuxt/test-utils/runtime` for component mounting. Props via `props: {}`, emits via `wrapper.emitted()`.
 

--- a/packages/admin/tests/components/layout/NavBuilder.test.ts
+++ b/packages/admin/tests/components/layout/NavBuilder.test.ts
@@ -24,7 +24,7 @@ vi.mock('~/composables/useEntity', () => ({
   }),
 }))
 
-const defaultCaps = { list: true, get: true, create: true, update: true, delete: true, schema: true }
+const defaultCaps = { list: false, get: false, create: false, update: false, delete: false, schema: false }
 
 function entry(overrides: Partial<CatalogEntry> & Pick<CatalogEntry, 'id' | 'label'>): CatalogEntry {
   const { id, label, ...rest } = overrides

--- a/packages/admin/tests/fixtures/entityTypes.ts
+++ b/packages/admin/tests/fixtures/entityTypes.ts
@@ -1,20 +1,18 @@
 // packages/admin/tests/fixtures/entityTypes.ts
 import type { CatalogEntry } from '~/contracts'
 
-const defaultCaps = { list: true, get: true, create: true, update: true, delete: true, schema: true }
-
 export const entityTypes: CatalogEntry[] = [
-  { id: 'user', label: 'User', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'node', label: 'Content', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'node_type', label: 'Content Type', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'taxonomy_term', label: 'Taxonomy Term', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'taxonomy_vocabulary', label: 'Taxonomy Vocabulary', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'media', label: 'Media', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'media_type', label: 'Media Type', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'path_alias', label: 'Path Alias', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'menu', label: 'Menu', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'menu_link', label: 'Menu Link', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'workflow', label: 'Workflow', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'pipeline', label: 'Pipeline', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'note', label: 'Note', capabilities: defaultCaps, fields: [], actions: [] },
+  { id: 'user', label: 'User', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'node', label: 'Content', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'node_type', label: 'Content Type', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'taxonomy_term', label: 'Taxonomy Term', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'taxonomy_vocabulary', label: 'Taxonomy Vocabulary', capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true }, fields: [], actions: [] },
+  { id: 'media', label: 'Media', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'media_type', label: 'Media Type', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'path_alias', label: 'Path Alias', capabilities: { list: true, get: true, create: false, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'menu', label: 'Menu', capabilities: { list: true, get: true, create: true, update: true, delete: false, schema: true }, fields: [], actions: [] },
+  { id: 'menu_link', label: 'Menu Link', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
+  { id: 'workflow', label: 'Workflow', capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true }, fields: [], actions: [] },
+  { id: 'pipeline', label: 'Pipeline', capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true }, fields: [], actions: [] },
+  { id: 'note', label: 'Note', capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true }, fields: [], actions: [] },
 ]

--- a/packages/admin/tests/pages/dashboard.test.ts
+++ b/packages/admin/tests/pages/dashboard.test.ts
@@ -1,24 +1,142 @@
-import { describe, it, expect } from 'vitest'
-import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
+import type { CatalogEntry } from '~/contracts'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import Dashboard from '~/pages/index.vue'
 
+const { catalogRef, listSpy } = vi.hoisted(() => {
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    catalogRef: ref<CatalogEntry[]>([]),
+    listSpy: vi.fn(),
+  }
+})
+
+vi.mock('~/composables/useAdmin', () => ({
+  useAdmin: () => ({
+    catalog: catalogRef.value,
+  }),
+}))
+
+vi.mock('~/composables/useEntity', () => ({
+  useEntity: () => ({
+    list: listSpy,
+  }),
+}))
+
 describe('Dashboard onboarding', () => {
+  beforeEach(() => {
+    catalogRef.value = []
+    listSpy.mockReset()
+  })
+
   it('shows onboarding prompt when no content types exist', async () => {
-    registerEndpoint('/admin/_surface/node_type', () => ({
-      ok: true,
-      data: {
-        entities: [],
-        total: 0,
-        offset: 0,
-        limit: 1,
+    catalogRef.value = [
+      {
+        id: 'node_type',
+        label: 'Content Type',
+        capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
       },
-    }))
+      {
+        id: 'note',
+        label: 'Note',
+        capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
+      },
+    ]
+    listSpy.mockResolvedValue({
+      data: [],
+      meta: { total: 0 },
+    })
 
     const wrapper = await mountSuspended(Dashboard)
     await flushPromises()
 
+    expect(listSpy).toHaveBeenCalledWith('node_type', { page: { offset: 0, limit: 1 } })
     expect(wrapper.text()).toContain('Get started with your first content type')
     expect(wrapper.text()).toContain('Use Note (built-in)')
+    expect(wrapper.findAll('a').find(link => link.text().includes('Use Note'))?.attributes('href')).toContain('/note/create')
+    expect(wrapper.findAll('a').find(link => link.text().includes('Create custom type'))?.attributes('href')).toContain('/node_type/create')
+  })
+
+  it('falls back to the first create-capable type when node_type is not creatable', async () => {
+    catalogRef.value = [
+      {
+        id: 'node_type',
+        label: 'Content Type',
+        capabilities: { list: true, get: true, create: false, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
+      },
+      {
+        id: 'media',
+        label: 'Media',
+        capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
+      },
+    ]
+    listSpy.mockResolvedValue({
+      data: [],
+      meta: { total: 0 },
+    })
+
+    const wrapper = await mountSuspended(Dashboard)
+    await flushPromises()
+
+    expect(wrapper.findAll('a').find(link => link.text().includes('Create custom type'))?.attributes('href')).toContain('/media/create')
+  })
+
+  it('falls back to root when the note entity type is absent', async () => {
+    catalogRef.value = [
+      {
+        id: 'node_type',
+        label: 'Content Type',
+        capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
+      },
+    ]
+    listSpy.mockResolvedValue({
+      data: [],
+      meta: { total: 0 },
+    })
+
+    const wrapper = await mountSuspended(Dashboard)
+    await flushPromises()
+
+    expect(wrapper.findAll('a').find(link => link.text().includes('Use Note'))?.attributes('href')).toBe('/admin/')
+  })
+
+  it('probes the first listable entity type when node_type is absent', async () => {
+    catalogRef.value = [
+      {
+        id: 'user',
+        label: 'User',
+        capabilities: { list: false, get: true, create: false, update: true, delete: false, schema: true },
+        fields: [],
+        actions: [],
+      },
+      {
+        id: 'media',
+        label: 'Media',
+        capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+        fields: [],
+        actions: [],
+      },
+    ]
+    listSpy.mockResolvedValue({
+      data: [],
+      meta: { total: 0 },
+    })
+
+    const wrapper = await mountSuspended(Dashboard)
+    await flushPromises()
+
+    expect(listSpy).toHaveBeenCalledWith('media', { page: { offset: 0, limit: 1 } })
+    expect(wrapper.text()).toContain('Get started with your first content type')
   })
 })

--- a/packages/admin/tests/setup.ts
+++ b/packages/admin/tests/setup.ts
@@ -6,21 +6,95 @@ import { vi } from 'vitest'
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
 import type { AdminSurfaceCatalogEntry } from '../../admin-surface/contract/types'
 
-const defaultCaps = { list: true, get: true, create: true, update: true, delete: true, schema: true }
-
 const catalogEntities: AdminSurfaceCatalogEntry[] = [
-  { id: 'user', label: 'User', description: 'User accounts', disabled: false, capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'node', label: 'Content', description: 'Content entries', disabled: false, capabilities: defaultCaps, fields: [], actions: [{ id: 'board-config', label: 'Board Config', scope: 'collection' }] },
-  { id: 'node_type', label: 'Content Type', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'taxonomy_term', label: 'Taxonomy Term', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'taxonomy_vocabulary', label: 'Taxonomy Vocabulary', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'media', label: 'Media', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'media_type', label: 'Media Type', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'path_alias', label: 'Path Alias', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'menu', label: 'Menu', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'menu_link', label: 'Menu Link', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'workflow', label: 'Workflow', capabilities: defaultCaps, fields: [], actions: [] },
-  { id: 'pipeline', label: 'Pipeline', capabilities: defaultCaps, fields: [], actions: [] },
+  {
+    id: 'user',
+    label: 'User',
+    description: 'User accounts',
+    disabled: false,
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'node',
+    label: 'Content',
+    description: 'Content entries',
+    disabled: false,
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [{ id: 'board-config', label: 'Board Config', scope: 'collection' }],
+  },
+  {
+    id: 'node_type',
+    label: 'Content Type',
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'taxonomy_term',
+    label: 'Taxonomy Term',
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'taxonomy_vocabulary',
+    label: 'Taxonomy Vocabulary',
+    capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'media',
+    label: 'Media',
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'media_type',
+    label: 'Media Type',
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'path_alias',
+    label: 'Path Alias',
+    capabilities: { list: true, get: true, create: false, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'menu',
+    label: 'Menu',
+    capabilities: { list: true, get: true, create: true, update: true, delete: false, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'menu_link',
+    label: 'Menu Link',
+    capabilities: { list: true, get: true, create: true, update: true, delete: true, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'workflow',
+    label: 'Workflow',
+    capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true },
+    fields: [],
+    actions: [],
+  },
+  {
+    id: 'pipeline',
+    label: 'Pipeline',
+    capabilities: { list: true, get: true, create: false, update: true, delete: false, schema: true },
+    fields: [],
+    actions: [],
+  },
 ]
 
 // /admin/_surface/session — the admin plugin checks this first


### PR DESCRIPTION
## Summary

This PR closes F10 in `#1021` by narrowing the admin test fixture capability surface and backfilling the audited capability-specific dashboard branches.

It replaces broad default capability fixtures with explicit per-entity capability declarations in the shared admin test catalog, keeps `NavBuilder` on capability-minimal fixtures because its behavior is not capability-driven, and rewrites dashboard onboarding tests to assert the actual `list` / `create` fallback rules directly instead of inheriting them from the broad bootstrap fixture.

## Verification

- `cd packages/admin && npm test -- tests/pages/dashboard.test.ts tests/components/layout/NavBuilder.test.ts tests/unit/plugins/admin.test.ts tests/unit/composables/useAdmin.test.ts tests/unit/composables/useNavGroups.test.ts`
- `cd packages/admin && npm exec nuxi typecheck`
- `bash tools/drift-detector.sh 5`
