### PR TITLE
feat(#622): add ObservabilityServiceProvider + disabled-mode test

### DIFF
--- a/packages/ai-observability/src/ObservabilityServiceProvider.php
+++ b/packages/ai-observability/src/ObservabilityServiceProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\AI\Observability;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\AI\Observability\Analysis\AnomalyDetector;
+use Waaseyaa\AI\Observability\Cost\BudgetManager;
+use Waaseyaa\AI\Observability\Cost\CostTracker;
+use Waaseyaa\AI\Observability\Cost\ModelPricing;
+use Waaseyaa\AI\Observability\Cost\TokenAccountant;
+use Waaseyaa\AI\Observability\Listener\LlmCallListener;
+use Waaseyaa\AI\Observability\Listener\ToolCallListener;
+use Waaseyaa\AI\Observability\Recorder\NullTraceRecorder;
+use Waaseyaa\AI\Observability\Recorder\TraceRecorder;
+use Waaseyaa\AI\Observability\Recorder\TraceRecorderInterface;
+use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+final class ObservabilityServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: 'trace',
+            label: 'Trace',
+            description: 'Agent execution trace',
+            class: Trace::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'label'],
+            group: 'ai',
+        ));
+
+        $this->singleton(TraceContext::class, fn(): TraceContext => new TraceContext());
+
+        $overrides = $this->config['observability']['model_pricing_overrides'] ?? [];
+        $this->singleton(ModelPricing::class, fn(): ModelPricing => new ModelPricing(is_array($overrides) ? $overrides : []));
+
+        $enabled = (bool) ($this->config['observability']['enabled'] ?? true);
+        $this->singleton(TraceRecorderInterface::class, function () use ($enabled): TraceRecorderInterface {
+            if (!$enabled) {
+                return new NullTraceRecorder();
+            }
+
+            $repo = $this->resolve(EntityTypeManager::class)->getRepository('trace');
+            $database = $this->resolve(DatabaseInterface::class);
+            $context = $this->resolve(TraceContext::class);
+
+            return new TraceRecorder($repo, $database, $context);
+        });
+
+        $this->singleton(TokenAccountant::class, fn(): TokenAccountant => new TokenAccountant(
+            $this->resolve(TraceRecorderInterface::class),
+            $this->resolve(ModelPricing::class),
+        ));
+
+        $this->singleton(CostTracker::class, fn(): CostTracker => new CostTracker(
+            $this->resolve(DatabaseInterface::class),
+        ));
+
+        $dailyLimit = (float) ($this->config['observability']['daily_limit_usd'] ?? 100.0);
+        $perRequestLimit = (float) ($this->config['observability']['per_request_limit_usd'] ?? 10.0);
+        $this->singleton(BudgetManager::class, fn(): BudgetManager => new BudgetManager(
+            $this->resolve(CostTracker::class),
+            $dailyLimit,
+            $perRequestLimit,
+        ));
+
+        $this->singleton(AnomalyDetector::class, fn(): AnomalyDetector => new AnomalyDetector());
+    }
+
+    public function boot(): void
+    {
+        $dispatcher = $this->resolve(EventDispatcherInterface::class);
+        if (!$dispatcher instanceof EventDispatcher) {
+            return;
+        }
+
+        $dispatcher->addSubscriber(new LlmCallListener(
+            $this->resolve(TraceContext::class),
+            $this->resolve(TokenAccountant::class),
+        ));
+
+        $dispatcher->addSubscriber(new ToolCallListener(
+            $this->resolve(TraceContext::class),
+            $this->resolve(TraceRecorderInterface::class),
+        ));
+    }
+}

--- a/packages/ai-observability/tests/Unit/Analysis/AnomalyDetectorTest.php
+++ b/packages/ai-observability/tests/Unit/Analysis/AnomalyDetectorTest.php
@@ -21,7 +21,7 @@ final class AnomalyDetectorTest extends TestCase
 
         $anomalies = $detector->check('x', $spans, []);
 
-        self::assertContains(Anomaly::KIND_TOOL_LOOP, array_map(fn (Anomaly $a) => $a->kind, $anomalies));
+        self::assertContains(Anomaly::KIND_TOOL_LOOP, array_map(fn(Anomaly $a) => $a->kind, $anomalies));
     }
 
     #[Test]
@@ -36,31 +36,31 @@ final class AnomalyDetectorTest extends TestCase
 
         $anomalies = $detector->check('x', $spans, []);
 
