### PR TITLE
refactor(#1238): add final to 22 non-final leaf classes

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -291,7 +291,7 @@ Extends `WaaseyaaPlugin`. Used for attribute-based plugin discovery (distinct fr
 
 ```php
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class AccessPolicy extends WaaseyaaPlugin
+final class AccessPolicy extends WaaseyaaPlugin
 {
     public function __construct(
         string $id,
@@ -367,7 +367,7 @@ If no access requirements are present on the route, returns `AccessResult::neutr
 **Namespace:** `Waaseyaa\Access`
 
 ```php
-class PermissionHandler implements PermissionHandlerInterface
+final class PermissionHandler implements PermissionHandlerInterface
 {
     public function registerPermission(string $id, string $title, string $description = ''): void
     public function getPermissions(): array // array<string, array{title: string, description: string}>

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -893,7 +893,7 @@ $entities = $storage->loadMultiple($ids);
 File: `packages/entity/src/Event/EntityEvent.php`
 
 ```php
-class EntityEvent extends Event
+final class EntityEvent extends Event
 {
     public function __construct(
         public readonly EntityInterface $entity,
@@ -1237,7 +1237,7 @@ Contains `FieldItemInterface[]` items. Supports `__get($name)` to access first i
 ### FieldTypeManager
 
 File: `packages/field/src/FieldTypeManager.php`
-Class: `class FieldTypeManager extends DefaultPluginManager implements FieldTypeManagerInterface`
+Class: `final class FieldTypeManager extends DefaultPluginManager implements FieldTypeManagerInterface`
 
 Constructor: `(array $directories = [], ?CacheBackendInterface $cache = null)`
 
@@ -1253,7 +1253,7 @@ File: `packages/field/src/Attribute/FieldType.php`
 
 ```php
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class FieldType extends WaaseyaaPlugin
+final class FieldType extends WaaseyaaPlugin
 {
     public function __construct(
         string $id,

--- a/packages/access/src/Attribute/AccessPolicy.php
+++ b/packages/access/src/Attribute/AccessPolicy.php
@@ -13,7 +13,7 @@ use Waaseyaa\Plugin\Attribute\WaaseyaaPlugin;
  * to enable attribute-based plugin discovery.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class AccessPolicy extends WaaseyaaPlugin
+final class AccessPolicy extends WaaseyaaPlugin
 {
     /**
      * @param string   $id          Unique plugin ID.

--- a/packages/access/src/PermissionHandler.php
+++ b/packages/access/src/PermissionHandler.php
@@ -7,7 +7,7 @@ namespace Waaseyaa\Access;
 /**
  * Simple in-memory registry of permissions.
  */
-class PermissionHandler implements PermissionHandlerInterface
+final class PermissionHandler implements PermissionHandlerInterface
 {
     /**
      * @var array<string, array{title: string, description: string}>

--- a/packages/entity/src/Attribute/EntityTypeAttribute.php
+++ b/packages/entity/src/Attribute/EntityTypeAttribute.php
@@ -22,7 +22,7 @@ use Waaseyaa\Plugin\Attribute\WaaseyaaPlugin;
  *   class Node extends ContentEntityBase { ... }
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class EntityTypeAttribute extends WaaseyaaPlugin
+final class EntityTypeAttribute extends WaaseyaaPlugin
 {
     /**
      * @param string $id Machine name of the entity type.

--- a/packages/entity/src/Event/EntityEvent.php
+++ b/packages/entity/src/Event/EntityEvent.php
@@ -7,7 +7,7 @@ namespace Waaseyaa\Entity\Event;
 use Symfony\Contracts\EventDispatcher\Event;
 use Waaseyaa\Entity\EntityInterface;
 
-class EntityEvent extends Event
+final class EntityEvent extends Event
 {
     public function __construct(
         public readonly EntityInterface $entity,

--- a/packages/field/src/Attribute/FieldType.php
+++ b/packages/field/src/Attribute/FieldType.php
@@ -7,7 +7,7 @@ namespace Waaseyaa\Field\Attribute;
 use Waaseyaa\Plugin\Attribute\WaaseyaaPlugin;
 
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class FieldType extends WaaseyaaPlugin
+final class FieldType extends WaaseyaaPlugin
 {
     public function __construct(
         string $id,

--- a/packages/field/src/FieldTypeManager.php
+++ b/packages/field/src/FieldTypeManager.php
@@ -9,7 +9,7 @@ use Waaseyaa\Field\Attribute\FieldType;
 use Waaseyaa\Plugin\DefaultPluginManager;
 use Waaseyaa\Plugin\Discovery\AttributeDiscovery;
 
-class FieldTypeManager extends DefaultPluginManager implements FieldTypeManagerInterface
+final class FieldTypeManager extends DefaultPluginManager implements FieldTypeManagerInterface
 {
     /**
      * @param string[] $directories Directories to scan for field type plugins.

--- a/packages/field/src/Item/BooleanItem.php
+++ b/packages/field/src/Item/BooleanItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class BooleanItem extends FieldItemBase
+final class BooleanItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/ComputedItem.php
+++ b/packages/field/src/Item/ComputedItem.php
@@ -16,7 +16,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class ComputedItem extends FieldItemBase implements ComputedFieldInterface
+final class ComputedItem extends FieldItemBase implements ComputedFieldInterface
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/DateItem.php
+++ b/packages/field/src/Item/DateItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'datetime',
     defaultCardinality: 1,
 )]
-class DateItem extends FieldItemBase
+final class DateItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/DateTimeItem.php
+++ b/packages/field/src/Item/DateTimeItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'datetime',
     defaultCardinality: 1,
 )]
-class DateTimeItem extends FieldItemBase
+final class DateTimeItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/DecimalItem.php
+++ b/packages/field/src/Item/DecimalItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'number',
     defaultCardinality: 1,
 )]
-class DecimalItem extends FieldItemBase
+final class DecimalItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/EmailItem.php
+++ b/packages/field/src/Item/EmailItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class EmailItem extends FieldItemBase
+final class EmailItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/EntityReferenceItem.php
+++ b/packages/field/src/Item/EntityReferenceItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'reference',
     defaultCardinality: 1,
 )]
-class EntityReferenceItem extends FieldItemBase
+final class EntityReferenceItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/FileItem.php
+++ b/packages/field/src/Item/FileItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'file',
     defaultCardinality: 1,
 )]
-class FileItem extends FieldItemBase
+final class FileItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/FloatItem.php
+++ b/packages/field/src/Item/FloatItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class FloatItem extends FieldItemBase
+final class FloatItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/ImageItem.php
+++ b/packages/field/src/Item/ImageItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'file',
     defaultCardinality: 1,
 )]
-class ImageItem extends FieldItemBase
+final class ImageItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/IntegerItem.php
+++ b/packages/field/src/Item/IntegerItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class IntegerItem extends FieldItemBase
+final class IntegerItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/JsonItem.php
+++ b/packages/field/src/Item/JsonItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class JsonItem extends FieldItemBase
+final class JsonItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/LinkItem.php
+++ b/packages/field/src/Item/LinkItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class LinkItem extends FieldItemBase
+final class LinkItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/ListItem.php
+++ b/packages/field/src/Item/ListItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class ListItem extends FieldItemBase
+final class ListItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/StringItem.php
+++ b/packages/field/src/Item/StringItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class StringItem extends FieldItemBase
+final class StringItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {

--- a/packages/field/src/Item/TextItem.php
+++ b/packages/field/src/Item/TextItem.php
@@ -14,7 +14,7 @@ use Waaseyaa\Field\FieldItemBase;
     category: 'general',
     defaultCardinality: 1,
 )]
-class TextItem extends FieldItemBase
+final class TextItem extends FieldItemBase
 {
     public static function propertyDefinitions(): array
     {


### PR DESCRIPTION
## Summary

- Added `final` keyword to 22 concrete leaf classes across `packages/access`, `packages/entity`, `packages/field`, and `packages/user`
- 16 field items, 3 attributes, 2 managers, 1 event class sealed
- Updated `docs/specs/entity-system.md` and `docs/specs/access-control.md` to reflect the `final` declarations

## Skipped (4 classes)

These classes are mocked or extended in tests and cannot be sealed without rewriting test seams:

| Class | Reason |
|---|---|
| `GenericAdminSurfaceHost` | Extended via anonymous class in test |
| `EntityTypeManager` | Mocked in 57 tests (has interface, tests should mock that) |
| `EntityAccessHandler` | Mocked in `GenericAdminSurfaceHostTest` |
| `AuthMailer` | Mocked directly in tests |

These should be addressed separately by migrating tests to mock interfaces instead of concrete classes.

## Test plan

- [x] `composer cs-check` passes
- [x] `composer phpstan` passes
- [x] `./vendor/bin/phpunit` passes (5970 tests, 0 errors)

Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)