### PR TITLE
fix(#1051): exclude test files from drift detector timestamp comparison

### DIFF
--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -141,7 +141,7 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
     service_last_commit=0
     for pattern in "${!PATTERN_TO_SPEC[@]}"; do
       if [ "${PATTERN_TO_SPEC[$pattern]}" = "$spec" ]; then
-        pattern_commit=$(git log -1 --format=%ct -- "$pattern" ':!*/vendor/*' 2>/dev/null)
+        pattern_commit=$(git log -1 --format=%ct -- "$pattern" ':!*/vendor/*' ':!*Test.php' ':!*_test.php' 2>/dev/null)
         pattern_commit=${pattern_commit:-0}
         if [ "$pattern_commit" -gt "$service_last_commit" ]; then
           service_last_commit=$pattern_commit


### PR DESCRIPTION
## Summary
- Adds `':!*Test.php' ':!*_test.php'` pathspec exclusions to the `git log` timestamp comparison in `drift-detector.sh` (line 144)
- The changed-files filter (line 45) already excluded test files, but the timestamp comparison did not, causing false STALE warnings from test-only commits

Closes #1051

## Test plan
- [x] `tools/drift-detector.sh 20` runs clean with no false positives
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)