### PR TITLE
feat(#768): wire DatabaseRateLimiter into ControllerDispatcher

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,6 +1,6 @@
 # Access Control
 
-<!-- Spec reviewed 2026-04-01 - post-M10 provider-owned user/auth routes, manifest-discovered policy wiring, C18 drift remediation (#1017) -->
+<!-- Spec reviewed 2026-04-03 - DatabaseRateLimiter wired as default in AuthServiceProvider and ControllerDispatcher (#768) -->
 
 Waaseyaa's access control system spans three packages: `packages/access/` (core primitives), `packages/routing/` (route-level checks), and `packages/user/` (session resolution, password reset). This document covers entity-level and route-level access. For field-level access, see `docs/specs/field-access.md`.
 
@@ -489,7 +489,7 @@ All auth controllers accept an optional `?LoggerInterface $logger` (defaults to 
 
 ### Rate Limiting
 
-All auth endpoints apply rate limiting via `RateLimiterInterface` keyed on IP or user identity. Two implementations exist: `RateLimiter` (in-memory, resets per process) and `DatabaseRateLimiter` (SQLite-backed via `DatabaseInterface`, persists across restarts). `AuthServiceProvider` registers the in-memory implementation by default; apps needing persistence can override the binding:
+All auth endpoints apply rate limiting via `RateLimiterInterface` keyed on IP or user identity. Two implementations exist: `RateLimiter` (in-memory, resets per process) and `DatabaseRateLimiter` (SQLite-backed via `DatabaseInterface`, persists across restarts). `AuthServiceProvider` registers `DatabaseRateLimiter` by default, resolving `DatabaseInterface` from the container. `HttpKernel` also injects a `DatabaseRateLimiter` into `ControllerDispatcher` for the login endpoint. The in-memory `RateLimiter` remains as a fallback when no `RateLimiterInterface` is injected (e.g., in tests):
 
 | Endpoint | Limit |
 |----------|-------|

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-04-02 - post-M10 package declarations, FoundationServiceProvider registration, provider-owned routes and CLI graph, C18 drift remediation (#1017), and production SQLite bootstrap guard follow-up (#748) -->
+<!-- Spec reviewed 2026-04-03 - DatabaseRateLimiter wired into ControllerDispatcher via HttpKernel (#768) -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
@@ -886,7 +886,9 @@ File: `packages/foundation/src/Http/ControllerDispatcher.php`
 
 Routes a matched controller name to the appropriate handler. Receives controller identifier, route params, and request context, then delegates to JSON:API controllers, discovery endpoints, SSR, MCP, or other handlers. Central dispatch hub for `HttpKernel`.
 
-**Auth login handler** (`auth.login`): Validates credentials via `AuthController::findUserByName()` + `User::checkPassword()`, sets `$_SESSION['waaseyaa_uid']`, then calls `session_regenerate_id(true)` (session fixation prevention) and `session_write_close()` to flush the `Set-Cookie` header before `ResponseSender::json()` terminates with `exit`.
+Constructor accepts an optional `?RateLimiterInterface $rateLimiter` (from `Waaseyaa\Auth`). `HttpKernel` injects a `DatabaseRateLimiter` backed by the kernel's DBAL connection. When null (e.g., in tests), the login handler falls back to the in-memory `RateLimiter`.
+
+**Auth login handler** (`auth.login`): Applies rate limiting (5 attempts per IP per 60s) via the injected `RateLimiterInterface`, then validates credentials via `AuthController::findUserByName()` + `User::checkPassword()`, sets `$_SESSION['waaseyaa_uid']`, then calls `session_regenerate_id(true)` (session fixation prevention) and `session_write_close()` to flush the `Set-Cookie` header before `ResponseSender::json()` terminates with `exit`.
 
 ### CorsHandler
 

--- a/packages/auth/src/AuthServiceProvider.php
+++ b/packages/auth/src/AuthServiceProvider.php
@@ -22,7 +22,10 @@ final class AuthServiceProvider extends ServiceProvider
     {
         $this->singleton(AuthManager::class, fn() => new AuthManager());
 
-        $this->singleton(RateLimiterInterface::class, fn() => new RateLimiter());
+        $this->singleton(RateLimiterInterface::class, function () {
+            $db = $this->resolve(\Waaseyaa\Database\DatabaseInterface::class);
+            return new DatabaseRateLimiter($db);
+        });
 
         $authConfig = $this->config['auth'] ?? [];
         $appEnv = $this->config['app_env'] ?? ($_ENV['APP_ENV'] ?? 'production');

--- a/packages/auth/src/DatabaseRateLimiter.php
+++ b/packages/auth/src/DatabaseRateLimiter.php
@@ -14,8 +14,7 @@ final class DatabaseRateLimiter implements RateLimiterInterface
 
     public function __construct(
         private readonly DatabaseInterface $database,
-    ) {
-    }
+    ) {}
 
     public function hit(string $key, int $decaySeconds): void
     {

--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -21,6 +21,7 @@ use Waaseyaa\Api\JsonApiDocument;
 use Waaseyaa\Api\OpenApi\OpenApiGenerator;
 use Waaseyaa\Api\ResourceSerializer;
 use Waaseyaa\Api\Schema\SchemaPresenter;
+use Waaseyaa\Auth\RateLimiterInterface;
 use Waaseyaa\Cache\CacheBackendInterface;
 use Waaseyaa\Entity\EntityTypeIdNormalizer;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
@@ -58,6 +59,7 @@ final class ControllerDispatcher
         private readonly array $config,
         /** @var array<string, array{args?: array<string, mixed>, resolve?: callable}> */
         private readonly array $graphqlMutationOverrides = [],
+        private readonly ?RateLimiterInterface $rateLimiter = null,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -692,12 +694,7 @@ final class ControllerDispatcher
                 })(),
 
                 $controller === 'auth.login' => (function () use ($body): never {
-                    // @todo Replace in-memory RateLimiter with cache-backed implementation
-                    // for PHP-FPM deployments. In-memory state is per-process only.
-                    static $rateLimiter = null;
-                    if ($rateLimiter === null) {
-                        $rateLimiter = new \Waaseyaa\Auth\RateLimiter();
-                    }
+                    $rateLimiter = $this->rateLimiter ?? new \Waaseyaa\Auth\RateLimiter();
 
                     $rateLimitKey = 'login:' . ($_SERVER['REMOTE_ADDR'] ?? '127.0.0.1');
 

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -13,6 +13,7 @@ use Waaseyaa\Access\Gate\EntityAccessGate;
 use Waaseyaa\Access\Middleware\AuthorizationMiddleware;
 use Waaseyaa\Api\Controller\BroadcastStorage;
 use Waaseyaa\Api\Http\DiscoveryApiHandler;
+use Waaseyaa\Auth\DatabaseRateLimiter;
 use Waaseyaa\Cache\Backend\DatabaseBackend;
 use Waaseyaa\Cache\CacheBackendInterface;
 use Waaseyaa\Cache\CacheConfigResolver;
@@ -273,6 +274,7 @@ final class HttpKernel extends AbstractKernel
             projectRoot: $this->projectRoot,
             config: $this->config,
             graphqlMutationOverrides: $gqlOverrides,
+            rateLimiter: new DatabaseRateLimiter($this->database),
         );
         $controllerDispatcher->dispatch($method, $params, $httpRequest, $queryString, $broadcastStorage, $account);
     }

--- a/packages/user/src/UserServiceProvider.php
+++ b/packages/user/src/UserServiceProvider.php
@@ -73,7 +73,7 @@ final class UserServiceProvider extends ServiceProvider
             driver: fn() => $this->resolve(MailDriverInterface::class),
             twig: \Waaseyaa\SSR\SsrServiceProvider::getTwigEnvironment(),
             baseUrl: $config['app']['url'] ?? throw new \RuntimeException(
-                "app.url is not configured. Add 'app' => ['url' => 'https://yourapp.com'] to your config/waaseyaa.php."
+                "app.url is not configured. Add 'app' => ['url' => 'https://yourapp.com'] to your config/waaseyaa.php.",
             ),
             appName: $config['app']['name'] ?? 'Waaseyaa',
         ));


### PR DESCRIPTION
## Summary

- **AuthServiceProvider** now registers `DatabaseRateLimiter` (SQLite-backed) instead of the in-memory `RateLimiter`, making rate limiting effective under PHP-FPM where each worker has its own process memory
- **ControllerDispatcher** accepts an optional `?RateLimiterInterface` constructor param; `HttpKernel` injects a `DatabaseRateLimiter` backed by the kernel's DBAL connection
- The in-memory `RateLimiter` is retained as a fallback when no interface is injected (backwards compatibility for tests)
- Updated `access-control.md` and `infrastructure.md` specs to reflect the new wiring

Closes #768

## Test plan

- [x] All 92 auth + ControllerDispatcher unit tests pass
- [x] All 42 HttpKernel unit tests pass
- [x] PHPStan clean (no errors)
- [x] PHP-CS-Fixer clean
- [x] Spec drift detector passes
- [ ] Manual: verify login rate limiting persists across dev server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)