### PR TITLE
feat(#571): add DomainRouterInterface, EntityTypeLifecycleRouter, SchemaRouter

### DIFF
--- a/packages/foundation/src/Http/Router/DomainRouterInterface.php
+++ b/packages/foundation/src/Http/Router/DomainRouterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http\Router;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface DomainRouterInterface
+{
+    public function supports(Request $request): bool;
+
+    public function handle(Request $request): Response;
+}

--- a/packages/foundation/src/Http/Router/EntityTypeLifecycleRouter.php
+++ b/packages/foundation/src/Http/Router/EntityTypeLifecycleRouter.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http\Router;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Entity\EntityTypeIdNormalizer;
+use Waaseyaa\Entity\EntityTypeLifecycleManager;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Http\JsonApiResponseTrait;
+
+final class EntityTypeLifecycleRouter implements DomainRouterInterface
+{
+    use JsonApiResponseTrait;
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly EntityTypeLifecycleManager $lifecycleManager,
+    ) {}
+
+    public function supports(Request $request): bool
+    {
+        $controller = $request->attributes->get('_controller', '');
+        return $controller === 'entity_types' || str_starts_with($controller, 'entity_type.');
+    }
+
+    public function handle(Request $request): Response
+    {
+        $controller = $request->attributes->get('_controller', '');
+        $ctx = WaaseyaaContext::fromRequest($request);
+        $params = $request->attributes->all();
+
+        return match ($controller) {
+            'entity_types' => $this->listTypes(),
+            'entity_type.disable' => $this->disableType($params, $ctx),
+            'entity_type.enable' => $this->enableType($params, $ctx),
+            default => $this->jsonApiResponse(404, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [['status' => '404', 'title' => 'Not Found', 'detail' => "Unknown lifecycle action: $controller"]],
+            ]),
+        };
+    }
+
+    private function listTypes(): Response
+    {
+        $disabledIds = $this->lifecycleManager->getDisabledTypeIds();
+        $types = [];
+        foreach ($this->entityTypeManager->getDefinitions() as $id => $def) {
+            $types[] = [
+                'id' => $id,
+                'label' => $def->getLabel(),
+                'keys' => $def->getKeys(),
+                'translatable' => $def->isTranslatable(),
+                'revisionable' => $def->isRevisionable(),
+                'group' => $def->getGroup(),
+                'disabled' => in_array($id, $disabledIds, true),
+            ];
+        }
+        return $this->jsonApiResponse(200, ['data' => $types]);
+    }
+
+    /** @param array<string, mixed> $params */
+    private function disableType(array $params, WaaseyaaContext $ctx): Response
+    {
+        $rawTypeId = (string) ($params['entity_type'] ?? '');
+        $normalizer = new EntityTypeIdNormalizer($this->entityTypeManager);
+        $typeId = $normalizer->normalize($rawTypeId);
+        $force = filter_var($ctx->query['force'] ?? false, FILTER_VALIDATE_BOOL);
+
+        if ($rawTypeId === '' || !$this->entityTypeManager->hasDefinition($typeId)) {
+            return $this->jsonApiResponse(404, [
+                'errors' => [['status' => '404', 'title' => 'Not Found', 'detail' => sprintf('Unknown entity type: "%s".', $rawTypeId)]],
+            ]);
+        }
+        if ($this->lifecycleManager->isDisabled($typeId)) {
+            return $this->jsonApiResponse(200, ['data' => ['id' => $typeId, 'disabled' => true]]);
+        }
+
+        $definitions = array_keys($this->entityTypeManager->getDefinitions());
+        $disabledIds = $this->lifecycleManager->getDisabledTypeIds();
+        $enabledCount = count(array_filter($definitions, fn(string $id) => !in_array($id, $disabledIds, true)));
+
+        if ($enabledCount <= 1 && !$force) {
+            return $this->jsonApiResponse(409, [
+                'errors' => [['status' => '409', 'title' => 'Conflict', 'detail' => 'Cannot disable the last enabled content type. Enable another type first.']],
+            ]);
+        }
+
+        $this->lifecycleManager->disable($typeId, (string) $ctx->account->id());
+        return $this->jsonApiResponse(200, ['data' => ['id' => $typeId, 'disabled' => true]]);
+    }
+
+    /** @param array<string, mixed> $params */
+    private function enableType(array $params, WaaseyaaContext $ctx): Response
+    {
+        $rawTypeId = (string) ($params['entity_type'] ?? '');
+        $normalizer = new EntityTypeIdNormalizer($this->entityTypeManager);
+        $typeId = $normalizer->normalize($rawTypeId);
+
+        if ($rawTypeId === '' || !$this->entityTypeManager->hasDefinition($typeId)) {
+            return $this->jsonApiResponse(404, [
+                'errors' => [['status' => '404', 'title' => 'Not Found', 'detail' => sprintf('Unknown entity type: "%s".', $rawTypeId)]],
+            ]);
+        }
+        if (!$this->lifecycleManager->isDisabled($typeId)) {
+            return $this->jsonApiResponse(200, ['data' => ['id' => $typeId, 'disabled' => false]]);
+        }
+
+        $this->lifecycleManager->enable($typeId, (string) $ctx->account->id());
+        return $this->jsonApiResponse(200, ['data' => ['id' => $typeId, 'disabled' => false]]);
+    }
+}

