### PR TITLE
feat(#1094): community-scoped query isolation (multi-tenancy)

### DIFF
--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -429,19 +429,68 @@ public function findBy(string $entityType, array $criteria = [], ?array $orderBy
 #### SqlStorageDriver
 
 File: `packages/entity-storage/src/Driver/SqlStorageDriver.php`
-Constructor: `(ConnectionResolverInterface $connectionResolver, string $idKey = 'id')`
+Constructor: `(ConnectionResolverInterface $connectionResolver, string $idKey = 'id', ?CommunityScope $communityScope = null)`
 
 Handles raw SQL I/O. Supports translation tables: if `{entityType}_translations` table exists, `read()` merges translation data over base values.
+
+When `$communityScope` is injected and active, all read/findBy/count/exists/remove operations add `WHERE community_id = ?` automatically. The `write()` method uses a scope-unaware existence check (raw ID lookup) to avoid duplicate INSERTs when the active community differs from the stored row's community, but scopes the UPDATE path to prevent cross-community overwrites. See **Community Scoping** section below.
 
 #### InMemoryStorageDriver
 
 File: `packages/entity-storage/src/Driver/InMemoryStorageDriver.php`
+Constructor: `(?CommunityScope $communityScope = null)`
 
-In-memory storage for testing. Additional methods beyond the interface:
+In-memory storage for testing. Accepts an optional `CommunityScope` and applies the same community isolation logic as `SqlStorageDriver` — all read/findBy/count/exists/remove operations are scoped when the context is active.
+
+Additional methods beyond the interface:
 - `writeTranslation(string $entityType, string $id, string $langcode, array $values): void`
 - `deleteTranslation(string $entityType, string $id, string $langcode): void`
 - `getAvailableLanguages(string $entityType, string $id): string[]`
 - `clear(): void`
+
+### Community Scoping (Multi-tenancy)
+
+Waaseyaa supports row-level multi-tenancy via community-scoped query isolation. All entity queries are automatically restricted to the active community when a `CommunityContext` is set.
+
+#### HasCommunityInterface / HasCommunityTrait
+
+File: `packages/entity/src/Community/HasCommunityInterface.php`
+
+Marker interface for entities that participate in community-scoped tenancy:
+
+```php
+interface HasCommunityInterface
+{
+    public function getCommunityId(): ?string;
+    public function setCommunityId(string $communityId): void;
+}
+```
+
+`HasCommunityTrait` provides the default implementation via `ContentEntityBase::get/set('community_id')`. Entities must declare `community_id` as a schema column.
+
+#### CommunityScope
+
+File: `packages/entity-storage/src/Tenancy/CommunityScope.php`
+
+Strategy object injected into storage drivers at **wiring time**. Service providers check `is_a($entityType->getClass(), HasCommunityInterface::class, true)` and inject `CommunityScope` only for community-aware entity types. Config entities and system entities receive no `CommunityScope`.
+
+```php
+final class CommunityScope
+{
+    public function __construct(CommunityContextInterface $context);
+    public function isActive(): bool;
+    public function getCommunityId(): string;  // throws LogicException if not active
+}
+```
+
+#### Wiring pattern
+
+```php
+// In an app service provider — only for entities implementing HasCommunityInterface:
+$scope  = $this->resolve(CommunityScope::class);
+$driver = new SqlStorageDriver($resolver, communityScope: $scope);
+$repo   = new EntityRepository($entityType, $driver, $dispatcher);
+```
 
 ### Connection Resolution
 
@@ -917,6 +966,8 @@ class FieldType extends WaaseyaaPlugin
 ## File Reference
 
 ### packages/entity/src/
+- `Community/HasCommunityInterface.php` -- marker interface for community-scoped entities; checked at wiring time
+- `Community/HasCommunityTrait.php` -- provides getCommunityId()/setCommunityId() via ContentEntityBase get/set
 - `EntityInterface.php` -- core entity contract
 - `EntityBase.php` -- abstract base with values array, UUID generation, enforceIsNew, lifecycle hooks (preSave/postSave/preDelete/postDelete)
 - `ContentEntityInterface.php` -- extends EntityInterface + FieldableInterface
@@ -952,8 +1003,9 @@ class FieldType extends WaaseyaaPlugin
 - `EntityRepository.php` -- high-level repository with language fallback
 - `UnitOfWork.php` -- transaction wrapper with event buffering
 - `Driver/EntityStorageDriverInterface.php` -- low-level I/O SPI
-- `Driver/SqlStorageDriver.php` -- SQL driver with translation table support
-- `Driver/InMemoryStorageDriver.php` -- in-memory driver for testing
+- `Driver/SqlStorageDriver.php` -- SQL driver with translation table support; accepts optional `CommunityScope`
+- `Driver/InMemoryStorageDriver.php` -- in-memory driver for testing; accepts optional `CommunityScope`
+- `Tenancy/CommunityScope.php` -- community isolation strategy injected into drivers at wiring time
 - `Connection/ConnectionResolverInterface.php` -- multi-tenancy seam
 - `Connection/SingleConnectionResolver.php` -- single-tenant default
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-<!-- Spec reviewed 2026-04-04e - SovereigntyProfile/Config added to foundation, FoundationServiceProvider registers SovereigntyConfig singleton -->
+<!-- Spec reviewed 2026-04-04 - SovereigntyProfile/Config added to foundation, FoundationServiceProvider registers SovereigntyConfig singleton; CommunityContext/CommunityMiddleware added for community-scoped query isolation -->
 
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
@@ -949,6 +949,44 @@ Registered as a singleton in `FoundationServiceProvider`:
 ```php
 $this->singleton(SovereigntyConfigInterface::class, fn() => SovereigntyConfig::fromArray($this->config));
 ```
+
+## Community Context
+
+Request-scoped community isolation for multi-tenant sovereign apps. When a `CommunityContext` is active, entity storage drivers that are wired with `CommunityScope` automatically restrict all queries to the active community.
+
+### CommunityContextInterface / CommunityContext
+
+File: `packages/foundation/src/Community/CommunityContextInterface.php`
+File: `packages/foundation/src/Community/CommunityContext.php`
+
+```php
+interface CommunityContextInterface
+{
+    public function set(string $communityId): void;
+    public function get(): ?string;
+    public function clear(): void;
+    public function isActive(): bool;
+}
+```
+
+`CommunityContext` is a mutable singleton registered in `FoundationServiceProvider`:
+
+```php
+$this->singleton(CommunityContextInterface::class, CommunityContext::class);
+```
+
+### CommunityMiddleware
+
+File: `packages/foundation/src/Community/CommunityMiddleware.php`
+Attribute: `#[AsMiddleware(pipeline: 'http', priority: 20)]`
+
+Resolves the active community from the incoming request and sets it on `CommunityContextInterface` for the duration of the request. Clears the context in a `finally` block after the response.
+
+**Resolution order (first match wins):**
+1. Route parameter `community_id` (e.g. `/community/{community_id}/...`)
+2. Session key `waaseyaa_community_id` (requires `SessionMiddleware` priority 30 to have run first)
+
+When no community is resolved (CLI, admin superuser, unauthenticated), the context remains inactive and queries are unscoped.
 
 ## HTTP Utilities
 

--- a/packages/entity-storage/src/Driver/InMemoryStorageDriver.php
+++ b/packages/entity-storage/src/Driver/InMemoryStorageDriver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\EntityStorage\Driver;
 
+use Waaseyaa\EntityStorage\Tenancy\CommunityScope;
+
 /**
  * In-memory storage driver for testing.
  *
@@ -12,6 +14,10 @@ namespace Waaseyaa\EntityStorage\Driver;
  */
 final class InMemoryStorageDriver implements EntityStorageDriverInterface
 {
+    public function __construct(
+        private readonly ?CommunityScope $communityScope = null,
+    ) {}
+
     /**
      * Main storage: entityType => id => values.
      *
@@ -33,6 +39,13 @@ final class InMemoryStorageDriver implements EntityStorageDriverInterface
         }
 
         $base = $this->store[$entityType][$id];
+
+        if ($this->communityScope?->isActive()) {
+            $communityId = $this->communityScope->getCommunityId();
+            if (($base['community_id'] ?? null) !== $communityId) {
+                return null;
+            }
+        }
 
         if ($langcode !== null && isset($this->translations[$entityType][$id][$langcode])) {
             $translation = $this->translations[$entityType][$id][$langcode];
@@ -95,19 +108,39 @@ final class InMemoryStorageDriver implements EntityStorageDriverInterface
 
     public function remove(string $entityType, string $id): void
     {
+        if ($this->communityScope?->isActive()) {
+            $row = $this->store[$entityType][$id] ?? null;
+            if ($row === null || ($row['community_id'] ?? null) !== $this->communityScope->getCommunityId()) {
+                return;
+            }
+        }
+
         unset($this->store[$entityType][$id]);
         unset($this->translations[$entityType][$id]);
     }
 
     public function exists(string $entityType, string $id): bool
     {
-        return isset($this->store[$entityType][$id]);
+        if (!isset($this->store[$entityType][$id])) {
+            return false;
+        }
+
+        if ($this->communityScope?->isActive()) {
+            $communityId = $this->communityScope->getCommunityId();
+            return ($this->store[$entityType][$id]['community_id'] ?? null) === $communityId;
+        }
+
+        return true;
     }
 
     public function count(string $entityType, array $criteria = []): int
     {
         if (!isset($this->store[$entityType])) {
             return 0;
+        }
+
+        if ($this->communityScope?->isActive()) {
+            $criteria['community_id'] = $this->communityScope->getCommunityId();
         }
 
         if (empty($criteria)) {
@@ -132,6 +165,10 @@ final class InMemoryStorageDriver implements EntityStorageDriverInterface
     ): array {
         if (!isset($this->store[$entityType])) {
             return [];
+        }
+
+        if ($this->communityScope?->isActive()) {
+            $criteria['community_id'] = $this->communityScope->getCommunityId();
         }
 
         $results = [];

--- a/packages/entity-storage/src/Driver/SqlStorageDriver.php
+++ b/packages/entity-storage/src/Driver/SqlStorageDriver.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\EntityStorage\Driver;
 
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\EntityStorage\Connection\ConnectionResolverInterface;
+use Waaseyaa\EntityStorage\Tenancy\CommunityScope;
 
 /**
  * SQL-based storage driver.
@@ -24,6 +25,7 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
     public function __construct(
         private readonly ConnectionResolverInterface $connectionResolver,
         private readonly string $idKey = 'id',
+        private readonly ?CommunityScope $communityScope = null,
     ) {}
 
     public function read(string $entityType, string $id, ?string $langcode = null): ?array
@@ -33,6 +35,10 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
         $query = $db->select($entityType)
             ->fields($entityType)
             ->condition($this->idKey, $id);
+
+        if ($this->communityScope?->isActive()) {
+            $query->condition('community_id', $this->communityScope->getCommunityId());
+        }
 
         if ($langcode !== null) {
             $translationTable = $entityType . '_translations';
@@ -63,10 +69,12 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
     {
         $db = $this->getDatabase();
 
-        // Check if row already exists.
-        $existing = $this->read($entityType, $id);
+        // Use a scope-unaware existence check: a row with this ID must trigger
+        // UPDATE regardless of which community it belongs to, preventing a
+        // duplicate INSERT when the active community differs from the stored one.
+        $rowExists = $this->rowExistsById($db, $entityType, $id);
 
-        if ($existing === null) {
+        if (!$rowExists) {
             // Insert.
             $db->insert($entityType)
                 ->fields(array_keys($values))
@@ -82,10 +90,15 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
                 $updateFields[$key] = $value;
             }
 
-            $db->update($entityType)
+            $update = $db->update($entityType)
                 ->fields($updateFields)
-                ->condition($this->idKey, $id)
-                ->execute();
+                ->condition($this->idKey, $id);
+
+            if ($this->communityScope?->isActive()) {
+                $update->condition('community_id', $this->communityScope->getCommunityId());
+            }
+
+            $update->execute();
         }
     }
 
@@ -101,21 +114,29 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
                 ->execute();
         }
 
-        $db->delete($entityType)
-            ->condition($this->idKey, $id)
-            ->execute();
+        $delete = $db->delete($entityType)
+            ->condition($this->idKey, $id);
+
+        if ($this->communityScope?->isActive()) {
+            $delete->condition('community_id', $this->communityScope->getCommunityId());
+        }
+
+        $delete->execute();
     }
 
     public function exists(string $entityType, string $id): bool
     {
         $db = $this->getDatabase();
 
-        $result = $db->select($entityType)
+        $query = $db->select($entityType)
             ->fields($entityType, [$this->idKey])
-            ->condition($this->idKey, $id)
-            ->execute();
+            ->condition($this->idKey, $id);
 
-        foreach ($result as $row) {
+        if ($this->communityScope?->isActive()) {
+            $query->condition('community_id', $this->communityScope->getCommunityId());
+        }
+
+        foreach ($query->execute() as $_row) {
             return true;
         }
 
@@ -128,6 +149,10 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
 
         $query = $db->select($entityType)
             ->countQuery();
+
+        if ($this->communityScope?->isActive()) {
+            $query->condition('community_id', $this->communityScope->getCommunityId());
+        }
 
         foreach ($criteria as $field => $value) {
             $query->condition($this->resolveField($db, $entityType, $field), $value);
@@ -153,6 +178,10 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
 
         $query = $db->select($entityType)
             ->fields($entityType);
+
+        if ($this->communityScope?->isActive()) {
+            $query->condition('community_id', $this->communityScope->getCommunityId());
+        }
 
         foreach ($criteria as $field => $value) {
             $query->condition($this->resolveField($db, $entityType, $field), $value);
@@ -190,10 +219,15 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
         string $langcode,
     ): ?array {
         // Load base entity first.
-        $baseResult = $db->select($entityType)
+        $baseQuery = $db->select($entityType)
             ->fields($entityType)
-            ->condition($this->idKey, $id)
-            ->execute();
+            ->condition($this->idKey, $id);
+
+        if ($this->communityScope?->isActive()) {
+            $baseQuery->condition('community_id', $this->communityScope->getCommunityId());
+        }
+
+        $baseResult = $baseQuery->execute();
 
         $base = null;
         foreach ($baseResult as $row) {
@@ -244,6 +278,26 @@ final class SqlStorageDriver implements EntityStorageDriverInterface
         }
 
         return "json_extract(_data, '\$." . $field . "')";
+    }
+
+    /**
+     * Scope-unaware existence check by primary key only.
+     *
+     * Used by write() to detect INSERT vs UPDATE without letting community
+     * scope cause a false "not found" that would produce a duplicate INSERT.
+     */
+    private function rowExistsById(DatabaseInterface $db, string $entityType, string $id): bool
+    {
+        $result = $db->select($entityType)
+            ->fields($entityType, [$this->idKey])
+            ->condition($this->idKey, $id)
+            ->execute();
+
+        foreach ($result as $_row) {
+            return true;
+        }
+
+        return false;
     }
 
     private function getDatabase(): DatabaseInterface

--- a/packages/entity-storage/src/Tenancy/CommunityScope.php
+++ b/packages/entity-storage/src/Tenancy/CommunityScope.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tenancy;
+
+use Waaseyaa\Foundation\Community\CommunityContextInterface;
+
+/**
+ * Applies community isolation to storage driver queries.
+ *
+ * Injected into storage drivers at wiring time — only for entity types
+ * whose class implements HasCommunityInterface. Drivers call isActive()
+ * before adding the community condition to avoid touching unscoped entities.
+ */
+final class CommunityScope
+{
+    public function __construct(
+        private readonly CommunityContextInterface $context,
+    ) {}
+
+    /**
+     * Return true when a community context is set for the current request.
+     */
+    public function isActive(): bool
+    {
+        return $this->context->isActive();
+    }
+
+    /**
+     * Return the active community ID.
+     *
+     * Only call this after confirming isActive() === true.
+     */
+    public function getCommunityId(): string
+    {
+        $id = $this->context->get();
+
+        if ($id === null) {
+            throw new \LogicException('CommunityScope::getCommunityId() called when no community context is active.');
+        }
+
+        return $id;
+    }
+}

--- a/packages/entity-storage/tests/Tenancy/CommunityScopeTest.php
+++ b/packages/entity-storage/tests/Tenancy/CommunityScopeTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Tenancy;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\EntityStorage\Driver\InMemoryStorageDriver;
+use Waaseyaa\EntityStorage\Tenancy\CommunityScope;
+use Waaseyaa\Foundation\Community\CommunityContext;
+
+#[CoversClass(CommunityScope::class)]
+#[CoversClass(InMemoryStorageDriver::class)]
+final class CommunityScopeTest extends TestCase
+{
+    private CommunityContext $context;
+    private CommunityScope $scope;
+    private InMemoryStorageDriver $driver;
+
+    protected function setUp(): void
+    {
+        $this->context = new CommunityContext();
+        $this->scope   = new CommunityScope($this->context);
+        $this->driver  = new InMemoryStorageDriver($this->scope);
+    }
+
+    #[Test]
+    public function entitiesInDifferentCommunitiesAreIsolated(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'title' => 'Community A post', 'community_id' => 'community-a']);
+        $this->driver->write('post', '2', ['id' => '2', 'title' => 'Community B post', 'community_id' => 'community-b']);
+
+        $this->context->set('community-a');
+
+        $results = $this->driver->findBy('post');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('community-a', $results[0]['community_id']);
+    }
+
+    #[Test]
+    public function entitiesInActiveCommunityAreReturned(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'title' => 'Post 1', 'community_id' => 'community-a']);
+        $this->driver->write('post', '2', ['id' => '2', 'title' => 'Post 2', 'community_id' => 'community-a']);
+        $this->driver->write('post', '3', ['id' => '3', 'title' => 'Post 3', 'community_id' => 'community-b']);
+
+        $this->context->set('community-a');
+
+        $results = $this->driver->findBy('post');
+
+        $this->assertCount(2, $results);
+        foreach ($results as $row) {
+            $this->assertSame('community-a', $row['community_id']);
+        }
+    }
+
+    #[Test]
+    public function queriesAreUnscopedWhenNoContextIsActive(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'community_id' => 'community-a']);
+        $this->driver->write('post', '2', ['id' => '2', 'community_id' => 'community-b']);
+
+        // No context set.
+        $results = $this->driver->findBy('post');
+
+        $this->assertCount(2, $results);
+    }
+
+    #[Test]
+    public function readByIdRespectsCommunityScope(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'community_id' => 'community-a']);
+
+        $this->context->set('community-b');
+
+        $row = $this->driver->read('post', '1');
+
+        $this->assertNull($row, 'Cross-community ID lookup must return null.');
+    }
+
+    #[Test]
+    public function readByIdSucceedsWhenCommunityMatches(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'community_id' => 'community-a']);
+
+        $this->context->set('community-a');
+
+        $row = $this->driver->read('post', '1');
+
+        $this->assertNotNull($row);
+        $this->assertSame('1', $row['id']);
+    }
+
+    #[Test]
+    public function countRespectsScope(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'community_id' => 'community-a']);
+        $this->driver->write('post', '2', ['id' => '2', 'community_id' => 'community-a']);
+        $this->driver->write('post', '3', ['id' => '3', 'community_id' => 'community-b']);
+
+        $this->context->set('community-a');
+
+        $this->assertSame(2, $this->driver->count('post'));
+    }
+
+    #[Test]
+    public function contextClearMakesQueriesUnscoped(): void
+    {
+        $this->driver->write('post', '1', ['id' => '1', 'community_id' => 'community-a']);
+        $this->driver->write('post', '2', ['id' => '2', 'community_id' => 'community-b']);
+
+        $this->context->set('community-a');
+        $this->context->clear();
+
+        $results = $this->driver->findBy('post');
+
+        $this->assertCount(2, $results);
+    }
+}

