### PR TITLE
feat(#1128): add EntityTypeManager::getRepository() with kernel factory

### DIFF
--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -327,8 +327,13 @@ interface EntityTypeManagerInterface
     public function getDefinitions(): array;        // array<string, EntityTypeInterface>
     public function hasDefinition(string $entityTypeId): bool;
     public function getStorage(string $entityTypeId): EntityStorageInterface;
+    public function getRepository(string $entityTypeId): EntityRepositoryInterface;
 }
 ```
+
+`getStorage()` returns the legacy `EntityStorageInterface` implementation (typically `SqlEntityStorage`) created via the optional storage factory.
+
+`getRepository()` returns `EntityRepositoryInterface` (the driver-backed repository with hydration, validation hooks, and transactional batch APIs). The kernel registers a repository factory alongside the storage factory so consumers can wrap `EntityTypeManager::getRepository($entityTypeId)` in thin domain repositories without manually assembling `SqlStorageDriver`, `RevisionableStorageDriver`, and `EntityRepository` dependencies.
 
 ### EntityStorageInterface
 
@@ -1277,7 +1282,7 @@ class FieldType extends WaaseyaaPlugin
 - `FieldableInterface.php` -- hasField, get, set, getFieldDefinitions
 - `EntityType.php` -- final readonly value object for entity type definitions
 - `EntityTypeInterface.php` -- entity type definition contract
-- `EntityTypeManager.php` -- registry with storage factory support
+- `EntityTypeManager.php` -- registry with storage factory and optional repository factory (`getRepository()`)
 - `EntityTypeManagerInterface.php` -- manager contract
 - `EntityConstants.php` -- SAVED_NEW (1), SAVED_UPDATED (2)
 - `TranslatableInterface.php` -- translation contract

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -10,6 +10,7 @@
 <!-- Spec reviewed 2026-04-08c - entity, entity-storage, queue, routing, typed-data, validation Symfony floors to ^7.0; see symfony-version-floors.md (#1151) -->
 <!-- Spec reviewed 2026-04-09 - typed-data: EntityCastCoercion, CoercionException, CastTokenMapper; entity ValueCaster delegates builtins (#1185); public surface map extended -->
 <!-- Spec reviewed 2026-04-10 - testing package EntityTypeFixtureValues + EntityFactory::defineFromEntityType (#1186) -->
+<!-- Spec reviewed 2026-04-11 - AbstractKernel::bootEntityTypeManager passes a third closure to EntityTypeManager wiring SqlSchemaHandler, SqlStorageDriver, optional RevisionableStorageDriver, and EntityRepository for getRepository() (#1128) -->
 <!-- Spec reviewed 2026-04-08 - #1129/#1134: HttpKernel::finalizeBoot() wires DB cache bins and discovery handler; SSR owns RenderCache listeners + SsrPageHandler via SsrServiceProvider::configureHttpKernel; ErrorPageRendererInterface bound in SSR; provider httpDomainRouters() merged after foundation routers through McpRouter and before BroadcastRouter; DiscoveryRouter/GraphQlRouter/MediaRouter live in api/graphql/media packages; ControllerDispatcher uses Inertia foundation interfaces + optional InertiaFullPageRendererInterface; LayerDependencyTest gates non-Router Foundation Http/ against non-Foundation Waaseyaa imports -->
 <!-- Spec reviewed 2026-04-08 - DX P2: HttpKernel boot catch returns HTML via DevExceptionRenderer when debug+package present else JSON:API bootFailureJsonResponse (non-empty body, #1117); ControllerDispatcher render.page returns 501 JSON when SsrPageHandler class unavailable (#1130); LogManager gains daily + fingers_crossed channel types -->
 <!-- Spec reviewed 2026-04-08 - LogManager: handler key string = type synonym only; fingers_crossed nested config via nested, inner, or array handler; channel buffer_limit caps FingersCrossedHandler in-memory buffer (drops oldest); handlerTypeFromConfig + fingersCrossedBufferLimit helpers -->
@@ -1306,7 +1307,7 @@ EnvLoader::load(.env)
   → new EntityAuditLogger($projectRoot)
   → register EntityWriteAuditListener on PRE_SAVE, POST_SAVE, POST_DELETE
   → bootDatabase()           // DatabaseBootstrapper
-  → bootEntityTypeManager()  // inline, wires storage factory closure
+  → bootEntityTypeManager()  // inline: storage factory (SqlEntityStorage) + repository factory (EntityRepository)
   → compileManifest()        // ManifestBootstrapper
   → bootMigrations()         // reuses DBAL connection from bootDatabase
   → discoverAndRegisterProviders()  // ProviderRegistry

--- a/docs/specs/relationship-modeling.md
+++ b/docs/specs/relationship-modeling.md
@@ -1,6 +1,7 @@
 # Relationship Modeling (v0.6)
 
 <!-- Spec reviewed 2026-04-11 - Relationship entity: widened constructor for duplicateInstance re-entry; modeling and traversal semantics unchanged (#alpha-119) -->
+<!-- Spec reviewed 2026-04-11b - Package tests only: EntityTypeManagerInterface stubs implement getRepository() (#1128); no relationship domain change -->
 <!-- Spec reviewed 2026-04-07 - RelationshipParameterValidator extracted from RelationshipDiscoveryService (579→442 lines); validation/normalization helpers in dedicated class, injected as constructor dependency; timelineSortDate converted to instance method for consistent injection -->
 <!-- Spec reviewed 2026-04-09 - RelationshipTraversalService: combined relationship queries where applicable; timeline active-window predicates pushed into SQL; browse still merges/sorts hub/cluster slices in PHP with batched entity loads -->
 <!-- Spec reviewed 2026-04-09k - traversal summaries, access policy, pre-save normalization, and discovery edge context use `EntityValues` / `get()` for cast-aware values (#1181 ST-8) -->

--- a/packages/entity/src/EntityTypeManager.php
+++ b/packages/entity/src/EntityTypeManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Entity;
 
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
 /**
  * Registry-based entity type manager.
@@ -30,13 +31,23 @@ class EntityTypeManager implements EntityTypeManagerInterface
     private array $storageInstances = [];
 
     /**
+     * Cached repository instances.
+     *
+     * @var array<string, EntityRepositoryInterface>
+     */
+    private array $repositoryInstances = [];
+
+    /**
      * @param EventDispatcherInterface $eventDispatcher The event dispatcher for entity lifecycle events.
      * @param \Closure|null $storageFactory A factory callable: fn(EntityTypeInterface): EntityStorageInterface.
      *                                     If null, getStorage() will throw when no storage class is configured.
+     * @param \Closure|null $repositoryFactory A factory callable: fn(string $entityTypeId, EntityTypeInterface): EntityRepositoryInterface.
+     *                                          If null, getRepository() throws.
      */
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ?\Closure $storageFactory = null,
+        private readonly ?\Closure $repositoryFactory = null,
     ) {}
 
     /**
@@ -144,6 +155,35 @@ class EntityTypeManager implements EntityTypeManagerInterface
         $this->storageInstances[$entityTypeId] = $storage;
 
         return $storage;
+    }
+
+    public function getRepository(string $entityTypeId): EntityRepositoryInterface
+    {
+        if (isset($this->repositoryInstances[$entityTypeId])) {
+            return $this->repositoryInstances[$entityTypeId];
+        }
+
+        if ($this->repositoryFactory === null) {
+            throw new \RuntimeException(\sprintf(
+                'No repository factory configured for EntityTypeManager; cannot build repository for entity type "%s".',
+                $entityTypeId,
+            ));
+        }
+
+        $definition = $this->getDefinition($entityTypeId);
+        $repository = ($this->repositoryFactory)($entityTypeId, $definition);
+
+        if (!$repository instanceof EntityRepositoryInterface) {
+            throw new \RuntimeException(\sprintf(
+                'Repository factory for entity type "%s" must return an instance of %s.',
+                $entityTypeId,
+                EntityRepositoryInterface::class,
+            ));
+        }
+
+        $this->repositoryInstances[$entityTypeId] = $repository;
+
+        return $repository;
     }
 
     /**

--- a/packages/entity/src/EntityTypeManagerInterface.php
+++ b/packages/entity/src/EntityTypeManagerInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Entity;
 
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
 interface EntityTypeManagerInterface
 {
     public function getDefinition(string $entityTypeId): EntityTypeInterface;
@@ -19,4 +21,11 @@ interface EntityTypeManagerInterface
     public function hasDefinition(string $entityTypeId): bool;
 
     public function getStorage(string $entityTypeId): Storage\EntityStorageInterface;
+
+    /**
+     * Returns the framework {@see EntityRepositoryInterface} for an entity type.
+     *
+     * Requires a repository factory to be configured on the manager (kernel wiring).
+     */
+    public function getRepository(string $entityTypeId): EntityRepositoryInterface;
 }

--- a/packages/entity/tests/Unit/EntityTypeManagerTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Waaseyaa\Entity\Tests\Unit;
 
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -172,6 +174,59 @@ class EntityTypeManagerTest extends TestCase
     public function testGetEventDispatcher(): void
     {
         $this->assertSame($this->eventDispatcher, $this->manager->getEventDispatcher());
+    }
+
+    public function testGetRepositoryThrowsWhenNoFactoryConfigured(): void
+    {
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $this->manager->registerEntityType($type);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No repository factory configured');
+
+        $this->manager->getRepository('node');
+    }
+
+    public function testGetRepositoryUsesFactoryAndCaches(): void
+    {
+        $mockRepo = $this->createMock(EntityRepositoryInterface::class);
+        $callCount = 0;
+
+        $manager = new EntityTypeManager(
+            $this->eventDispatcher,
+            null,
+            function (string $entityTypeId, EntityTypeInterface $definition) use ($mockRepo, &$callCount) {
+                $callCount++;
+                $this->assertSame('node', $entityTypeId);
+                $this->assertSame('node', $definition->id());
+
+                return $mockRepo;
+            },
+        );
+
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $manager->registerEntityType($type);
+
+        $this->assertSame($mockRepo, $manager->getRepository('node'));
+        $this->assertSame($mockRepo, $manager->getRepository('node'));
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testGetRepositoryThrowsWhenFactoryReturnsWrongType(): void
+    {
+        $manager = new EntityTypeManager(
+            $this->eventDispatcher,
+            null,
+            static fn (): object => new \stdClass(),
+        );
+
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $manager->registerEntityType($type);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('must return an instance');
+
+        $manager->getRepository('node');
     }
 
     public function testGetDefinitionsReturnsEmptyByDefault(): void

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -14,6 +14,11 @@ use Waaseyaa\Entity\Audit\EntityWriteAuditListener;
 use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\RevisionableStorageDriver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
@@ -147,6 +152,33 @@ abstract class AbstractKernel
                 $schemaHandler = new SqlSchemaHandler($definition, $database);
                 $schemaHandler->ensureTable();
                 return new SqlEntityStorage($definition, $database, $dispatcher);
+            },
+            function (string $_entityTypeId, EntityTypeInterface $definition) use ($database, $dispatcher): EntityRepositoryInterface {
+                $schemaHandler = new SqlSchemaHandler($definition, $database);
+                $schemaHandler->ensureTable();
+                if ($definition->isRevisionable()) {
+                    $schemaHandler->ensureRevisionTable();
+                }
+                if ($definition->isTranslatable()) {
+                    $schemaHandler->ensureTranslationTable();
+                }
+
+                $keys = $definition->getKeys();
+                $idKey = $keys['id'] ?? 'id';
+
+                $resolver = new SingleConnectionResolver($database);
+                $driver = new SqlStorageDriver($resolver, $idKey);
+                $revisionDriver = $definition->isRevisionable()
+                    ? new RevisionableStorageDriver($resolver, $definition)
+                    : null;
+
+                return new EntityRepository(
+                    $definition,
+                    $driver,
+                    $dispatcher,
+                    $revisionDriver,
+                    $database,
+                );
             },
         );
     }

--- a/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
+++ b/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Relationship\Tests\Fixtures;
 
 use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 
 /**
@@ -58,6 +59,11 @@ class StubEntityTypeManager implements EntityTypeManagerInterface
     public function getStorage(string $entityTypeId): EntityStorageInterface
     {
         return $this->storage ?? new StubEntityStorage();
+    }
+
+    public function getRepository(string $entityTypeId): EntityRepositoryInterface
+    {
+        throw new \BadMethodCallException('StubEntityTypeManager does not implement getRepository().');
     }
 
     public function getDefinitions(): array

--- a/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
@@ -484,6 +484,11 @@ final class DiscoveryEntityTypeManager implements EntityTypeManagerInterface
         return $this->storages[$entityTypeId];
     }
 
+    public function getRepository(string $entityTypeId): \Waaseyaa\Entity\Repository\EntityRepositoryInterface
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
+
     public function registerEntityType(EntityTypeInterface $type): void
     {
         throw new \RuntimeException('Not needed in test.');

--- a/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
@@ -317,6 +317,11 @@ final class TraversalEntityTypeManager implements EntityTypeManagerInterface
         return $this->storages[$entityTypeId];
     }
 
+    public function getRepository(string $entityTypeId): \Waaseyaa\Entity\Repository\EntityRepositoryInterface
+    {
+        throw new \RuntimeException('Not needed in test.');
+    }
+
     public function registerEntityType(EntityTypeInterface $type): void
     {
         throw new \RuntimeException('Not needed in test.');

--- a/tests/Integration/Phase12/EntityTypeManagerRepositoryIntegrationTest.php
+++ b/tests/Integration/Phase12/EntityTypeManagerRepositoryIntegrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Phase12;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityConstants;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\RevisionableStorageDriver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\EntityStorage\Tests\Fixtures\TestStorageEntity;
+
+/**
+ * Verifies {@see EntityTypeManager::getRepository()} wiring against SQLite (framework #1128).
+ */
+#[CoversNothing]
+final class EntityTypeManagerRepositoryIntegrationTest extends TestCase
+{
+    #[Test]
+    public function get_repository_persists_and_loads_via_sqlite(): void
+    {
+        $database = DBALDatabase::createSqlite();
+        $dispatcher = new EventDispatcher();
+
+        $manager = new EntityTypeManager(
+            $dispatcher,
+            function (EntityTypeInterface $definition) use ($database, $dispatcher): SqlEntityStorage {
+                $schemaHandler = new SqlSchemaHandler($definition, $database);
+                $schemaHandler->ensureTable();
+
+                return new SqlEntityStorage($definition, $database, $dispatcher);
+            },
+            function (string $entityTypeId, EntityTypeInterface $definition) use ($database, $dispatcher): EntityRepositoryInterface {
+                $schemaHandler = new SqlSchemaHandler($definition, $database);
+                $schemaHandler->ensureTable();
+                if ($definition->isRevisionable()) {
+                    $schemaHandler->ensureRevisionTable();
+                }
+                if ($definition->isTranslatable()) {
+                    $schemaHandler->ensureTranslationTable();
+                }
+
+                $keys = $definition->getKeys();
+                $idKey = $keys['id'] ?? 'id';
+                $resolver = new SingleConnectionResolver($database);
+                $driver = new SqlStorageDriver($resolver, $idKey);
+                $revisionDriver = $definition->isRevisionable()
+                    ? new RevisionableStorageDriver($resolver, $definition)
+                    : null;
+
+                return new EntityRepository(
+                    $definition,
+                    $driver,
+                    $dispatcher,
+                    $revisionDriver,
+                    $database,
+                );
+            },
+        );
+
+        $type = new EntityType(
+            id: 'repo_integration_entity',
+            label: 'Repo integration',
+            class: TestStorageEntity::class,
+            keys: [
+                'id' => 'id',
+                'uuid' => 'uuid',
+                'bundle' => 'bundle',
+                'label' => 'label',
+                'langcode' => 'langcode',
+            ],
+        );
+        $manager->registerEntityType($type);
+
+        $repository = $manager->getRepository('repo_integration_entity');
+
+        $entity = new TestStorageEntity(
+            values: ['id' => '1', 'label' => 'Hello', 'bundle' => 'article', 'langcode' => 'en'],
+            entityTypeId: 'repo_integration_entity',
+            entityKeys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'bundle', 'label' => 'label', 'langcode' => 'langcode'],
+        );
+        $entity->enforceIsNew();
+
+        $this->assertSame(EntityConstants::SAVED_NEW, $repository->save($entity));
+
+        $loaded = $repository->find('1');
+        $this->assertInstanceOf(TestStorageEntity::class, $loaded);
+        $this->assertSame('Hello', $loaded->get('label'));
+    }
+}


### PR DESCRIPTION
Closes #1128

## Summary

- Add `EntityTypeManagerInterface::getRepository(string $entityTypeId)` and optional repository factory on `EntityTypeManager` (memoized per type).
- Register the factory in `AbstractKernel::bootEntityTypeManager()`: `SqlSchemaHandler` (base + revision + translation tables when applicable), `SingleConnectionResolver`, `SqlStorageDriver`, optional `RevisionableStorageDriver`, and `EntityRepository` with the kernel DB and dispatcher.
- Unit tests on `EntityTypeManager`, SQLite integration test, `entity-system.md` updates, and `EntityTypeManagerInterface` stubs in relationship package tests.
- Spec review comments on `infrastructure.md` and `relationship-modeling.md` for drift gate.

## Checklist

- [x] `Closes #N` above references the issue this PR resolves
- [ ] The issue is assigned to a milestone
- [x] PR title includes the issue number (e.g. `feat(#42): description`)


Made with [Cursor](https://cursor.com)