-        self::assertContains(Anomaly::KIND_ERROR_RATIO, array_map(fn (Anomaly $a) => $a->kind, $anomalies));
+        self::assertContains(Anomaly::KIND_ERROR_RATIO, array_map(fn(Anomaly $a) => $a->kind, $anomalies));
     }
 
     #[Test]
     public function flagsSpanCountOutlier(): void
     {
         $detector = new AnomalyDetector();
-        $history = array_map(fn ($n) => ['span_count' => $n, 'cost_usd' => 0.10], [5, 5, 6, 4, 5, 5, 6, 4, 5, 5]);
+        $history = array_map(fn($n) => ['span_count' => $n, 'cost_usd' => 0.10], [5, 5, 6, 4, 5, 5, 6, 4, 5, 5]);
         $spans = array_fill(0, 30, ['kind' => 'tool_call', 'name' => 'x', 'status' => 'ok']);
 
         $anomalies = $detector->check('x', $spans, $history);
 
-        self::assertContains(Anomaly::KIND_SPAN_COUNT, array_map(fn (Anomaly $a) => $a->kind, $anomalies));
+        self::assertContains(Anomaly::KIND_SPAN_COUNT, array_map(fn(Anomaly $a) => $a->kind, $anomalies));
     }
 
     #[Test]
     public function flagsCostOutlier(): void
     {
         $detector = new AnomalyDetector();
-        $history = array_map(fn ($c) => ['span_count' => 5, 'cost_usd' => $c], [0.10, 0.12, 0.09, 0.11, 0.10, 0.12, 0.08, 0.10]);
+        $history = array_map(fn($c) => ['span_count' => 5, 'cost_usd' => $c], [0.10, 0.12, 0.09, 0.11, 0.10, 0.12, 0.08, 0.10]);
         $spans = [['kind' => 'llm_call', 'name' => 'x', 'status' => 'ok', 'cost_usd' => 1.00]];
 
         $anomalies = $detector->check('x', $spans, $history);
 
-        self::assertContains(Anomaly::KIND_COST, array_map(fn (Anomaly $a) => $a->kind, $anomalies));
+        self::assertContains(Anomaly::KIND_COST, array_map(fn(Anomaly $a) => $a->kind, $anomalies));
     }
 
     #[Test]

--- a/packages/ai-observability/tests/Unit/Cost/BudgetManagerTest.php
+++ b/packages/ai-observability/tests/Unit/Cost/BudgetManagerTest.php
@@ -44,7 +44,7 @@ final class BudgetManagerTest extends TestCase
 
     private function fakeTracker(float $dailyTotal): CostTracker
     {
-        return new class($dailyTotal) extends CostTracker {
+        return new class ($dailyTotal) extends CostTracker {
             public function __construct(private readonly float $total) {}
 
             public function totalForTrace(string $traceUuid): float

--- a/packages/ai-observability/tests/Unit/ObservabilityServiceProviderTest.php
+++ b/packages/ai-observability/tests/Unit/ObservabilityServiceProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\AI\Observability\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\AI\Observability\Analysis\AnomalyDetector;
+use Waaseyaa\AI\Observability\Cost\ModelPricing;
+use Waaseyaa\AI\Observability\ObservabilityServiceProvider;
+use Waaseyaa\AI\Observability\Recorder\NullTraceRecorder;
+use Waaseyaa\AI\Observability\Recorder\TraceRecorderInterface;
+use Waaseyaa\AI\Observability\TraceContext;
+
+#[CoversClass(ObservabilityServiceProvider::class)]
+final class ObservabilityServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function disabledModeBindsNullTraceRecorder(): void
+    {
+        $provider = new ObservabilityServiceProvider();
+        $provider->setKernelContext('', ['observability' => ['enabled' => false]]);
+        $provider->register();
+
+        $recorder = $provider->resolve(TraceRecorderInterface::class);
+
+        self::assertInstanceOf(NullTraceRecorder::class, $recorder);
+    }
+
+    #[Test]
+    public function registersLocalBindingsWithoutKernel(): void
+    {
+        $provider = new ObservabilityServiceProvider();
+        $provider->setKernelContext('', []);
+        $provider->register();
+
+        self::assertInstanceOf(TraceContext::class, $provider->resolve(TraceContext::class));
+        self::assertInstanceOf(ModelPricing::class, $provider->resolve(ModelPricing::class));
+        self::assertInstanceOf(AnomalyDetector::class, $provider->resolve(AnomalyDetector::class));
+    }
+
+    #[Test]
+    public function registersTraceEntityType(): void
+    {
+        $provider = new ObservabilityServiceProvider();
+        $provider->setKernelContext('', []);
+        $provider->register();
+
+        $entityTypes = $provider->getEntityTypes();
+        self::assertCount(1, $entityTypes);
+        self::assertSame('trace', $entityTypes[0]->id());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ObservabilityServiceProvider` — registers trace entity type, binds TraceContext/ModelPricing/TraceRecorder (Null when disabled)/TokenAccountant/CostTracker/BudgetManager/AnomalyDetector, and subscribes LlmCallListener + ToolCallListener in `boot()`.
- Closes Task 15 of the ai-observability plan.

## Test plan
- [x] `./vendor/bin/phpunit packages/ai-observability/tests/` — 29 passing
- [x] `composer phpstan` — clean
- [x] `composer cs-check` — clean
- [x] `composer check-composer-policy` — OK
- [x] `bin/waaseyaa optimize:manifest` — 34 providers compiled
- [ ] Follow-up: full TraceRecorder contract test (deferred — existing unit tests cover recorder behaviour)
- [ ] Follow-up: event-wiring integration test with real EntityRepository (deferred — scope)

Stacked on #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)