### PR TITLE
fix(#7): improve CLI diagnostics for missing provider classes

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1172,7 +1172,7 @@ public function discoverAndRegister(
 
 Discovery and registration follows a multi-phase process:
 
-1. **Instantiation**: Each provider class from `$manifest->providers` is instantiated. Non-`ServiceProvider` instances are logged and skipped.
+1. **Instantiation**: Each provider class from `$manifest->providers` is instantiated. Missing classes are logged with actionable remediation guidance (fix `composer.json` or run `optimize:manifest`) and skipped. Non-`ServiceProvider` instances are also logged and skipped.
 2. **Context injection**: Each provider receives kernel context via `setKernelContext($projectRoot, $config, $manifest->formatters)` and a kernel resolver closure via `setKernelResolver()`. The resolver provides cross-provider DI — it resolves `EntityTypeManager`, `DatabaseInterface`, `EventDispatcherInterface`, `LoggerInterface`, and any binding registered by previously-loaded providers.
 3. **Registration**: `register()` is called on each provider, allowing them to bind interfaces to implementations.
 4. **Entity type collection**: After all providers register, entity types from `$provider->getEntityTypes()` are registered with the `EntityTypeManager`. Registration failures are logged as errors but do not halt boot.

--- a/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
+++ b/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
@@ -38,7 +38,11 @@ final class ProviderRegistry
 
         foreach ($manifest->providers as $providerClass) {
             if (!class_exists($providerClass)) {
-                $this->logger->warning(sprintf('Provider class not found: %s', $providerClass));
+                $this->logger->warning(sprintf(
+                    'Provider class not found: %s. '
+                    . 'Fix the declaration in composer.json or run: php bin/waaseyaa optimize:manifest',
+                    $providerClass,
+                ));
                 continue;
             }
 

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
@@ -12,6 +12,9 @@ use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistry;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\LoggerTrait;
+use Waaseyaa\Foundation\Log\LogLevel;
 use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
@@ -82,10 +85,51 @@ final class ProviderRegistryTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $resolved);
         $this->assertSame('from-source', $resolved->origin);
     }
+    #[Test]
+    public function missing_provider_warning_includes_remediation_guidance(): void
+    {
+        $logger = new class implements LoggerInterface {
+            use LoggerTrait;
+
+            /** @var list<array{level: LogLevel, message: string}> */
+            public array $messages = [];
+
+            public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+            {
+                $this->messages[] = ['level' => $level, 'message' => (string) $message];
+            }
+        };
+
+        $registry = new ProviderRegistry($logger);
+        $database = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+
+        $manifest = new PackageManifest(
+            providers: ['App\\Provider\\NonexistentProvider'],
+        );
+
+        $registry->discoverAndRegister(
+            manifest: $manifest,
+            projectRoot: sys_get_temp_dir(),
+            config: [],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+
+        $warnings = array_filter($logger->messages, fn($m) => $m['level'] === LogLevel::WARNING);
+        $this->assertNotEmpty($warnings);
+
+        $warning = array_values($warnings)[0]['message'];
+        $this->assertStringContainsString('NonexistentProvider', $warning);
+        $this->assertStringContainsString('optimize:manifest', $warning);
+        $this->assertStringContainsString('composer.json', $warning);
+    }
 }
 
 /**
- * @internal Test fixture — provider that resolves EntityTypeManager from kernel.
+ * @internal Test fixture ��� provider that resolves EntityTypeManager from kernel.
  */
 final class KernelResolverTestProvider extends ServiceProvider
 {


### PR DESCRIPTION
## Summary

- ProviderRegistry warning for missing providers now includes actionable remediation: fix `composer.json` or run `optimize:manifest`
- Updates `docs/specs/infrastructure.md` to reflect the improved diagnostics

This is the final piece of the stale-manifest DX story. Combined with:
- Fingerprint auto-recompile (composer.json changes detected automatically)
- Known-missing stamp (#9/#1083, prevents repeated recompile)
- Minimal console for `optimize:manifest` (bypasses stale provider bootstrap)

Closes #7

## Test plan

- [x] `missing_provider_warning_includes_remediation_guidance` — verifies warning mentions `optimize:manifest` and `composer.json`
- [x] All 605 foundation tests pass
- [x] PHPStan clean, CS-Fixer clean, spec-drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)