--- a/packages/entity/src/Community/HasCommunityInterface.php
+++ b/packages/entity/src/Community/HasCommunityInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Community;
+
+/**
+ * Marker interface for entities that participate in community-scoped tenancy.
+ *
+ * Entity classes that implement this interface signal that their storage
+ * should be community-isolated. When a CommunityContext is active, storage
+ * drivers wired for community scoping will restrict all queries to the
+ * active community's data.
+ *
+ * Usage:
+ *
+ *   class Post extends ContentEntityBase implements HasCommunityInterface
+ *   {
+ *       use HasCommunityTrait;
+ *   }
+ *
+ * Service providers check this interface at wiring time:
+ *
+ *   if (is_a($entityType->getClass(), HasCommunityInterface::class, true)) {
+ *       // wire CommunityScope into the driver
+ *   }
+ *
+ * Config entities and system entities should NOT implement this interface.
+ */
+interface HasCommunityInterface
+{
+    /**
+     * Return the community ID this entity belongs to, or null if unset.
+     */
+    public function getCommunityId(): ?string;
+
+    /**
+     * Set the community ID for this entity.
+     */
+    public function setCommunityId(string $communityId): void;
+}

--- a/packages/entity/src/Community/HasCommunityTrait.php
+++ b/packages/entity/src/Community/HasCommunityTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Community;
+
+/**
+ * Provides getCommunityId() and setCommunityId() for content entities.
+ *
+ * Entities using this trait must also declare `community_id` as a
+ * schema column so that SqlStorageDriver can apply the scope as a
+ * native SQL condition rather than a JSON-extract expression.
+ *
+ * @see HasCommunityInterface
+ */
+trait HasCommunityTrait
+{
+    public function getCommunityId(): ?string
+    {
+        $value = $this->get('community_id');
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function setCommunityId(string $communityId): void
+    {
+        $this->set('community_id', $communityId);
+    }
+}

--- a/packages/foundation/src/Community/CommunityContext.php
+++ b/packages/foundation/src/Community/CommunityContext.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Community;
+
+/**
+ * Default implementation of the request-scoped community context.
+ *
+ * Registered as a singleton in FoundationServiceProvider. Holds one
+ * community ID per request; CommunityMiddleware sets it from the
+ * incoming request and clears it in a finally block after the response.
+ */
+final class CommunityContext implements CommunityContextInterface
+{
+    private ?string $communityId = null;
+
+    public function set(string $communityId): void
+    {
+        $this->communityId = $communityId;
+    }
+
+    public function get(): ?string
+    {
+        return $this->communityId;
+    }
+
+    public function clear(): void
+    {
+        $this->communityId = null;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->communityId !== null;
+    }
+}

--- a/packages/foundation/src/Community/CommunityContextInterface.php
+++ b/packages/foundation/src/Community/CommunityContextInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Community;
+
+/**
+ * Request-scoped community context.
+ *
+ * Holds the active community ID for the current request. When set,
+ * entity storage drivers that are wired with community scoping will
+ * automatically restrict queries to the active community.
+ *
+ * Not set during CLI execution, admin superuser sessions, or any
+ * context where cross-community access is intentional.
+ */
+interface CommunityContextInterface
+{
+    /**
+     * Set the active community for the current request.
+     */
+    public function set(string $communityId): void;
+
+    /**
+     * Return the active community ID, or null if no community is set.
+     */
+    public function get(): ?string;
+
+    /**
+     * Clear the active community context.
+     */
+    public function clear(): void;
+
+    /**
+     * Return true if a community context is currently active.
+     */
+    public function isActive(): bool;
+}

--- a/packages/foundation/src/Community/CommunityMiddleware.php
+++ b/packages/foundation/src/Community/CommunityMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Community;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+
+/**
+ * Resolves the active community from the incoming request and sets
+ * it on CommunityContextInterface for the duration of the request.
+ *
+ * Resolution order (first match wins):
+ *   1. Route parameter  — e.g. /community/{community_id}/...
+ *   2. Session key      — 'waaseyaa_community_id'
+ *
+ * When no community is resolved (CLI, admin, unauthenticated), the
+ * context remains inactive and queries are unscoped.
+ *
+ * Priority 20 ensures this runs after SessionMiddleware (priority 30),
+ * so session data is already available when community is resolved.
+ */
+#[AsMiddleware(pipeline: 'http', priority: 20)]
+final class CommunityMiddleware implements HttpMiddlewareInterface
+{
+    public function __construct(
+        private readonly CommunityContextInterface $context,
+    ) {}
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+    {
+        $communityId = $this->resolve($request);
+
+        if ($communityId !== null) {
+            $this->context->set($communityId);
+        }
+
+        try {
+            return $next->handle($request);
+        } finally {
+            $this->context->clear();
+        }
+    }
+
+    private function resolve(Request $request): ?string
+    {
+        // 1. Route parameter (most explicit — wins over session).
+        $routeParam = $request->attributes->get('community_id');
+        if (is_string($routeParam) && $routeParam !== '') {
+            return $routeParam;
+        }
+
+        // 2. Session key — requires SessionMiddleware (priority 30) to have run first.
+        $session = $request->attributes->get('_session');
+        if (is_array($session)) {
+            $sessionValue = $session['waaseyaa_community_id'] ?? null;
+            if (is_string($sessionValue) && $sessionValue !== '') {
+                return $sessionValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/foundation/src/FoundationServiceProvider.php
+++ b/packages/foundation/src/FoundationServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation;
 
+use Waaseyaa\Foundation\Community\CommunityContext;
+use Waaseyaa\Foundation\Community\CommunityContextInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Foundation\Sovereignty\SovereigntyConfig;
 use Waaseyaa\Foundation\Sovereignty\SovereigntyConfigInterface;
@@ -13,5 +15,6 @@ final class FoundationServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->singleton(SovereigntyConfigInterface::class, fn() => SovereigntyConfig::fromArray($this->config));
+        $this->singleton(CommunityContextInterface::class, CommunityContext::class);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `CommunityContext` (request-scoped singleton in Foundation) and `CommunityMiddleware` (priority 20, resolves community from route param then session key) to set/clear the active community per request
- Adds `CommunityScope` strategy object injected into storage drivers at wiring time — only entity types whose class implements `HasCommunityInterface` are scoped; config/system entities are unaffected
- `SqlStorageDriver` and `InMemoryStorageDriver` apply `WHERE community_id = ?` to all read/findBy/count/exists/remove operations when scope is active; `write()` uses a scope-unaware existence check to prevent duplicate INSERTs on cross-community IDs
- Adds `HasCommunityInterface` + `HasCommunityTrait` as the opt-in marker for content entities
- Updates `docs/specs/entity-system.md` and `docs/specs/infrastructure.md`

## Test plan

- [ ] `CommunityScopeTest` (7 tests): two-community isolation, same-community access, unscoped when no context, cross-community ID block, count scoping, context clear
- [ ] All 249 existing entity-storage tests pass with no regressions
- [ ] PHPStan level 5 clean
- [ ] Spec drift hook passes

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)