### PR TITLE
refactor(#598): replace instanceof dispatch with strategy pattern in API

### DIFF
--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,6 +1,6 @@
 # API Layer
 
-<!-- Spec reviewed 2026-04-01 - post-M10 ApiServiceProvider route ownership, package-declared API surfaces, C18 drift remediation (#1017) -->
+<!-- Spec reviewed 2026-04-05 - #598 replace instanceof dispatch with JsonApiDocumentException in TranslationController -->
 
 Technical specification for the Waaseyaa JSON:API layer and routing system. This document covers the `packages/api/` and `packages/routing/` packages, which together provide RESTful CRUD endpoints, resource serialization, query parsing, JSON Schema presentation, route building, and access checking. The current post-M10 baseline uses package-owned service providers for API route registration: `packages/api/composer.json` declares `Waaseyaa\Api\ApiServiceProvider`, and that provider delegates CRUD route registration to `JsonApiRouteProvider` while foundation keeps only shared infrastructure endpoints.
 
@@ -37,6 +37,7 @@ Foundation still owns the shared HTTP surfaces that are not entity-package speci
 | `src/Cache/ApiCacheMiddleware.php` | `Waaseyaa\Api\Cache` | ETag, If-None-Match, Cache-Control header generation |
 | `src/OpenApi/OpenApiGenerator.php` | `Waaseyaa\Api\OpenApi` | Generates OpenAPI 3.1 spec from entity type definitions |
 | `src/OpenApi/SchemaBuilder.php` | `Waaseyaa\Api\OpenApi` | Builds component schemas for OpenAPI spec |
+| `src/Exception/JsonApiDocumentException.php` | `Waaseyaa\Api\Exception` | Exception carrying a JsonApiDocument error response for controller helpers |
 | `src/MutableTranslatableInterface.php` | `Waaseyaa\Api` | Extension of TranslatableInterface with `addTranslation()` |
 
 ### packages/routing/
@@ -636,6 +637,10 @@ final class TranslationController
 
 Creating a translation requires `MutableTranslatableInterface`. Deleting the original language returns 422.
 
+### Error Handling Pattern
+
+`TranslationController::loadTranslatableEntity()` throws `JsonApiDocumentException` when the entity cannot be loaded or is not translatable, rather than returning a union type. Each CRUD method catches the exception once and returns the error document. This eliminates repeated `instanceof JsonApiDocument` dispatch checks and keeps the return type narrow (`TranslatableInterface`).
+
 ## API Cache Middleware
 
 ```php
@@ -741,6 +746,8 @@ packages/api/
       CodifiedContextController.php
       SchemaController.php
       TranslationController.php
+    Exception/
+      JsonApiDocumentException.php
     Http/
       DiscoveryApiHandler.php
     OpenApi/

--- a/packages/api/src/Controller/TranslationController.php
+++ b/packages/api/src/Controller/TranslationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Api\Controller;
 
+use Waaseyaa\Api\Exception\JsonApiDocumentException;
 use Waaseyaa\Api\JsonApiDocument;
 use Waaseyaa\Api\JsonApiError;
 use Waaseyaa\Api\JsonApiResource;
@@ -37,9 +38,10 @@ final class TranslationController
      */
     public function index(string $entityTypeId, int|string $id): JsonApiDocument
     {
-        $entity = $this->loadTranslatableEntity($entityTypeId, $id);
-        if ($entity instanceof JsonApiDocument) {
-            return $entity;
+        try {
+            $entity = $this->loadTranslatableEntity($entityTypeId, $id);
+        } catch (JsonApiDocumentException $e) {
+            return $e->document;
         }
 
         $languages = $entity->getTranslationLanguages();
@@ -70,9 +72,10 @@ final class TranslationController
      */
     public function show(string $entityTypeId, int|string $id, string $langcode): JsonApiDocument
     {
-        $entity = $this->loadTranslatableEntity($entityTypeId, $id);
-        if ($entity instanceof JsonApiDocument) {
-            return $entity;
+        try {
+            $entity = $this->loadTranslatableEntity($entityTypeId, $id);
+        } catch (JsonApiDocumentException $e) {
+            return $e->document;
         }
 
         if (!$entity->hasTranslation($langcode)) {
@@ -105,9 +108,10 @@ final class TranslationController
      */
     public function store(string $entityTypeId, int|string $id, string $langcode, array $data): JsonApiDocument
     {
-        $entity = $this->loadTranslatableEntity($entityTypeId, $id);
-        if ($entity instanceof JsonApiDocument) {
-            return $entity;
+        try {
+            $entity = $this->loadTranslatableEntity($entityTypeId, $id);
+        } catch (JsonApiDocumentException $e) {
+            return $e->document;
         }
 
         if ($entity->hasTranslation($langcode)) {
@@ -168,9 +172,10 @@ final class TranslationController
      */
     public function update(string $entityTypeId, int|string $id, string $langcode, array $data): JsonApiDocument
     {
-        $entity = $this->loadTranslatableEntity($entityTypeId, $id);
-        if ($entity instanceof JsonApiDocument) {
-            return $entity;
+        try {
+            $entity = $this->loadTranslatableEntity($entityTypeId, $id);
+        } catch (JsonApiDocumentException $e) {
+            return $e->document;
         }
 
         if (!$entity->hasTranslation($langcode)) {
@@ -212,9 +217,10 @@ final class TranslationController
      */
     public function destroy(string $entityTypeId, int|string $id, string $langcode): JsonApiDocument
     {
-        $entity = $this->loadTranslatableEntity($entityTypeId, $id);
-        if ($entity instanceof JsonApiDocument) {
-            return $entity;
+        try {
+            $entity = $this->loadTranslatableEntity($entityTypeId, $id);
+        } catch (JsonApiDocumentException $e) {
+            return $e->document;
         }
 
         // Cannot delete the original language.
@@ -250,24 +256,24 @@ final class TranslationController
     /**
      * Load an entity and validate it supports translations.
      *
-     * @return TranslatableInterface|JsonApiDocument The entity if translatable, or an error document.
+     * @throws JsonApiDocumentException When the entity cannot be loaded or is not translatable.
      */
-    private function loadTranslatableEntity(string $entityTypeId, int|string $id): TranslatableInterface|JsonApiDocument
+    private function loadTranslatableEntity(string $entityTypeId, int|string $id): TranslatableInterface
     {
         if (!$this->entityTypeManager->hasDefinition($entityTypeId)) {
-            return $this->errorDocument(
-                JsonApiError::notFound("Unknown entity type: {$entityTypeId}."),
+            throw new JsonApiDocumentException(
+                $this->errorDocument(JsonApiError::notFound("Unknown entity type: {$entityTypeId}.")),
             );
         }
 
         $entityType = $this->entityTypeManager->getDefinition($entityTypeId);
         if (!$entityType->isTranslatable()) {
-            return $this->errorDocument(
-                new JsonApiError(
+            throw new JsonApiDocumentException(
+                $this->errorDocument(new JsonApiError(
                     status: '422',
                     title: 'Unprocessable Entity',
                     detail: "Entity type '{$entityTypeId}' does not support translations.",
-                ),
+                )),
             );
         }
 
@@ -275,18 +281,18 @@ final class TranslationController
         $entity = $storage->load($id);
 
         if ($entity === null) {
-            return $this->errorDocument(
-                JsonApiError::notFound("Entity of type '{$entityTypeId}' with ID '{$id}' not found."),
+            throw new JsonApiDocumentException(
+                $this->errorDocument(JsonApiError::notFound("Entity of type '{$entityTypeId}' with ID '{$id}' not found.")),
             );
         }
 
         if (!$entity instanceof TranslatableInterface) {
-            return $this->errorDocument(
-                new JsonApiError(
+            throw new JsonApiDocumentException(
+                $this->errorDocument(new JsonApiError(
                     status: '422',
                     title: 'Unprocessable Entity',
                     detail: "Entity '{$id}' does not implement TranslatableInterface.",
-                ),
+                )),
             );
         }
 

--- a/packages/api/src/Exception/JsonApiDocumentException.php
+++ b/packages/api/src/Exception/JsonApiDocumentException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api\Exception;
+
+use Waaseyaa\Api\JsonApiDocument;
+
+/**
+ * Exception that carries a JsonApiDocument error response.
+ *
+ * Used to replace union return types (e.g., Entity|JsonApiDocument) in controller
+ * helper methods. Instead of returning an error document that callers must
+ * instanceof-check, the helper throws this exception and callers catch it once.
+ */
+final class JsonApiDocumentException extends \RuntimeException
+{
+    public function __construct(
+        public readonly JsonApiDocument $document,
+    ) {
+        parent::__construct('JSON:API error response', $document->statusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- Created `JsonApiDocumentException` to replace union return type pattern in TranslationController
- Eliminated 5 `instanceof JsonApiDocument` dispatch checks in CRUD methods by narrowing `loadTranslatableEntity()` return type
- 9 remaining instanceof checks are legitimate type guards (capability checks, null-safety), not dispatch logic

Closes #598

## Test plan
- [x] 351 API tests pass
- [x] PHPStan clean
- [x] PHP-CS-Fixer clean
- [x] Spec drift detector satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)