### PR TITLE
feat(#1282): OidcClient entity type + config seeder

### DIFF
--- a/packages/oidc/src/Access/OidcClientAccessPolicy.php
+++ b/packages/oidc/src/Access/OidcClientAccessPolicy.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Access policy for OidcClient entities.
+ *
+ * Entity operations (view/update/delete/create) are gated by the
+ * `administer oidc clients` permission. Authenticated non-admin users and
+ * anonymous callers cannot enumerate, read, or mutate clients via the
+ * entity API. The OIDC authorize/token endpoints must look up clients via
+ * a dedicated storage-bypass service (not through entity access checks) to
+ * validate client_id + redirect_uri without exposing the entity CRUD surface.
+ *
+ * Field-level rules:
+ *  - `client_secret_hash` is Forbidden for all view operations (the hash
+ *    is never exposed through the API, even to admins — rotation is
+ *    write-only).
+ *  - `client_id` is Forbidden for edit on existing clients (immutable
+ *    public identifier per OIDC spec); allowed on new entities so admins
+ *    can set it at creation.
+ *  - All other fields are Neutral (open-by-default per field policy
+ *    semantics).
+ */
+#[PolicyAttribute(entityType: 'oidc_client')]
+final class OidcClientAccessPolicy implements AccessPolicyInterface, FieldAccessPolicyInterface
+{
+    private const ADMIN_PERMISSION = 'administer oidc clients';
+
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'oidc_client';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission(self::ADMIN_PERMISSION)) {
+            return AccessResult::allowed('User has "administer oidc clients" permission.');
+        }
+
+        return AccessResult::neutral('OIDC clients are admin-only.');
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission(self::ADMIN_PERMISSION)) {
+            return AccessResult::allowed('User has "administer oidc clients" permission.');
+        }
+
+        return AccessResult::neutral('OIDC clients are admin-only.');
+    }
+
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation,
+        AccountInterface $account,
+    ): AccessResult {
+        if ($fieldName === 'client_secret_hash' && $operation === 'view') {
+            return AccessResult::forbidden('client_secret_hash is never exposed through the API.');
+        }
+
+        if ($fieldName === 'client_id' && $operation === 'edit' && !$entity->isNew()) {
+            return AccessResult::forbidden('client_id is immutable after creation.');
+        }
+
+        return AccessResult::neutral('No field-level restriction.');
+    }
+}

