### PR TITLE
feat(#732): add RequestContextProcessor for structured log context

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-04-03 - DatabaseRateLimiter wired into ControllerDispatcher via HttpKernel (#768) -->
+<!-- Spec reviewed 2026-04-03 - RequestContextProcessor added to LogManager, wired in HttpKernel (#732) -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -784,7 +784,7 @@ Immutable value object carrying a single log entry: `level` (LogLevel), `message
 
 File: `packages/foundation/src/Log/LogManager.php`
 
-Central log orchestrator. Implements `LoggerInterface` — calling `log()` delegates to the default channel. Constructor accepts `LoggerInterface|HandlerInterface` for the default handler (legacy loggers are wrapped in `LegacyLoggerHandler`). `channel(string $name)` returns a `ChannelLogger` for the named channel; unknown channels fall back to the default. `fromConfig(array $config)` static factory builds channels from config (two-pass: non-stack handlers first, then stack handlers that reference other channels).
+Central log orchestrator. Implements `LoggerInterface` — calling `log()` delegates to the default channel. Constructor accepts `LoggerInterface|HandlerInterface` for the default handler (legacy loggers are wrapped in `LegacyLoggerHandler`). `channel(string $name)` returns a `ChannelLogger` for the named channel; unknown channels fall back to the default. `fromConfig(array $config)` static factory builds channels from config (two-pass: non-stack handlers first, then stack handlers that reference other channels). `addGlobalProcessor(ProcessorInterface $processor)` allows runtime registration of processors (used by `HttpKernel` to add `RequestContextProcessor` after request resolution).
 
 The kernel constructs `LogManager(new Handler\ErrorLogHandler())` at startup, then upgrades it after config loads: if `config['logging']['channels']` exists, uses `LogManager::fromConfig()`; otherwise falls back to `log_level` config with a single `Handler\ErrorLogHandler(minimumLevel: $level)`.
 
@@ -824,6 +824,7 @@ Processors enrich `LogRecord` context before handlers receive the record. Execut
 | `RequestIdProcessor` | `Log/Processor/RequestIdProcessor.php` | Adds `request_id` (UUID hex) to context. Same ID for all records within a single processor instance. |
 | `HostnameProcessor` | `Log/Processor/HostnameProcessor.php` | Adds `hostname` to context. Defaults to `gethostname()`. |
 | `MemoryUsageProcessor` | `Log/Processor/MemoryUsageProcessor.php` | Adds `memory_peak_mb` (float) to context. |
+| `RequestContextProcessor` | `Log/Processor/RequestContextProcessor.php` | Adds `http_method`, `uri`, and optional `request_id` to context. Registered by `HttpKernel` during request handling. |
 
 ### Legacy logger implementations
 
@@ -1276,7 +1277,8 @@ Log/
         ProcessorInterface.php   -- process(LogRecord): LogRecord (immutable enrichment)
         RequestIdProcessor.php   -- adds request_id (UUID hex) to context
         HostnameProcessor.php    -- adds hostname to context
-        MemoryUsageProcessor.php -- adds memory_peak_mb to context
+        MemoryUsageProcessor.php    -- adds memory_peak_mb to context
+        RequestContextProcessor.php -- adds http_method, uri, request_id to context (HTTP requests)
 RateLimit/
     RateLimiterInterface.php     -- attempt(key, max, window): {allowed, remaining, retryAfter}
     InMemoryRateLimiter.php      -- sliding-window in-memory implementation

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -97,6 +97,13 @@ final class HttpKernel extends AbstractKernel
         }
         $queryString = $_SERVER['QUERY_STRING'] ?? '';
 
+        // Register request context on the logger so all subsequent log entries carry HTTP context.
+        if ($this->logger instanceof \Waaseyaa\Foundation\Log\LogManager) {
+            $this->logger->addGlobalProcessor(
+                new \Waaseyaa\Foundation\Log\Processor\RequestContextProcessor($method, $path),
+            );
+        }
+
         // Broadcast storage for SSE.
         $broadcastStorage = new BroadcastStorage($this->database);
         $listenerRegistrar = new EventListenerRegistrar($this->dispatcher);

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -21,6 +21,8 @@ use Waaseyaa\Cache\CacheConfiguration;
 use Waaseyaa\Cache\CacheFactory;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Http\ControllerDispatcher;
+use Waaseyaa\Foundation\Log\LogManager;
+use Waaseyaa\Foundation\Log\Processor\RequestContextProcessor;
 use Waaseyaa\Foundation\Http\CorsHandler;
 use Waaseyaa\Foundation\Http\ResponseSender;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
@@ -98,10 +100,10 @@ final class HttpKernel extends AbstractKernel
         $queryString = $_SERVER['QUERY_STRING'] ?? '';
 
         // Register request context on the logger so all subsequent log entries carry HTTP context.
-        if ($this->logger instanceof \Waaseyaa\Foundation\Log\LogManager) {
-            $this->logger->addGlobalProcessor(
-                new \Waaseyaa\Foundation\Log\Processor\RequestContextProcessor($method, $path),
-            );
+        // Note: if RequestIdProcessor is also active (via config), it writes request_id independently.
+        // This processor does not pass a request_id to avoid overwriting the config-driven one.
+        if ($this->logger instanceof LogManager) {
+            $this->logger->addGlobalProcessor(new RequestContextProcessor($method, $path));
         }
 
         // Broadcast storage for SSE.

--- a/packages/foundation/src/Log/LogManager.php
+++ b/packages/foundation/src/Log/LogManager.php
@@ -170,6 +170,11 @@ final class LogManager implements LoggerInterface
         $this->handlers[$this->defaultChannel]->handle($record);
     }
 
+    public function addGlobalProcessor(ProcessorInterface $processor): void
+    {
+        $this->globalProcessors[] = $processor;
+    }
+
     private static function buildHandler(array $config): HandlerInterface
     {
         $type = $config['type'] ?? 'errorlog';

--- a/packages/foundation/src/Log/Processor/RequestContextProcessor.php
+++ b/packages/foundation/src/Log/Processor/RequestContextProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Log\Processor;
+
+use Waaseyaa\Foundation\Log\LogRecord;
+
+/**
+ * Adds HTTP request context (method, URI, request ID) to every log entry.
+ *
+ * Intended for use during HTTP request handling only. The kernel registers
+ * this processor after routing so that all subsequent log entries carry
+ * request context automatically.
+ */
+final class RequestContextProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly string $method,
+        private readonly string $uri,
+        private readonly ?string $requestId = null,
+    ) {}
+
+    public function process(LogRecord $record): LogRecord
+    {
+        $context = ['http_method' => $this->method, 'uri' => $this->uri];
+
+        if ($this->requestId !== null) {
+            $context['request_id'] = $this->requestId;
+        }
+
+        return new LogRecord(
+            level: $record->level,
+            message: $record->message,
+            context: array_merge($record->context, $context),
+            channel: $record->channel,
+            timestamp: $record->timestamp,
+        );
+    }
+}

--- a/packages/foundation/tests/Unit/Log/LogManagerTest.php
+++ b/packages/foundation/tests/Unit/Log/LogManagerTest.php
@@ -280,4 +280,40 @@ final class LogManagerTest extends TestCase
             }
         }
     }
