### PR TITLE
feat(#1093): add SovereigntyProfile to Layer 0 (foundation)

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-04-04d - parseJsonBody returns early on malformed JSON, all 10 domain routers wired in HttpKernel -->
+<!-- Spec reviewed 2026-04-04e - SovereigntyProfile/Config added to foundation, FoundationServiceProvider registers SovereigntyConfig singleton -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
@@ -894,6 +894,62 @@ Reads Vite `manifest.json` files to resolve source paths to hashed asset URLs. M
 
 `TenantAssetResolver` (`packages/foundation/src/Asset/TenantAssetResolver.php`) resolves tenant-specific asset paths.
 
+## Sovereignty Configuration
+
+File: `packages/foundation/src/Sovereignty/SovereigntyConfig.php`
+
+Provides deployment-mode defaults so applications can declare a sovereignty profile (`local`, `self_hosted`, `northops`) and get sane defaults for storage, embeddings, LLM provider, transcriber, vector store, and queue backend.
+
+### SovereigntyProfile
+
+File: `packages/foundation/src/Sovereignty/SovereigntyProfile.php`
+
+```php
+enum SovereigntyProfile: string
+{
+    case Local = 'local';
+    case SelfHosted = 'self_hosted';
+    case NorthOps = 'northops';
+}
+```
+
+### SovereigntyDefaults
+
+File: `packages/foundation/src/Sovereignty/SovereigntyDefaults.php`
+
+Maps each profile to its default settings:
+
+| Setting | `local` | `self_hosted` | `northops` |
+|---|---|---|---|
+| storage | filesystem | filesystem | s3 |
+| embeddings | sqlite | sqlite | pgvector |
+| llm_provider | ollama | ollama | api |
+| transcriber | whisper_ollama | whisper_ollama | api |
+| vector_store | sqlite | sqlite | pgvector |
+| queue_backend | sync | database | redis |
+
+### SovereigntyConfigInterface / SovereigntyConfig
+
+File: `packages/foundation/src/Sovereignty/SovereigntyConfigInterface.php`
+
+```php
+interface SovereigntyConfigInterface
+{
+    public function get(string $key): ?string;
+    public function getProfile(): SovereigntyProfile;
+    /** @return array<string, string> */
+    public function all(): array;
+}
+```
+
+`SovereigntyConfig` resolves effective settings: profile defaults merged with per-key overrides from app config. `SovereigntyConfig::fromArray($appConfig)` reads `sovereignty_profile` from the config array (defaults to `local`) and extracts recognized override keys.
+
+Registered as a singleton in `FoundationServiceProvider`:
+
+```php
+$this->singleton(SovereigntyConfigInterface::class, fn() => SovereigntyConfig::fromArray($this->config));
+```
+
 ## HTTP Utilities
 
 ### ControllerDispatcher and Domain Routers
@@ -1359,6 +1415,11 @@ Http/
         McpRouter.php                    -- MCP JSON-RPC endpoint
         SsrRouter.php                    -- server-side page rendering
         BroadcastRouter.php              -- SSE broadcast stream
+Sovereignty/
+    SovereigntyProfile.php       -- enum: Local, SelfHosted, NorthOps
+    SovereigntyDefaults.php      -- profile → default settings mapping
+    SovereigntyConfigInterface.php -- get/getProfile/all contract
+    SovereigntyConfig.php        -- effective config: profile defaults + overrides
 Diagnostic/
     DiagnosticCode.php           -- string-backed enum of operator error codes
     DiagnosticEntry.php          -- structured diagnostic log entry

--- a/packages/foundation/src/FoundationServiceProvider.php
+++ b/packages/foundation/src/FoundationServiceProvider.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Waaseyaa\Foundation;
 
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyConfig;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyConfigInterface;
 
 final class FoundationServiceProvider extends ServiceProvider
 {
-    public function register(): void {}
+    public function register(): void
+    {
+        $this->singleton(SovereigntyConfigInterface::class, fn() => SovereigntyConfig::fromArray($this->config));
+    }
 }

--- a/packages/foundation/src/Sovereignty/SovereigntyConfig.php
+++ b/packages/foundation/src/Sovereignty/SovereigntyConfig.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Sovereignty;
+
+final class SovereigntyConfig implements SovereigntyConfigInterface
+{
+    /** @var array<string, string> */
+    private readonly array $effective;
+
+    /** @param array<string, string> $overrides */
+    public function __construct(
+        private readonly SovereigntyProfile $profile,
+        array $overrides,
+    ) {
+        $this->effective = array_merge(
+            SovereigntyDefaults::for($this->profile),
+            array_filter($overrides, is_string(...)),
+        );
+    }
+
+    public function get(string $key): ?string
+    {
+        return $this->effective[$key] ?? null;
+    }
+
+    public function getProfile(): SovereigntyProfile
+    {
+        return $this->profile;
+    }
+
+    /** @return array<string, string> */
+    public function all(): array
+    {
+        return $this->effective;
+    }
+
+    /**
+     * Create from an app config array (e.g., config/waaseyaa.php contents).
+     *
+     * Reads 'sovereignty_profile' for the profile name, defaults to 'local'.
+     * All other recognized keys are treated as overrides.
+     *
+     * @param array<string, mixed> $appConfig
+     */
+    public static function fromArray(array $appConfig): self
+    {
+        $profileName = (string) ($appConfig['sovereignty_profile'] ?? 'local');
+        $profile = SovereigntyProfile::tryFrom($profileName) ?? SovereigntyProfile::Local;
+
+        $knownKeys = ['storage', 'embeddings', 'llm_provider', 'transcriber', 'vector_store', 'queue_backend'];
+        $overrides = [];
+        foreach ($knownKeys as $key) {
+            if (isset($appConfig[$key]) && is_string($appConfig[$key])) {
+                $overrides[$key] = $appConfig[$key];
+            }
+        }
+
+        return new self($profile, $overrides);
+    }
+}

--- a/packages/foundation/src/Sovereignty/SovereigntyConfigInterface.php
+++ b/packages/foundation/src/Sovereignty/SovereigntyConfigInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Sovereignty;
+
+interface SovereigntyConfigInterface
+{
+    public function get(string $key): ?string;
+
+    public function getProfile(): SovereigntyProfile;
+
+    /** @return array<string, string> */
+    public function all(): array;
+}

--- a/packages/foundation/src/Sovereignty/SovereigntyDefaults.php
+++ b/packages/foundation/src/Sovereignty/SovereigntyDefaults.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Sovereignty;
+
+final class SovereigntyDefaults
+{
+    /** @var array<string, array<string, string>> */
+    private const DEFAULTS = [
+        'local' => [
+            'storage' => 'filesystem',
+            'embeddings' => 'sqlite',
+            'llm_provider' => 'ollama',
+            'transcriber' => 'whisper_ollama',
+            'vector_store' => 'sqlite',
+            'queue_backend' => 'sync',
+        ],
+        'self_hosted' => [
+            'storage' => 'filesystem',
+            'embeddings' => 'sqlite',
+            'llm_provider' => 'ollama',
+            'transcriber' => 'whisper_ollama',
+            'vector_store' => 'sqlite',
+            'queue_backend' => 'database',
+        ],
+        'northops' => [
+            'storage' => 's3',
+            'embeddings' => 'pgvector',
+            'llm_provider' => 'api',
+            'transcriber' => 'api',
+            'vector_store' => 'pgvector',
+            'queue_backend' => 'redis',
+        ],
+    ];
+
+    /** @return array<string, string> */
+    public static function for(SovereigntyProfile $profile): array
+    {
+        return self::DEFAULTS[$profile->value];
+    }
+}

--- a/packages/foundation/src/Sovereignty/SovereigntyProfile.php
+++ b/packages/foundation/src/Sovereignty/SovereigntyProfile.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Sovereignty;
+
+enum SovereigntyProfile: string
+{
+    case Local = 'local';
+    case SelfHosted = 'self_hosted';
+    case NorthOps = 'northops';
+}

--- a/packages/foundation/tests/Unit/Sovereignty/SovereigntyConfigTest.php
+++ b/packages/foundation/tests/Unit/Sovereignty/SovereigntyConfigTest.php
@@ -167,4 +167,12 @@ final class SovereigntyConfigTest extends TestCase
 
         self::assertSame(SovereigntyProfile::Local, $config->getProfile());
     }