--- a/packages/oidc/src/ClientRegistry/OidcClientSeeder.php
+++ b/packages/oidc/src/ClientRegistry/OidcClientSeeder.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\ClientRegistry;
+
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+/**
+ * Seeds OidcClient entities from config.
+ *
+ * Reads the `oidc.clients` config map and upserts each entry into storage by
+ * `client_id`. Non-destructive: entries removed from config are not deleted
+ * from the database, and admin-created clients (not present in config) are
+ * untouched.
+ *
+ * Expected config shape:
+ *
+ *     'oidc' => [
+ *         'clients' => [
+ *             'minoo-web' => [
+ *                 'name' => 'Minoo',
+ *                 'redirect_uris' => ['https://minoo.test/callback'],
+ *                 'scopes' => ['openid', 'profile'],           // optional
+ *                 'grant_types' => ['authorization_code'],     // optional
+ *                 'is_confidential' => false,                  // optional
+ *                 'client_secret_hash' => null,                // optional
+ *             ],
+ *         ],
+ *     ]
+ */
+final class OidcClientSeeder
+{
+    public function __construct(
+        private readonly SqlEntityStorage $storage,
+    ) {}
+
+    /**
+     * @param array<array-key, array<string, mixed>> $clients client_id => config
+     */
+    public function seed(array $clients): void
+    {
+        foreach ($clients as $clientId => $config) {
+            if (!is_string($clientId) || $clientId === '') {
+                throw new \InvalidArgumentException(
+                    'OIDC client config key must be a non-empty string (the client_id).',
+                );
+            }
+
+            $this->seedOne($clientId, $config);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function seedOne(string $clientId, array $config): void
+    {
+        $this->validate($clientId, $config);
+
+        $values = [
+            'client_id' => $clientId,
+            'name' => (string) $config['name'],
+            'redirect_uris' => array_values($config['redirect_uris']),
+        ];
+
+        foreach (['scopes', 'grant_types'] as $arrayField) {
+            if (isset($config[$arrayField]) && is_array($config[$arrayField])) {
+                $values[$arrayField] = array_values($config[$arrayField]);
+            }
+        }
+
+        if (array_key_exists('is_confidential', $config)) {
+            $values['is_confidential'] = (bool) $config['is_confidential'];
+        }
+
+        if (array_key_exists('client_secret_hash', $config)) {
+            $hash = $config['client_secret_hash'];
+            $values['client_secret_hash'] = is_string($hash) && $hash !== '' ? $hash : null;
+        }
+
+        $existing = $this->findByClientId($clientId);
+
+        if ($existing !== null) {
+            foreach ($values as $field => $value) {
+                $existing->set($field, $value);
+            }
+            $this->storage->save($existing);
+            return;
+        }
+
+        $entity = $this->storage->create($values);
+        $this->storage->save($entity);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function validate(string $clientId, array $config): void
+    {
+        if (!isset($config['name']) || !is_string($config['name']) || $config['name'] === '') {
+            throw new \InvalidArgumentException(
+                "OIDC client '$clientId' is missing required 'name'.",
+            );
+        }
+
+        if (!isset($config['redirect_uris'])) {
+            throw new \InvalidArgumentException(
+                "OIDC client '$clientId' is missing required 'redirect_uris'.",
+            );
+        }
+
+        if (!is_array($config['redirect_uris']) || $config['redirect_uris'] === []) {
+            throw new \InvalidArgumentException(
+                "OIDC client '$clientId' must declare at least one redirect_uri.",
+            );
+        }
+    }
+
+    private function findByClientId(string $clientId): ?OidcClient
+    {
+        $ids = $this->storage->getQuery()
+            ->condition('client_id', $clientId)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $entity = $this->storage->load($ids[0]);
+
+        return $entity instanceof OidcClient ? $entity : null;
+    }
+}

--- a/packages/oidc/src/Entity/OidcClient.php
+++ b/packages/oidc/src/Entity/OidcClient.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Entity;
+
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\Hydration\HydratableFromStorageInterface;
+use Waaseyaa\Entity\Hydration\HydrationContext;
+
+/**
+ * The OidcClient content entity.
+ *
+ * Models a relying-party client registered with the OIDC issuer (Minoo, biindigen, etc.).
+ * The `client_id` field is the stable public identifier per OIDC spec — its value is
+ * user-defined at creation time and never rewritten. The `id` column is an internal
+ * auto-increment primary key for entity-system consistency.
+ */
+final class OidcClient extends ContentEntityBase implements HydratableFromStorageInterface
+{
+    private const ENTITY_TYPE_ID = 'oidc_client';
+
+    /**
+     * @var array<string, string>
+     */
+    private const ENTITY_KEYS = [
+        'id' => 'id',
+        'uuid' => 'uuid',
+        'label' => 'name',
+    ];
+
+    /**
+     * @var array<string, string|array<string, mixed>>
+     */
+    protected array $casts = [
+        'is_confidential' => 'bool',
+    ];
+
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, string> $entityKeys
+     * @param array<string, mixed> $fieldDefinitions
+     */
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        $values += [
+            'redirect_uris' => [],
+            'scopes' => ['openid'],
+            'grant_types' => ['authorization_code'],
+            'is_confidential' => false,
+            'client_secret_hash' => null,
+        ];
+
+        $entityTypeId = $entityTypeId !== '' ? $entityTypeId : self::ENTITY_TYPE_ID;
+        $entityKeys = $entityKeys !== [] ? $entityKeys : self::ENTITY_KEYS;
+
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
+    }
+
+    public static function fromStorage(array $values, HydrationContext $context): static
+    {
+        return new self(
+            values: $values,
+            entityTypeId: $context->entityTypeId,
+            entityKeys: $context->entityKeys,
+            fieldDefinitions: [],
+        );
+    }
+
+    protected function duplicateInstance(array $values): static
+    {
+        return new static(
+            values: $values,
+            entityTypeId: $this->getEntityTypeId(),
+            entityKeys: $this->entityKeys,
+            fieldDefinitions: $this->getFieldDefinitions(),
+        );
+    }
+
+    public function getClientId(): string
+    {
+        return (string) ($this->get('client_id') ?? '');
+    }
+
+    public function setClientId(string $clientId): static
+    {
+        return $this->set('client_id', $clientId);
+    }
+
+    public function getName(): string
+    {
+        return (string) ($this->get('name') ?? '');
+    }
+
+    public function setName(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRedirectUris(): array
+    {
+        $uris = $this->get('redirect_uris');
+
+        return \is_array($uris) ? array_values(array_filter($uris, 'is_string')) : [];
+    }
+
+    /**
+     * @param string[] $uris
+     */
+    public function setRedirectUris(array $uris): static
+    {
+        return $this->set('redirect_uris', array_values($uris));
+    }
+
+    /**
+     * Byte-for-byte exact match per OIDC spec §3.1.2.1.
+     */
+    public function hasRedirectUri(string $redirectUri): bool
+    {
+        return \in_array($redirectUri, $this->getRedirectUris(), true);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getScopes(): array
+    {
+        $scopes = $this->get('scopes');
+
+        return \is_array($scopes) ? array_values(array_filter($scopes, 'is_string')) : [];
+    }
+
+    /**
+     * @param string[] $scopes
+     */
+    public function setScopes(array $scopes): static
+    {
+        return $this->set('scopes', array_values($scopes));
+    }
+
+    public function hasScope(string $scope): bool
+    {
+        return \in_array($scope, $this->getScopes(), true);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGrantTypes(): array
+    {
+        $grantTypes = $this->get('grant_types');
+
+        return \is_array($grantTypes) ? array_values(array_filter($grantTypes, 'is_string')) : [];
+    }
+
+    /**
+     * @param string[] $grantTypes
+     */
+    public function setGrantTypes(array $grantTypes): static
+    {
+        return $this->set('grant_types', array_values($grantTypes));
+    }
+
+    public function supportsGrantType(string $grantType): bool
+    {
+        return \in_array($grantType, $this->getGrantTypes(), true);
+    }
+
+    public function isConfidential(): bool
+    {
+        return (bool) ($this->get('is_confidential') ?? false);
+    }
+
+    public function setConfidential(bool $confidential): static
+    {
+        return $this->set('is_confidential', $confidential);
+    }
+
+    public function getClientSecretHash(): ?string
+    {
+        $hash = $this->get('client_secret_hash');
+
+        return \is_string($hash) && $hash !== '' ? $hash : null;
+    }
+
+    public function setClientSecretHash(?string $hash): static
+    {
+        return $this->set('client_secret_hash', $hash);
+    }
+}

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Oidc;
 
+use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientSeeder;
+use Waaseyaa\Oidc\Entity\OidcClient;
 use Waaseyaa\Oidc\Http\DiscoveryController;
 use Waaseyaa\Oidc\Http\JwksController;
 use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
@@ -16,6 +22,59 @@ final class OidcServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->entityType(new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            description: 'Relying-party clients registered with the OIDC issuer.',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+            group: 'oidc',
+            fieldDefinitions: [
+                'client_id' => [
+                    'type' => 'string',
+                    'label' => 'Client ID',
+                    'description' => 'Stable public identifier for the client (OIDC spec).',
+                    'weight' => 0,
+                ],
+                'name' => [
+                    'type' => 'string',
+                    'label' => 'Name',
+                    'description' => 'Human-readable name shown in admin UIs.',
+                    'weight' => 1,
+                ],
+                'redirect_uris' => [
+                    'type' => 'string_list',
+                    'label' => 'Redirect URIs',
+                    'description' => 'Registered redirect URIs. Matched byte-for-byte per OIDC spec §3.1.2.1.',
+                    'weight' => 2,
+                ],
+                'scopes' => [
+                    'type' => 'string_list',
+                    'label' => 'Scopes',
+                    'description' => 'Scopes the client may request.',
+                    'weight' => 3,
+                ],
+                'grant_types' => [
+                    'type' => 'string_list',
+                    'label' => 'Grant types',
+                    'description' => 'OAuth grant types the client may use.',
+                    'weight' => 4,
+                ],
+                'is_confidential' => [
+                    'type' => 'boolean',
+                    'label' => 'Confidential',
+                    'description' => 'Whether the client authenticates with a secret.',
+                    'weight' => 5,
+                ],
+                'client_secret_hash' => [
+                    'type' => 'string',
+                    'label' => 'Client secret hash',
+                    'description' => 'Hashed client secret. Never exposed through the API.',
+                    'weight' => 6,
+                ],
+            ],
+        ));
+
         $this->singleton(
             DiscoveryController::class,
             fn(): DiscoveryController => new DiscoveryController(issuer: $this->resolveIssuer()),
@@ -32,6 +91,65 @@ final class OidcServiceProvider extends ServiceProvider
                 keyLoader: $this->resolve(OidcKeyLoaderInterface::class),
             ),
         );
+    }
+
+    public function boot(): void
+    {
+        $this->ensureOidcClientSchema();
+        $this->seedOidcClientsFromConfig();
+    }
+
+    /**
+     * Ensure the columns we need for indexed lookups exist on the oidc_client table.
+     *
+     * The kernel's storage factory calls ensureTable() (id/uuid/langcode/_data) when
+     * storage is first resolved; addFieldColumns() is idempotent, so re-running on
+     * each boot is safe. When package-level migrations land, this should move there.
+     */
+    private function ensureOidcClientSchema(): void
+    {
+        try {
+            $database = $this->resolve(DatabaseInterface::class);
+            $entityTypeManager = $this->resolve(EntityTypeManager::class);
+        } catch (\Throwable) {
+            return;
+        }
+
+        if (!$entityTypeManager->hasDefinition('oidc_client')) {
+            return;
+        }
+
+        $definition = $entityTypeManager->getDefinition('oidc_client');
+
+        $handler = new SqlSchemaHandler($definition, $database);
+        $handler->ensureTable();
+        $handler->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+    }
+
+    private function seedOidcClientsFromConfig(): void
+    {
+        $clients = $this->config['oidc']['clients'] ?? null;
+        if (!is_array($clients) || $clients === []) {
+            return;
+        }
+
+        try {
+            $entityTypeManager = $this->resolve(EntityTypeManager::class);
+            $storage = $entityTypeManager->getStorage('oidc_client');
+        } catch (\Throwable) {
+            return;
+        }
+
+        if (!$storage instanceof SqlEntityStorage) {
+            return;
+        }
+
+        (new OidcClientSeeder($storage))->seed($clients);
     }
 
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void

--- a/packages/oidc/tests/Integration/ClientRegistry/OidcClientSeederTest.php
+++ b/packages/oidc/tests/Integration/ClientRegistry/OidcClientSeederTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\ClientRegistry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientSeeder;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+#[CoversClass(OidcClientSeeder::class)]
+final class OidcClientSeederTest extends TestCase
+{
+    private SqlEntityStorage $storage;
+    private OidcClientSeeder $seeder;
+
+    protected function setUp(): void
+    {
+        $database = DBALDatabase::createSqlite();
+
+        $entityType = new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+
+        (new SqlSchemaHandler($entityType, $database))->ensureTable();
+        (new SqlSchemaHandler($entityType, $database))->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+
+        $this->storage = new SqlEntityStorage($entityType, $database, new EventDispatcher());
+        $this->seeder = new OidcClientSeeder($this->storage);
+    }
+
+    public function testSeedEmptyConfigIsNoOp(): void
+    {
+        $this->seeder->seed([]);
+        $this->assertCount(0, $this->storage->getQuery()->execute());
+    }
+
+    public function testSeedCreatesNewClient(): void
+    {
+        $this->seeder->seed([
+            'minoo-web' => [
+                'name' => 'Minoo',
+                'redirect_uris' => ['https://minoo.test/callback'],
+            ],
+        ]);
+
+        $ids = $this->storage->getQuery()->condition('client_id', 'minoo-web')->execute();
+        $this->assertCount(1, $ids);
+
+        $client = $this->storage->load($ids[0]);
+        $this->assertSame('minoo-web', $client->getClientId());
+        $this->assertSame('Minoo', $client->getName());
+        $this->assertSame(['https://minoo.test/callback'], $client->getRedirectUris());
+        $this->assertSame(['openid'], $client->getScopes(), 'default scopes applied');
+        $this->assertSame(['authorization_code'], $client->getGrantTypes(), 'default grant types applied');
+    }
+
+    public function testSeedAppliesAllOptionalFields(): void
+    {
+        $this->seeder->seed([
+            'biindigen' => [
+                'name' => 'Biindigen',
+                'redirect_uris' => ['https://biindigen.test/cb'],
+                'scopes' => ['openid', 'profile', 'email'],
+                'grant_types' => ['authorization_code', 'refresh_token'],
+                'is_confidential' => true,
+                'client_secret_hash' => 'hashed',
+            ],
+        ]);
+
+        $ids = $this->storage->getQuery()->condition('client_id', 'biindigen')->execute();
+        $client = $this->storage->load($ids[0]);
+        $this->assertSame(['openid', 'profile', 'email'], $client->getScopes());
+        $this->assertSame(['authorization_code', 'refresh_token'], $client->getGrantTypes());
+        $this->assertTrue($client->isConfidential());
+        $this->assertSame('hashed', $client->getClientSecretHash());
+    }
+
+    public function testSeedUpdatesExistingClient(): void
+    {
+        // First seed.
+        $this->seeder->seed([
+            'minoo-web' => [
+                'name' => 'Minoo',
+                'redirect_uris' => ['https://minoo.test/callback'],
+            ],
+        ]);
+        $ids = $this->storage->getQuery()->condition('client_id', 'minoo-web')->execute();
+        $originalId = $ids[0];
+        $originalUuid = $this->storage->load($originalId)->uuid();
+
+        // Re-seed with updated fields.
+        $this->seeder->seed([
+            'minoo-web' => [
+                'name' => 'Minoo (renamed)',
+                'redirect_uris' => [
+                    'https://minoo.test/callback',
+                    'https://minoo.test/new-callback',
+                ],
+                'scopes' => ['openid', 'profile'],
+            ],
+        ]);
+
+        // Still only one row.
+        $this->assertCount(1, $this->storage->getQuery()->condition('client_id', 'minoo-web')->execute());
+
+        // Updated in place: same id, same uuid, new fields.
+        $reloaded = $this->storage->load($originalId);
+        $this->assertSame($originalId, $reloaded->id());
+        $this->assertSame($originalUuid, $reloaded->uuid());
+        $this->assertSame('Minoo (renamed)', $reloaded->getName());
+        $this->assertSame(
+            ['https://minoo.test/callback', 'https://minoo.test/new-callback'],
+            $reloaded->getRedirectUris(),
+        );
+        $this->assertSame(['openid', 'profile'], $reloaded->getScopes());
+    }
+
+    public function testSeedIsIdempotent(): void
+    {
+        $config = [
+            'minoo-web' => [
+                'name' => 'Minoo',
+                'redirect_uris' => ['https://minoo.test/callback'],
+            ],
+        ];
+
+        $this->seeder->seed($config);
+        $this->seeder->seed($config);
+        $this->seeder->seed($config);
+
+        $this->assertCount(1, $this->storage->getQuery()->execute());
+    }
+
+    public function testSeedDoesNotDeleteAdminCreatedClients(): void
+    {
+        // Admin creates a client outside of config.
+        $admin = $this->storage->create([
+            'client_id' => 'admin-added',
+            'name' => 'Admin-created client',
+            'redirect_uris' => ['https://example.test/cb'],
+        ]);
+        $this->storage->save($admin);
+
+        // Seed does not mention admin-added.
+        $this->seeder->seed([
+            'minoo-web' => [
+                'name' => 'Minoo',
+                'redirect_uris' => ['https://minoo.test/callback'],
+            ],
+        ]);
+
+        // Admin client survives.
+        $this->assertCount(
+            1,
+            $this->storage->getQuery()->condition('client_id', 'admin-added')->execute(),
+            'admin-added client must not be deleted by seeder',
+        );
+    }
+
+    public function testSeedDoesNotDeleteClientsRemovedFromConfig(): void
+    {
+        // Seed two clients.
+        $this->seeder->seed([
+            'minoo-web' => ['name' => 'Minoo', 'redirect_uris' => ['https://minoo.test/cb']],
+            'biindigen' => ['name' => 'Biindigen', 'redirect_uris' => ['https://biindigen.test/cb']],
+        ]);
+        $this->assertCount(2, $this->storage->getQuery()->execute());
+
+        // Re-seed with only one.
+        $this->seeder->seed([
+            'minoo-web' => ['name' => 'Minoo', 'redirect_uris' => ['https://minoo.test/cb']],
+        ]);
+
+        // biindigen was NOT deleted — config removal is non-destructive.
+        $this->assertCount(2, $this->storage->getQuery()->execute());
+    }
+
+    public function testSeedThrowsOnMissingName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('name');
+
+        $this->seeder->seed([
+            'minoo-web' => ['redirect_uris' => ['https://minoo.test/cb']],
+        ]);
+    }
+
+    public function testSeedThrowsOnMissingRedirectUris(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('redirect_uris');
+
+        $this->seeder->seed([
+            'minoo-web' => ['name' => 'Minoo'],
+        ]);
+    }
+
+    public function testSeedThrowsOnEmptyRedirectUris(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->seeder->seed([
+            'minoo-web' => ['name' => 'Minoo', 'redirect_uris' => []],
+        ]);
+    }
+
+    public function testSeedThrowsOnNonStringClientId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->seeder->seed([
+            0 => ['name' => 'x', 'redirect_uris' => ['https://x.test/cb']],
+        ]);
+    }
+}

