### PR TITLE
feat(#737): add DebugHeaderMiddleware with X-Debug-* response headers

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-04-03 - RequestContextProcessor added to LogManager, wired in HttpKernel (#732) -->
+<!-- Spec reviewed 2026-04-03 - DebugHeaderMiddleware added to foundation middleware (#737) -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
@@ -1227,6 +1227,8 @@ Middleware/
     HttpMiddlewareInterface.php  -- process(Request, HttpHandlerInterface): Response
     HttpHandlerInterface.php     -- handle(Request): Response
     HttpPipeline.php             -- onion-pattern HTTP middleware stack
+    DebugHeaderMiddleware.php    -- X-Debug-Time/Memory/Request-Id headers (APP_DEBUG only)
+    BodySizeLimitMiddleware.php  -- rejects oversized request bodies (413)
     EventMiddlewareInterface.php -- process(DomainEvent, EventHandlerInterface): void
     EventHandlerInterface.php    -- handle(DomainEvent): void
     EventPipeline.php            -- onion-pattern event middleware stack

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -21,10 +21,11 @@ use Waaseyaa\Cache\CacheConfiguration;
 use Waaseyaa\Cache\CacheFactory;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
 use Waaseyaa\Foundation\Http\ControllerDispatcher;
-use Waaseyaa\Foundation\Log\LogManager;
-use Waaseyaa\Foundation\Log\Processor\RequestContextProcessor;
 use Waaseyaa\Foundation\Http\CorsHandler;
 use Waaseyaa\Foundation\Http\ResponseSender;
+use Waaseyaa\Foundation\Log\LogManager;
+use Waaseyaa\Foundation\Log\Processor\RequestContextProcessor;
+use Waaseyaa\Foundation\Middleware\DebugHeaderMiddleware;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpPipeline;
 use Waaseyaa\Routing\WaaseyaaRouter;
@@ -222,6 +223,12 @@ final class HttpKernel extends AbstractKernel
             new CsrfMiddleware(),
             new AuthorizationMiddleware($accessChecker, $errorPageRenderer),
         ];
+
+        if ($this->isDebugMode()) {
+            $middlewares[] = new DebugHeaderMiddleware(
+                startTime: $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true),
+            );
+        }
 
         // Collect middleware contributed by service providers.
         foreach ($this->providers as $provider) {

--- a/packages/foundation/src/Middleware/DebugHeaderMiddleware.php
+++ b/packages/foundation/src/Middleware/DebugHeaderMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+
+/**
+ * Adds X-Debug-* headers to all responses when APP_DEBUG=true.
+ *
+ * Gives SPA devtools and curl users useful debugging signals without
+ * requiring an HTML toolbar.
+ *
+ * Headers:
+ *   X-Debug-Time       — request duration in milliseconds
+ *   X-Debug-Memory     — peak memory usage (e.g. "4.2MB")
+ *   X-Debug-Request-Id — links log entries to this request
+ *
+ * X-Debug-Queries is deferred until a query counter is added to the
+ * database layer (see debugging-dx spec).
+ */
+#[AsMiddleware(pipeline: 'http', priority: 90)]
+final class DebugHeaderMiddleware implements HttpMiddlewareInterface
+{
+    public function __construct(
+        private readonly float $startTime,
+        private readonly ?string $requestId = null,
+    ) {}
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+    {
+        $response = $next->handle($request);
+
+        $elapsedMs = (int) round((microtime(true) - $this->startTime) * 1000);
+        $peakMb = round(memory_get_peak_usage(true) / 1_048_576, 1);
+
+        $response->headers->set('X-Debug-Time', $elapsedMs . 'ms');
+        $response->headers->set('X-Debug-Memory', $peakMb . 'MB');
+
+        if ($this->requestId !== null) {
+            $response->headers->set('X-Debug-Request-Id', $this->requestId);
+        }
+
+        return $response;
+    }
+}

--- a/packages/foundation/tests/Unit/Middleware/DebugHeaderMiddlewareTest.php
+++ b/packages/foundation/tests/Unit/Middleware/DebugHeaderMiddlewareTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Middleware\DebugHeaderMiddleware;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+
+#[CoversClass(DebugHeaderMiddleware::class)]
+final class DebugHeaderMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function adds_time_and_memory_headers(): void
+    {
+        $middleware = new DebugHeaderMiddleware(startTime: microtime(true));
+
+        $response = $middleware->process(
+            Request::create('/api/nodes'),
+            $this->passthrough(),
+        );
+
+        $this->assertTrue($response->headers->has('X-Debug-Time'));
+        $this->assertTrue($response->headers->has('X-Debug-Memory'));
+        $this->assertMatchesRegularExpression('/^\d+ms$/', $response->headers->get('X-Debug-Time'));
+        $this->assertMatchesRegularExpression('/^[\d.]+MB$/', $response->headers->get('X-Debug-Memory'));
+    }
+
+    #[Test]
+    public function time_header_reflects_elapsed_duration(): void
+    {
+        $startTime = microtime(true) - 0.042; // 42ms ago
+        $middleware = new DebugHeaderMiddleware(startTime: $startTime);
+
+        $response = $middleware->process(
+            Request::create('/'),
+            $this->passthrough(),
+        );
+
+        $timeMs = (int) rtrim($response->headers->get('X-Debug-Time'), 'ms');
+        $this->assertGreaterThanOrEqual(42, $timeMs);
+        $this->assertLessThan(200, $timeMs);
+    }
+
+    #[Test]
+    public function includes_request_id_when_provided(): void
+    {
+        $middleware = new DebugHeaderMiddleware(
+            startTime: microtime(true),
+            requestId: 'req-abc-123',
+        );
+
+        $response = $middleware->process(
+            Request::create('/'),
+            $this->passthrough(),
+        );
+
+        $this->assertSame('req-abc-123', $response->headers->get('X-Debug-Request-Id'));
+    }
+
+    #[Test]
+    public function omits_request_id_when_not_provided(): void
+    {
+        $middleware = new DebugHeaderMiddleware(startTime: microtime(true));
+
+        $response = $middleware->process(
+            Request::create('/'),
+            $this->passthrough(),
+        );
+
+        $this->assertFalse($response->headers->has('X-Debug-Request-Id'));
+    }
+
+    #[Test]
+    public function preserves_existing_response_headers(): void
+    {
+        $middleware = new DebugHeaderMiddleware(startTime: microtime(true));
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('OK', 200, ['X-Custom' => 'preserved']);
+            }
+        };
+
+        $response = $middleware->process(Request::create('/'), $next);
+
+        $this->assertSame('preserved', $response->headers->get('X-Custom'));
+        $this->assertTrue($response->headers->has('X-Debug-Time'));
+    }
+
+    #[Test]
+    public function preserves_response_status_and_content(): void
+    {
+        $middleware = new DebugHeaderMiddleware(startTime: microtime(true));
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('{"data":[]}', 201, ['Content-Type' => 'application/json']);
+            }
+        };
+
+        $response = $middleware->process(Request::create('/'), $next);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('{"data":[]}', $response->getContent());
+    }
+
+    private function passthrough(): HttpHandlerInterface
+    {
+        return new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('', 200);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DebugHeaderMiddleware` that appends `X-Debug-Time`, `X-Debug-Memory`, and optional `X-Debug-Request-Id` headers to all responses when `APP_DEBUG=true`
- HttpKernel registers the middleware gated on `isDebugMode()`
- Uses `$_SERVER['REQUEST_TIME_FLOAT']` for accurate request duration
- `X-Debug-Queries` deferred until a query counter is added to the database layer (per debugging-dx spec)
- Updates `docs/specs/infrastructure.md` file tree

Closes #737

## Test plan
- [x] `DebugHeaderMiddlewareTest` — 6 tests: time/memory headers, request ID presence/absence, response preservation, elapsed duration accuracy
- [x] Full unit suite passes (5,044 tests)
- [x] PHPStan clean, CS-fixer clean, spec drift resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)