### PR TITLE
fix(#1046): throw when app.url is not configured

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -485,6 +485,8 @@ These three request surfaces are registered by `packages/user/src/UserServicePro
 
 All auth controllers accept an optional `?LoggerInterface $logger` (defaults to `NullLogger`). DevLog-mode verification/reset URLs and best-effort email failures are logged via this interface rather than `error_log()`.
 
+**Required configuration:** `UserServiceProvider` registers `AuthMailer` with `baseUrl` from `$config['app']['url']`. If `app.url` is not set in `config/waaseyaa.php`, registration throws a `RuntimeException` with remediation guidance. An empty base URL would produce malformed password-reset and email-verification links (e.g., `http:///reset-password?token=...`).
+
 ### Rate Limiting
 
 All auth endpoints apply rate limiting via `RateLimiter` keyed on IP or user identity:

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -72,7 +72,9 @@ final class UserServiceProvider extends ServiceProvider
         $this->singleton(AuthMailer::class, fn() => new AuthMailer(
             driver: fn() => $this->resolve(MailDriverInterface::class),
             twig: \Waaseyaa\SSR\SsrServiceProvider::getTwigEnvironment(),
-            baseUrl: $config['app']['url'] ?? '',
+            baseUrl: $config['app']['url'] ?? throw new \RuntimeException(
+                "app.url is not configured. Add 'app' => ['url' => 'https://yourapp.com'] to your config/waaseyaa.php."
+            ),
             appName: $config['app']['name'] ?? 'Waaseyaa',
         ));
     }

--- a/packages/user/tests/Unit/UserServiceProviderTest.php
+++ b/packages/user/tests/Unit/UserServiceProviderTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\User\User;
+use Waaseyaa\User\AuthMailer;
 use Waaseyaa\User\UserServiceProvider;
 
 #[CoversClass(UserServiceProvider::class)]
@@ -53,6 +54,18 @@ final class UserServiceProviderTest extends TestCase
         $this->assertSame('uid', $keys['id']);
         $this->assertSame('uuid', $keys['uuid']);
         $this->assertSame('name', $keys['label']);
+    }
+
+    #[Test]
+    public function throws_when_app_url_not_configured(): void
+    {
+        $provider = new UserServiceProvider();
+        $provider->register();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('app.url is not configured');
+
+        $provider->resolve(AuthMailer::class);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- `UserServiceProvider` silently defaulted `baseUrl` to `''` when `app.url` was missing, producing broken password-reset and email-verification URLs (`http:///reset-password?token=...`)
- Now throws a `RuntimeException` with actionable remediation guidance
- Added regression test verifying the exception
- Updated `access-control.md` spec to document the configuration requirement

Closes #1046

## Test plan
- [x] New test `throws_when_app_url_not_configured` passes
- [x] All 253 user/auth tests pass
- [x] PHPStan clean
- [x] Drift detector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)