--- a/packages/oidc/tests/Integration/Entity/OidcClientStorageTest.php
+++ b/packages/oidc/tests/Integration/Entity/OidcClientStorageTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Entity;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+/**
+ * Full CRUD lifecycle for OidcClient against a real in-memory SQLite database.
+ *
+ * Verifies that the entity's default values (scopes, grant_types), array fields
+ * (redirect_uris), and scalar fields (client_id, client_secret_hash) all round-trip
+ * cleanly through SqlEntityStorage.
+ */
+#[CoversClass(OidcClient::class)]
+final class OidcClientStorageTest extends TestCase
+{
+    private DBALDatabase $database;
+    private SqlEntityStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+
+        $entityType = new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $this->database);
+        $schemaHandler->ensureTable();
+
+        // client_id gets an explicit indexed column — every authorize request
+        // looks up clients by this field, so it must not live in the _data blob.
+        $schemaHandler->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+
+        $this->storage = new SqlEntityStorage(
+            $entityType,
+            $this->database,
+            new EventDispatcher(),
+        );
+    }
+
+    public function testCreateAndSaveAssignsId(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+
+        $this->storage->save($client);
+
+        $this->assertNotNull($client->id());
+        $this->assertIsInt($client->id());
+        $this->assertFalse($client->isNew());
+    }
+
+    public function testDefaultsAreAppliedOnCreate(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+        ]);
+
+        $this->assertSame(['openid'], $client->getScopes());
+        $this->assertSame(['authorization_code'], $client->getGrantTypes());
+        $this->assertFalse($client->isConfidential());
+        $this->assertSame([], $client->getRedirectUris());
+    }
+
+    public function testFullRoundTripPreservesAllFields(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'biindigen',
+            'name' => 'Biindigen Community Portal',
+            'redirect_uris' => [
+                'https://biindigen.test/auth/callback',
+                'https://biindigen.test/auth/silent',
+            ],
+            'scopes' => ['openid', 'profile', 'email'],
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'is_confidential' => true,
+            'client_secret_hash' => 'hashed-secret',
+        ]);
+        $this->storage->save($client);
+        $id = $client->id();
+        $uuid = $client->uuid();
+
+        $loaded = $this->storage->load($id);
+
+        $this->assertNotNull($loaded);
+        $this->assertInstanceOf(OidcClient::class, $loaded);
+        $this->assertSame($id, $loaded->id());
+        $this->assertSame($uuid, $loaded->uuid());
+        $this->assertSame('biindigen', $loaded->getClientId());
+        $this->assertSame('Biindigen Community Portal', $loaded->getName());
+        $this->assertSame(
+            ['https://biindigen.test/auth/callback', 'https://biindigen.test/auth/silent'],
+            $loaded->getRedirectUris(),
+        );
+        $this->assertSame(['openid', 'profile', 'email'], $loaded->getScopes());
+        $this->assertSame(['authorization_code', 'refresh_token'], $loaded->getGrantTypes());
+        $this->assertTrue($loaded->isConfidential());
+        $this->assertSame('hashed-secret', $loaded->getClientSecretHash());
+    }
+
+    public function testUpdatePersistsChanges(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        $this->storage->save($client);
+        $id = $client->id();
+
+        $client->setRedirectUris([
+            'https://minoo.test/callback',
+            'https://minoo.test/new-callback',
+        ]);
+        $client->setScopes(['openid', 'profile']);
+        $this->storage->save($client);
+
+        $reloaded = $this->storage->load($id);
+        $this->assertSame(
+            ['https://minoo.test/callback', 'https://minoo.test/new-callback'],
+            $reloaded->getRedirectUris(),
+        );
+        $this->assertSame(['openid', 'profile'], $reloaded->getScopes());
+    }
+
+    public function testUpdatePreservesUuid(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+        ]);
+        $this->storage->save($client);
+        $originalUuid = $client->uuid();
+
+        $client->setName('Minoo (renamed)');
+        $this->storage->save($client);
+
+        $loaded = $this->storage->load($client->id());
+        $this->assertSame($originalUuid, $loaded->uuid());
+    }
+
+    public function testQueryByClientId(): void
+    {
+        $this->seedClients();
+
+        $ids = $this->storage->getQuery()
+            ->condition('client_id', 'biindigen')
+            ->execute();
+
+        $this->assertCount(1, $ids);
+        $client = $this->storage->load($ids[0]);
+        $this->assertSame('biindigen', $client->getClientId());
+    }
+
+    public function testDeleteRemovesClient(): void
+    {
+        $this->seedClients();
+        $all = $this->storage->getQuery()->execute();
+        $this->assertCount(2, $all);
+
+        $toDelete = $this->storage->load($all[0]);
+        $this->storage->delete([$toDelete]);
+
+        $remaining = $this->storage->getQuery()->execute();
+        $this->assertCount(1, $remaining);
+        $this->assertNull($this->storage->load($all[0]));
+    }
+
+    public function testFreshStorageLoadsSameEntity(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'scopes' => ['openid', 'profile'],
+        ]);
+        $this->storage->save($client);
+        $id = $client->id();
+
+        $fresh = new SqlEntityStorage(
+            new EntityType(
+                id: 'oidc_client',
+                label: 'OIDC Client',
+                class: OidcClient::class,
+                keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+            ),
+            $this->database,
+            new EventDispatcher(),
+        );
+
+        $loaded = $fresh->load($id);
+        $this->assertNotNull($loaded);
+        $this->assertSame('minoo-web', $loaded->getClientId());
+        $this->assertSame(['openid', 'profile'], $loaded->getScopes());
+    }
+
+    private function seedClients(): void
+    {
+        $seeds = [
+            ['client_id' => 'minoo-web', 'name' => 'Minoo'],
+            ['client_id' => 'biindigen', 'name' => 'Biindigen'],
+        ];
+        foreach ($seeds as $values) {
+            $client = $this->storage->create($values);
+            $this->storage->save($client);
+        }
+    }
+}

