### PR TITLE
feat: alpha-119 entity architecture — duplicate re-entry, hydration, casts

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,5 +1,6 @@
 # Access Control
 
+<!-- Spec reviewed 2026-04-11 - User/UserBlock: widened constructors (optional entityTypeId, entityKeys, fieldDefinitions) for ContentEntityBase::duplicateInstance re-entry; no change to gate or policy semantics (#alpha-119) -->
 <!-- Spec reviewed 2026-04-08 - LoginController: removed session_write_close() after successful JSON login so Set-Cookie is emitted with the response (#813); no change to gate/session access semantics -->
 <!-- Spec reviewed 2026-04-07 - packages/auth composer.json: waaseyaa/* requires use ^0.1 for split/Packagist consumers (#1138); no access API change -->
 <!-- Spec reviewed 2026-04-03c - auth controller review fixes: JSON_THROW_ON_ERROR, session guard, AccountInterface null check (#571) -->

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -20,6 +20,7 @@
 <!-- Spec reviewed 2026-04-08g - symfony/* require ^7.0 on entity + entity-storage (#1151); no entity behavior change — symfony-version-floors.md -->
 <!-- Spec reviewed 2026-04-09 - backed enum invalid-value policy + value_object casts (#1184), FromArrayEntityValueInterface, EntityValues VO JSON normalization; cross-links #1181 -->
 <!-- Spec reviewed 2026-04-10 - waaseyaa/testing EntityTypeFixtureValues + EntityFactory::defineFromEntityType (#1186) -->
+<!-- Spec reviewed 2026-04-10b - P3 duplicate constructor arity contract; Hydratable scaffold; core User/Node hydration (#1188 follow-up) -->
 
 Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
 
@@ -252,6 +253,10 @@ Files: `packages/entity/src/EntityBase.php`, `packages/entity/src/ContentEntityB
 **Public API:** `EntityBase::duplicate()`, `with()`, `withValues()`; readonly `EntityValuesSnapshot`. **Extension hook:** `protected function duplicateInstance(array $values): static` (not listed as public semver surface in `docs/public-surface-map.php`).
 
 **Constructor re-entry:** `duplicate()` builds a shallow copy of the internal value bag and reconstructs the instance via `duplicateInstance()`, which must call `new $class(...)` so subclass / `ConfigEntityBase` / `ContentEntityBase` constructors run (status, dependencies, `fieldDefinitions`, etc.). Subclasses with exotic constructors may override `duplicate()` or `duplicateInstance()` explicitly; that is not the default.
+
+**Subclass constructor arity:** `ContentEntityBase::duplicateInstance()` calls `new static($values, $entityTypeId, $entityKeys, $fieldDefinitions)`. `ConfigEntityBase` inherits `EntityBase::duplicateInstance()`, which passes `($values, $entityTypeId, $entityKeys)`. A subclass that declares only `__construct(array $values = [])` will receive **too many arguments** under PHP 8+, and `duplicate()` / `with()` / `withValues()` will throw `ArgumentCountError`. Remedies: (1) **widen** `__construct` with optional `$entityTypeId`, `$entityKeys`, and (for content) `$fieldDefinitions`, defaulting to the type’s canonical id/keys and forwarding to `parent::__construct`; (2) **override** `duplicateInstance()` to reconstruct safely (e.g. `HydratableFromStorageInterface::fromStorage()` for types that implement it, plus any extra state such as `fieldDefinitions` not carried in `HydrationContext`). Regression coverage: `tests/Integration/ShippedEntityDuplicateReentryTest.php`.
+
+**Scaffold / greenfield content entities:** Prefer `HydratableFromStorageInterface` + `public static function fromStorage(array $values, HydrationContext $context): static` for storage hydration (`EntityInstantiator`), optional `public static function make(array $values): self` for tests, `$casts` for domain-shaped fields, and `get()`/`set()` in accessors (not raw `$this->values[…]`). Framework references: `packages/user/src/User.php`, `packages/node/src/Node.php`. CLI: `make:entity-type --content` emits a widening constructor stub and interface imports — adjust the machine name and keys to match your `EntityType` registration.
 
 **Shallow-copy invariant:** `duplicate()` copies top-level keys only; nested arrays / JSON-shaped structures are **not** deep-cloned and remain **reference-shared** with the source entity’s bag. Deep clone is **out of scope** for P3 and needs a dedicated design (blobs, relationship metadata, performance).
 

--- a/docs/specs/ingestion-defaults.md
+++ b/docs/specs/ingestion-defaults.md
@@ -1,5 +1,6 @@
 # Ingestion Defaults
 
+<!-- Spec reviewed 2026-04-11 - Note entity: widened constructor for duplicateInstance re-entry; no ingestion envelope or pipeline behavior change (#alpha-119) -->
 <!-- Spec reviewed 2026-04-04a - @internal annotations added to EnvelopeValidator and PayloadValidatorInterface, no behavioral changes -->
 <!-- Spec reviewed 2026-04-08 - composer manifest policy normalization for packages/ingestion and packages/note; no ingestion runtime behavior change -->
 

--- a/docs/specs/relationship-modeling.md
+++ b/docs/specs/relationship-modeling.md
@@ -1,5 +1,6 @@
 # Relationship Modeling (v0.6)
 
+<!-- Spec reviewed 2026-04-11 - Relationship entity: widened constructor for duplicateInstance re-entry; modeling and traversal semantics unchanged (#alpha-119) -->
 <!-- Spec reviewed 2026-04-07 - RelationshipParameterValidator extracted from RelationshipDiscoveryService (579→442 lines); validation/normalization helpers in dedicated class, injected as constructor dependency; timelineSortDate converted to instance method for consistent injection -->
 <!-- Spec reviewed 2026-04-09 - RelationshipTraversalService: combined relationship queries where applicable; timeline active-window predicates pushed into SQL; browse still merges/sorts hub/cluster slices in PHP with batched entity loads -->
 <!-- Spec reviewed 2026-04-09k - traversal summaries, access policy, pre-save normalization, and discovery edge context use `EntityValues` / `get()` for cast-aware values (#1181 ST-8) -->

--- a/packages/ai-pipeline/src/Pipeline.php
+++ b/packages/ai-pipeline/src/Pipeline.php
@@ -27,9 +27,15 @@ final class Pipeline extends ConfigEntityBase
 
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
+        $this->steps = [];
+
         if (\array_key_exists('description', $values)) {
             $this->description = (string) $values['description'];
         }
@@ -52,11 +58,10 @@ final class Pipeline extends ConfigEntityBase
 
         $this->syncStepsToValues();
 
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'pipeline',
-            entityKeys: ['id' => 'id', 'label' => 'label'],
-        );
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'pipeline';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : ['id' => 'id', 'label' => 'label'];
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/packages/cli/src/Command/MakeEntityTypeCommand.php
+++ b/packages/cli/src/Command/MakeEntityTypeCommand.php
@@ -27,13 +27,94 @@ class MakeEntityTypeCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = $input->getArgument('name');
-        $isContent = $input->getOption('content');
+        $isContent = (bool) $input->getOption('content');
 
         $className = str_replace('_', '', ucwords($name, '_'));
         $baseClass = $isContent ? 'ContentEntityBase' : 'ConfigEntityBase';
         $baseImport = $isContent
             ? 'use Waaseyaa\Entity\ContentEntityBase;'
             : 'use Waaseyaa\Entity\ConfigEntityBase;';
+
+        $hydrationUse = $isContent
+            ? "use Waaseyaa\\Entity\\Hydration\\HydratableFromStorageInterface;\nuse Waaseyaa\\Entity\\Hydration\\HydrationContext;"
+            : '';
+
+        $implements = $isContent ? ' implements HydratableFromStorageInterface' : '';
+
+        $extraBody = '';
+        if ($isContent) {
+            $extraBody = <<<'PHP'
+
+    /**
+     * Widen the constructor so {@see \Waaseyaa\Entity\ContentEntityBase::duplicateInstance()} can reconstruct instances.
+     * Replace the defaults below with your entity type id and key map (must match EntityType registration).
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'CHANGE_ME';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : [
+            'id' => 'id',
+            'uuid' => 'uuid',
+            'label' => 'label',
+        ];
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public static function make(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function fromStorage(array $values, HydrationContext $context): static
+    {
+        return new self(
+            values: $values,
+            entityTypeId: $context->entityTypeId,
+            entityKeys: $context->entityKeys,
+            fieldDefinitions: [],
+        );
+    }
+
+    protected function duplicateInstance(array $values): static
+    {
+        return new static(
+            values: $values,
+            entityTypeId: $this->getEntityTypeId(),
+            entityKeys: $this->entityKeys,
+            fieldDefinitions: $this->getFieldDefinitions(),
+        );
+    }
+PHP;
+        } else {
+            $extraBody = <<<'PHP'
+
+    /**
+     * Widen the constructor so {@see \Waaseyaa\Entity\EntityBase::duplicateInstance()} can reconstruct instances.
+     * Replace the defaults below with your entity type id and key map (must match EntityType registration).
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'CHANGE_ME';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : [
+            'id' => 'id',
+            'label' => 'label',
+        ];
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
+    }
+PHP;
+        }
 
         $template = <<<PHP
 <?php
@@ -43,9 +124,11 @@ declare(strict_types=1);
 namespace App\Entity;
 
 {$baseImport}
+{$hydrationUse}
 
-class {$className} extends {$baseClass}
+class {$className} extends {$baseClass}{$implements}
 {
+{$extraBody}
 }
 
 PHP;

--- a/packages/cli/tests/Unit/Command/MakeEntityTypeCommandTest.php
+++ b/packages/cli/tests/Unit/Command/MakeEntityTypeCommandTest.php
@@ -29,6 +29,8 @@ class MakeEntityTypeCommandTest extends TestCase
         $this->assertStringContainsString('class Event extends ConfigEntityBase', $output);
         $this->assertStringContainsString('use Waaseyaa\\Entity\\ConfigEntityBase;', $output);
         $this->assertStringContainsString('declare(strict_types=1);', $output);
+        $this->assertStringContainsString('string $entityTypeId = \'\'', $output);
+        $this->assertStringContainsString('CHANGE_ME', $output);
     }
 
     #[Test]
@@ -44,5 +46,8 @@ class MakeEntityTypeCommandTest extends TestCase
         $output = $tester->getDisplay();
         $this->assertStringContainsString('class Article extends ContentEntityBase', $output);
         $this->assertStringContainsString('use Waaseyaa\\Entity\\ContentEntityBase;', $output);
+        $this->assertStringContainsString('HydratableFromStorageInterface', $output);
+        $this->assertStringContainsString('function fromStorage', $output);
+        $this->assertStringContainsString('function make', $output);
     }
 }

--- a/packages/engagement/src/Comment.php
+++ b/packages/engagement/src/Comment.php
@@ -16,9 +16,16 @@ final class Comment extends ContentEntityBase
         'label' => 'body',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         foreach (['user_id', 'target_type', 'target_id', 'body'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -32,6 +39,9 @@ final class Comment extends ContentEntityBase
             $values['created_at'] = time();
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/engagement/src/Follow.php
+++ b/packages/engagement/src/Follow.php
@@ -16,9 +16,16 @@ final class Follow extends ContentEntityBase
         'label' => 'target_type',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         foreach (['user_id', 'target_type', 'target_id'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -29,6 +36,9 @@ final class Follow extends ContentEntityBase
             $values['created_at'] = time();
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/engagement/src/Reaction.php
+++ b/packages/engagement/src/Reaction.php
@@ -18,10 +18,16 @@ final class Reaction extends ContentEntityBase
 
     /**
      * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      * @param list<string>|null $allowedReactionTypes Allowed types (null = accept any non-empty string)
      */
-    public function __construct(array $values = [], ?array $allowedReactionTypes = null)
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+        ?array $allowedReactionTypes = null,
+    ) {
         foreach (['user_id', 'target_type', 'target_id', 'reaction_type'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -38,6 +44,9 @@ final class Reaction extends ContentEntityBase
             $values['created_at'] = time();
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/media/src/Media.php
+++ b/packages/media/src/Media.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Media;
 
+use DateTimeInterface;
 use Waaseyaa\Entity\ContentEntityBase;
 
 /**
@@ -15,18 +16,32 @@ use Waaseyaa\Entity\ContentEntityBase;
  */
 final class Media extends ContentEntityBase
 {
-    public function __construct(array $values = [])
-    {
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'media',
-            entityKeys: [
-                'id' => 'mid',
-                'uuid' => 'uuid',
-                'label' => 'name',
-                'bundle' => 'bundle',
-            ],
-        );
+    /**
+     * @var array<string, string|array<string, mixed>>
+     */
+    protected array $casts = [
+        'created' => ['type' => 'datetime_immutable', 'storage' => 'unix'],
+        'changed' => ['type' => 'datetime_immutable', 'storage' => 'unix'],
+    ];
+
+    /**
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'media';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : [
+            'id' => 'mid',
+            'uuid' => 'uuid',
+            'label' => 'name',
+            'bundle' => 'bundle',
+        ];
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 
     /**
@@ -99,8 +114,14 @@ final class Media extends ContentEntityBase
     public function getCreatedTime(): ?int
     {
         $created = $this->get('created');
+        if ($created === null) {
+            return null;
+        }
+        if ($created instanceof DateTimeInterface) {
+            return $created->getTimestamp();
+        }
 
-        return $created !== null ? (int) $created : null;
+        return (int) $created;
     }
 
     /**
@@ -119,8 +140,14 @@ final class Media extends ContentEntityBase
     public function getChangedTime(): ?int
     {
         $changed = $this->get('changed');
+        if ($changed === null) {
+            return null;
+        }
+        if ($changed instanceof DateTimeInterface) {
+            return $changed->getTimestamp();
+        }
 
-        return $changed !== null ? (int) $changed : null;
+        return (int) $changed;
     }
 
     /**

--- a/packages/media/src/MediaType.php
+++ b/packages/media/src/MediaType.php
@@ -32,8 +32,14 @@ final class MediaType extends ConfigEntityBase
      */
     protected array $sourceConfiguration = [];
 
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
         // Extract media-type-specific values before passing to parent.
         if (isset($values['source']) && \is_string($values['source'])) {
             $this->source = $values['source'];
@@ -47,11 +53,10 @@ final class MediaType extends ConfigEntityBase
             $this->sourceConfiguration = $values['source_configuration'];
         }
 
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'media_type',
-            entityKeys: ['id' => 'id', 'label' => 'label'],
-        );
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'media_type';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : ['id' => 'id', 'label' => 'label'];
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/packages/menu/src/Menu.php
+++ b/packages/menu/src/Menu.php
@@ -28,9 +28,13 @@ final class Menu extends ConfigEntityBase
 
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
         if (\array_key_exists('description', $values)) {
             $this->description = (string) $values['description'];
         }
@@ -39,11 +43,10 @@ final class Menu extends ConfigEntityBase
             $this->locked = (bool) $values['locked'];
         }
 
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'menu',
-            entityKeys: ['id' => 'id', 'label' => 'label'],
-        );
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'menu';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : ['id' => 'id', 'label' => 'label'];
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/packages/menu/src/MenuLink.php
+++ b/packages/menu/src/MenuLink.php
@@ -16,9 +16,14 @@ final class MenuLink extends ContentEntityBase
 {
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         // Set defaults for optional values.
         $values += [
             'enabled' => true,
@@ -27,16 +32,15 @@ final class MenuLink extends ContentEntityBase
             'parent_id' => null,
         ];
 
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'menu_link',
-            entityKeys: [
-                'id' => 'id',
-                'uuid' => 'uuid',
-                'label' => 'title',
-                'bundle' => 'menu_name',
-            ],
-        );
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'menu_link';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : [
+            'id' => 'id',
+            'uuid' => 'uuid',
+            'label' => 'title',
+            'bundle' => 'menu_name',
+        ];
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 
     /**

--- a/packages/messaging/src/MessageThread.php
+++ b/packages/messaging/src/MessageThread.php
@@ -16,9 +16,16 @@ final class MessageThread extends ContentEntityBase
         'label' => 'title',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         if (!isset($values['created_by'])) {
             throw new \InvalidArgumentException('Missing required field: created_by');
         }
@@ -42,6 +49,9 @@ final class MessageThread extends ContentEntityBase
             $values['last_message_at'] = $values['created_at'];
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/messaging/src/ThreadMessage.php
+++ b/packages/messaging/src/ThreadMessage.php
@@ -16,9 +16,16 @@ final class ThreadMessage extends ContentEntityBase
         'label' => 'body',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         foreach (['thread_id', 'sender_id', 'body'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -44,6 +51,9 @@ final class ThreadMessage extends ContentEntityBase
             $values['deleted_at'] = null;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/messaging/src/ThreadParticipant.php
+++ b/packages/messaging/src/ThreadParticipant.php
@@ -16,9 +16,16 @@ final class ThreadParticipant extends ContentEntityBase
         'label' => 'role',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         foreach (['thread_id', 'user_id', 'thread_creator_id'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -38,6 +45,9 @@ final class ThreadParticipant extends ContentEntityBase
             $values['last_read_at'] = 0;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/node/src/Node.php
+++ b/packages/node/src/Node.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Node;
 
+use DateTimeInterface;
 use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\Hydration\HydratableFromStorageInterface;
+use Waaseyaa\Entity\Hydration\HydrationContext;
 
 /**
  * Represents a piece of content (a node).
@@ -13,7 +16,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * to a node type (bundle) and has properties like title, author, status,
  * and timestamps.
  */
-final class Node extends ContentEntityBase
+final class Node extends ContentEntityBase implements HydratableFromStorageInterface
 {
     protected string $entityTypeId = 'node';
 
@@ -25,10 +28,23 @@ final class Node extends ContentEntityBase
     ];
 
     /**
-     * @param array<string, mixed> $values Initial entity values.
+     * @var array<string, string|array<string, mixed>>
      */
-    public function __construct(array $values = [])
-    {
+    protected array $casts = [
+        'created' => ['type' => 'datetime_immutable', 'storage' => 'unix'],
+        'changed' => ['type' => 'datetime_immutable', 'storage' => 'unix'],
+    ];
+
+    /**
+     * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         // Ensure defaults for optional properties.
         if (!array_key_exists('status', $values)) {
             $values['status'] = 1;
@@ -46,7 +62,38 @@ final class Node extends ContentEntityBase
             $values['changed'] = 0;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public static function make(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function fromStorage(array $values, HydrationContext $context): static
+    {
+        return new self(
+            values: $values,
+            entityTypeId: $context->entityTypeId,
+            entityKeys: $context->entityKeys,
+            fieldDefinitions: [],
+        );
+    }
+
+    protected function duplicateInstance(array $values): static
+    {
+        return new static(
+            values: $values,
+            entityTypeId: $this->getEntityTypeId(),
+            entityKeys: $this->entityKeys,
+            fieldDefinitions: $this->getFieldDefinitions(),
+        );
     }
 
     /**
@@ -152,7 +199,12 @@ final class Node extends ContentEntityBase
      */
     public function getCreatedTime(): int
     {
-        return (int) ($this->get('created') ?? 0);
+        $v = $this->get('created');
+        if ($v instanceof DateTimeInterface) {
+            return $v->getTimestamp();
+        }
+
+        return (int) ($v ?? 0);
     }
 
     /**
@@ -170,7 +222,12 @@ final class Node extends ContentEntityBase
      */
     public function getChangedTime(): int
     {
-        return (int) ($this->get('changed') ?? 0);
+        $v = $this->get('changed');
+        if ($v instanceof DateTimeInterface) {
+            return $v->getTimestamp();
+        }
+
+        return (int) ($v ?? 0);
     }
 
     /**

--- a/packages/node/src/NodeType.php
+++ b/packages/node/src/NodeType.php
@@ -24,9 +24,13 @@ final class NodeType extends ConfigEntityBase
 
     /**
      * @param array<string, mixed> $values Initial config values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
         // Ensure defaults for optional properties.
         if (!array_key_exists('description', $values)) {
             $values['description'] = '';
@@ -38,7 +42,10 @@ final class NodeType extends ConfigEntityBase
             $values['display_submitted'] = true;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/packages/note/src/Note.php
+++ b/packages/note/src/Note.php
@@ -24,10 +24,18 @@ final class Note extends ContentEntityBase
 
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 
     public function getTitle(): string

--- a/packages/path/src/PathAlias.php
+++ b/packages/path/src/PathAlias.php
@@ -17,25 +17,29 @@ final class PathAlias extends ContentEntityBase
 {
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         // Set defaults before passing to parent.
         $values += [
             'langcode' => 'en',
             'status' => true,
         ];
 
-        parent::__construct(
-            values: $values,
-            entityTypeId: 'path_alias',
-            entityKeys: [
-                'id' => 'id',
-                'uuid' => 'uuid',
-                'label' => 'alias',
-                'langcode' => 'langcode',
-            ],
-        );
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : 'path_alias';
+        $entityKeys = $entityKeys !== [] ? $entityKeys : [
+            'id' => 'id',
+            'uuid' => 'uuid',
+            'label' => 'alias',
+            'langcode' => 'langcode',
+        ];
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 
     /**

--- a/packages/relationship/src/Relationship.php
+++ b/packages/relationship/src/Relationship.php
@@ -20,14 +20,22 @@ final class Relationship extends ContentEntityBase
 
     /**
      * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         $values += [
             'directionality' => 'directed',
             'status' => 1,
         ];
 
-        parent::__construct($values, self::ENTITY_TYPE_ID, self::ENTITY_KEYS);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : self::ENTITY_TYPE_ID;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : self::ENTITY_KEYS;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/ssr/src/Formatter/DateFormatter.php
+++ b/packages/ssr/src/Formatter/DateFormatter.php
@@ -18,6 +18,10 @@ final class DateFormatter implements FieldFormatterInterface
             return '';
         }
 
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value)->format($format);
+        }
+
         try {
             $date = is_numeric($value)
                 ? new \DateTimeImmutable('@' . (int) $value)

--- a/packages/ssr/tests/Unit/FieldFormatterRegistryTest.php
+++ b/packages/ssr/tests/Unit/FieldFormatterRegistryTest.php
@@ -35,6 +35,10 @@ final class FieldFormatterRegistryTest extends TestCase
         $registry = new FieldFormatterRegistry();
 
         $this->assertSame('2026-01-05', $registry->format('datetime', 1767571200, ['format' => 'Y-m-d']));
+        $this->assertSame(
+            '2025-01-01',
+            $registry->format('datetime', new \DateTimeImmutable('@1735689600'), ['format' => 'Y-m-d']),
+        );
         $this->assertSame('Published', $registry->format('boolean', true, ['true_label' => 'Published']));
         $this->assertSame('<img src="/files/a.jpg" alt="Hero" class="image-style-large">', $registry->format('image', '/files/a.jpg', ['alt' => 'Hero', 'image_style' => 'large']));
     }

--- a/packages/taxonomy/src/Term.php
+++ b/packages/taxonomy/src/Term.php
@@ -26,9 +26,14 @@ final class Term extends ContentEntityBase
 
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         // Ensure defaults for optional properties.
         if (!array_key_exists('description', $values)) {
             $values['description'] = '';
@@ -43,7 +48,10 @@ final class Term extends ContentEntityBase
             $values['status'] = true;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 
     /**
@@ -59,9 +67,7 @@ final class Term extends ContentEntityBase
      */
     public function setName(string $name): static
     {
-        $this->values['name'] = $name;
-
-        return $this;
+        return $this->set('name', $name);
     }
 
     /**
@@ -77,7 +83,7 @@ final class Term extends ContentEntityBase
      */
     public function getDescription(): string
     {
-        return (string) ($this->values['description'] ?? '');
+        return (string) ($this->get('description') ?? '');
     }
 
     /**
@@ -85,9 +91,7 @@ final class Term extends ContentEntityBase
      */
     public function setDescription(string $description): static
     {
-        $this->values['description'] = $description;
-
-        return $this;
+        return $this->set('description', $description);
     }
 
     /**
@@ -95,7 +99,7 @@ final class Term extends ContentEntityBase
      */
     public function getWeight(): int
     {
-        return (int) ($this->values['weight'] ?? 0);
+        return (int) ($this->get('weight') ?? 0);
     }
 
     /**
@@ -103,9 +107,7 @@ final class Term extends ContentEntityBase
      */
     public function setWeight(int $weight): static
     {
-        $this->values['weight'] = $weight;
-
-        return $this;
+        return $this->set('weight', $weight);
     }
 
     /**
@@ -113,7 +115,7 @@ final class Term extends ContentEntityBase
      */
     public function getParentId(): ?int
     {
-        $parentId = $this->values['parent_id'] ?? null;
+        $parentId = $this->get('parent_id');
 
         if ($parentId === null || $parentId === 0) {
             return $parentId === 0 ? 0 : null;
@@ -129,9 +131,7 @@ final class Term extends ContentEntityBase
      */
     public function setParentId(?int $parentId): static
     {
-        $this->values['parent_id'] = $parentId;
-
-        return $this;
+        return $this->set('parent_id', $parentId);
     }
 
     /**
@@ -139,7 +139,7 @@ final class Term extends ContentEntityBase
      */
     public function isRoot(): bool
     {
-        $parentId = $this->values['parent_id'] ?? null;
+        $parentId = $this->get('parent_id');
 
         return $parentId === null || $parentId === 0;
     }
@@ -149,7 +149,7 @@ final class Term extends ContentEntityBase
      */
     public function isPublished(): bool
     {
-        return (bool) ($this->values['status'] ?? true);
+        return (bool) ($this->get('status') ?? true);
     }
 
     /**
@@ -157,8 +157,6 @@ final class Term extends ContentEntityBase
      */
     public function setPublished(bool $published): static
     {
-        $this->values['status'] = $published;
-
-        return $this;
+        return $this->set('status', $published);
     }
 }

--- a/packages/taxonomy/src/Vocabulary.php
+++ b/packages/taxonomy/src/Vocabulary.php
@@ -24,9 +24,13 @@ final class Vocabulary extends ConfigEntityBase
 
     /**
      * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
         // Ensure defaults for optional properties.
         if (!array_key_exists('description', $values)) {
             $values['description'] = '';
@@ -35,7 +39,10 @@ final class Vocabulary extends ConfigEntityBase
             $values['weight'] = 0;
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/packages/user/src/User.php
+++ b/packages/user/src/User.php
@@ -6,6 +6,8 @@ namespace Waaseyaa\User;
 
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\Hydration\HydratableFromStorageInterface;
+use Waaseyaa\Entity\Hydration\HydrationContext;
 
 /**
  * The User content entity.
@@ -19,7 +21,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * service) is responsible for populating the permissions from role
  * definitions.
  */
-final class User extends ContentEntityBase implements AccountInterface
+final class User extends ContentEntityBase implements AccountInterface, HydratableFromStorageInterface
 {
     /**
      * The entity type machine name.
@@ -36,10 +38,23 @@ final class User extends ContentEntityBase implements AccountInterface
     ];
 
     /**
-     * @param array<string, mixed> $values Initial entity values.
+     * @var array<string, string|array<string, mixed>>
      */
-    public function __construct(array $values = [])
-    {
+    protected array $casts = [
+        // status stays 0/1 in storage and in get()/validate(); use isActive() for booleans.
+        'email_verified' => 'bool',
+    ];
+
+    /**
+     * @param array<string, mixed> $values Initial entity values.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         // Ensure sensible defaults.
         $hasUid = isset($values['uid']);
 
@@ -49,13 +64,44 @@ final class User extends ContentEntityBase implements AccountInterface
             'status' => 1,
         ];
 
-        parent::__construct($values, self::ENTITY_TYPE_ID, self::ENTITY_KEYS);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : self::ENTITY_TYPE_ID;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : self::ENTITY_KEYS;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
 
         // Since id() always returns int (never null), EntityBase::isNew()
         // can never detect "new" via id() === null. Mark explicitly.
         if (!$hasUid) {
             $this->enforceIsNew();
         }
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public static function make(array $values): self
+    {
+        return new self($values);
+    }
+
+    public static function fromStorage(array $values, HydrationContext $context): static
+    {
+        return new self(
+            values: $values,
+            entityTypeId: $context->entityTypeId,
+            entityKeys: $context->entityKeys,
+            fieldDefinitions: [],
+        );
+    }
+
+    protected function duplicateInstance(array $values): static
+    {
+        return new static(
+            values: $values,
+            entityTypeId: $this->getEntityTypeId(),
+            entityKeys: $this->entityKeys,
+            fieldDefinitions: $this->getFieldDefinitions(),
+        );
     }
 
     // -----------------------------------------------------------------
@@ -252,7 +298,7 @@ final class User extends ContentEntityBase implements AccountInterface
      */
     public function isActive(): bool
     {
-        return (int) ($this->get('status') ?? 0) === 1;
+        return (bool) ($this->get('status') ?? false);
     }
 
     /**
@@ -272,7 +318,7 @@ final class User extends ContentEntityBase implements AccountInterface
      */
     public function isEmailVerified(): bool
     {
-        return (int) ($this->get('email_verified') ?? 0) === 1;
+        return (bool) ($this->get('email_verified') ?? false);
     }
 
     /**

--- a/packages/user/src/UserBlock.php
+++ b/packages/user/src/UserBlock.php
@@ -16,9 +16,16 @@ final class UserBlock extends ContentEntityBase
         'label' => 'blocker_id',
     ];
 
-    /** @param array<string, mixed> $values */
-    public function __construct(array $values = [])
-    {
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see ContentEntityBase::duplicateInstance()}.
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
         foreach (['blocker_id', 'blocked_id'] as $field) {
             if (!isset($values[$field])) {
                 throw new \InvalidArgumentException("Missing required field: {$field}");
@@ -33,6 +40,9 @@ final class UserBlock extends ContentEntityBase
             $values['created_at'] = time();
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 }

--- a/packages/workflows/src/Workflow.php
+++ b/packages/workflows/src/Workflow.php
@@ -41,9 +41,16 @@ final class Workflow extends ConfigEntityBase
     /**
      * @param array<string, mixed> $values Initial entity values. May include
      *   'states' and 'transitions' arrays for hydration from config.
+     * @param array<string, string> $entityKeys Explicit keys when reconstructing via {@see EntityBase::duplicateInstance()}.
      */
-    public function __construct(array $values = [])
-    {
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+    ) {
+        $this->states = [];
+        $this->transitions = [];
+
         // Extract and hydrate states from values before passing to parent.
         if (isset($values['states']) && \is_array($values['states'])) {
             foreach ($values['states'] as $stateId => $stateData) {
@@ -77,7 +84,10 @@ final class Workflow extends ConfigEntityBase
             }
         }
 
-        parent::__construct($values, $this->entityTypeId, $this->entityKeys);
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : $this->entityTypeId;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : $this->entityKeys;
+
+        parent::__construct($values, $entityTypeId, $entityKeys);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -547,12 +547,6 @@ parameters:
 			path: packages/cli/src/Command/Make/MakeTestCommand.php
 
 		-
-			message: '#^Only booleans are allowed in a ternary operator condition, mixed given\.$#'
-			identifier: ternary.condNotBoolean
-			count: 2
-			path: packages/cli/src/Command/MakeEntityTypeCommand.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, mixed given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 2

--- a/tests/Integration/ShippedEntityDuplicateReentryTest.php
+++ b/tests/Integration/ShippedEntityDuplicateReentryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\AI\Pipeline\Pipeline;
+use Waaseyaa\Engagement\Comment;
+use Waaseyaa\Engagement\Follow;
+use Waaseyaa\Engagement\Reaction;
+use Waaseyaa\Media\Media;
+use Waaseyaa\Media\MediaType;
+use Waaseyaa\Menu\Menu;
+use Waaseyaa\Menu\MenuLink;
+use Waaseyaa\Messaging\MessageThread;
+use Waaseyaa\Messaging\ThreadMessage;
+use Waaseyaa\Messaging\ThreadParticipant;
+use Waaseyaa\Node\Node;
+use Waaseyaa\Node\NodeType;
+use Waaseyaa\Note\Note;
+use Waaseyaa\Path\PathAlias;
+use Waaseyaa\Relationship\Relationship;
+use Waaseyaa\Taxonomy\Term;
+use Waaseyaa\Taxonomy\Vocabulary;
+use Waaseyaa\User\User;
+use Waaseyaa\User\UserBlock;
+use Waaseyaa\Workflows\Workflow;
+
+/**
+ * Ensures {@see \Waaseyaa\Entity\EntityBase::duplicate()} can reconstruct subclasses
+ * whose public constructors accept the full parent arity (P3 / #1188 follow-up).
+ */
+#[CoversNothing]
+final class ShippedEntityDuplicateReentryTest extends TestCase
+{
+    #[Test]
+    public function duplicate_and_with_round_trip_core_content_entities(): void
+    {
+        $user = new User(['uid' => 1, 'name' => 'a', 'mail' => 'a@x.test']);
+        $this->assertNotSame($user, $user->duplicate());
+        $this->assertSame('b', $user->with('name', 'b')->getName());
+        $this->assertSame('a', $user->getName(), 'with() must not mutate the original entity');
+
+        $node = new Node(['type' => 'page', 'title' => 'T', 'uid' => 1]);
+        $this->assertNotSame($node, $node->duplicate());
+        $this->assertSame('U', $node->with('title', 'U')->getTitle());
+
+        $note = new Note(['title' => 'N', 'body' => '']);
+        $this->assertNotSame($note, $note->duplicate());
+
+        $term = new Term(['vid' => 'tags', 'name' => 'tag1']);
+        $this->assertNotSame($term, $term->duplicate());
+
+        $media = new Media(['bundle' => 'file', 'name' => 'f']);
+        $this->assertNotSame($media, $media->duplicate());
+
+        $alias = new PathAlias(['path' => '/node/1', 'alias' => '/about']);
+        $this->assertNotSame($alias, $alias->duplicate());
+
+        $link = new MenuLink(['title' => 'Home', 'url' => '/', 'menu_name' => 'main']);
+        $this->assertNotSame($link, $link->duplicate());
+
+        $rel = new Relationship([
+            'relationship_type' => 'mentions',
+            'source_entity_type' => 'node',
+            'source_entity_id' => 1,
+            'target_entity_type' => 'node',
+            'target_entity_id' => 2,
+        ]);
+        $this->assertNotSame($rel, $rel->duplicate());
+
+        $reaction = new Reaction([
+            'user_id' => 1,
+            'target_type' => 'post',
+            'target_id' => 1,
+            'reaction_type' => 'like',
+        ]);
+        $this->assertNotSame($reaction, $reaction->duplicate());
+
+        $comment = new Comment([
+            'user_id' => 1,
+            'target_type' => 'post',
+            'target_id' => 1,
+            'body' => 'Hello',
+        ]);
+        $this->assertNotSame($comment, $comment->duplicate());
+
+        $follow = new Follow([
+            'user_id' => 1,
+            'target_type' => 'user',
+            'target_id' => 2,
+        ]);
+        $this->assertNotSame($follow, $follow->duplicate());
+
+        $block = new UserBlock(['blocker_id' => 1, 'blocked_id' => 2]);
+        $this->assertNotSame($block, $block->duplicate());
+
+        $thread = new MessageThread(['created_by' => 1]);
+        $this->assertNotSame($thread, $thread->duplicate());
+
+        $participant = new ThreadParticipant([
+            'thread_id' => 1,
+            'user_id' => 2,
+            'thread_creator_id' => 1,
+        ]);
+        $this->assertNotSame($participant, $participant->duplicate());
+
+        $message = new ThreadMessage([
+            'thread_id' => 1,
+            'sender_id' => 1,
+            'body' => 'Hi',
+        ]);
+        $this->assertNotSame($message, $message->duplicate());
+    }
+
+    #[Test]
+    public function duplicate_config_entities(): void
+    {
+        $nodeType = new NodeType([
+            'type' => 'article',
+            'name' => 'Article',
+        ]);
+        $this->assertNotSame($nodeType, $nodeType->duplicate());
+
+        $voc = new Vocabulary([
+            'vid' => 'tags',
+            'name' => 'Tags',
+        ]);
+        $this->assertNotSame($voc, $voc->duplicate());
+
+        $mediaType = new MediaType([
+            'id' => 'image',
+            'label' => 'Image',
+            'source' => 'file',
+        ]);
+        $this->assertNotSame($mediaType, $mediaType->duplicate());
+
+        $menu = new Menu([
+            'id' => 'main',
+            'label' => 'Main',
+        ]);
+        $this->assertNotSame($menu, $menu->duplicate());
+
+        $workflow = new Workflow([
+            'id' => 'editorial',
+            'label' => 'Editorial',
+        ]);
+        $this->assertNotSame($workflow, $workflow->duplicate());
+
+        $pipeline = new Pipeline([
+            'id' => 'default',
+            'label' => 'Default',
+        ]);
+        $this->assertNotSame($pipeline, $pipeline->duplicate());
+    }
+}

--- a/tests/Integration/UserNodeEntityInstantiatorTest.php
+++ b/tests/Integration/UserNodeEntityInstantiatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Hydration\EntityInstantiator;
+use Waaseyaa\Node\Node;
+use Waaseyaa\User\User;
+
+#[CoversNothing]
+final class UserNodeEntityInstantiatorTest extends TestCase
+{
+    #[Test]
+    public function entityInstantiatorLoadsUserViaFromStorage(): void
+    {
+        $entityType = new EntityType(
+            id: 'user',
+            label: 'User',
+            class: User::class,
+            keys: [
+                'id' => 'uid',
+                'uuid' => 'uuid',
+                'label' => 'name',
+            ],
+        );
+
+        $entity = (new EntityInstantiator($entityType))->instantiate(User::class, [
+            'uid' => 5,
+            'name' => 'entity',
+            'mail' => 'e@example.test',
+            'uuid' => '550e8400-e29b-41d4-a716-446655440000',
+        ]);
+
+        $this->assertInstanceOf(User::class, $entity);
+        $this->assertSame(5, $entity->id());
+        $this->assertSame('entity', $entity->getName());
+    }
+
+    #[Test]
+    public function entityInstantiatorLoadsNodeViaFromStorage(): void
+    {
+        $entityType = new EntityType(
+            id: 'node',
+            label: 'Node',
+            class: Node::class,
+            keys: [
+                'id' => 'nid',
+                'uuid' => 'uuid',
+                'label' => 'title',
+                'bundle' => 'type',
+            ],
+        );
+
+        $entity = (new EntityInstantiator($entityType))->instantiate(Node::class, [
+            'nid' => 9,
+            'type' => 'page',
+            'title' => 'Hello',
+            'uid' => 1,
+            'uuid' => '660e8400-e29b-41d4-a716-446655440001',
+        ]);
+
+        $this->assertInstanceOf(Node::class, $entity);
+        $this->assertSame(9, $entity->id());
+        $this->assertSame('Hello', $entity->getTitle());
+        $this->assertSame('page', $entity->getType());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the alpha-119 entity architecture audit follow-through:

- **P3 / duplicate re-entry:** Widens shipped `ContentEntityBase` / `ConfigEntityBase` subclass constructors (optional `entityTypeId`, `entityKeys`, `fieldDefinitions` where applicable) so `duplicate()`, `with()`, and `withValues()` no longer throw `ArgumentCountError`.
- **Hydration:** `User` and `Node` implement `HydratableFromStorageInterface` with `make()`, `fromStorage()`, and `duplicateInstance()` preserving field definitions on Node/User.
- **Casts:** Node/Media datetime (`unix` storage); User `email_verified` bool (`status` stays int for `EntityValidator` + `AllowedValues`).
- **SSR:** `DateFormatter` accepts `DateTimeInterface` for cast-aware node timestamps.
- **CLI:** `make:entity-type` scaffolds hydratable content entities; content flag cast for PHPStan.
- **Docs:** `entity-system.md` P3 + hydratable notes; spec review markers for access-control, ingestion-defaults, relationship-modeling.
- **Tests:** `ShippedEntityDuplicateReentryTest`, `UserNodeEntityInstantiatorTest`; DateFormatter registry test.
- **Chore:** Drop stale PHPStan baseline entries for `MakeEntityTypeCommand`.

## Checklist

Closes #(add issue — optional; link alpha-119 / entity audit issue if filed)

- [ ] `Closes #N` references the tracking issue (if any)
- [ ] Issue assigned to a milestone (repo policy)
- [x] Spec drift + pre-push hooks pass locally


Made with [Cursor](https://cursor.com)