### PR TITLE
fix(#1061): add missing app.url config to SsrHttpKernelIntegrationTest

### DIFF
--- a/tests/Integration/Phase13/SsrHttpKernelIntegrationTest.php
+++ b/tests/Integration/Phase13/SsrHttpKernelIntegrationTest.php
@@ -266,6 +266,7 @@ declare(strict_types=1);
 return [
     'database' => '{$databasePath}',
     'environment' => 'local',
+    'app' => ['url' => 'http://localhost', 'name' => 'Waaseyaa Test'],
     'cors_origins' => ['http://localhost:3000'],
     'ssr' => [
         'theme' => '',


### PR DESCRIPTION
## Summary
- Adds `app.url` and `app.name` to the test config in `SsrHttpKernelIntegrationTest::buildConfigFile()`
- Fixes all 8 Phase13 SSR integration tests that broke after #1046 made `app.url` required
- This was causing CI failures on main

Closes #1061

## Test plan
- [x] All 8 `SsrHttpKernelIntegrationTest` tests pass locally (were all failing with 500)
- [x] No other tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)