### PR TITLE
feat(#727): add emailVerified field to OAuthUserProfile

### DIFF
--- a/packages/oauth-provider/src/OAuthUserProfile.php
+++ b/packages/oauth-provider/src/OAuthUserProfile.php
@@ -11,5 +11,6 @@ final readonly class OAuthUserProfile
         public string $email,
         public string $name,
         public ?string $avatarUrl = null,
+        public bool $emailVerified = false,
     ) {}
 }

--- a/packages/oauth-provider/src/Provider/GitHubOAuthProvider.php
+++ b/packages/oauth-provider/src/Provider/GitHubOAuthProvider.php
@@ -96,9 +96,11 @@ final class GitHubOAuthProvider implements OAuthProviderInterface
         $emailsData = $emailsResponse->json();
 
         $email = '';
+        $emailVerified = false;
         foreach ($emailsData as $entry) {
             if (isset($entry['primary'], $entry['verified']) && $entry['primary'] && $entry['verified']) {
                 $email = (string) $entry['email'];
+                $emailVerified = true;
                 break;
             }
         }
@@ -112,6 +114,7 @@ final class GitHubOAuthProvider implements OAuthProviderInterface
             email: $email,
             name: $name,
             avatarUrl: isset($userData['avatar_url']) ? (string) $userData['avatar_url'] : null,
+            emailVerified: $emailVerified,
         );
     }
 }

--- a/packages/oauth-provider/src/Provider/GoogleOAuthProvider.php
+++ b/packages/oauth-provider/src/Provider/GoogleOAuthProvider.php
@@ -81,6 +81,7 @@ final class GoogleOAuthProvider implements OAuthProviderInterface
             email: (string) $data['email'],
             name: (string) $data['name'],
             avatarUrl: isset($data['picture']) ? (string) $data['picture'] : null,
+            emailVerified: !empty($data['verified_email']),
         );
     }
 

--- a/packages/oauth-provider/tests/OAuthUserProfileTest.php
+++ b/packages/oauth-provider/tests/OAuthUserProfileTest.php
@@ -16,12 +16,14 @@ final class OAuthUserProfileTest extends TestCase
             email: 'user@example.com',
             name: 'Jane Doe',
             avatarUrl: 'https://example.com/avatar.jpg',
+            emailVerified: true,
         );
 
         self::assertSame('12345', $profile->providerId);
         self::assertSame('user@example.com', $profile->email);
         self::assertSame('Jane Doe', $profile->name);
         self::assertSame('https://example.com/avatar.jpg', $profile->avatarUrl);
+        self::assertTrue($profile->emailVerified);
     }
 
     public function testCreateWithNullAvatar(): void
@@ -33,5 +35,6 @@ final class OAuthUserProfileTest extends TestCase
         );
 
         self::assertNull($profile->avatarUrl);
+        self::assertFalse($profile->emailVerified);
     }
 }

--- a/packages/oauth-provider/tests/Provider/GitHubOAuthProviderTest.php
+++ b/packages/oauth-provider/tests/Provider/GitHubOAuthProviderTest.php
@@ -105,6 +105,7 @@ final class GitHubOAuthProviderTest extends TestCase
         self::assertSame('jonesrussell42@gmail.com', $profile->email);
         self::assertSame('Russell Jones', $profile->name);
         self::assertSame('https://avatars.githubusercontent.com/u/42', $profile->avatarUrl);
+        self::assertTrue($profile->emailVerified);
     }
 
     public function testGetUserProfileFallsBackToLoginWhenNameIsNull(): void

--- a/packages/oauth-provider/tests/Provider/GoogleOAuthProviderTest.php
+++ b/packages/oauth-provider/tests/Provider/GoogleOAuthProviderTest.php
@@ -115,10 +115,11 @@ final class GoogleOAuthProviderTest extends TestCase
     public function testGetUserProfile(): void
     {
         $responseBody = json_encode([
-            'id'      => '1234567890',
-            'email'   => 'user@example.com',
-            'name'    => 'Test User',
-            'picture' => 'https://lh3.googleusercontent.com/photo.jpg',
+            'id'             => '1234567890',
+            'email'          => 'user@example.com',
+            'verified_email' => true,
+            'name'           => 'Test User',
+            'picture'        => 'https://lh3.googleusercontent.com/photo.jpg',
         ]);
 
         $this->httpClient
@@ -134,5 +135,6 @@ final class GoogleOAuthProviderTest extends TestCase
         self::assertSame('user@example.com', $profile->email);
         self::assertSame('Test User', $profile->name);
         self::assertSame('https://lh3.googleusercontent.com/photo.jpg', $profile->avatarUrl);
+        self::assertTrue($profile->emailVerified);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `emailVerified` boolean field to `OAuthUserProfile` value object (defaults to `false`)
- Google provider maps `verified_email` from userinfo response
- GitHub provider sets `true` when primary email is verified

Closes #727

## Test plan
- [x] `OAuthUserProfileTest` covers both `true` and default `false` cases
- [x] `GoogleOAuthProviderTest` asserts `emailVerified` from mock response
- [x] `GitHubOAuthProviderTest` asserts `emailVerified` for primary verified email
- [x] All 25 oauth-provider tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)