+
+    #[Test]
+    public function add_global_processor_at_runtime(): void
+    {
+        $tmpFile = sys_get_temp_dir() . '/waaseyaa_addproc_test_' . uniqid() . '.log';
+
+        try {
+            $config = [
+                'default' => 'file',
+                'channels' => [
+                    'file' => [
+                        'type' => 'file',
+                        'path' => $tmpFile,
+                        'level' => 'debug',
+                        'formatter' => 'json',
+                    ],
+                ],
+            ];
+
+            $manager = LogManager::fromConfig($config);
+            $manager->addGlobalProcessor(
+                new \Waaseyaa\Foundation\Log\Processor\RequestContextProcessor('GET', '/api/nodes', 'req-test-1'),
+            );
+            $manager->info('runtime processor test');
+
+            $content = trim(file_get_contents($tmpFile));
+            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+            $this->assertSame('GET', $decoded['context']['http_method']);
+            $this->assertSame('/api/nodes', $decoded['context']['uri']);
+            $this->assertSame('req-test-1', $decoded['context']['request_id']);
+        } finally {
+            if (file_exists($tmpFile)) {
+                unlink($tmpFile);
+            }
+        }
+    }
 }

--- a/packages/foundation/tests/Unit/Log/Processor/RequestContextProcessorTest.php
+++ b/packages/foundation/tests/Unit/Log/Processor/RequestContextProcessorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Log\Processor;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\LogLevel;
+use Waaseyaa\Foundation\Log\LogRecord;
+use Waaseyaa\Foundation\Log\Processor\RequestContextProcessor;
+
+#[CoversClass(RequestContextProcessor::class)]
+final class RequestContextProcessorTest extends TestCase
+{
+    #[Test]
+    public function adds_method_and_uri_to_context(): void
+    {
+        $processor = new RequestContextProcessor('GET', '/api/nodes');
+        $record = new LogRecord(LogLevel::INFO, 'test');
+
+        $result = $processor->process($record);
+
+        $this->assertSame('GET', $result->context['http_method']);
+        $this->assertSame('/api/nodes', $result->context['uri']);
+    }
+
+    #[Test]
+    public function adds_request_id_when_provided(): void
+    {
+        $processor = new RequestContextProcessor('POST', '/api/users', 'req-abc-123');
+        $result = $processor->process(new LogRecord(LogLevel::INFO, 'test'));
+
+        $this->assertSame('req-abc-123', $result->context['request_id']);
+        $this->assertSame('POST', $result->context['http_method']);
+        $this->assertSame('/api/users', $result->context['uri']);
+    }
+
+    #[Test]
+    public function omits_request_id_when_not_provided(): void
+    {
+        $processor = new RequestContextProcessor('DELETE', '/api/nodes/5');
+        $result = $processor->process(new LogRecord(LogLevel::INFO, 'test'));
+
+        $this->assertArrayNotHasKey('request_id', $result->context);
+        $this->assertSame('DELETE', $result->context['http_method']);
+    }
+
+    #[Test]
+    public function does_not_mutate_input(): void
+    {
+        $processor = new RequestContextProcessor('GET', '/');
+        $original = new LogRecord(LogLevel::INFO, 'test', ['existing' => 'value']);
+
+        $result = $processor->process($original);
+
+        $this->assertArrayNotHasKey('http_method', $original->context);
+        $this->assertArrayNotHasKey('uri', $original->context);
+        $this->assertSame('value', $result->context['existing']);
+        $this->assertSame('GET', $result->context['http_method']);
+    }
+
+    #[Test]
+    public function preserves_all_record_fields(): void
+    {
+        $processor = new RequestContextProcessor('PUT', '/api/config');
+        $original = new LogRecord(
+            level: LogLevel::ERROR,
+            message: 'Something failed',
+            context: ['detail' => 'info'],
+            channel: 'app',
+        );
+
+        $result = $processor->process($original);
+
+        $this->assertSame(LogLevel::ERROR, $result->level);
+        $this->assertSame('Something failed', $result->message);
+        $this->assertSame('app', $result->channel);
+        $this->assertSame($original->timestamp, $result->timestamp);
+        $this->assertSame('info', $result->context['detail']);
+    }
+
+    #[Test]
+    public function same_context_across_multiple_records(): void
+    {
+        $processor = new RequestContextProcessor('GET', '/api/nodes');
+        $r1 = $processor->process(new LogRecord(LogLevel::INFO, 'first'));
+        $r2 = $processor->process(new LogRecord(LogLevel::INFO, 'second'));
+
+        $this->assertSame($r1->context['http_method'], $r2->context['http_method']);
+        $this->assertSame($r1->context['uri'], $r2->context['uri']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RequestContextProcessor` that enriches log entries with `http_method`, `uri`, and optional `request_id` during HTTP request handling
- Adds `LogManager::addGlobalProcessor()` for runtime processor registration
- `HttpKernel::serveHttpRequest()` automatically registers the processor after resolving the request path
- Updates `docs/specs/infrastructure.md` to reflect the new processor

Closes #732

## Test plan
- [x] `RequestContextProcessorTest` — 6 tests covering context injection, immutability, optional request_id, field preservation
- [x] `LogManagerTest::add_global_processor_at_runtime` — verifies runtime registration flows through to JSON output
- [x] Full unit suite passes (5,038 tests)
- [x] PHPStan clean, CS-fixer clean, spec drift resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)