### PR TITLE
feat(entity): value object field casts (#1184)

### DIFF
--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -118,6 +118,7 @@ return [
     'Waaseyaa\Entity\Event\EntityEvents' => 'public',
     'Waaseyaa\Entity\Hydration\HydratableFromStorageInterface' => 'public',
     'Waaseyaa\Entity\Hydration\HydrationContext' => 'public',
+    'Waaseyaa\Entity\Cast\FromArrayEntityValueInterface' => 'public',
     'Waaseyaa\Entity\EntityValues' => 'public',
     'Waaseyaa\Entity\Snapshot\EntityValuesSnapshot' => 'public',
     'Waaseyaa\Entity\DateTime\EntityClockInterface' => 'public',

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -9,6 +9,7 @@
 <!-- Spec reviewed 2026-04-09k - `ResourceSerializer`, `DiscoveryRouter`, and `DiscoveryApiHandler` build attribute/visibility maps via `EntityValues::toCastAwareMap()` (#1181 ST-8) -->
 <!-- Spec reviewed 2026-04-09 ST-9 - JSON:API attribute pipeline cross-linked to docs/specs/jsonapi.md; ResourceSerializer uses toCastAwareMap (#1181) -->
 <!-- Spec reviewed 2026-04-09 ST-10 - ResourceSerializer delegates JSON value normalization to EntityValues::normalizeValueForJson() (#1181) -->
+<!-- Spec reviewed 2026-04-09 - SchemaPresenter: admin JSON Schema from field definitions, not EntityBase::$casts; cross-link entity-system #1184 -->
 
 Technical specification for the Waaseyaa JSON:API layer and routing system. This document covers the `packages/api/` and `packages/routing/` packages, which together provide RESTful CRUD endpoints, resource serialization, query parsing, JSON Schema presentation, route building, and access checking. The current post-M10 baseline uses package-owned service providers for API route registration: `packages/api/composer.json` declares `Waaseyaa\Api\ApiServiceProvider`, and that provider delegates CRUD route registration to `JsonApiRouteProvider` while foundation keeps only shared infrastructure endpoints.
 
@@ -257,6 +258,8 @@ if ($accessHandler !== null && $account !== null) {
 Only two of the four possible states (both-null, both-non-null) are meaningful. Passing one without the other silently skips access filtering.
 
 ## Schema Presenter
+
+**Field definitions vs `$casts` (#1184):** `SchemaPresenter::present()` builds properties from **EntityType field definitions** (the `$fieldDefinitions` argument, usually from the entity type registry), not from `EntityBase::$casts` on the entity PHP class. A field may still appear in JSON:API `attributes` with correct typing when the entity uses `$casts` and serializers call `EntityValues` (see **`docs/specs/jsonapi.md`** and **`docs/specs/entity-system.md`**). Admin form widgets for cast-only value objects may require explicit field definition metadata in a follow-up.
 
 ```php
 // packages/api/src/Schema/SchemaPresenter.php

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -18,6 +18,7 @@
 <!-- Spec reviewed 2026-04-09 - field-definition → Symfony constraints + save merge (#1182) -->
 <!-- Spec reviewed 2026-04-09 - P3 branching: duplicate/with/withValues, duplicateInstance hook, EntityValuesSnapshot, shallow-copy invariant -->
 <!-- Spec reviewed 2026-04-08g - symfony/* require ^7.0 on entity + entity-storage (#1151); no entity behavior change — symfony-version-floors.md -->
+<!-- Spec reviewed 2026-04-09 - backed enum invalid-value policy + value_object casts (#1184), FromArrayEntityValueInterface, EntityValues VO JSON normalization; cross-links #1181 -->
 
 Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
 
@@ -29,7 +30,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 
 | Package | Interfaces/Classes |
 |---------|-------------------|
-| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
+| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FromArrayEntityValueInterface`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
 | entity-storage | `EntityStorageDriverInterface`, `ConnectionResolverInterface` |
 | field | `FieldItemInterface`, `FieldItemListInterface`, `FieldDefinitionInterface`, `FieldTypeInterface`, `FieldFormatterInterface`, `FieldTypeManagerInterface`, `FieldItemBase`, `ViewModeConfigInterface` |
 | config | `ConfigInterface`, `ConfigFactoryInterface`, `ConfigManagerInterface`, `StorageInterface`, `TranslatableConfigFactoryInterface` |
@@ -51,7 +52,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 
 ## Casting & hydration architecture (ST-9, #1181)
 
-This section is the canonical contract for **storage-shaped values** vs **domain-shaped values**, where each applies, and how presentation layers stay consistent. Deeper package references: `packages/entity/src/Cast/`, `packages/entity/src/EntityBase.php`, `packages/entity/src/EntityValues.php`, `packages/entity-storage/src/Hydration/EntityInstantiator.php`.
+This section is the canonical contract for **storage-shaped values** vs **domain-shaped values**, where each applies, and how presentation layers stay consistent. Deeper package references: `packages/entity/src/Cast/`, `packages/entity/src/EntityBase.php`, `packages/entity/src/EntityValues.php`, `packages/entity-storage/src/Hydration/EntityInstantiator.php`. Casting and hydration boundary details: **#1181**; **backed enums and value-object (`FromArrayEntityValueInterface`) casts: #1184**.
 
 ### Hydration pipeline (row → instance)
 
@@ -89,7 +90,8 @@ flowchart LR
 
 | Field kind | Stored in `$values` / `toArray()` | Returned by `get()` when `$casts` set | Notes |
 |------------|-----------------------------------|----------------------------------------|-------|
-| Backed enum | Backing scalar (`string`/`int`) | Enum instance | `set()` accepts instance or backing value; `castOut` persists scalar |
+| Backed enum | Backing scalar (`string`/`int`) | Enum instance | `set()` accepts instance or backing value; `castOut` persists scalar. **Invalid backing / unknown case:** `get()` throws `CastException` (no silent null). |
+| Value object (`FromArrayEntityValueInterface`) | **Same as `array` cast:** JSON string in `$values` after `set()` | VO instance | **Storage invariant (#1184):** identical pipeline to `array` — `EntityCastCoercion::castInArray` / `castOutArray` so there is no alternate encoding or schema drift. Hydrate may supply a PHP `array` or JSON string; `get()` returns the VO. **`set()`:** MUST accept a VO instance of the cast class; MAY accept an `array` (via `fromArray` then `toArray` → storage); MUST NOT accept arbitrary scalars. **Immutability:** the framework does not enforce readonly VOs; implementations **SHOULD** be immutable for predictable cast behavior. Cast spec: backed enum class-string **or** VO class-string implementing `FromArrayEntityValueInterface`, or `['type' => 'value_object', 'class' => ClassName::class]`. **Wrong class:** stable error *Value object cast requires class implementing FromArrayEntityValueInterface*. |
 | `datetime_immutable` | ISO string, Unix int, or string digits | `DateTimeImmutable` | `castOut` → ISO-8601 `ATOM` |
 | `array` / `json` | JSON string | `array` | `castOut` re-encodes with `JSON_THROW_ON_ERROR` |
 | `int` / `float` / `bool` / `string` | Normalized scalar | Same PHP scalar (validated) | Empty string → error for numeric casts per `ValueCaster` rules |
@@ -110,7 +112,7 @@ flowchart LR
 File: `packages/entity/src/EntityValues.php`
 
 - **`toCastAwareMap(EntityInterface $entity): array`** — For each key in `array_keys($entity->toArray())`, set `$map[$key] = $entity->get($key)`. Same keys as the persistence bag, values as domain types where casts apply. Use for GraphQL, SSR field bags, MCP payloads, discovery visibility, workflow validation listeners, relationship traversal summaries, and any code that previously iterated `toArray()` expecting “real” types.
-- **`toJsonReadyMap(EntityInterface $entity): array`** — `toCastAwareMap()` plus recursive JSON normalization (backed enums → scalar, `DateTimeInterface` → ISO-8601 ATOM, `JsonSerializable`, nested arrays). Use for embedding text construction, MCP/logging payloads, and anywhere `json_encode` must not receive raw storage scalars when casts exist. `ResourceSerializer` delegates attribute normalization to **`normalizeValueForJson(mixed $value): mixed`** (same implementation) so JSON:API and other sinks stay aligned (#1181 ST-10).
+- **`toJsonReadyMap(EntityInterface $entity): array`** — `toCastAwareMap()` plus recursive JSON normalization (backed enums → scalar, `DateTimeInterface` → ISO-8601 ATOM, `JsonSerializable`, **`FromArrayEntityValueInterface` → `toArray()` then same recursion as nested arrays** — including nested VOs inside arrays, #1184). Use for embedding text construction, MCP/logging payloads, and anywhere `json_encode` must not receive raw storage scalars when casts exist. `ResourceSerializer` delegates attribute normalization to **`normalizeValueForJson(mixed $value): mixed`** (same implementation) so JSON:API and other sinks stay aligned (#1181 ST-10).
 - **`statusToInt(mixed $status): int`** — Normalizes bool/int/string/`BackedEnum` to `0|1` for strict published checks; use with `$entity->get('status')` or values taken from a cast-aware map.
 - **Do not use** `EntityValues` for: persistence, `SqlEntityStorage`, repository `save()`, or low-level drivers.
 
@@ -126,8 +128,12 @@ File: `packages/entity/src/EntityValues.php`
 
 ### Rules for `get()` / `set()`
 
-- **`get()`** — The only supported way to read cast fields as domain objects (enums, `DateTimeImmutable`, decoded arrays) without duplicating cast logic.
-- **`set()`** — Accepts domain input for cast fields; always persists storage shape into `$values`.
+- **`get()`** — The only supported way to read cast fields as domain objects (enums, `DateTimeImmutable`, decoded arrays, **VOs implementing `FromArrayEntityValueInterface`**) without duplicating cast logic.
+- **`set()`** — Accepts domain input for cast fields; always persists storage shape into `$values`. For **value-object** casts, see the table above (instance required; array optional; scalars rejected, #1184).
+
+### Admin JSON Schema vs `$casts`
+
+`SchemaPresenter` (`packages/api/src/Schema/SchemaPresenter.php`) builds widgets from **EntityType field definitions**, not from entity class `$casts`. A VO field may still serialize correctly over JSON:API via `EntityValues` when `$casts` is set on the entity class; **admin form schema** for structured VOs may require explicit field definition work (e.g. object / JSON widget) in a follow-up — not inferred automatically from `$casts` (#1184).
 - Direct mutation of `$values` from outside the entity class is unsupported; subclasses that override `get`/`set` must preserve cast semantics or document exceptions.
 
 ### Rules for `toArray()`

--- a/packages/api/src/Schema/SchemaPresenter.php
+++ b/packages/api/src/Schema/SchemaPresenter.php
@@ -13,6 +13,10 @@ use Waaseyaa\Entity\EntityTypeInterface;
  * Converts EntityType definitions (and optional FieldDefinitions) to JSON Schema
  * representations with widget hints for admin SPA consumption.
  *
+ * This presenter reads **field definitions on the entity type**, not `EntityBase::$casts`.
+ * Cast-only value objects or enums on the entity class do not automatically appear here; align definitions
+ * with admin UX when structured fields need widgets (#1184 / entity-system spec).
+ *
  * The output follows JSON Schema draft-07 format with custom extensions:
  * - "x-widget": widget type hint for the admin UI (text, textarea, richtext, select, boolean, etc.)
  * - "x-label": human-readable field label

--- a/packages/entity-storage/tests/Fixtures/CastPersistenceLeafVo.php
+++ b/packages/entity-storage/tests/Fixtures/CastPersistenceLeafVo.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Fixtures;
+
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
+final class CastPersistenceLeafVo implements FromArrayEntityValueInterface
+{
+    public function __construct(
+        public readonly string $code = '',
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new self(code: (string) ($data['code'] ?? ''));
+    }
+
+    public function toArray(): array
+    {
+        return ['code' => $this->code];
+    }
+}

--- a/packages/entity-storage/tests/Fixtures/CastPersistenceOuterVo.php
+++ b/packages/entity-storage/tests/Fixtures/CastPersistenceOuterVo.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Fixtures;
+
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
+final class CastPersistenceOuterVo implements FromArrayEntityValueInterface
+{
+    public function __construct(
+        public readonly CastPersistenceLeafVo $leaf,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        $leafRaw = $data['leaf'] ?? [];
+        if (!is_array($leafRaw)) {
+            $leafRaw = [];
+        }
+
+        return new self(leaf: CastPersistenceLeafVo::fromArray($leafRaw));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'leaf' => $this->leaf->toArray(),
+        ];
+    }
+}

--- a/packages/entity-storage/tests/Fixtures/CastPersistenceTestEntity.php
+++ b/packages/entity-storage/tests/Fixtures/CastPersistenceTestEntity.php
@@ -18,6 +18,7 @@ class CastPersistenceTestEntity extends ContentEntityBase
         'score' => 'int',
         'tags' => 'array',
         'mode' => CastPersistenceStringEnum::class,
+        'nested_profile' => CastPersistenceOuterVo::class,
     ];
 
     public function __construct(

--- a/packages/entity-storage/tests/Unit/CastPersistenceIntegrationTest.php
+++ b/packages/entity-storage/tests/Unit/CastPersistenceIntegrationTest.php
@@ -15,6 +15,8 @@ use Waaseyaa\EntityStorage\Driver\InMemoryStorageDriver;
 use Waaseyaa\EntityStorage\EntityRepository;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\EntityStorage\Tests\Fixtures\CastPersistenceLeafVo;
+use Waaseyaa\EntityStorage\Tests\Fixtures\CastPersistenceOuterVo;
 use Waaseyaa\EntityStorage\Tests\Fixtures\CastPersistenceStringEnum;
 use Waaseyaa\EntityStorage\Tests\Fixtures\CastPersistenceTestEntity;
 
@@ -111,6 +113,38 @@ final class CastPersistenceIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function repository_round_trip_nested_value_object(): void
+    {
+        [, $driver, $repository] = $this->createRepositoryFixture();
+
+        $entity = new CastPersistenceTestEntity(
+            values: [
+                'id' => 10,
+                'uuid' => '10101010-1010-4101-8101-101010101010',
+                'label' => 'Ten',
+                'bundle' => 'article',
+                'langcode' => 'en',
+            ],
+            entityKeys: self::ENTITY_KEYS,
+        );
+        $entity->enforceIsNew(true);
+        $entity->set(
+            'nested_profile',
+            new CastPersistenceOuterVo(leaf: new CastPersistenceLeafVo(code: 'persisted')),
+        );
+        $repository->save($entity);
+
+        $found = $repository->find('10');
+        self::assertInstanceOf(CastPersistenceTestEntity::class, $found);
+        $profile = $found->get('nested_profile');
+        self::assertInstanceOf(CastPersistenceOuterVo::class, $profile);
+        self::assertSame('persisted', $profile->leaf->code);
+
+        $row = $this->readInMemoryRow($driver, 'cast_persist_entity', '10');
+        self::assertSame('{"leaf":{"code":"persisted"}}', $row['nested_profile']);
+    }
+
+    #[Test]
     public function repository_find_casts_numeric_string_from_driver_like_sqlite(): void
     {
         [, $driver, $repository] = $this->createRepositoryFixture();
@@ -201,6 +235,54 @@ final class CastPersistenceIntegrationTest extends TestCase
         self::assertIsString($internal['tags']);
         self::assertSame('on', $internal['mode']);
         self::assertSame(7, $internal['score']);
+    }
+
+    #[Test]
+    public function sql_storage_nested_value_object_round_trip_in_data_blob(): void
+    {
+        $database = DBALDatabase::createSqlite();
+        $entityType = new EntityType(
+            id: 'cast_persist_entity',
+            label: 'Cast Persist',
+            class: CastPersistenceTestEntity::class,
+            keys: self::ENTITY_KEYS,
+            fieldDefinitions: [
+                'created' => ['type' => 'timestamp'],
+                'changed' => ['type' => 'timestamp'],
+            ],
+        );
+        $schemaHandler = new SqlSchemaHandler($entityType, $database);
+        $schemaHandler->ensureTable();
+
+        $storage = new SqlEntityStorage(
+            $entityType,
+            $database,
+            new EventDispatcher(),
+        );
+
+        $entity = $storage->create([
+            'label' => 'Sql nested vo',
+            'bundle' => 'page',
+        ]);
+        $entity->set(
+            'nested_profile',
+            new CastPersistenceOuterVo(leaf: new CastPersistenceLeafVo(code: 'sql-leaf')),
+        );
+        $storage->save($entity);
+
+        $id = $entity->id();
+        self::assertNotNull($id);
+
+        $loaded = $storage->load($id);
+        self::assertNotNull($loaded);
+        self::assertInstanceOf(CastPersistenceTestEntity::class, $loaded);
+        $profile = $loaded->get('nested_profile');
+        self::assertInstanceOf(CastPersistenceOuterVo::class, $profile);
+        self::assertSame('sql-leaf', $profile->leaf->code);
+
+        $internal = $loaded->toArray();
+        self::assertIsString($internal['nested_profile']);
+        self::assertSame('{"leaf":{"code":"sql-leaf"}}', $internal['nested_profile']);
     }
 
     /**

--- a/packages/entity/src/Cast/CastDefinition.php
+++ b/packages/entity/src/Cast/CastDefinition.php
@@ -7,8 +7,11 @@ namespace Waaseyaa\Entity\Cast;
 /**
  * Declarative cast specification for a single field.
  *
- * - String tokens name built-ins (`int`, `array`, `datetime_immutable`, …) or a backed enum class-string.
+ * - String tokens name built-ins (`int`, `array`, `datetime_immutable`, …), a backed enum class-string,
+ *   or a class-string implementing {@see FromArrayEntityValueInterface} (same JSON storage shape as `array`, #1184).
  * - Array form supports `['type' => 'json']` as an alias for the `array` built-in (JSON in storage).
+ * - Value object array form: `['type' => 'value_object', 'class' => SomeVo::class]` when `SomeVo` implements
+ *   {@see FromArrayEntityValueInterface}.
  */
 final readonly class CastDefinition
 {

--- a/packages/entity/src/Cast/Exception/CastException.php
+++ b/packages/entity/src/Cast/Exception/CastException.php
@@ -39,14 +39,14 @@ final class CastException extends \InvalidArgumentException
     }
 
     /**
-     * Non-enum class-strings are reserved for value-object casts (#1184).
+     * Stable contract when a cast class-string exists but does not implement {@see \Waaseyaa\Entity\Cast\FromArrayEntityValueInterface}.
      */
-    public static function unsupportedValueObjectCast(string $field, string $class): self
+    public static function valueObjectRequiresInterface(string $field, string $class): self
     {
         return new self(sprintf(
-            'Cast to class "%s" for field "%s" is not supported yet (value-object casts: #1184).',
-            $class,
+            'Value object cast requires class implementing FromArrayEntityValueInterface (field "%s", class "%s").',
             $field,
+            $class,
         ));
     }
 

--- a/packages/entity/src/Cast/FromArrayEntityValueInterface.php
+++ b/packages/entity/src/Cast/FromArrayEntityValueInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Cast;
+
+/**
+ * Contract for entity field value objects hydrated from persisted array/JSON (#1184).
+ *
+ * Storage shape matches the {@code array} cast: JSON string in the entity value bag after {@see set()},
+ * PHP array or JSON string acceptable when loading. The framework does not enforce immutability;
+ * implementations SHOULD use readonly properties for predictable cast behavior.
+ */
+interface FromArrayEntityValueInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): static;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/packages/entity/src/Cast/ValueCaster.php
+++ b/packages/entity/src/Cast/ValueCaster.php
@@ -18,6 +18,7 @@ use Waaseyaa\TypedData\Coercion\EntityCastCoercion;
  *
  * Builtin scalar and JSON-array casts delegate to {@see EntityCastCoercion} in `waaseyaa/typed-data` (#1185).
  * {@code datetime_immutable} and backed enums remain here (#1183 / enum handling).
+ * Value objects use {@see FromArrayEntityValueInterface} with the same storage shape as the {@code array} cast (#1184).
  *
  * Optional Carbon: array spec `['type' => 'datetime_immutable', 'domain' => 'carbon_immutable']` requires
  * `nesbot/carbon` (#1183).
@@ -65,6 +66,13 @@ final class ValueCaster
             return $this->castInBuiltin($field, $stored, $resolved['token'], $castSpec);
         }
 
+        if ($resolved['kind'] === 'value_object') {
+            /** @var class-string<FromArrayEntityValueInterface> $voClass */
+            $voClass = $resolved['class'];
+
+            return $this->castInValueObject($field, $stored, $voClass);
+        }
+
         /** @var class-string<BackedEnum> $enumClass */
         $enumClass = $resolved['class'];
 
@@ -88,6 +96,13 @@ final class ValueCaster
             return $this->castOutBuiltin($field, $domain, $resolved['token'], $castSpec);
         }
 
+        if ($resolved['kind'] === 'value_object') {
+            /** @var class-string<FromArrayEntityValueInterface> $voClass */
+            $voClass = $resolved['class'];
+
+            return $this->castOutValueObject($field, $domain, $voClass);
+        }
+
         /** @var class-string<BackedEnum> $enumClass */
         $enumClass = $resolved['class'];
 
@@ -95,10 +110,37 @@ final class ValueCaster
     }
 
     /**
-     * @return array{kind: 'builtin', token: string}|array{kind: 'enum', class: class-string<BackedEnum>}
+     * Whether {@code $class} is a value-object cast target (single extension seam for VO detection).
+     *
+     * @param class-string $class
+     */
+    private function isValueObjectCast(string $class): bool
+    {
+        return class_exists($class) && is_subclass_of($class, FromArrayEntityValueInterface::class);
+    }
+
+    /**
+     * @return array{kind: 'builtin', token: string}|array{kind: 'enum', class: class-string<BackedEnum>}|array{kind: 'value_object', class: class-string<FromArrayEntityValueInterface>}
      */
     private function resolveCastTarget(string $field, string|array $castSpec): array
     {
+        if (is_array($castSpec)) {
+            $declaredType = $castSpec['type'] ?? '';
+            if ($declaredType === 'value_object') {
+                $class = $castSpec['class'] ?? null;
+                if (!is_string($class) || $class === '' || !class_exists($class)) {
+                    throw CastException::invalidCastSpec($field);
+                }
+
+                if (!$this->isValueObjectCast($class)) {
+                    throw CastException::valueObjectRequiresInterface($field, $class);
+                }
+
+                /** @var class-string<FromArrayEntityValueInterface> $class */
+                return ['kind' => 'value_object', 'class' => $class];
+            }
+        }
+
         $token = $this->normalizeSpecToToken($field, $castSpec);
         if ($token === '') {
             throw CastException::invalidCastSpec($field);
@@ -110,7 +152,12 @@ final class ValueCaster
 
         if (!enum_exists($token)) {
             if (class_exists($token)) {
-                throw CastException::unsupportedValueObjectCast($field, $token);
+                if ($this->isValueObjectCast($token)) {
+                    /** @var class-string<FromArrayEntityValueInterface> $token */
+                    return ['kind' => 'value_object', 'class' => $token];
+                }
+
+                throw CastException::valueObjectRequiresInterface($field, $token);
             }
 
             throw CastException::unknownBuiltinCast($field, $token);
@@ -471,5 +518,72 @@ final class ValueCaster
         }
 
         throw CastException::invalidDomainValue($field, $enumClass, $domain);
+    }
+
+    /**
+     * @param class-string<FromArrayEntityValueInterface> $voClass
+     */
+    private function castInValueObject(string $field, mixed $stored, string $voClass): FromArrayEntityValueInterface
+    {
+        if ($stored instanceof FromArrayEntityValueInterface && $stored::class === $voClass) {
+            return $stored;
+        }
+
+        $data = $this->typedCastIn(
+            static fn() => EntityCastCoercion::castInArray($field, $stored),
+        );
+
+        try {
+            return $voClass::fromArray($data);
+        } catch (\Throwable $e) {
+            throw new CastException(
+                sprintf('Cannot cast stored value for field "%s" to value object %s.', $field, $voClass),
+                0,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * @param class-string<FromArrayEntityValueInterface> $voClass
+     *
+     * @return non-falsy-string JSON string (same storage shape as {@code array} cast).
+     */
+    private function castOutValueObject(string $field, mixed $domain, string $voClass): string
+    {
+        $vo = $this->normalizeDomainToValueObject($field, $domain, $voClass);
+
+        return $this->typedCastOut(
+            static fn() => EntityCastCoercion::castOutArray($field, $vo->toArray()),
+        );
+    }
+
+    /**
+     * @param class-string<FromArrayEntityValueInterface> $voClass
+     */
+    private function normalizeDomainToValueObject(string $field, mixed $domain, string $voClass): FromArrayEntityValueInterface
+    {
+        if ($domain instanceof FromArrayEntityValueInterface && $domain::class === $voClass) {
+            return $domain;
+        }
+
+        if (is_array($domain)) {
+            try {
+                return $voClass::fromArray($domain);
+            } catch (\Throwable $e) {
+                throw new CastException(
+                    sprintf('Cannot cast domain value for field "%s" to storage for value object %s.', $field, $voClass),
+                    0,
+                    $e,
+                );
+            }
+        }
+
+        throw CastException::invalidDomainValue(
+            $field,
+            $voClass,
+            $domain,
+            'Value object cast accepts only an instance of the cast class or an array (fromArray); scalars are not accepted.',
+        );
     }
 }

--- a/packages/entity/src/EntityBase.php
+++ b/packages/entity/src/EntityBase.php
@@ -46,7 +46,8 @@ abstract class EntityBase implements EntityInterface
     protected array $entityKeys = [];
 
     /**
-     * Per-field cast specifications (string token, backed enum class-string, or `['type' => ...]`).
+     * Per-field cast specifications (string token, backed enum class-string,
+     * {@see \Waaseyaa\Entity\Cast\FromArrayEntityValueInterface} class-string, or `['type' => ...]`).
      *
      * @var array<string, string|array<string, mixed>>
      */

--- a/packages/entity/src/EntityValues.php
+++ b/packages/entity/src/EntityValues.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Entity;
 
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
 /**
  * Helpers for read paths that need cast-aware field values (#1181).
  *
@@ -101,6 +103,10 @@ final class EntityValues
 
         if ($value instanceof \JsonSerializable) {
             return self::normalizeValueForJson($value->jsonSerialize());
+        }
+
+        if ($value instanceof FromArrayEntityValueInterface) {
+            return self::normalizeValueForJson($value->toArray());
         }
 
         if (\is_array($value)) {

--- a/packages/entity/tests/Unit/Cast/Fixture/SampleNestedChildVo.php
+++ b/packages/entity/tests/Unit/Cast/Fixture/SampleNestedChildVo.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Cast\Fixture;
+
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
+final class SampleNestedChildVo implements FromArrayEntityValueInterface
+{
+    public function __construct(
+        public readonly string $code = '',
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new self(code: (string) ($data['code'] ?? ''));
+    }
+
+    public function toArray(): array
+    {
+        return ['code' => $this->code];
+    }
+}

--- a/packages/entity/tests/Unit/Cast/Fixture/SampleNestedParentVo.php
+++ b/packages/entity/tests/Unit/Cast/Fixture/SampleNestedParentVo.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Cast\Fixture;
+
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
+final class SampleNestedParentVo implements FromArrayEntityValueInterface
+{
+    public function __construct(
+        public readonly SampleNestedChildVo $child,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        $childRaw = $data['child'] ?? [];
+        if (!is_array($childRaw)) {
+            $childRaw = [];
+        }
+
+        return new self(child: SampleNestedChildVo::fromArray($childRaw));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'child' => $this->child->toArray(),
+        ];
+    }
+}

--- a/packages/entity/tests/Unit/Cast/Fixture/SampleValueObject.php
+++ b/packages/entity/tests/Unit/Cast/Fixture/SampleValueObject.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Tests\Unit\Cast\Fixture;
+
+use Waaseyaa\Entity\Cast\FromArrayEntityValueInterface;
+
+final class SampleValueObject implements FromArrayEntityValueInterface
+{
+    public function __construct(
+        public readonly string $title = '',
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new self(title: (string) ($data['title'] ?? ''));
+    }
+
+    public function toArray(): array
+    {
+        return ['title' => $this->title];
+    }
+}

--- a/packages/entity/tests/Unit/Cast/ValueCasterTest.php
+++ b/packages/entity/tests/Unit/Cast/ValueCasterTest.php
@@ -12,8 +12,11 @@ use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\Cast\Exception\CastException;
 use Waaseyaa\Entity\Cast\ValueCaster;
 use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleIntEnum;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleNestedChildVo;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleNestedParentVo;
 use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleStringEnum;
 use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleUnitEnum;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleValueObject;
 
 /**
  * @covers \Waaseyaa\Entity\Cast\ValueCaster
@@ -363,11 +366,83 @@ final class ValueCasterTest extends TestCase
     }
 
     #[Test]
-    public function plain_class_string_throws_value_object_not_supported(): void
+    public function plain_class_string_requires_value_object_interface(): void
     {
         $this->expectException(CastException::class);
-        $this->expectExceptionMessage('#1184');
+        $this->expectExceptionMessage('Value object cast requires class implementing FromArrayEntityValueInterface');
         (new ValueCaster())->castIn(self::FIELD, 'x', \stdClass::class);
+    }
+
+    #[Test]
+    public function value_object_round_trip_json_string_storage(): void
+    {
+        $c = new ValueCaster();
+        $spec = SampleValueObject::class;
+        $vo = new SampleValueObject(title: 'Hello');
+        $json = $c->castOut(self::FIELD, $vo, $spec);
+        self::assertSame('{"title":"Hello"}', $json);
+        $round = $c->castIn(self::FIELD, $json, $spec);
+        self::assertInstanceOf(SampleValueObject::class, $round);
+        self::assertSame('Hello', $round->title);
+    }
+
+    #[Test]
+    public function value_object_cast_in_accepts_php_array_like_hydrate(): void
+    {
+        $c = new ValueCaster();
+        $spec = SampleValueObject::class;
+        $vo = $c->castIn(self::FIELD, ['title' => 'Arr'], $spec);
+        self::assertInstanceOf(SampleValueObject::class, $vo);
+        self::assertSame('Arr', $vo->title);
+    }
+
+    #[Test]
+    public function value_object_cast_out_accepts_array_domain(): void
+    {
+        $c = new ValueCaster();
+        $spec = SampleValueObject::class;
+        $json = $c->castOut(self::FIELD, ['title' => 'From array'], $spec);
+        self::assertSame('{"title":"From array"}', $json);
+    }
+
+    #[Test]
+    public function value_object_cast_out_rejects_scalar_domain(): void
+    {
+        $this->expectException(CastException::class);
+        $this->expectExceptionMessage('scalars are not accepted');
+        (new ValueCaster())->castOut(self::FIELD, 'nope', SampleValueObject::class);
+    }
+
+    #[Test]
+    public function value_object_nested_round_trip(): void
+    {
+        $c = new ValueCaster();
+        $spec = SampleNestedParentVo::class;
+        $vo = new SampleNestedParentVo(
+            child: new SampleNestedChildVo(code: 'inner'),
+        );
+        $json = $c->castOut(self::FIELD, $vo, $spec);
+        self::assertSame('{"child":{"code":"inner"}}', $json);
+        $in = $c->castIn(self::FIELD, $json, $spec);
+        self::assertInstanceOf(SampleNestedParentVo::class, $in);
+        self::assertSame('inner', $in->child->code);
+    }
+
+    #[Test]
+    public function value_object_array_cast_spec_with_class_key(): void
+    {
+        $c = new ValueCaster();
+        $spec = ['type' => 'value_object', 'class' => SampleValueObject::class];
+        $vo = $c->castIn(self::FIELD, '{"title":"Spec"}', $spec);
+        self::assertInstanceOf(SampleValueObject::class, $vo);
+        self::assertSame('Spec', $vo->title);
+    }
+
+    #[Test]
+    public function value_object_array_spec_missing_class_throws(): void
+    {
+        $this->expectException(CastException::class);
+        (new ValueCaster())->castIn(self::FIELD, '{}', ['type' => 'value_object']);
     }
 
     #[Test]

--- a/packages/entity/tests/Unit/EntityValuesTest.php
+++ b/packages/entity/tests/Unit/EntityValuesTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\ContentEntityBase;
 use Waaseyaa\Entity\EntityValues;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleNestedChildVo;
+use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleNestedParentVo;
 use Waaseyaa\Entity\Tests\Unit\Cast\Fixture\SampleStringEnum;
 
 #[CoversClass(EntityValues::class)]
@@ -54,6 +56,22 @@ final class EntityValuesTest extends TestCase
             EntityValues::normalizeValueForJson(new \DateTimeImmutable('2026-01-02T03:04:05+00:00')),
         );
         self::assertSame(['x' => 'a'], EntityValues::normalizeValueForJson(['x' => SampleStringEnum::Alpha]));
+    }
+
+    #[Test]
+    public function normalizeValueForJsonRecursesNestedValueObjectsLikeNestedArrays(): void
+    {
+        $nested = new SampleNestedParentVo(child: new SampleNestedChildVo(code: 'c1'));
+        self::assertSame(
+            ['child' => ['code' => 'c1']],
+            EntityValues::normalizeValueForJson($nested),
+        );
+        self::assertSame(
+            ['wrap' => ['child' => ['code' => 'c2']]],
+            EntityValues::normalizeValueForJson([
+                'wrap' => new SampleNestedParentVo(child: new SampleNestedChildVo(code: 'c2')),
+            ]),
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Implements **#1184** (first-class value object casts) on top of the existing **#1181** cast pipeline.

- Add `FromArrayEntityValueInterface` (`fromArray` / `toArray`) and `ValueCaster` VO path using the **same JSON storage shape as the `array` cast** (`EntityCastCoercion::castInArray` / `castOutArray`).
- `set()` / `castOut`: accept VO instance or `array` only; reject arbitrary scalars with `CastException`.
- Replace placeholder VO error with stable message: **Value object cast requires class implementing FromArrayEntityValueInterface**.
- `EntityValues::normalizeValueForJson`: VO → `toArray()` then same recursion as nested arrays (nested VOs).
- Optional cast spec `['type' => 'value_object', 'class' => ...]`.
- Tests: unit (incl. nested VO), `CastPersistenceIntegrationTest` (in-memory + SQLite), `EntityValuesTest`, `PublicSurfaceVerificationTest`.
- Specs: `entity-system.md`, `api-layer.md` (SchemaPresenter vs `$casts`), `SchemaPresenter` / `CastDefinition` / `EntityBase` docs; `docs/public-surface-map.php`.

## Closes

Closes #1184

## Verification

- `./vendor/bin/phpunit` (pre-push hook)
- `phpstan` (pre-push hook)
- `task drift:check` / spec-drift (pre-push hook)


Made with [Cursor](https://cursor.com)