### PR TITLE
feat(#1186): add EntityType-aware factories for tests and seeds

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3086,7 +3086,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "dev-main",
+            "version": "dev-feat/1187-entity-p3-immutability",
             "dist": {
                 "type": "path",
                 "url": "packages/access",
@@ -4111,7 +4111,7 @@
         },
         {
             "name": "waaseyaa/github",
-            "version": "dev-feat/1187-entity-p3-immutability",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "packages/github",
@@ -9459,12 +9459,16 @@
             "dist": {
                 "type": "path",
                 "url": "packages/testing",
-                "reference": "51594667ba85ba75420c62ced9b2ff2dfad91d55"
+                "reference": "2688049a779b60b18ef8a668058356f01362b176"
             },
             "require": {
                 "php": ">=8.4",
                 "phpunit/phpunit": "^10.5",
-                "symfony/event-dispatcher": "^7.0"
+                "symfony/event-dispatcher": "^7.0",
+                "waaseyaa/entity": "^0.1"
+            },
+            "suggest": {
+                "fakerphp/faker": "Optional realistic strings and emails for EntityTypeFixtureValues (framework#1186)."
             },
             "type": "library",
             "extra": {

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -19,6 +19,7 @@
 <!-- Spec reviewed 2026-04-09 - P3 branching: duplicate/with/withValues, duplicateInstance hook, EntityValuesSnapshot, shallow-copy invariant -->
 <!-- Spec reviewed 2026-04-08g - symfony/* require ^7.0 on entity + entity-storage (#1151); no entity behavior change — symfony-version-floors.md -->
 <!-- Spec reviewed 2026-04-09 - backed enum invalid-value policy + value_object casts (#1184), FromArrayEntityValueInterface, EntityValues VO JSON normalization; cross-links #1181 -->
+<!-- Spec reviewed 2026-04-10 - waaseyaa/testing EntityTypeFixtureValues + EntityFactory::defineFromEntityType (#1186) -->
 
 Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
 
@@ -994,6 +995,20 @@ File: `packages/entity/src/Validation/EntityTypeValidationConstraints.php`
 Opt-out: `EntityRepository::save($entity, validate: false)` (and `saveMany`) skips validation entirely; there is no separate flag for “manual only.”
 
 Invalid data raises `EntityValidationException` with property paths equal to field names (plus nested paths when a constraint reports a sub-path), unchanged from `EntityValidator` behavior.
+
+#### Entity fixture values for tests and seeds (#1186)
+
+Files: `packages/testing/src/Factory/EntityTypeFixtureValues.php`, `packages/testing/src/Factory/EntityFactory.php` (`defineFromEntityType`).
+
+**Purpose:** Generate **storage-shaped** value arrays for PHPUnit, in-memory fixtures, and app seed scripts (non-goal: framework CLI seed commands). Optional `fakerphp/faker` improves human-like strings/emails when installed; otherwise small deterministic defaults are used.
+
+**Constraint source:** `EntityTypeFixtureValues::values()` uses the same merged map as persistence validation — `EntityTypeValidationConstraints::forEntityType()` (derived field definitions + manual `getConstraints()`, identical merge semantics to `EntityRepository::doSave()`). Generated samples are intended to satisfy `EntityValidator` for that map when values are loaded on an entity whose `get()` semantics match storage (no `$casts` surprises).
+
+**Distinction vs production hydration (#1188):** Factories are **not** `HydratableFromStorageInterface` / `EntityInstantiator` / static `make()` rehydration. They synthesize dummy data from metadata; production paths merge **real** storage or API rows. A future domain `make()` may wrap a compatible value bag, but factories remain test/seed-only.
+
+**API surface:** `EntityTypeFixtureValues` accepts a sequence index (for `Choice` cycling and uniqueness) and an optional per-field resolver: `callable(string $field, list<Constraint> $constraints): mixed|null` — return `null` to fall back to built-in generation for that field; use `values(..., $overrides)` for explicit nulls or replacements. `EntityType::getKeys()` triggers defaults for `uuid` (RFC 4122 via `symfony/uid`), `label`, `bundle`, and `langcode` when those mappings exist. `EntityFactory::defineFromEntityType()` registers those defaults so existing `sequence()` / `createMany()` usage keeps working.
+
+**Extension:** Unknown Symfony `Constraint` subclasses are not synthesized — supply values via overrides or the custom resolver. Cast-heavy entities should keep fixtures storage-canonical (same rule as constructor values in #1181).
 
 ### Entity Lifecycle Hooks
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -9,6 +9,7 @@
 <!-- Spec reviewed 2026-04-08b - restored packages/foundation, packages/search, and packages/testing Symfony floors (^7.3 -> ^7.0) where no runtime/API requirement justified tighter constraints -->
 <!-- Spec reviewed 2026-04-08c - entity, entity-storage, queue, routing, typed-data, validation Symfony floors to ^7.0; see symfony-version-floors.md (#1151) -->
 <!-- Spec reviewed 2026-04-09 - typed-data: EntityCastCoercion, CoercionException, CastTokenMapper; entity ValueCaster delegates builtins (#1185); public surface map extended -->
+<!-- Spec reviewed 2026-04-10 - testing package EntityTypeFixtureValues + EntityFactory::defineFromEntityType (#1186) -->
 <!-- Spec reviewed 2026-04-08 - #1129/#1134: HttpKernel::finalizeBoot() wires DB cache bins and discovery handler; SSR owns RenderCache listeners + SsrPageHandler via SsrServiceProvider::configureHttpKernel; ErrorPageRendererInterface bound in SSR; provider httpDomainRouters() merged after foundation routers through McpRouter and before BroadcastRouter; DiscoveryRouter/GraphQlRouter/MediaRouter live in api/graphql/media packages; ControllerDispatcher uses Inertia foundation interfaces + optional InertiaFullPageRendererInterface; LayerDependencyTest gates non-Router Foundation Http/ against non-Foundation Waaseyaa imports -->
 <!-- Spec reviewed 2026-04-08 - DX P2: HttpKernel boot catch returns HTML via DevExceptionRenderer when debug+package present else JSON:API bootFailureJsonResponse (non-empty body, #1117); ControllerDispatcher render.page returns 501 JSON when SsrPageHandler class unavailable (#1130); LogManager gains daily + fingers_crossed channel types -->
 <!-- Spec reviewed 2026-04-08 - LogManager: handler key string = type synonym only; fingers_crossed nested config via nested, inner, or array handler; channel buffer_limit caps FingersCrossedHandler in-memory buffer (drops oldest); handlerTypeFromConfig + fingersCrossedBufferLimit helpers -->
@@ -34,7 +35,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 | typed-data | `TypedDataInterface`, `DataDefinitionInterface`, `ComplexDataInterface`, `ListInterface`, `PrimitiveInterface`, `TypedDataManagerInterface`, `CastTokenMapper`, `CoercionException`, `EntityCastCoercion` |
 | i18n | `LanguageManagerInterface`, `TranslatorInterface` |
 | queue | `QueueInterface` |
-| testing | `CreatesApplication`, `InteractsWithApi`, `InteractsWithAuth`, `InteractsWithEvents`, `RefreshDatabase` |
+| testing | `CreatesApplication`, `InteractsWithApi`, `InteractsWithAuth`, `InteractsWithEvents`, `RefreshDatabase`, `EntityFactory`, `EntityTypeFixtureValues` |
 
 **`@internal`** (implementation details, may change without notice):
 
@@ -61,6 +62,14 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 | `packages/plugin/` | `Waaseyaa\Plugin\` | 0 (Foundation) | PluginManager, attribute-based plugin discovery, plugin factory |
 | `packages/mail/` | `Waaseyaa\Mail\` | 0 (Foundation) | `MailerInterface` + `Envelope`; pluggable `TransportInterface` (array, local file, SendGrid API when configured) |
 | `packages/http-client/` | `Waaseyaa\HttpClient\` | 0 (Foundation) | Minimal HTTP client for JSON APIs and webhooks, zero external dependencies |
+
+### Testing fixture factories (`packages/testing/`)
+
+`EntityFactory` remains the lightweight defaults/overrides + sequence helper for value arrays.
+`EntityTypeFixtureValues` adds metadata-aware dummy generation for tests/seeds by reading
+`EntityTypeValidationConstraints::forEntityType()` from `waaseyaa/entity`, so generated values
+follow the same merged field-definition + manual constraint map used by `EntityRepository` save
+validation. This is explicitly a fixture path (not production hydration via `EntityInstantiator`).
 
 ## Domain Events
 

--- a/packages/testing/composer.json
+++ b/packages/testing/composer.json
@@ -3,10 +3,20 @@
     "description": "Testing utilities for Waaseyaa \u2014 base test case, entity factories, and helper traits.",
     "type": "library",
     "license": "GPL-2.0-or-later",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../entity"
+        }
+    ],
     "require": {
         "php": ">=8.4",
         "phpunit/phpunit": "^10.5",
-        "symfony/event-dispatcher": "^7.0"
+        "symfony/event-dispatcher": "^7.0",
+        "waaseyaa/entity": "^0.1"
+    },
+    "suggest": {
+        "fakerphp/faker": "Optional realistic strings and emails for EntityTypeFixtureValues (framework#1186)."
     },
     "autoload": {
         "psr-4": {

--- a/packages/testing/src/Factory/EntityFactory.php
+++ b/packages/testing/src/Factory/EntityFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Testing\Factory;
 
+use Waaseyaa\Entity\EntityTypeInterface;
+
 /**
  * Test data generator for entity values.
  *
@@ -59,6 +61,27 @@ final class EntityFactory
         $this->counters[$entityTypeId] = 0;
 
         return $this;
+    }
+
+    /**
+     * Register defaults from {@see EntityTypeFixtureValues} (field definitions + merged validation constraints).
+     *
+     * @param array<string, mixed> $overrides Merged into generated defaults before registering.
+     * @param (callable(string, list<\Symfony\Component\Validator\Constraint>): mixed|null)|null $customResolver
+     *   Passed to {@see EntityTypeFixtureValues}; return null to use built-in generation for that field.
+     */
+    public function defineFromEntityType(
+        EntityTypeInterface $type,
+        array $overrides = [],
+        ?int $sequence = null,
+        ?callable $customResolver = null,
+    ): self {
+        $generator = new EntityTypeFixtureValues(
+            sequence: $sequence ?? 1,
+            customResolver: $customResolver,
+        );
+
+        return $this->define($type->id(), $generator->values($type, $overrides));
     }
 
     /**

--- a/packages/testing/src/Factory/EntityTypeFixtureValues.php
+++ b/packages/testing/src/Factory/EntityTypeFixtureValues.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Testing\Factory;
+
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Type;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\Validation\EntityTypeValidationConstraints;
+
+/**
+ * Builds storage-shaped entity value bags for tests and seeds from {@see EntityTypeInterface}
+ * metadata and the same merged validation constraint map as {@see EntityTypeValidationConstraints}.
+ *
+ * Distinct from production hydration ({@see \Waaseyaa\EntityStorage\Hydration\EntityInstantiator},
+ * static `make()` / #1188): this path is for **dummy data** only (optional `fakerphp/faker` package).
+ */
+final class EntityTypeFixtureValues
+{
+    private int $sequence;
+
+    /**
+     * Optional callable(string $field, list<Constraint> $constraints): mixed|null —
+     * non-null return replaces auto-generated value; null means use built-in rules.
+     */
+    private mixed $customResolver;
+
+    public function __construct(int $sequence = 1, mixed $customResolver = null)
+    {
+        if ($customResolver !== null && !is_callable($customResolver)) {
+            throw new \InvalidArgumentException('customResolver must be callable or null.');
+        }
+
+        $this->sequence = $sequence;
+        $this->customResolver = $customResolver;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides Merged last; use for explicit nulls or replacements.
+     * @return array<string, mixed>
+     */
+    public function values(EntityTypeInterface $type, array $overrides = []): array
+    {
+        $values = [];
+        $this->applyEntityKeyDefaults($type, $values);
+
+        $constraintMap = EntityTypeValidationConstraints::forEntityType($type);
+        $fieldDefinitions = $type->getFieldDefinitions();
+
+        $allFields = array_unique(array_merge(
+            array_keys($fieldDefinitions),
+            array_keys($constraintMap),
+        ));
+        sort($allFields);
+
+        foreach ($allFields as $field) {
+            if (array_key_exists($field, $values)) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $def */
+            $def = $fieldDefinitions[$field] ?? [];
+            /** @var list<Constraint> $constraints */
+            $constraints = $constraintMap[$field] ?? [];
+
+            $resolved = $this->resolveWithCustom($field, $constraints);
+            if ($resolved !== self::useBuiltin()) {
+                $values[$field] = $resolved;
+
+                continue;
+            }
+
+            if ($constraints === []) {
+                $fallback = $this->valueFromFieldDefinitionOnly($def);
+                if ($fallback !== self::skipField()) {
+                    $values[$field] = $fallback;
+                }
+
+                continue;
+            }
+
+            $values[$field] = $this->valueFromConstraints($def, $constraints);
+        }
+
+        return array_merge($values, $overrides);
+    }
+
+    private static function useBuiltin(): \stdClass
+    {
+        static $marker = null;
+
+        return $marker ??= new \stdClass();
+    }
+
+    private static function skipField(): \stdClass
+    {
+        static $marker = null;
+
+        return $marker ??= new \stdClass();
+    }
+
+    /**
+     * @param list<Constraint> $constraints
+     */
+    private function resolveWithCustom(string $field, array $constraints): mixed
+    {
+        if ($this->customResolver === null) {
+            return self::useBuiltin();
+        }
+
+        $result = ($this->customResolver)($field, $constraints);
+
+        return $result === null ? self::useBuiltin() : $result;
+    }
+
+    private function applyEntityKeyDefaults(EntityTypeInterface $type, array &$values): void
+    {
+        $keys = $type->getKeys();
+        if ($keys === []) {
+            return;
+        }
+
+        if (isset($keys['uuid'])) {
+            $k = $keys['uuid'];
+            if (!array_key_exists($k, $values)) {
+                $values[$k] = Uuid::v4()->toRfc4122();
+            }
+        }
+
+        if (isset($keys['label'])) {
+            $k = $keys['label'];
+            if (!array_key_exists($k, $values)) {
+                $values[$k] = $this->readableString('title');
+            }
+        }
+
+        if (isset($keys['bundle'])) {
+            $k = $keys['bundle'];
+            if (!array_key_exists($k, $values)) {
+                $values[$k] = $type->id();
+            }
+        }
+
+        if (isset($keys['langcode'])) {
+            $k = $keys['langcode'];
+            if (!array_key_exists($k, $values)) {
+                $values[$k] = 'en';
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $def
+     */
+    private function valueFromFieldDefinitionOnly(array $def): mixed
+    {
+        $required = $this->truthy($def['required'] ?? false);
+        if (!$required) {
+            return self::skipField();
+        }
+
+        $type = (string) ($def['type'] ?? 'string');
+
+        return $this->scalarDefaultForFieldType($type);
+    }
+
+    /**
+     * @param array<string, mixed> $def
+     * @param list<Constraint> $constraints
+     */
+    private function valueFromConstraints(array $def, array $constraints): mixed
+    {
+        $choiceValues = null;
+        $hasEmail = false;
+        $lengthMin = null;
+        $lengthMax = null;
+        $phpTypes = [];
+        $needsNotNull = false;
+        $needsNotBlank = false;
+
+        foreach ($constraints as $c) {
+            if ($c instanceof Choice) {
+                $choiceValues = array_values($c->choices ?? []);
+            } elseif ($c instanceof Email) {
+                $hasEmail = true;
+            } elseif ($c instanceof Length) {
+                if ($c->max !== null) {
+                    $lengthMax = $lengthMax === null ? $c->max : min($lengthMax, $c->max);
+                }
+                if ($c->min !== null) {
+                    $lengthMin = $lengthMin === null ? $c->min : max($lengthMin, $c->min);
+                }
+            } elseif ($c instanceof Type) {
+                $t = $c->type;
+                if (is_string($t)) {
+                    $phpTypes[] = $t;
+                } elseif (is_array($t)) {
+                    foreach ($t as $one) {
+                        if (is_string($one)) {
+                            $phpTypes[] = $one;
+                        }
+                    }
+                }
+            } elseif ($c instanceof NotNull) {
+                $needsNotNull = true;
+            } elseif ($c instanceof NotBlank) {
+                $needsNotBlank = true;
+            }
+        }
+
+        if ($choiceValues !== null && $choiceValues !== []) {
+            $idx = ($this->sequence - 1) % count($choiceValues);
+
+            return $choiceValues[$idx];
+        }
+
+        if ($hasEmail) {
+            return $this->generatedEmail();
+        }
+
+        $fieldType = (string) ($def['type'] ?? 'string');
+        $primaryPhpType = $phpTypes[0] ?? null;
+
+        if ($primaryPhpType === 'int' || $primaryPhpType === 'float' || $fieldType === 'integer'
+            || $fieldType === 'int' || $fieldType === 'float' || $fieldType === 'double') {
+            return $this->sequence;
+        }
+
+        if ($primaryPhpType === 'bool' || $fieldType === 'boolean' || $fieldType === 'bool') {
+            return false;
+        }
+
+        if ($primaryPhpType === 'array' || $fieldType === 'array' || $fieldType === 'json') {
+            return [];
+        }
+
+        if ($fieldType === 'entity_reference' || $fieldType === 'timestamp' || $fieldType === 'datetime'
+            || $fieldType === 'datetime_immutable') {
+            return $this->sequence;
+        }
+
+        $minLen = $lengthMin ?? ($needsNotBlank || $needsNotNull ? 1 : 0);
+        if ($minLen < 1 && ($needsNotBlank || ($needsNotNull && $primaryPhpType === 'string'))) {
+            $minLen = 1;
+        }
+
+        $maxLen = $lengthMax ?? max($minLen, 32);
+
+        return $this->fixedLengthString($minLen, $maxLen);
+    }
+
+    private function fixedLengthString(int $minLen, int $maxLen): string
+    {
+        $target = min($maxLen, max($minLen, strlen('fixture') + $this->sequence));
+        $base = $this->readableString('f');
+        $out = $base;
+        while (strlen($out) < $target) {
+            $out .= $base;
+        }
+
+        if (strlen($out) > $maxLen) {
+            $out = substr($out, 0, $maxLen);
+        }
+
+        if (strlen($out) < $minLen) {
+            $out = str_pad($out, $minLen, 'x');
+        }
+
+        return $out;
+    }
+
+    private function readableString(string $prefix): string
+    {
+        if (class_exists('Faker\\Factory')) {
+            $faker = \call_user_func(['Faker\\Factory', 'create']);
+
+            return $prefix . '-' . $faker->lexify('????');
+        }
+
+        return $prefix . '-' . $this->sequence;
+    }
+
+    private function generatedEmail(): string
+    {
+        if (class_exists('Faker\\Factory')) {
+            $faker = \call_user_func(['Faker\\Factory', 'create']);
+
+            return $faker->safeEmail();
+        }
+
+        return 'fixture-' . $this->sequence . '@example.com';
+    }
+
+    private function scalarDefaultForFieldType(string $type): string|int|bool|array
+    {
+        return match ($type) {
+            'boolean', 'bool' => false,
+            'integer', 'int', 'float', 'double', 'entity_reference', 'timestamp', 'datetime', 'datetime_immutable' => $this->sequence,
+            'array', 'json' => [],
+            default => $this->readableString('v'),
+        };
+    }
+
+    private function truthy(mixed $value): bool
+    {
+        return $value === true || $value === 1 || $value === '1' || $value === 'true';
+    }
+}

--- a/packages/testing/tests/Fixture/StubFieldableEntity.php
+++ b/packages/testing/tests/Fixture/StubFieldableEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Testing\Tests\Fixture;
+
+use Waaseyaa\Entity\ContentEntityBase;
+
+/**
+ * @internal Minimal fieldable content entity for {@see EntityType} class pointers in tests.
+ */
+final class StubFieldableEntity extends ContentEntityBase
+{
+    public function __construct(array $values = [])
+    {
+        parent::__construct(
+            values: $values,
+            entityTypeId: 'stub_fieldable',
+            entityKeys: [
+                'id' => 'id',
+                'uuid' => 'uuid',
+                'label' => 'title',
+                'bundle' => 'type',
+                'langcode' => 'langcode',
+            ],
+        );
+    }
+}

--- a/packages/testing/tests/Unit/EntityFactoryTest.php
+++ b/packages/testing/tests/Unit/EntityFactoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Testing\Tests\Unit;
 
+use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Testing\Factory\EntityFactory;
+use Waaseyaa\Testing\Tests\Fixture\StubFieldableEntity;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -226,5 +228,32 @@ final class EntityFactoryTest extends TestCase
 
         $this->assertSame('user1', $user['name']);
         $this->assertSame('user1@example.com', $user['mail']);
+    }
+
+    #[Test]
+    public function defineFromEntityTypeRegistersDefaults(): void
+    {
+        $type = new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: StubFieldableEntity::class,
+            fieldDefinitions: [
+                'title' => ['type' => 'string', 'required' => true],
+                'status' => [
+                    'type' => 'string',
+                    'required' => true,
+                    'allowed_values' => ['draft', 'published'],
+                ],
+            ],
+        );
+
+        $this->factory->defineFromEntityType($type, ['title' => 'Seeded title']);
+
+        $this->assertTrue($this->factory->hasDefinition('article'));
+
+        $values = $this->factory->create('article', []);
+
+        $this->assertSame('Seeded title', $values['title']);
+        $this->assertContains($values['status'], ['draft', 'published']);
     }
 }

--- a/packages/testing/tests/Unit/EntityTypeFixtureValuesTest.php
+++ b/packages/testing/tests/Unit/EntityTypeFixtureValuesTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Testing\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\Validation\EntityTypeValidationConstraints;
+use Waaseyaa\Entity\Validation\EntityValidator;
+use Waaseyaa\Testing\Factory\EntityTypeFixtureValues;
+use Waaseyaa\Testing\Tests\Fixture\StubFieldableEntity;
+
+#[CoversClass(EntityTypeFixtureValues::class)]
+final class EntityTypeFixtureValuesTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = Validation::createValidator();
+    }
+
+    #[Test]
+    public function generatedValuesPassEntityValidator(): void
+    {
+        $type = $this->makeArticleType();
+        $values = (new EntityTypeFixtureValues(sequence: 1))->values($type);
+
+        $entity = new StubFieldableEntity($values);
+        $constraints = EntityTypeValidationConstraints::forEntityType($type);
+        $violations = (new EntityValidator($this->validator))->validate($entity, $constraints);
+
+        self::assertCount(0, $violations, (string) $violations);
+    }
+
+    #[Test]
+    public function overridesWin(): void
+    {
+        $type = $this->makeArticleType();
+        $values = (new EntityTypeFixtureValues(sequence: 1))->values($type, [
+            'title' => 'Fixed title',
+            'status' => 'draft',
+        ]);
+
+        self::assertSame('Fixed title', $values['title']);
+        self::assertSame('draft', $values['status']);
+    }
+
+    #[Test]
+    public function respectsLengthMax(): void
+    {
+        $type = new EntityType(
+            id: 'code_item',
+            label: 'Code',
+            class: StubFieldableEntity::class,
+            fieldDefinitions: [
+                'code' => ['type' => 'string', 'maxLength' => 4],
+            ],
+        );
+        $values = (new EntityTypeFixtureValues(sequence: 1))->values($type);
+
+        self::assertArrayHasKey('code', $values);
+        self::assertLessThanOrEqual(4, strlen((string) $values['code']));
+
+        $entity = new StubFieldableEntity($values);
+        $constraints = EntityTypeValidationConstraints::forEntityType($type);
+        $violations = (new EntityValidator($this->validator))->validate($entity, $constraints);
+        self::assertCount(0, $violations, (string) $violations);
+    }
+
+    #[Test]
+    public function choiceCyclesWithSequence(): void
+    {
+        $type = new EntityType(
+            id: 'status_item',
+            label: 'Status',
+            class: StubFieldableEntity::class,
+            fieldDefinitions: [
+                'status' => [
+                    'type' => 'string',
+                    'allowed_values' => ['draft', 'published'],
+                ],
+            ],
+        );
+        $first = (new EntityTypeFixtureValues(sequence: 1))->values($type);
+        $second = (new EntityTypeFixtureValues(sequence: 2))->values($type);
+
+        self::assertSame('draft', $first['status']);
+        self::assertSame('published', $second['status']);
+    }
+
+    #[Test]
+    public function emailFieldUsesValidAddress(): void
+    {
+        $type = new EntityType(
+            id: 'user_stub',
+            label: 'User',
+            class: StubFieldableEntity::class,
+            fieldDefinitions: [
+                'mail' => ['type' => 'email'],
+            ],
+        );
+        $values = (new EntityTypeFixtureValues(sequence: 3))->values($type);
+
+        self::assertStringContainsString('@', (string) $values['mail']);
+
+        $entity = new StubFieldableEntity($values);
+        $constraints = EntityTypeValidationConstraints::forEntityType($type);
+        $violations = (new EntityValidator($this->validator))->validate($entity, $constraints);
+        self::assertCount(0, $violations, (string) $violations);
+    }
+
+    #[Test]
+    public function manualConstraintsWithoutFieldDefinition(): void
+    {
+        $type = new EntityType(
+            id: 'legacy',
+            label: 'Legacy',
+            class: StubFieldableEntity::class,
+            constraints: [
+                'note' => new NotBlank(allowNull: false),
+            ],
+        );
+        $values = (new EntityTypeFixtureValues(sequence: 1))->values($type);
+
+        self::assertArrayHasKey('note', $values);
+        self::assertNotSame('', trim((string) $values['note']));
+
+        $entity = new StubFieldableEntity($values);
+        $constraints = EntityTypeValidationConstraints::forEntityType($type);
+        $violations = (new EntityValidator($this->validator))->validate($entity, $constraints);
+        self::assertCount(0, $violations, (string) $violations);
+    }
+
+    #[Test]
+    public function customResolverOverridesBuiltIn(): void
+    {
+        $type = $this->makeArticleType();
+        $values = (new EntityTypeFixtureValues(
+            sequence: 1,
+            customResolver: static fn (string $field, array $constraints): ?string => $field === 'title' ? 'From resolver' : null,
+        ))->values($type);
+
+        self::assertSame('From resolver', $values['title']);
+    }
+
+    #[Test]
+    public function entityKeyDefaultsPopulateUuidAndTitle(): void
+    {
+        $type = new EntityType(
+            id: 'node_like',
+            label: 'Node',
+            class: StubFieldableEntity::class,
+            keys: [
+                'uuid' => 'uuid',
+                'label' => 'title',
+                'bundle' => 'type',
+                'langcode' => 'langcode',
+            ],
+            fieldDefinitions: [
+                'body' => ['type' => 'text', 'required' => true],
+            ],
+        );
+        $values = (new EntityTypeFixtureValues(sequence: 1))->values($type);
+
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+            (string) $values['uuid'],
+        );
+        self::assertNotSame('', (string) $values['title']);
+        self::assertSame('node_like', $values['type']);
+        self::assertSame('en', $values['langcode']);
+    }
+
+    private function makeArticleType(): EntityTypeInterface
+    {
+        return new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: StubFieldableEntity::class,
+            fieldDefinitions: [
+                'title' => ['type' => 'string', 'required' => true],
+                'status' => [
+                    'type' => 'string',
+                    'required' => true,
+                    'allowed_values' => ['draft', 'published'],
+                ],
+                'body' => ['type' => 'text', 'required' => false],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `EntityTypeFixtureValues` in `waaseyaa/testing` to generate storage-shaped fixture arrays from `EntityTypeValidationConstraints::forEntityType()`
- add `EntityFactory::defineFromEntityType()` bridge so existing `sequence()` and `createMany()` workflows can seed defaults from entity metadata
- add coverage and docs updates for #1186, including factory vs production hydration (`make()` / `EntityInstantiator`) distinction and infrastructure-spec drift update

## Test plan
- [x] `./vendor/bin/phpunit packages/testing/tests/Unit`
- [x] `./vendor/bin/phpunit --filter 'EntityTypeFixtureValuesTest|EntityFactoryTest'`
- [x] `./vendor/bin/phpstan analyse packages/testing/src/Factory/EntityTypeFixtureValues.php packages/testing/src/Factory/EntityFactory.php --no-progress`
- [x] `./tools/drift-detector.sh`
- [x] pre-push hooks (`spec-drift`, `phpstan`, `composer-policy`, `phpunit`) passed on `git push -u origin HEAD`

Closes #1186

Made with [Cursor](https://cursor.com)