--- a/packages/oidc/tests/Unit/Access/OidcClientAccessPolicyTest.php
+++ b/packages/oidc/tests/Unit/Access/OidcClientAccessPolicyTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Access;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
+use Waaseyaa\Oidc\Access\OidcClientAccessPolicy;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+#[CoversClass(OidcClientAccessPolicy::class)]
+final class OidcClientAccessPolicyTest extends TestCase
+{
+    private OidcClientAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new OidcClientAccessPolicy();
+    }
+
+    public function testImplementsEntityAccessPolicy(): void
+    {
+        $this->assertInstanceOf(AccessPolicyInterface::class, $this->policy);
+    }
+
+    public function testImplementsFieldAccessPolicy(): void
+    {
+        $this->assertInstanceOf(FieldAccessPolicyInterface::class, $this->policy);
+    }
+
+    public function testAppliesToOidcClient(): void
+    {
+        $this->assertTrue($this->policy->appliesTo('oidc_client'));
+    }
+
+    public function testDoesNotApplyToOtherEntityTypes(): void
+    {
+        $this->assertFalse($this->policy->appliesTo('user'));
+        $this->assertFalse($this->policy->appliesTo('node'));
+    }
+
+    // ---- Entity-level access ----
+
+    public function testAdminCanView(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'view', $this->admin());
+        $this->assertTrue($result->isAllowed());
+    }
+
+    public function testAdminCanUpdate(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'update', $this->admin());
+        $this->assertTrue($result->isAllowed());
+    }
+
+    public function testAdminCanDelete(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'delete', $this->admin());
+        $this->assertTrue($result->isAllowed());
+    }
+
+    public function testAdminCanCreate(): void
+    {
+        $result = $this->policy->createAccess('oidc_client', '', $this->admin());
+        $this->assertTrue($result->isAllowed());
+    }
+
+    public function testNonAdminCannotView(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'view', $this->nonAdmin());
+        $this->assertFalse($result->isAllowed());
+    }
+
+    public function testNonAdminCannotUpdate(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'update', $this->nonAdmin());
+        $this->assertFalse($result->isAllowed());
+    }
+
+    public function testNonAdminCannotDelete(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'delete', $this->nonAdmin());
+        $this->assertFalse($result->isAllowed());
+    }
+
+    public function testNonAdminCannotCreate(): void
+    {
+        $result = $this->policy->createAccess('oidc_client', '', $this->nonAdmin());
+        $this->assertFalse($result->isAllowed());
+    }
+
+    public function testAnonymousCannotView(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->access($client, 'view', $this->anonymous());
+        $this->assertFalse($result->isAllowed());
+    }
+
+    // ---- Field-level access ----
+
+    public function testClientSecretHashIsForbiddenForAdminView(): void
+    {
+        // Even admins cannot read the hash through the API — they can rotate, not read.
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->fieldAccess($client, 'client_secret_hash', 'view', $this->admin());
+        $this->assertTrue($result->isForbidden());
+    }
+
+    public function testClientSecretHashIsForbiddenForEveryone(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $result = $this->policy->fieldAccess($client, 'client_secret_hash', 'view', $this->nonAdmin());
+        $this->assertTrue($result->isForbidden());
+    }
+
+    public function testClientIdEditForbiddenOnExistingClient(): void
+    {
+        // client_id is an immutable public identifier per OIDC spec.
+        $client = new OidcClient(['id' => 1, 'client_id' => 'minoo-web']);
+        $result = $this->policy->fieldAccess($client, 'client_id', 'edit', $this->admin());
+        $this->assertTrue($result->isForbidden());
+    }
+
+    public function testClientIdEditAllowedOnNewClient(): void
+    {
+        // New clients need client_id to be set.
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        $this->assertTrue($client->isNew());
+        $result = $this->policy->fieldAccess($client, 'client_id', 'edit', $this->admin());
+        $this->assertFalse($result->isForbidden());
+    }
+
+    public function testOtherFieldsOpenForView(): void
+    {
+        $client = new OidcClient(['client_id' => 'minoo-web']);
+        foreach (['name', 'redirect_uris', 'scopes', 'grant_types', 'is_confidential'] as $field) {
+            $result = $this->policy->fieldAccess($client, $field, 'view', $this->admin());
+            $this->assertFalse(
+                $result->isForbidden(),
+                "Field '$field' view should not be forbidden for admin",
+            );
+        }
+    }
+
+    public function testOtherFieldsOpenForEdit(): void
+    {
+        $client = new OidcClient(['id' => 1, 'client_id' => 'minoo-web']);
+        foreach (['name', 'redirect_uris', 'scopes', 'grant_types', 'is_confidential'] as $field) {
+            $result = $this->policy->fieldAccess($client, $field, 'edit', $this->admin());
+            $this->assertFalse(
+                $result->isForbidden(),
+                "Field '$field' edit should not be forbidden for admin",
+            );
+        }
+    }
+
+    // ---- Helpers ----
+
+    private function admin(): AccountInterface
+    {
+        $mock = $this->createMock(AccountInterface::class);
+        $mock->method('hasPermission')
+            ->willReturnCallback(fn(string $p): bool => $p === 'administer oidc clients');
+        $mock->method('id')->willReturn(1);
+        return $mock;
+    }
+
+    private function nonAdmin(): AccountInterface
+    {
+        $mock = $this->createMock(AccountInterface::class);
+        $mock->method('hasPermission')->willReturn(false);
+        $mock->method('id')->willReturn(2);
+        return $mock;
+    }
+
+    private function anonymous(): AccountInterface
+    {
+        $mock = $this->createMock(AccountInterface::class);
+        $mock->method('hasPermission')->willReturn(false);
+        $mock->method('id')->willReturn(0);
+        $mock->method('isAuthenticated')->willReturn(false);
+        return $mock;
+    }
+}

