### PR TITLE
test(#3): regression tests for kernel resolver fallback

### DIFF
--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Kernel\Bootstrap;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistry;
+use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+/**
+ * Regression test for issue #3: service provider DI cannot resolve
+ * kernel-provided services (EntityTypeManager, DatabaseInterface, etc.).
+ */
+#[CoversClass(ProviderRegistry::class)]
+final class ProviderRegistryTest extends TestCase
+{
+    #[Test]
+    public function provider_can_resolve_kernel_services_via_fallback(): void
+    {
+        $registry = new ProviderRegistry(new NullLogger());
+        $database = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+
+        // Use a concrete provider class defined below that resolves EntityTypeManager
+        $manifest = new PackageManifest(
+            providers: [KernelResolverTestProvider::class],
+        );
+
+        $providers = $registry->discoverAndRegister(
+            manifest: $manifest,
+            projectRoot: sys_get_temp_dir(),
+            config: [],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+
+        $this->assertCount(1, $providers);
+
+        // The provider's register() resolves EntityTypeManager via kernel resolver
+        $resolved = $providers[0]->resolve(EntityTypeManager::class);
+        $this->assertSame($entityTypeManager, $resolved);
+    }
+
+    #[Test]
+    public function provider_can_resolve_cross_provider_bindings(): void
+    {
+        $registry = new ProviderRegistry(new NullLogger());
+        $database = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+
+        $manifest = new PackageManifest(
+            providers: [
+                CrossProviderSourceProvider::class,
+                CrossProviderConsumerProvider::class,
+            ],
+        );
+
+        $providers = $registry->discoverAndRegister(
+            manifest: $manifest,
+            projectRoot: sys_get_temp_dir(),
+            config: [],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+
+        $this->assertCount(2, $providers);
+
+        // Consumer provider resolves a binding registered by the source provider
+        $resolved = $providers[1]->resolve('test.cross_provider_service');
+        $this->assertInstanceOf(\stdClass::class, $resolved);
+        $this->assertSame('from-source', $resolved->origin);
+    }
+}
+
+/**
+ * @internal Test fixture — provider that resolves EntityTypeManager from kernel.
+ */
+final class KernelResolverTestProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // No local bindings — EntityTypeManager must come from kernel resolver.
+    }
+}
+
+/**
+ * @internal Test fixture — provider that registers a binding for cross-provider resolution.
+ */
+final class CrossProviderSourceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->singleton('test.cross_provider_service', static function (): \stdClass {
+            $obj = new \stdClass();
+            $obj->origin = 'from-source';
+
+            return $obj;
+        });
+    }
+}
+
+/**
+ * @internal Test fixture — provider that consumes a binding from another provider.
+ */
+final class CrossProviderConsumerProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // No local bindings — depends on CrossProviderSourceProvider's binding.
+    }
+}

--- a/packages/foundation/tests/Unit/ServiceProvider/ServiceProviderResolveTest.php
+++ b/packages/foundation/tests/Unit/ServiceProvider/ServiceProviderResolveTest.php
@@ -112,4 +112,36 @@ final class ServiceProviderResolveTest extends TestCase
         $service = $provider->resolvePublic('test.service');
         $this->assertInstanceOf(\stdClass::class, $service);
     }
+
+    #[Test]
+    public function resolve_falls_back_to_kernel_resolver_for_unbound_service(): void
+    {
+        $kernelService = new \stdClass();
+        $kernelService->origin = 'kernel';
+
+        $provider = new class extends ServiceProvider {
+            public function register(): void {}
+        };
+        $provider->register();
+        $provider->setKernelResolver(function (string $className) use ($kernelService): ?object {
+            return $className === \stdClass::class ? $kernelService : null;
+        });
+
+        $resolved = $provider->resolve(\stdClass::class);
+        $this->assertSame($kernelService, $resolved);
+    }
+
+    #[Test]
+    public function resolve_throws_when_kernel_resolver_also_returns_null(): void
+    {
+        $provider = new class extends ServiceProvider {
+            public function register(): void {}
+        };
+        $provider->register();
+        $provider->setKernelResolver(fn(string $className): ?object => null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No binding registered for');
+        $provider->resolve('Nonexistent\\Service');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds regression tests for #3 (service provider DI cannot resolve kernel-provided services)
- The fix was already shipped in 92d19ba4/c6def435 as part of the bootstrapper extraction, but had no test coverage
- `ServiceProviderResolveTest`: kernel resolver fallback + throws when resolver also returns null
- `ProviderRegistryTest`: kernel service resolution + cross-provider binding resolution

## Test plan
- [x] All 4990 unit tests pass
- [x] PHPStan clean
- [x] PHP CS Fixer clean

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)