### PR TITLE
feat(#1182): derive Symfony constraints from EntityType field definitions

### DIFF
--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -13,6 +13,7 @@
 <!-- Spec reviewed 2026-04-09j - EntityValues helper, presentation layers use cast-aware maps (#1181 ST-8) -->
 <!-- Spec reviewed 2026-04-09 ST-9 - casting + hydration architecture finalization: diagrams, invariants, EntityValues/get/set/toArray/config rules (#1181) -->
 <!-- Spec reviewed 2026-04-09 ST-10 - layering: EntityValues::toJsonReadyMap / normalizeValueForJson; AI vector uses cast-aware paths (#1181) -->
+<!-- Spec reviewed 2026-04-09 - field-definition → Symfony constraints + save merge (#1182) -->
 <!-- Spec reviewed 2026-04-08g - symfony/* require ^7.0 on entity + entity-storage (#1151); no entity behavior change — symfony-version-floors.md -->
 
 Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
@@ -25,7 +26,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 
 | Package | Interfaces/Classes |
 |---------|-------------------|
-| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException` |
+| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
 | entity-storage | `EntityStorageDriverInterface`, `ConnectionResolverInterface` |
 | field | `FieldItemInterface`, `FieldItemListInterface`, `FieldDefinitionInterface`, `FieldTypeInterface`, `FieldFormatterInterface`, `FieldTypeManagerInterface`, `FieldItemBase`, `ViewModeConfigInterface` |
 | config | `ConfigInterface`, `ConfigFactoryInterface`, `ConfigManagerInterface`, `StorageInterface`, `TranslatableConfigFactoryInterface` |
@@ -364,7 +365,7 @@ interface EntityRepositoryInterface
 }
 ```
 
-`save()` accepts `bool $validate = true`. When true and an `EntityValidator` is injected, validates against `EntityType::getConstraints()` before persisting. Throws `EntityValidationException` on failure.
+`save()` accepts `bool $validate = true`. When true and an `EntityValidator` is injected, validates against the merged map from `EntityTypeValidationConstraints::forEntityType()` (field definitions + `getConstraints()`, see “Field definitions → constraints” below) before persisting. Throws `EntityValidationException` on failure.
 
 `saveMany()`/`deleteMany()` wrap all operations in a `UnitOfWork` transaction. Events are buffered and dispatched only after successful commit. Requires `$database` to be non-null (throws `\LogicException` otherwise).
 
@@ -430,7 +431,7 @@ PHP attribute `#[EntityTypeAttribute(...)]` for class-level discovery. Extends `
 
 The `EntityRepository::save()` pipeline (used for all high-level persistence):
 
-1. Validates entity against `EntityType::getConstraints()` if `$validate === true` and `EntityValidator` is injected
+1. Validates entity against the combined constraint map (`EntityTypeValidationConstraints::forEntityType()`) if `$validate === true` and `EntityValidator` is injected
 2. Calls `$entity->preSave($isNew)` lifecycle hook (if entity extends `EntityBase`)
 3. Dispatches `EntityEvents::PRE_SAVE` event (via `EntityEventFactoryInterface`)
 4. Writes to storage driver (`$driver->write()`)
@@ -576,7 +577,7 @@ Higher-level layer that handles:
 - Entity hydration (`hydrate()` method with `_data` merge and constructor adaptation)
 - Language fallback via `setFallbackChain(string[] $chain)` (default: `['en']`)
 - Event dispatch via `EntityEventFactoryInterface` (defaults to `DefaultEntityEventFactory`)
-- Pre-save validation via `EntityValidator` (when injected and `validate: true`)
+- Pre-save validation via `EntityValidator` (when injected and `validate: true`) using `EntityTypeValidationConstraints::forEntityType()` (derived from field definitions plus manual `getConstraints()` per-field override)
 - Entity lifecycle hooks (`preSave`, `postSave`, `preDelete`, `postDelete` on `EntityBase`)
 - Batch operations via `saveMany()`/`deleteMany()` with `UnitOfWork` transaction wrapping
 - Batch reads via `findMany(array $ids, ...)` delegating to `EntityStorageDriverInterface::readMultiple()`
@@ -927,6 +928,33 @@ final class EntityValidationException extends \RuntimeException
 ```
 
 Thrown by `EntityRepository::save()` when validation fails. The `$violations` property provides programmatic access to all constraint violations.
+
+#### Field definitions → constraints (#1182)
+
+File: `packages/entity/src/Validation/FieldDefinitionConstraintBuilder.php`
+
+Maps `EntityType::getFieldDefinitions()` metadata to per-field Symfony `Constraint` lists (same key shape as `getConstraints()`). Supported keys on each field array:
+
+| Metadata | Symfony constraints | Notes |
+|----------|---------------------|--------|
+| `required` / `required: true` | `NotBlank` for string-like `type` (`string`, `email`, `text`, `slug`, default) | |
+| `required` + `boolean` / `integer` / `entity_reference` / `timestamp` / `datetime`_* | `NotNull` | So `false` and `0` remain valid when a field is required. |
+| `max_length` / `maxLength`, `min_length` / `minLength` | `Length` | Single constraint when either bound is set. |
+| `type: email` | `Email` | In addition to string typing when applicable. |
+| `allowed_values` / `allowedValues` | `Choice` | Non-empty list only. |
+| `enum_class` / `enumClass` (`BackedEnum`) | `Choice` on backing values | PHP enum class name. |
+| `type` scalar | `Type` | `bool`, `int`, `float`, `string` (incl. `email`/`text`/`slug`), `array`/`json`. Omitted for `entity_reference` and `timestamp` (storage shape varies). |
+
+File: `packages/entity/src/Validation/EntityTypeValidationConstraints.php`
+
+`EntityTypeValidationConstraints::forEntityType(EntityTypeInterface)` builds the map used by `EntityRepository::doSave()` when a validator is configured:
+
+1. Derive constraints from `getFieldDefinitions()` via `FieldDefinitionConstraintBuilder::build()`.
+2. Merge `getConstraints()`: **for each field name present in `getConstraints()`, the manual value replaces the derived list entirely** for that field. Manual-only fields are included. Derived-only fields keep builder output.
+
+Opt-out: `EntityRepository::save($entity, validate: false)` (and `saveMany`) skips validation entirely; there is no separate flag for “manual only.”
+
+Invalid data raises `EntityValidationException` with property paths equal to field names (plus nested paths when a constraint reports a sub-path), unchanged from `EntityValidator` behavior.
 
 ### Entity Lifecycle Hooks
 

--- a/packages/entity-storage/src/EntityRepository.php
+++ b/packages/entity-storage/src/EntityRepository.php
@@ -16,6 +16,7 @@ use Waaseyaa\Entity\Event\EntityEventFactoryInterface;
 use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 use Waaseyaa\Entity\RevisionableInterface;
+use Waaseyaa\Entity\Validation\EntityTypeValidationConstraints;
 use Waaseyaa\Entity\Validation\EntityValidationException;
 use Waaseyaa\Entity\Validation\EntityValidator;
 use Waaseyaa\EntityStorage\Driver\EntityStorageDriverInterface;
@@ -203,7 +204,7 @@ final class EntityRepository implements EntityRepositoryInterface
         $entityTypeId = $this->entityType->id();
 
         if ($validate && $this->validator !== null) {
-            $constraints = $this->entityType->getConstraints();
+            $constraints = EntityTypeValidationConstraints::forEntityType($this->entityType);
             if ($constraints !== []) {
                 $violations = $this->validator->validate($entity, $constraints);
                 if ($violations->count() > 0) {

--- a/packages/entity-storage/tests/Unit/EntityRepositoryTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryTest.php
@@ -738,6 +738,90 @@ final class EntityRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function saveThrowsWhenOnlyFieldDefinitionsRequireLabel(): void
+    {
+        $type = new EntityType(
+            id: 'test_entity',
+            label: 'Test Entity',
+            class: TestStorageEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'bundle', 'label' => 'label', 'langcode' => 'langcode'],
+            constraints: [],
+            fieldDefinitions: [
+                'label' => ['type' => 'string', 'required' => true],
+            ],
+        );
+
+        $db = DBALDatabase::createSqlite();
+        $driver = new SqlStorageDriver(new SingleConnectionResolver($db));
+        (new SqlSchemaHandler($type, $db))->ensureTable();
+
+        $validator = new \Waaseyaa\Entity\Validation\EntityValidator(
+            \Symfony\Component\Validator\Validation::createValidator(),
+        );
+
+        $repository = new EntityRepository(
+            $type,
+            $driver,
+            $this->eventDispatcher,
+            database: $db,
+            validator: $validator,
+        );
+
+        $entity = new TestStorageEntity(
+            values: ['id' => '1', 'label' => '', 'bundle' => 'article', 'langcode' => 'en'],
+            entityTypeId: 'test_entity',
+            entityKeys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'bundle', 'label' => 'label', 'langcode' => 'langcode'],
+        );
+        $entity->enforceIsNew(true);
+
+        $this->expectException(\Waaseyaa\Entity\Validation\EntityValidationException::class);
+        $repository->save($entity);
+    }
+
+    #[Test]
+    public function saveReplacesDerivedFieldConstraintsWhenManualConstraintsPresentForField(): void
+    {
+        $type = new EntityType(
+            id: 'test_entity',
+            label: 'Test Entity',
+            class: TestStorageEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'bundle', 'label' => 'label', 'langcode' => 'langcode'],
+            fieldDefinitions: [
+                'label' => ['type' => 'string', 'required' => true],
+            ],
+            constraints: [
+                'label' => [new \Symfony\Component\Validator\Constraints\Length(max: 80)],
+            ],
+        );
+
+        $db = DBALDatabase::createSqlite();
+        $driver = new SqlStorageDriver(new SingleConnectionResolver($db));
+        (new SqlSchemaHandler($type, $db))->ensureTable();
+
+        $validator = new \Waaseyaa\Entity\Validation\EntityValidator(
+            \Symfony\Component\Validator\Validation::createValidator(),
+        );
+
+        $repository = new EntityRepository(
+            $type,
+            $driver,
+            $this->eventDispatcher,
+            database: $db,
+            validator: $validator,
+        );
+
+        $entity = new TestStorageEntity(
+            values: ['id' => '1', 'label' => '', 'bundle' => 'article', 'langcode' => 'en'],
+            entityTypeId: 'test_entity',
+            entityKeys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'bundle', 'label' => 'label', 'langcode' => 'langcode'],
+        );
+        $entity->enforceIsNew(true);
+
+        $result = $repository->save($entity);
+        $this->assertSame(EntityConstants::SAVED_NEW, $result);
+    }
+
+    #[Test]
     public function savePassesWhenEntityTypeExpectsBackedEnumAndEntityCastsScalarStorage(): void
     {
         $enumConstrainedType = new EntityType(

--- a/packages/entity/src/Validation/EntityTypeValidationConstraints.php
+++ b/packages/entity/src/Validation/EntityTypeValidationConstraints.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Validation;
+
+use Symfony\Component\Validator\Constraint;
+use Waaseyaa\Entity\EntityTypeInterface;
+
+/**
+ * Resolves the constraint map used by {@see \Waaseyaa\EntityStorage\EntityRepository} on save.
+ *
+ * Precedence: for each field name present in {@see EntityTypeInterface::getConstraints()}, those
+ * constraints **replace** any constraints derived from {@see EntityTypeInterface::getFieldDefinitions()}.
+ * Manual keys that do not appear in field definitions are still applied. Fields only described in
+ * field definitions use derived constraints only.
+ */
+final class EntityTypeValidationConstraints
+{
+    /**
+     * @return array<string, Constraint|list<Constraint>>
+     */
+    public static function forEntityType(EntityTypeInterface $entityType): array
+    {
+        $merged = FieldDefinitionConstraintBuilder::build($entityType->getFieldDefinitions());
+
+        foreach ($entityType->getConstraints() as $field => $manual) {
+            $merged[$field] = self::normalizeToList($manual);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * @return list<Constraint>
+     */
+    private static function normalizeToList(mixed $constraints): array
+    {
+        if ($constraints instanceof Constraint) {
+            return [$constraints];
+        }
+
+        if (is_array($constraints)) {
+            /** @var list<Constraint> */
+            return array_values($constraints);
+        }
+
+        throw new \InvalidArgumentException(
+            'EntityType::getConstraints() values must be a Constraint or a list of Constraint objects.',
+        );
+    }
+}

--- a/packages/entity/src/Validation/FieldDefinitionConstraintBuilder.php
+++ b/packages/entity/src/Validation/FieldDefinitionConstraintBuilder.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Validation;
+
+use BackedEnum;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * Builds per-field Symfony {@see Constraint} lists from entity type field definition arrays.
+ *
+ * Full metadata → constraint mapping: `docs/specs/entity-system.md` (Field definitions → constraints, #1182).
+ */
+final class FieldDefinitionConstraintBuilder
+{
+    /**
+     * @param array<string, mixed> $fieldDefinitions
+     *
+     * @return array<string, list<Constraint>>
+     */
+    public static function build(array $fieldDefinitions): array
+    {
+        $out = [];
+        foreach ($fieldDefinitions as $name => $def) {
+            if (!is_array($def)) {
+                continue;
+            }
+            /** @var array<string, mixed> $def */
+            $constraints = self::constraintsForField($def);
+            if ($constraints !== []) {
+                $out[$name] = $constraints;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $def
+     *
+     * @return list<Constraint>
+     */
+    private static function constraintsForField(array $def): array
+    {
+        $constraints = [];
+        $type = (string) ($def['type'] ?? 'string');
+        $required = self::truthy($def['required'] ?? false);
+
+        if ($required) {
+            $constraints[] = self::requiredConstraintForType($type);
+        }
+
+        $length = self::lengthConstraint($def);
+        if ($length !== null) {
+            $constraints[] = $length;
+        }
+
+        if ($type === 'email') {
+            $constraints[] = new Email();
+        }
+
+        $allowed = $def['allowed_values'] ?? $def['allowedValues'] ?? null;
+        if (is_array($allowed) && $allowed !== []) {
+            $constraints[] = new Choice(choices: array_values($allowed));
+        }
+
+        $enumClass = $def['enum_class'] ?? $def['enumClass'] ?? null;
+        if (is_string($enumClass) && $enumClass !== '' && enum_exists($enumClass)
+            && is_subclass_of($enumClass, BackedEnum::class)) {
+            /** @var class-string<BackedEnum> $enumClass */
+            $choices = array_map(static fn(BackedEnum $e): string|int => $e->value, $enumClass::cases());
+            $constraints[] = new Choice(choices: $choices);
+        }
+
+        $typeConstraint = self::scalarTypeConstraint($type);
+        if ($typeConstraint !== null) {
+            $constraints[] = $typeConstraint;
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @param array<string, mixed> $def
+     */
+    private static function lengthConstraint(array $def): ?Length
+    {
+        $maxRaw = $def['max_length'] ?? $def['maxLength'] ?? null;
+        $minRaw = $def['min_length'] ?? $def['minLength'] ?? null;
+        $max = is_numeric($maxRaw) ? (int) $maxRaw : null;
+        $min = is_numeric($minRaw) ? (int) $minRaw : null;
+
+        if ($max === null && $min === null) {
+            return null;
+        }
+
+        if ($max !== null && $min !== null) {
+            return new Length(min: $min, max: $max);
+        }
+
+        if ($max !== null) {
+            return new Length(max: $max);
+        }
+
+        return new Length(min: $min);
+    }
+
+    private static function requiredConstraintForType(string $type): NotBlank|NotNull
+    {
+        return match ($type) {
+            'boolean', 'bool',
+            'integer', 'int',
+            'float', 'double',
+            'entity_reference',
+            'timestamp', 'datetime', 'datetime_immutable' => new NotNull(),
+            default => new NotBlank(),
+        };
+    }
+
+    private static function scalarTypeConstraint(string $type): ?Type
+    {
+        return match ($type) {
+            'boolean', 'bool' => new Type('bool'),
+            'integer', 'int' => new Type('int'),
+            'float', 'double' => new Type('float'),
+            'string', 'email', 'text', 'slug' => new Type('string'),
+            'array', 'json' => new Type('array'),
+            default => null,
+        };
+    }
+
+    private static function truthy(mixed $value): bool
+    {
+        return $value === true || $value === 1 || $value === '1' || $value === 'true';
+    }
+}

--- a/packages/entity/tests/Unit/Validation/EntityTypeValidationConstraintsTest.php
+++ b/packages/entity/tests/Unit/Validation/EntityTypeValidationConstraintsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Validation;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\Tests\Unit\TestEntity;
+use Waaseyaa\Entity\Tests\Unit\Validation\Fixture\FieldableEntityDouble;
+use Waaseyaa\Entity\Validation\EntityTypeValidationConstraints;
+use Waaseyaa\Entity\Validation\EntityValidator;
+
+#[CoversClass(EntityTypeValidationConstraints::class)]
+final class EntityTypeValidationConstraintsTest extends TestCase
+{
+    #[Test]
+    public function manualConstraintsReplaceDerivedForSameField(): void
+    {
+        $type = new EntityType(
+            id: 'x',
+            label: 'X',
+            class: TestEntity::class,
+            fieldDefinitions: [
+                'title' => ['type' => 'string', 'required' => true],
+            ],
+            constraints: [
+                'title' => [new Length(max: 3)],
+            ],
+        );
+
+        $merged = EntityTypeValidationConstraints::forEntityType($type);
+
+        $entity = $this->stubEntity(['title' => '']);
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $merged);
+
+        self::assertCount(0, $violations, 'Manual constraints replaced derived NotBlank; empty title is allowed by Length(max:3).');
+    }
+
+    #[Test]
+    public function manualConstraintsAugmentFieldsNotInManual(): void
+    {
+        $type = new EntityType(
+            id: 'x',
+            label: 'X',
+            class: TestEntity::class,
+            fieldDefinitions: [
+                'title' => ['type' => 'string', 'required' => true],
+            ],
+            constraints: [
+                'slug' => [new NotBlank()],
+            ],
+        );
+
+        $merged = EntityTypeValidationConstraints::forEntityType($type);
+        $entity = $this->stubEntity(['title' => 'ok', 'slug' => '']);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $merged);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('slug', $violations->get(0)->getPropertyPath());
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function stubEntity(array $values): FieldableEntityDouble
+    {
+        $entity = $this->createMock(FieldableEntityDouble::class);
+        $entity->method('get')->willReturnCallback(
+            static fn (string $name): mixed => $values[$name] ?? null,
+        );
+
+        return $entity;
+    }
+}

--- a/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
+++ b/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleStringEnum;
+use Waaseyaa\Entity\Tests\Unit\Validation\Fixture\FieldableEntityDouble;
+use Waaseyaa\Entity\Validation\EntityValidator;
+use Waaseyaa\Entity\Validation\FieldDefinitionConstraintBuilder;
+
+#[CoversClass(FieldDefinitionConstraintBuilder::class)]
+final class FieldDefinitionConstraintBuilderTest extends TestCase
+{
+    #[Test]
+    public function requiredStringRejectsBlank(): void
+    {
+        $entity = $this->stubEntity(['title' => '']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'title' => ['type' => 'string', 'required' => true],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('title', $violations->get(0)->getPropertyPath());
+    }
+
+    #[Test]
+    public function optionalFieldAllowsNull(): void
+    {
+        $entity = $this->stubEntity(['subtitle' => null]);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'subtitle' => ['type' => 'string', 'required' => false],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertCount(0, $violations);
+    }
+
+    #[Test]
+    public function allowedValuesRejectsInvalidChoice(): void
+    {
+        $entity = $this->stubEntity(['status' => 'archived']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'status' => [
+                'type' => 'string',
+                'allowed_values' => ['draft', 'published'],
+            ],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('status', $violations->get(0)->getPropertyPath());
+    }
+
+    #[Test]
+    public function camelCaseAllowedValuesAliasWorks(): void
+    {
+        $entity = $this->stubEntity(['status' => 'ok']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'status' => [
+                'type' => 'string',
+                'allowedValues' => ['ok'],
+            ],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertCount(0, $violations);
+    }
+
+    #[Test]
+    public function maxLengthRejectsLongString(): void
+    {
+        $entity = $this->stubEntity(['code' => 'abcdef']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'code' => ['type' => 'string', 'maxLength' => 3],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('code', $violations->get(0)->getPropertyPath());
+    }
+
+    #[Test]
+    public function emailTypeRejectsInvalidEmail(): void
+    {
+        $entity = $this->stubEntity(['mail' => 'not-an-email']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'mail' => ['type' => 'email'],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('mail', $violations->get(0)->getPropertyPath());
+    }
+
+    #[Test]
+    public function emailTypeAcceptsValidEmail(): void
+    {
+        $entity = $this->stubEntity(['mail' => 'user@example.com']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'mail' => ['type' => 'email'],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertCount(0, $violations);
+    }
+
+    #[Test]
+    public function enumClassUsesBackedEnumValues(): void
+    {
+        $entity = $this->stubEntity(['letter' => 'z']);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'letter' => ['type' => 'string', 'enumClass' => SampleStringEnum::class],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('letter', $violations->get(0)->getPropertyPath());
+    }
+
+    #[Test]
+    public function requiredBooleanAllowsFalse(): void
+    {
+        $entity = $this->stubEntity(['active' => false]);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'active' => ['type' => 'boolean', 'required' => true],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertCount(0, $violations);
+    }
+
+    #[Test]
+    public function requiredBooleanRejectsNull(): void
+    {
+        $entity = $this->stubEntity(['active' => null]);
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'active' => ['type' => 'boolean', 'required' => true],
+        ]);
+
+        $violations = (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints);
+
+        self::assertGreaterThan(0, $violations->count());
+        self::assertSame('active', $violations->get(0)->getPropertyPath());
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function stubEntity(array $values): FieldableEntityDouble
+    {
+        $entity = $this->createMock(FieldableEntityDouble::class);
+        $entity->method('get')->willReturnCallback(
+            static fn (string $name): mixed => $values[$name] ?? null,
+        );
+
+        return $entity;
+    }
+}

--- a/packages/entity/tests/Unit/Validation/Fixture/FieldableEntityDouble.php
+++ b/packages/entity/tests/Unit/Validation/Fixture/FieldableEntityDouble.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Validation\Fixture;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\FieldableInterface;
+
+/**
+ * @internal For validation unit tests that need EntityInterface&FieldableInterface mocks.
+ */
+interface FieldableEntityDouble extends EntityInterface, FieldableInterface
+{
+}


### PR DESCRIPTION
Closes #1182

## Summary

Implements a single validation surface for `EntityRepository::save()` by deriving Symfony constraints from `EntityType::getFieldDefinitions()` and merging them with the existing `getConstraints()` map. Per-field manual `getConstraints()` entries **replace** derived rules for that field name, so apps can override or supply constraints only where needed.

Adds `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints`, unit tests (required/optional string, choice, max length, email, backed enum, boolean required semantics, merge precedence, repository integration), and updates `docs/specs/entity-system.md` with the mapping table and precedence rules.

## Checklist

- [x] `Closes #N` above references the issue this PR resolves
- [ ] The issue is assigned to a milestone
- [x] PR title includes the issue number (e.g. `feat(#42): description`)

Made with [Cursor](https://cursor.com)