--- a/packages/oidc/tests/Unit/Entity/OidcClientTest.php
+++ b/packages/oidc/tests/Unit/Entity/OidcClientTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Entity;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+#[CoversClass(OidcClient::class)]
+final class OidcClientTest extends TestCase
+{
+    public function testExtendsContentEntityBase(): void
+    {
+        $client = new OidcClient();
+        $this->assertInstanceOf(ContentEntityBase::class, $client);
+    }
+
+    public function testEntityTypeId(): void
+    {
+        $client = new OidcClient();
+        $this->assertSame('oidc_client', $client->getEntityTypeId());
+    }
+
+    public function testNewClientHasNoId(): void
+    {
+        $client = new OidcClient();
+        $this->assertNull($client->id());
+    }
+
+    public function testNewClientIsNew(): void
+    {
+        $client = new OidcClient();
+        $this->assertTrue($client->isNew());
+    }
+
+    public function testClientWithIdIsNotNew(): void
+    {
+        $client = new OidcClient(['id' => 7]);
+        $this->assertSame(7, $client->id());
+        $this->assertFalse($client->isNew());
+    }
+
+    public function testAutoGeneratesUuid(): void
+    {
+        $client = new OidcClient();
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $client->uuid(),
+        );
+    }
+
+    public function testExplicitUuidIsPreserved(): void
+    {
+        $client = new OidcClient(['uuid' => 'my-uuid']);
+        $this->assertSame('my-uuid', $client->uuid());
+    }
+
+    public function testLabelReturnsName(): void
+    {
+        $client = new OidcClient(['name' => 'Minoo']);
+        $this->assertSame('Minoo', $client->label());
+    }
+
+    public function testClientIdGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setClientId('minoo-web');
+        $this->assertSame('minoo-web', $client->getClientId());
+    }
+
+    public function testClientIdFromValues(): void
+    {
+        $client = new OidcClient(['client_id' => 'biindigen']);
+        $this->assertSame('biindigen', $client->getClientId());
+    }
+
+    public function testRedirectUrisGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setRedirectUris(['https://minoo.test/callback', 'https://minoo.test/silent']);
+        $this->assertSame(
+            ['https://minoo.test/callback', 'https://minoo.test/silent'],
+            $client->getRedirectUris(),
+        );
+    }
+
+    public function testRedirectUrisDefaultsToEmptyArray(): void
+    {
+        $client = new OidcClient();
+        $this->assertSame([], $client->getRedirectUris());
+    }
+
+    public function testHasRedirectUriExactMatch(): void
+    {
+        $client = new OidcClient([
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        $this->assertTrue($client->hasRedirectUri('https://minoo.test/callback'));
+    }
+
+    public function testHasRedirectUriRejectsTrailingSlashVariant(): void
+    {
+        $client = new OidcClient([
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        // Exact match only — OIDC spec requires byte-for-byte match.
+        $this->assertFalse($client->hasRedirectUri('https://minoo.test/callback/'));
+    }
+
+    public function testHasRedirectUriRejectsCaseVariant(): void
+    {
+        $client = new OidcClient([
+            'redirect_uris' => ['https://minoo.test/Callback'],
+        ]);
+        $this->assertFalse($client->hasRedirectUri('https://minoo.test/callback'));
+    }
+
+    public function testScopesGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setScopes(['openid', 'profile', 'email']);
+        $this->assertSame(['openid', 'profile', 'email'], $client->getScopes());
+    }
+
+    public function testScopesDefaultsToOpenid(): void
+    {
+        $client = new OidcClient();
+        $this->assertSame(['openid'], $client->getScopes());
+    }
+
+    public function testHasScope(): void
+    {
+        $client = new OidcClient(['scopes' => ['openid', 'profile']]);
+        $this->assertTrue($client->hasScope('openid'));
+        $this->assertTrue($client->hasScope('profile'));
+        $this->assertFalse($client->hasScope('email'));
+    }
+
+    public function testGrantTypesGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setGrantTypes(['authorization_code', 'refresh_token']);
+        $this->assertSame(['authorization_code', 'refresh_token'], $client->getGrantTypes());
+    }
+
+    public function testGrantTypesDefaultsToAuthorizationCode(): void
+    {
+        $client = new OidcClient();
+        $this->assertSame(['authorization_code'], $client->getGrantTypes());
+    }
+
+    public function testSupportsGrantType(): void
+    {
+        $client = new OidcClient([
+            'grant_types' => ['authorization_code', 'refresh_token'],
+        ]);
+        $this->assertTrue($client->supportsGrantType('authorization_code'));
+        $this->assertFalse($client->supportsGrantType('client_credentials'));
+    }
+
+    public function testIsConfidentialDefaultsFalse(): void
+    {
+        // Public clients (SPAs, mobile) are the default for OIDC + PKCE.
+        $client = new OidcClient();
+        $this->assertFalse($client->isConfidential());
+    }
+
+    public function testIsConfidentialGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setConfidential(true);
+        $this->assertTrue($client->isConfidential());
+    }
+
+    public function testClientSecretHashNullByDefault(): void
+    {
+        $client = new OidcClient();
+        $this->assertNull($client->getClientSecretHash());
+    }
+
+    public function testClientSecretHashGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setClientSecretHash('hashed-secret-value');
+        $this->assertSame('hashed-secret-value', $client->getClientSecretHash());
+    }
+
+    public function testNameGetterSetter(): void
+    {
+        $client = new OidcClient();
+        $client->setName('Minoo Web App');
+        $this->assertSame('Minoo Web App', $client->getName());
+    }
+}

