### PR TITLE
feat(#8): add Dockerfile to skeleton

### DIFF
--- a/skeleton/.dockerignore
+++ b/skeleton/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+node_modules
+vendor
+storage/*.sqlite
+tests
+phpunit.xml.dist
+*.md
+.claude
+.cursor

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,0 +1,35 @@
+FROM php:8.4-fpm-alpine AS base
+
+RUN apk add --no-cache \
+    sqlite-libs \
+    icu-libs \
+    && docker-php-ext-install \
+    intl \
+    opcache \
+    pdo_sqlite
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+FROM base AS deps
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-scripts --prefer-dist --optimize-autoloader
+
+FROM base AS production
+
+COPY --from=deps /app/vendor /app/vendor
+COPY . /app
+
+RUN composer dump-autoload --optimize --no-dev \
+    && mkdir -p /app/storage \
+    && chown -R www-data:www-data /app/storage
+
+ENV APP_ENV=production
+ENV APP_DEBUG=false
+ENV WAASEYAA_DB=/app/storage/waaseyaa.sqlite
+
+EXPOSE 9000
+
+USER www-data


### PR DESCRIPTION
## Summary
- Adds multi-stage Dockerfile to skeleton using PHP 8.4 FPM Alpine
- Installs SQLite, intl, and opcache extensions
- Adds `.dockerignore` to exclude dev files from image
- Uses Composer multi-stage for optimized dependency layer caching

## Test plan
- [ ] `docker build -t waaseyaa-test skeleton/` builds successfully
- [ ] Container starts with `docker run -p 9000:9000 waaseyaa-test`
- [ ] Pair with Caddy/nginx reverse proxy for HTTP access

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)