### PR TITLE
fix(#1236): default serve host to 0.0.0.0 and add skeleton dev script

### DIFF
--- a/packages/cli/src/Command/ServeCommand.php
+++ b/packages/cli/src/Command/ServeCommand.php
@@ -24,8 +24,8 @@ final class ServeCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('host', null, InputOption::VALUE_OPTIONAL, 'The host address', (string) (getenv('APP_HOST') ?: '127.0.0.1'))
-            ->addOption('port', 'p', InputOption::VALUE_OPTIONAL, 'The port', (string) (getenv('APP_PORT') ?: '8080'));
+            ->addOption('host', null, InputOption::VALUE_OPTIONAL, 'Specify which IP address the server should listen on. Set to 127.0.0.1 to restrict to localhost only. Can also be set via APP_HOST.', (string) (getenv('APP_HOST') ?: '0.0.0.0'))
+            ->addOption('port', 'p', InputOption::VALUE_OPTIONAL, 'Specify which port the server should listen on. Can also be set via APP_PORT.', (string) (getenv('APP_PORT') ?: '8080'));
     }
 
     /**
@@ -71,7 +71,8 @@ final class ServeCommand extends Command
             );
         }
 
-        $output->writeln(sprintf('<info>Waaseyaa development server started:</info> http://%s:%s', $host, $port));
+        $displayHost = $host === '0.0.0.0' ? 'localhost' : $host;
+        $output->writeln(sprintf('<info>Waaseyaa development server started:</info> http://%s:%s', $displayHost, $port));
         $output->writeln('<comment>Press Ctrl+C to stop.</comment>');
 
         $process = proc_open(

--- a/skeleton/.env.example
+++ b/skeleton/.env.example
@@ -9,6 +9,7 @@
 APP_NAME=Waaseyaa
 APP_ENV=local
 APP_DEBUG=true
+# APP_HOST=127.0.0.1  # Uncomment to restrict the dev server to localhost only
 APP_URL=http://localhost:8080
 
 # Minimum log level: debug | info | notice | warning | error | critical | alert | emergency

--- a/skeleton/composer.json
+++ b/skeleton/composer.json
@@ -46,6 +46,10 @@
     },
     "scripts": {
         "audit-site": "./bin/waaseyaa-audit-site",
+        "dev": [
+            "Composer\\Config::disableProcessTimeout",
+            "PHP_CLI_SERVER_WORKERS=4 bin/waaseyaa serve"
+        ],
         "post-create-project-cmd": [
             "chmod +x bin/waaseyaa bin/waaseyaa-version bin/verify-deploy-rsync bin/waaseyaa-audit-site",
             "php bin/post-create-setup.php"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `ServeCommand` now defaults to `0.0.0.0` so `localhost:8080` works in WSL2, Docker, and VMs without any configuration
- Startup URL displays `http://localhost:8080` instead of `http://0.0.0.0:8080` (matches Vite DX)
- Improved `--host`/`--port` option descriptions to match Vite's wording
- Skeleton gets a `composer dev` script so `composer run dev` works in app projects
- Skeleton `.env.example` documents `APP_HOST=127.0.0.1` for users who want to restrict access

## Test plan

- [ ] `composer run dev` starts server and prints `http://localhost:8080`
- [ ] `localhost:8080` is reachable from a browser on WSL2/Windows host
- [ ] `APP_HOST=127.0.0.1 bin/waaseyaa serve` restricts to loopback
- [ ] `bin/waaseyaa serve --host 127.0.0.1` restricts to loopback

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)