--- a/packages/oidc/tests/Unit/OidcServiceProviderTest.php
+++ b/packages/oidc/tests/Unit/OidcServiceProviderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Waaseyaa\Oidc\Entity\OidcClient;
 use Waaseyaa\Oidc\Http\DiscoveryController;
 use Waaseyaa\Oidc\Http\JwksController;
 use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
@@ -188,6 +189,39 @@ final class OidcServiceProviderTest extends TestCase
         $body = json_decode((string) $controller->serve()->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertCount(1, $body['keys']);
         self::assertSame('jwks-key', $body['keys'][0]['kid']);
+    }
+
+    #[Test]
+    public function registerRegistersOidcClientEntityType(): void
+    {
+        $provider = new OidcServiceProvider();
+        $provider->setKernelContext('/tmp/oidc-test', []);
+
+        $provider->register();
+
+        $entityTypes = $provider->getEntityTypes();
+        $ids = array_map(fn($t) => $t->id(), $entityTypes);
+        self::assertContains('oidc_client', $ids);
+
+        $oidcClient = null;
+        foreach ($entityTypes as $type) {
+            if ($type->id() === 'oidc_client') {
+                $oidcClient = $type;
+                break;
+            }
+        }
+        self::assertNotNull($oidcClient);
+        self::assertSame(OidcClient::class, $oidcClient->getClass());
+        self::assertSame(
+            ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+            $oidcClient->getKeys(),
+        );
+
+        $fields = $oidcClient->getFieldDefinitions();
+        self::assertArrayHasKey('client_id', $fields);
+        self::assertArrayHasKey('redirect_uris', $fields);
+        self::assertArrayHasKey('scopes', $fields);
+        self::assertArrayHasKey('client_secret_hash', $fields);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #1282

## Summary

Models OIDC relying-party clients (Minoo, biindigen, etc.) as first-class Waaseyaa entities. Dogfoods the entity system and matches industry-standard IdPs (Keycloak, Auth0, Ory Hydra) which all persist clients in a DB with admin UI rather than static config only.

- **OidcClient** content entity (int id, uuid, unique client_id, name label, redirect_uris/scopes/grant_types arrays, is_confidential, optional client_secret_hash). Defaults: `['openid']` scope, `['authorization_code']` grant, non-confidential. Helpers: `hasRedirectUri()` (byte-for-byte exact match per OIDC spec §3.1.2.1), `hasScope()`, `supportsGrantType()`.
- **OidcClientAccessPolicy** gates entity ops behind `administer oidc clients`. Field policy forbids view of `client_secret_hash` for everyone (rotation is write-only) and forbids edit of `client_id` after creation (immutable public identifier per OIDC spec).
- **OidcClientSeeder** upserts by `client_id` from `config[oidc][clients]` on boot. Idempotent. Non-destructive: config removals do not delete DB rows; admin-created clients outside config are untouched. Validates required `name` + non-empty `redirect_uris`.
- **OidcServiceProvider** registers the entity type with field definitions, and `boot()` ensures indexed columns (idempotent `addFieldColumns`) before running the seeder. A code comment notes the `addFieldColumns` path should move to a package migration once those are wired.

## Verification

- `vendor/bin/phpunit` — 6250 tests, 14927 assertions, all green
- `composer phpstan` — clean
- `composer cs-check` — clean
- `composer check-composer-policy` — clean
- OIDC package alone: 93 tests, 244 assertions
- No new interfaces/abstracts introduced; `docs/public-surface-map.php` unaffected

## Unblocks

- #1284 (/authorize endpoint) — needs client lookup + redirect_uri validation, which this PR provides
- Runs in parallel with #1283 (authorization code repository)

## Checklist

- [x] `Closes #1282` above references the issue this PR resolves
- [x] The issue is assigned to milestone "Track 5 — Ecosystem identity"
- [x] PR title includes the issue number

🤖 Generated with [Claude Code](https://claude.com/claude-code)