+
+    #[Test]
+    public function createFromConfigArrayFallsBackToLocalOnInvalidProfile(): void
+    {
+        $config = SovereigntyConfig::fromArray(['sovereignty_profile' => 'bogus']);
+
+        self::assertSame(SovereigntyProfile::Local, $config->getProfile());
+    }
 }

--- a/packages/foundation/tests/Unit/Sovereignty/SovereigntyConfigTest.php
+++ b/packages/foundation/tests/Unit/Sovereignty/SovereigntyConfigTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Sovereignty;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyConfig;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyConfigInterface;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyDefaults;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyProfile;
+
+#[CoversClass(SovereigntyConfig::class)]
+#[CoversClass(SovereigntyProfile::class)]
+#[CoversClass(SovereigntyDefaults::class)]
+final class SovereigntyConfigTest extends TestCase
+{
+    #[Test]
+    public function profileEnumHasThreeCases(): void
+    {
+        $cases = SovereigntyProfile::cases();
+
+        self::assertCount(3, $cases);
+        self::assertSame('local', SovereigntyProfile::Local->value);
+        self::assertSame('self_hosted', SovereigntyProfile::SelfHosted->value);
+        self::assertSame('northops', SovereigntyProfile::NorthOps->value);
+    }
+
+    #[Test]
+    public function profileCanBeCreatedFromString(): void
+    {
+        self::assertSame(SovereigntyProfile::Local, SovereigntyProfile::from('local'));
+        self::assertSame(SovereigntyProfile::SelfHosted, SovereigntyProfile::from('self_hosted'));
+        self::assertSame(SovereigntyProfile::NorthOps, SovereigntyProfile::from('northops'));
+    }
+
+    #[Test]
+    public function defaultsReturnsCompleteSettingsForAllProfiles(): void
+    {
+        $expectedKeys = ['storage', 'embeddings', 'llm_provider', 'transcriber', 'vector_store', 'queue_backend'];
+
+        foreach (SovereigntyProfile::cases() as $profile) {
+            $defaults = SovereigntyDefaults::for($profile);
+
+            foreach ($expectedKeys as $key) {
+                self::assertArrayHasKey($key, $defaults, sprintf(
+                    'Profile "%s" is missing default for key "%s"',
+                    $profile->value,
+                    $key,
+                ));
+                self::assertIsString($defaults[$key], sprintf(
+                    'Profile "%s" key "%s" must be a string',
+                    $profile->value,
+                    $key,
+                ));
+            }
+        }
+    }
+
+    #[Test]
+    public function localProfileHasExpectedDefaults(): void
+    {
+        $defaults = SovereigntyDefaults::for(SovereigntyProfile::Local);
+
+        self::assertSame('filesystem', $defaults['storage']);
+        self::assertSame('sqlite', $defaults['embeddings']);
+        self::assertSame('ollama', $defaults['llm_provider']);
+        self::assertSame('whisper_ollama', $defaults['transcriber']);
+        self::assertSame('sqlite', $defaults['vector_store']);
+        self::assertSame('sync', $defaults['queue_backend']);
+    }
+
+    #[Test]
+    public function northopsProfileHasExpectedDefaults(): void
+    {
+        $defaults = SovereigntyDefaults::for(SovereigntyProfile::NorthOps);
+
+        self::assertSame('s3', $defaults['storage']);
+        self::assertSame('pgvector', $defaults['embeddings']);
+        self::assertSame('api', $defaults['llm_provider']);
+        self::assertSame('api', $defaults['transcriber']);
+        self::assertSame('pgvector', $defaults['vector_store']);
+        self::assertSame('redis', $defaults['queue_backend']);
+    }
+
+    #[Test]
+    public function configImplementsInterface(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::Local, []);
+
+        self::assertInstanceOf(SovereigntyConfigInterface::class, $config);
+    }
+
+    #[Test]
+    public function getReturnsProfileDefaultWhenNoOverride(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::Local, []);
+
+        self::assertSame('ollama', $config->get('llm_provider'));
+        self::assertSame('sync', $config->get('queue_backend'));
+    }
+
+    #[Test]
+    public function getReturnsOverrideWhenSet(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::Local, [
+            'llm_provider' => 'api',
+        ]);
+
+        self::assertSame('api', $config->get('llm_provider'));
+        // Non-overridden keys still return profile default.
+        self::assertSame('sync', $config->get('queue_backend'));
+    }
+
+    #[Test]
+    public function getReturnsNullForUnknownKey(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::Local, []);
+
+        self::assertNull($config->get('nonexistent_key'));
+    }
+
+    #[Test]
+    public function getProfileReturnsActiveProfile(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::SelfHosted, []);
+
+        self::assertSame(SovereigntyProfile::SelfHosted, $config->getProfile());
+    }
+
+    #[Test]
+    public function allReturnsmergedDefaultsAndOverrides(): void
+    {
+        $config = new SovereigntyConfig(SovereigntyProfile::Local, [
+            'llm_provider' => 'api',
+            'vector_store' => 'pgvector',
+        ]);
+
+        $all = $config->all();
+
+        self::assertSame('api', $all['llm_provider']);
+        self::assertSame('pgvector', $all['vector_store']);
+        self::assertSame('filesystem', $all['storage']);
+        self::assertSame('sync', $all['queue_backend']);
+    }
+
+    #[Test]
+    public function createFromConfigArrayResolvesProfile(): void
+    {
+        $appConfig = [
+            'sovereignty_profile' => 'local',
+            'llm_provider' => 'api',
+        ];
+
+        $config = SovereigntyConfig::fromArray($appConfig);
+
+        self::assertSame(SovereigntyProfile::Local, $config->getProfile());
+        self::assertSame('api', $config->get('llm_provider'));
+    }
+
+    #[Test]
+    public function createFromConfigArrayDefaultsToLocal(): void
+    {
+        $config = SovereigntyConfig::fromArray([]);
+
+        self::assertSame(SovereigntyProfile::Local, $config->getProfile());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SovereigntyProfile` enum (`Local`, `SelfHosted`, `NorthOps`) to foundation package
- Adds `SovereigntyDefaults` mapping each profile to sane defaults for storage, embeddings, LLM provider, transcriber, vector store, and queue backend
- Adds `SovereigntyConfig` (with interface) that resolves effective settings: profile defaults merged with per-key overrides from app config
- Registers `SovereigntyConfigInterface` as singleton in `FoundationServiceProvider`
- Updates infrastructure spec with new subsystem documentation

Closes #1093

## Test plan

- [x] 13 unit tests, 69 assertions covering all acceptance criteria
- [x] Full suite passes (5091 tests)
- [x] PHPStan clean
- [x] CS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)