### PR TITLE
docs: add fresh app bootstrap playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Waaseyaa replaces Drupal's legacy runtime with a clean, modular architecture org
 ```bash
 composer create-project waaseyaa/waaseyaa my-site
 cd my-site
-bin/waaseyaa install
+./vendor/bin/phpunit
 bin/waaseyaa serve
 ```
+
+The scaffold now creates `tests/Unit` and `tests/Integration`, so the default PHPUnit command is usable immediately. For static or marketing-style sites, you can start from the clean scaffold, add a `SiteServiceProvider`, `PageController`, Twig templates, and a small regression test before wiring deploy infrastructure.
 
 Create your first content:
 
@@ -50,6 +52,26 @@ curl -X POST http://localhost:8081/api/note \
 ```
 
 Waaseyaa ships with a built-in `core.note` content type that is always available at boot. To define custom content types, see the [`waaseyaa/node`](packages/node) package as a reference.
+
+## Fresh App Workflow
+
+Use this minimal sequence for a new public-facing site:
+
+```bash
+composer create-project waaseyaa/waaseyaa my-site --stability=dev
+cd my-site
+./vendor/bin/phpunit
+php bin/waaseyaa optimize:manifest
+bin/waaseyaa serve
+```
+
+When turning the scaffold into a site:
+
+1. Add a failing integration test for your public routes and rendered HTML.
+2. Register your site provider in `composer.json` under `extra.waaseyaa.providers`.
+3. Add your `PageController`, `SiteServiceProvider`, shared Twig layout, and site templates.
+4. Re-run PHPUnit and `php bin/waaseyaa optimize:manifest`.
+5. Add repo-local deployment files (`deploy.php`, `.github/workflows/*`) only after the site passes locally.
 
 ## Architecture
 

--- a/docs/specs/operations-playbooks.md
+++ b/docs/specs/operations-playbooks.md
@@ -128,6 +128,33 @@ Use this as the default runbook for upgrades, baseline refreshes, and verificati
    - `php bin/waaseyaa fixture:pack:refresh --input-dir tests/fixtures/scenarios --output tests/fixtures/scenarios/fixture-pack.aggregate.json`
 3. Verify repeated refresh runs keep the same aggregate hash.
 
+### Playbook G: Fresh App Bootstrap And Site Bring-Up
+
+1. Scaffold the app:
+   - `composer create-project waaseyaa/waaseyaa my-site --stability=dev`
+2. Verify the clean scaffold before customization:
+   - `cd my-site`
+   - `./vendor/bin/phpunit`
+   - `php bin/waaseyaa optimize:manifest`
+3. Add a failing public-site test first:
+   - route registration,
+   - shared layout rendering,
+   - key page headings / links.
+4. Add app-level provider registration in `composer.json`:
+   - `extra.waaseyaa.providers`
+5. Implement only the app-specific surface:
+   - `src/Controller/PageController.php`
+   - `src/Provider/SiteServiceProvider.php`
+   - `templates/*.html.twig`
+   - `public/css/site.css`
+6. Re-run verification:
+   - `./vendor/bin/phpunit`
+   - `php bin/waaseyaa optimize:manifest`
+7. Only after green verification, add repo-local deploy files:
+   - `deploy.php`
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/deploy.yml`
+
 ## CLI Command Reference
 
 ### Queue Operations

--- a/skeleton/README.md
+++ b/skeleton/README.md
@@ -38,8 +38,9 @@ and all references when moving code.
 
 ```bash
 composer install                    # Install dependencies
-php -S localhost:8080 -t public     # Dev server
 ./vendor/bin/phpunit                # Run tests
+php bin/waaseyaa optimize:manifest  # Rebuild provider manifest
+bin/waaseyaa serve                  # Dev server
 bin/waaseyaa                        # CLI
 ```
 


### PR DESCRIPTION
## Summary
- document the clean create-project bootstrap path for new Waaseyaa apps
- capture the provider registration, verification, and deployment handoff steps
- align the skeleton and operations docs with the working OIATC process

## Testing
- not run (documentation only)