--- a/packages/foundation/src/Http/Router/SchemaRouter.php
+++ b/packages/foundation/src/Http/Router/SchemaRouter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http\Router;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Api\Controller\SchemaController;
+use Waaseyaa\Api\OpenApi\OpenApiGenerator;
+use Waaseyaa\Api\Schema\SchemaPresenter;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Http\JsonApiResponseTrait;
+
+final class SchemaRouter implements DomainRouterInterface
+{
+    use JsonApiResponseTrait;
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly EntityAccessHandler $accessHandler,
+    ) {}
+
+    public function supports(Request $request): bool
+    {
+        $controller = $request->attributes->get('_controller', '');
+        return $controller === 'openapi' || str_contains($controller, 'SchemaController');
+    }
+
+    public function handle(Request $request): Response
+    {
+        $controller = $request->attributes->get('_controller', '');
+
+        if ($controller === 'openapi') {
+            $openApi = new OpenApiGenerator($this->entityTypeManager);
+            return $this->jsonApiResponse(200, $openApi->generate());
+        }
+
+        $ctx = WaaseyaaContext::fromRequest($request);
+        $schemaPresenter = new SchemaPresenter();
+        $schemaController = new SchemaController($this->entityTypeManager, $schemaPresenter, $this->accessHandler, $ctx->account);
+        $document = $schemaController->show($request->attributes->get('entity_type'));
+        return $this->jsonApiResponse($document->statusCode, $document->toArray());
+    }
+}

--- a/packages/foundation/src/Http/Router/WaaseyaaContext.php
+++ b/packages/foundation/src/Http/Router/WaaseyaaContext.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http\Router;
+
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Api\Controller\BroadcastStorage;
+
+final class WaaseyaaContext
+{
+    /**
+     * @param ?array<string, mixed> $parsedBody
+     * @param array<string, mixed> $query
+     */
+    public function __construct(
+        public readonly AccountInterface $account,
+        public readonly ?array $parsedBody,
+        public readonly array $query,
+        public readonly string $method,
+        public readonly BroadcastStorage $broadcastStorage,
+    ) {}
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            account: $request->attributes->get('_account'),
+            parsedBody: $request->attributes->get('_parsed_body'),
+            query: $request->query->all(),
+            method: $request->getMethod(),
+            broadcastStorage: $request->attributes->get('_broadcast_storage'),
+        );
+    }
+}

