### PR TITLE
refactor(#1074): extract shared JsonApiResponseTrait

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -835,7 +835,7 @@ Reads Vite `manifest.json` files to resolve source paths to hashed asset URLs. M
 
 File: `packages/foundation/src/Http/ControllerDispatcher.php`
 
-Routes a matched controller name to the appropriate handler. Receives controller identifier, route params, and request context, then delegates to JSON:API controllers, discovery endpoints, SSR, MCP, or other handlers. Central dispatch hub for `HttpKernel`.
+Routes a matched controller name to the appropriate handler. Receives controller identifier, route params, and request context, then delegates to JSON:API controllers, discovery endpoints, SSR, MCP, or other handlers. Central dispatch hub for `HttpKernel`. Uses `JsonApiResponseTrait` for JSON:API response construction.
 
 Handles callable controllers (objects with `__invoke(Request): JsonResponse`) and string controller keys. Callable controllers are invoked directly and their `Response` is sent. String keys are matched via a `match` expression to built-in handlers (JSON:API, SSR, media upload, discovery, MCP, GraphQL, etc.). Auth routes (`login`, `logout`, `me`) were extracted to dedicated controller classes in `packages/auth/src/Controller/` and are now registered as callables via `AuthServiceProvider`.
 
@@ -1224,6 +1224,7 @@ Asset/
     TenantAssetResolver.php      -- tenant-specific asset path resolution
 Http/
     ControllerDispatcher.php     -- routes controller names to handlers
+    JsonApiResponseTrait.php     -- shared JSON:API response builder (used by HttpKernel and ControllerDispatcher)
     CorsHandler.php              -- CORS preflight and header resolution
 Diagnostic/
     DiagnosticCode.php           -- string-backed enum of operator error codes

--- a/packages/foundation/src/Http/ControllerDispatcher.php
+++ b/packages/foundation/src/Http/ControllerDispatcher.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Foundation\Http;
 
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -44,6 +43,8 @@ use Waaseyaa\SSR\SsrPageHandler;
  */
 final class ControllerDispatcher
 {
+    use JsonApiResponseTrait;
+
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -986,20 +987,6 @@ final class ControllerDispatcher
         return '/files/' . ltrim($path, '/');
     }
 
-    /**
-     * Build a JSON:API response with correct content type and encoding.
-     *
-     * @param array<string, mixed> $data
-     * @param array<string, string> $headers
-     */
-    private function jsonApiResponse(int $status, array $data, array $headers = []): JsonResponse
-    {
-        $response = new JsonResponse($data, $status, $headers);
-        $response->setEncodingOptions(JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
-        $response->headers->set('Content-Type', 'application/vnd.api+json');
-
-        return $response;
-    }
 
     /**
      * Build an HTML response.

--- a/packages/foundation/src/Http/JsonApiResponseTrait.php
+++ b/packages/foundation/src/Http/JsonApiResponseTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+trait JsonApiResponseTrait
+{
+    /**
+     * Build a JSON:API response with correct content type and encoding.
+     *
+     * @param array<string, mixed> $data
+     * @param array<string, string> $headers
+     */
+    private function jsonApiResponse(int $status, array $data, array $headers = []): JsonResponse
+    {
+        $response = new JsonResponse($data, $status, $headers);
+        $response->setEncodingOptions(JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $response->headers->set('Content-Type', 'application/vnd.api+json');
+
+        return $response;
+    }
+}

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Kernel;
 
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use Symfony\Component\Routing\RequestContext;
@@ -25,6 +24,7 @@ use Waaseyaa\Foundation\Http\CorsHandler;
 use Waaseyaa\Foundation\Log\LogManager;
 use Waaseyaa\Foundation\Log\Processor\RequestContextProcessor;
 use Waaseyaa\Foundation\Middleware\DebugHeaderMiddleware;
+use Waaseyaa\Foundation\Http\JsonApiResponseTrait;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpPipeline;
 use Waaseyaa\Routing\WaaseyaaRouter;
@@ -46,6 +46,8 @@ use Waaseyaa\User\Middleware\SessionMiddleware;
  */
 final class HttpKernel extends AbstractKernel
 {
+    use JsonApiResponseTrait;
+
     private ?RenderCache $renderCache = null;
     private ?CacheBackendInterface $discoveryCache = null;
     private ?CacheBackendInterface $mcpReadCache = null;
@@ -377,18 +379,4 @@ final class HttpKernel extends AbstractKernel
         return ($authConfig['dev_fallback_account'] ?? false) === true;
     }
 
-    /**
-     * Build a JSON:API response with correct content type and encoding.
-     *
-     * @param array<string, mixed> $data
-     * @param array<string, string> $headers
-     */
-    private function jsonApiResponse(int $status, array $data, array $headers = []): JsonResponse
-    {
-        $response = new JsonResponse($data, $status, $headers);
-        $response->setEncodingOptions(JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
-        $response->headers->set('Content-Type', 'application/vnd.api+json');
-
-        return $response;
-    }
 }


### PR DESCRIPTION
## Summary
- Extracts identical `jsonApiResponse()` methods from `HttpKernel` and `ControllerDispatcher` into a shared `JsonApiResponseTrait`
- Both classes now `use JsonApiResponseTrait` instead of duplicating the method
- Updates infrastructure spec to document the new trait

## Test plan
- [x] All 5036 unit tests passing
- [x] PHPStan clean (no errors)
- [x] Spec drift resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1074