### PR TITLE
feat(ai-agent): add NullLlmProvider for dev and testing

### DIFF
--- a/packages/ai-agent/src/Provider/NullLlmProvider.php
+++ b/packages/ai-agent/src/Provider/NullLlmProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\AI\Agent\Provider;
+
+/**
+ * Deterministic LLM provider for development and testing.
+ *
+ * Returns a fixed placeholder response without network I/O. Do NOT use in
+ * production - every request returns the same placeholder regardless of input.
+ *
+ * Apps can bind this as the default implementation of {@see ProviderInterface}
+ * in dev/test environments, then rebind to a real provider (e.g.
+ * {@see AnthropicProvider}) once credentials are configured.
+ */
+final class NullLlmProvider implements ProviderInterface
+{
+    public const PLACEHOLDER = '[LLM unavailable in this environment - configure an LLM provider to enable AI features.]';
+
+    public function sendMessage(MessageRequest $request): MessageResponse
+    {
+        return new MessageResponse(
+            content: [
+                [
+                    'type' => 'text',
+                    'text' => self::PLACEHOLDER,
+                ],
+            ],
+            stopReason: 'end_turn',
+            usage: [
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+            ],
+        );
+    }
+}

--- a/packages/ai-agent/tests/Unit/Provider/NullLlmProviderTest.php
+++ b/packages/ai-agent/tests/Unit/Provider/NullLlmProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\AI\Agent\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\AI\Agent\Provider\MessageRequest;
+use Waaseyaa\AI\Agent\Provider\MessageResponse;
+use Waaseyaa\AI\Agent\Provider\NullLlmProvider;
+
+#[CoversClass(NullLlmProvider::class)]
+final class NullLlmProviderTest extends TestCase
+{
+    #[Test]
+    public function sendMessageReturnsPlaceholderText(): void
+    {
+        $provider = new NullLlmProvider();
+        $request = new MessageRequest(messages: [
+            ['role' => 'user', 'content' => 'hello'],
+        ]);
+
+        $response = $provider->sendMessage($request);
+
+        self::assertInstanceOf(MessageResponse::class, $response);
+        self::assertStringContainsString('LLM unavailable', $response->getText());
+    }
+
+    #[Test]
+    public function sendMessageIsDeterministic(): void
+    {
+        $provider = new NullLlmProvider();
+        $request = new MessageRequest(messages: [
+            ['role' => 'user', 'content' => 'anything'],
+        ]);
+
+        $first = $provider->sendMessage($request);
+        $second = $provider->sendMessage($request);
+
+        self::assertSame(NullLlmProvider::PLACEHOLDER, $first->getText());
+        self::assertSame($first->getText(), $second->getText());
+    }
+
+    #[Test]
+    public function constructionDoesNotPerformIo(): void
+    {
+        new NullLlmProvider();
+        new NullLlmProvider();
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- New NullLlmProvider implements Waaseyaa\AI\Agent\Provider\ProviderInterface with a deterministic placeholder response and zero network I/O
- Use in dev/test when wiring an app against ProviderInterface before a real LLM is configured
- Returns the same fixed response on every call - explicitly NOT for production

## Test plan
- [x] ./vendor/bin/phpunit packages/ai-agent/tests/Unit/Provider/NullLlmProviderTest.php green (3 tests, 5 assertions)
- [x] Full ai-agent suite green (61 tests, 190 assertions)

Note: namespace is `Waaseyaa\AI\Agent\Provider` (not `Waaseyaa\AiAgent\Provider`) to match the existing package namespace.

Generated with [Claude Code](https://claude.com/claude-code)