--- a/packages/foundation/tests/Unit/Http/Router/EntityTypeLifecycleRouterTest.php
+++ b/packages/foundation/tests/Unit/Http/Router/EntityTypeLifecycleRouterTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Http\Router;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Entity\EntityTypeLifecycleManager;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Http\Router\EntityTypeLifecycleRouter;
+
+#[CoversClass(EntityTypeLifecycleRouter::class)]
+final class EntityTypeLifecycleRouterTest extends TestCase
+{
+    private function createRouter(): EntityTypeLifecycleRouter
+    {
+        $etm = new EntityTypeManager(new EventDispatcher());
+        return new EntityTypeLifecycleRouter($etm, new EntityTypeLifecycleManager('/tmp'));
+    }
+
+    #[Test]
+    public function supports_entity_types_controller(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/entity-types');
+        $request->attributes->set('_controller', 'entity_types');
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function supports_entity_type_disable(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/entity-types/node/disable', 'POST');
+        $request->attributes->set('_controller', 'entity_type.disable');
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function supports_entity_type_enable(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/entity-types/node/enable', 'POST');
+        $request->attributes->set('_controller', 'entity_type.enable');
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function does_not_support_unrelated_controller(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/graphql');
+        $request->attributes->set('_controller', 'graphql.endpoint');
+        self::assertFalse($router->supports($request));
+    }
+
+    #[Test]
+    public function handle_entity_types_returns_list(): void
+    {
+        $router = $this->createRouter();
+        $account = $this->createStub(\Waaseyaa\Access\AccountInterface::class);
+        $broadcastStorage = new \Waaseyaa\Api\Controller\BroadcastStorage(\Waaseyaa\Database\DBALDatabase::createSqlite());
+        $request = Request::create('/api/entity-types');
+        $request->attributes->set('_controller', 'entity_types');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_broadcast_storage', $broadcastStorage);
+        $request->attributes->set('_parsed_body', null);
+
+        $response = $router->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('data', $data);
+        self::assertIsArray($data['data']);
+    }
+}

--- a/packages/foundation/tests/Unit/Http/Router/SchemaRouterTest.php
+++ b/packages/foundation/tests/Unit/Http/Router/SchemaRouterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Http\Router;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Http\Router\SchemaRouter;
+
+#[CoversClass(SchemaRouter::class)]
+final class SchemaRouterTest extends TestCase
+{
+    private function createRouter(): SchemaRouter
+    {
+        $etm = new EntityTypeManager(new EventDispatcher());
+        $accessHandler = new EntityAccessHandler();
+        return new SchemaRouter($etm, $accessHandler);
+    }
+
+    #[Test]
+    public function supports_openapi_controller(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/openapi');
+        $request->attributes->set('_controller', 'openapi');
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function supports_schema_controller(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/schema/node');
+        $request->attributes->set('_controller', 'Waaseyaa\\Api\\Controller\\SchemaController');
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function does_not_support_unrelated(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/mcp');
+        $request->attributes->set('_controller', 'mcp.endpoint');
+        self::assertFalse($router->supports($request));
+    }
+
+    #[Test]
+    public function handle_openapi_returns_json(): void
+    {
+        $router = $this->createRouter();
+        $request = Request::create('/api/openapi');
+        $request->attributes->set('_controller', 'openapi');
+        $response = $router->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/vnd.api+json', $response->headers->get('Content-Type'));
+    }
+}

--- a/packages/foundation/tests/Unit/Http/Router/WaaseyaaContextTest.php
+++ b/packages/foundation/tests/Unit/Http/Router/WaaseyaaContextTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Http\Router;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Api\Controller\BroadcastStorage;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Foundation\Http\Router\WaaseyaaContext;
+
+#[CoversClass(WaaseyaaContext::class)]
+final class WaaseyaaContextTest extends TestCase
+{
+    #[Test]
+    public function from_request_extracts_all_attributes(): void
+    {
+        $account = $this->createStub(AccountInterface::class);
+        $broadcastStorage = new BroadcastStorage(DBALDatabase::createSqlite());
+
+        $request = Request::create('/test', 'POST');
+        $request->query->set('page', '2');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_parsed_body', ['title' => 'Hello']);
+        $request->attributes->set('_broadcast_storage', $broadcastStorage);
+
+        $ctx = WaaseyaaContext::fromRequest($request);
+
+        self::assertSame($account, $ctx->account);
+        self::assertSame(['title' => 'Hello'], $ctx->parsedBody);
+        self::assertSame('POST', $ctx->method);
+        self::assertSame('2', $ctx->query['page']);
+        self::assertSame($broadcastStorage, $ctx->broadcastStorage);
+    }
+
+    #[Test]
+    public function from_request_handles_null_parsed_body(): void
+    {
+        $account = $this->createStub(AccountInterface::class);
+        $broadcastStorage = new BroadcastStorage(DBALDatabase::createSqlite());
+
+        $request = Request::create('/test', 'GET');
+        $request->attributes->set('_account', $account);
+        $request->attributes->set('_parsed_body', null);
+        $request->attributes->set('_broadcast_storage', $broadcastStorage);
+
+        $ctx = WaaseyaaContext::fromRequest($request);
+
+        self::assertNull($ctx->parsedBody);
+        self::assertSame('GET', $ctx->method);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DomainRouterInterface` contract (`supports(Request): bool`, `handle(Request): Response`)
- Adds `WaaseyaaContext` typed value object built from Request attributes
- Implements `EntityTypeLifecycleRouter` (entity_types, entity_type.disable, entity_type.enable)
- Implements `SchemaRouter` (openapi, *SchemaController)
- Unit tests for all new classes

Part of #571 (ControllerDispatcher Split P1). Unit 1 of 5 parallel router batches.

## Test plan
- [x] `./vendor/bin/phpunit packages/foundation/tests/Unit/Http/Router/` passes
- [ ] Integration tests pass after all units merge (Unit 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)