### PR TITLE
docs(#853): clarify create-project package identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Waaseyaa replaces Drupal's legacy runtime with a clean, modular architecture org
 
 ## Quick Start
 
+The `composer create-project` target below installs the published Waaseyaa project skeleton package (`waaseyaa/waaseyaa`). This repository is the `waaseyaa/framework` monorepo that supplies the underlying framework packages.
+
 ```bash
 composer create-project waaseyaa/waaseyaa my-site
 cd my-site


### PR DESCRIPTION
Closes #853

## Summary
- clarify that `composer create-project waaseyaa/waaseyaa` installs the published Waaseyaa project skeleton package
- explain that this repository is the `waaseyaa/framework` monorepo providing the underlying framework packages

## Checklist
- [x] `Closes #N` above references the issue this PR resolves
- [x] The issue is assigned to a milestone
- [x] PR title includes the issue number (e.g. `feat(#42): description`)

## Test Plan
- [x] README quick-start copy reviewed locally
- [x] `./tools/drift-detector.sh`
- [x] pre-push hook: `spec-drift`
