### PR TITLE
feat(#1283): authorization code repository

### DIFF
--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -203,6 +203,7 @@ return [
     'Waaseyaa\Mcp\Bridge\ToolRegistryInterface' => 'public',
     'Waaseyaa\Mcp\Auth\McpAuthInterface' => 'public',
     'Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface' => 'public',
+    'Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface' => 'public',
     'Waaseyaa\SSR\ThemeInterface' => 'public',
 
     // Layer 1: Core Data — public (discovered during L5-L6 scan)

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Oidc;
 
 use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
@@ -16,6 +17,8 @@ use Waaseyaa\Oidc\Http\DiscoveryController;
 use Waaseyaa\Oidc\Http\JwksController;
 use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
 use Waaseyaa\Oidc\Keys\PemFileKeyLoader;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+use Waaseyaa\Oidc\Repository\DatabaseAuthorizationCodeRepository;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class OidcServiceProvider extends ServiceProvider
@@ -90,6 +93,21 @@ final class OidcServiceProvider extends ServiceProvider
             fn(): JwksController => new JwksController(
                 keyLoader: $this->resolve(OidcKeyLoaderInterface::class),
             ),
+        );
+
+        $this->singleton(
+            AuthorizationCodeRepositoryInterface::class,
+            function (): AuthorizationCodeRepositoryInterface {
+                $database = $this->resolve(DatabaseInterface::class);
+                if (!$database instanceof DBALDatabase) {
+                    throw new \RuntimeException(
+                        'OIDC authorization code repository requires a DBALDatabase instance; '
+                        . 'got ' . $database::class . '.',
+                    );
+                }
+
+                return new DatabaseAuthorizationCodeRepository(database: $database);
+            },
         );
     }
 

--- a/packages/oidc/src/Repository/AuthorizationCode.php
+++ b/packages/oidc/src/Repository/AuthorizationCode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Repository;
+
+/**
+ * Short-lived, single-use authorization code issued by the OIDC authorize endpoint
+ * and exchanged at the token endpoint for an ID token + access token.
+ *
+ * Per OAuth 2.1, codes live for 60 seconds and may be consumed exactly once. Binding
+ * fields (clientId, redirectUri, codeChallenge) are validated at exchange time — the
+ * repository stores them verbatim; it does not enforce them.
+ */
+final readonly class AuthorizationCode
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public string $code,
+        public string $clientId,
+        public string $accountId,
+        public string $redirectUri,
+        public array $scopes,
+        public string $codeChallenge,
+        public string $codeChallengeMethod,
+        public int $issuedAt,
+        public int $expiresAt,
+        public ?int $consumedAt = null,
+    ) {}
+
+    public function isExpired(int $now): bool
+    {
+        return $now >= $this->expiresAt;
+    }
+
+    public function isConsumed(): bool
+    {
+        return $this->consumedAt !== null;
+    }
+}

--- a/packages/oidc/src/Repository/AuthorizationCodeRepositoryInterface.php
+++ b/packages/oidc/src/Repository/AuthorizationCodeRepositoryInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Repository;
+
+use Waaseyaa\Access\AccountInterface;
+
+/**
+ * Persistence port for OIDC authorization codes.
+ *
+ * Codes are short-lived (60 s per OAuth 2.1) and single-use. Atomicity of consume()
+ * is part of the contract: a second consume() for the same code MUST return null,
+ * even under concurrent callers.
+ *
+ * Alternate backends (Redis, in-memory) are allowed; the /token endpoint depends
+ * only on this interface.
+ */
+interface AuthorizationCodeRepositoryInterface
+{
+    /**
+     * Issue a fresh code bound to the given client, account, redirect URI, scopes,
+     * and PKCE challenge. Returns the persisted AuthorizationCode with its generated
+     * code, issuedAt, and expiresAt fields.
+     *
+     * @param list<string> $scopes
+     */
+    public function issue(
+        string $clientId,
+        AccountInterface $account,
+        string $redirectUri,
+        array $scopes,
+        string $codeChallenge,
+        string $codeChallengeMethod,
+    ): AuthorizationCode;
+
+    /**
+     * Atomically consume a code. Returns the stored code on the first successful
+     * consume, or null if the code does not exist, is already consumed, or has
+     * expired. Callers still validate client binding, redirect URI, and PKCE
+     * verifier against the returned object.
+     */
+    public function consume(string $code): ?AuthorizationCode;
+
+    /**
+     * Remove codes whose expiresAt is in the past. Returns the number of rows
+     * removed. Safe to call from a scheduled job.
+     */
+    public function purgeExpired(): int;
+}

--- a/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
+++ b/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Repository;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Database\DBALDatabase;
+
+/**
+ * DBAL-backed authorization code repository.
+ *
+ * Single-use is guaranteed by a single-statement atomic UPDATE with affected-rows
+ * check: `UPDATE ... SET consumed_at = ? WHERE code = ? AND consumed_at IS NULL
+ * AND expires_at > ?`. Concurrent consume() calls race on this one statement;
+ * exactly one observes a non-zero affected-rows count.
+ */
+final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepositoryInterface
+{
+    private const TABLE = 'oidc_authorization_codes';
+
+    public const TTL_SECONDS = 60;
+
+    /** @var \Closure():int */
+    private readonly \Closure $clock;
+
+    private bool $tableEnsured = false;
+
+    /**
+     * @param (\Closure():int)|null $clock Clock returning Unix timestamp; defaults to time().
+     */
+    public function __construct(
+        private readonly DBALDatabase $database,
+        ?\Closure $clock = null,
+    ) {
+        $this->clock = $clock ?? static fn(): int => time();
+    }
+
+    public function issue(
+        string $clientId,
+        AccountInterface $account,
+        string $redirectUri,
+        array $scopes,
+        string $codeChallenge,
+        string $codeChallengeMethod,
+    ): AuthorizationCode {
+        $this->ensureTable();
+
+        $now = ($this->clock)();
+        $expiresAt = $now + self::TTL_SECONDS;
+
+        $code = bin2hex(random_bytes(32));
+        $accountId = (string) $account->id();
+        $scopesJson = json_encode(array_values($scopes), JSON_THROW_ON_ERROR);
+
+        $this->database->insert(self::TABLE)
+            ->values([
+                'code' => $code,
+                'client_id' => $clientId,
+                'account_id' => $accountId,
+                'redirect_uri' => $redirectUri,
+                'scopes' => $scopesJson,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+                'issued_at' => $now,
+                'expires_at' => $expiresAt,
+                'consumed_at' => null,
+            ])
+            ->execute();
+
+        return new AuthorizationCode(
+            code: $code,
+            clientId: $clientId,
+            accountId: $accountId,
+            redirectUri: $redirectUri,
+            scopes: array_values($scopes),
+            codeChallenge: $codeChallenge,
+            codeChallengeMethod: $codeChallengeMethod,
+            issuedAt: $now,
+            expiresAt: $expiresAt,
+            consumedAt: null,
+        );
+    }
+
+    public function consume(string $code): ?AuthorizationCode
+    {
+        $this->ensureTable();
+
+        $now = ($this->clock)();
+
+        $affected = $this->database->getConnection()->executeStatement(
+            'UPDATE ' . self::TABLE . ' SET consumed_at = ? WHERE code = ? AND consumed_at IS NULL AND expires_at > ?',
+            [$now, $code, $now],
+        );
+
+        if ($affected === 0) {
+            return null;
+        }
+
+        $row = $this->fetchByCode($code);
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->hydrate($row);
+    }
+
+    public function purgeExpired(): int
+    {
+        $this->ensureTable();
+
+        return $this->database->delete(self::TABLE)
+            ->condition('expires_at', ($this->clock)(), '<=')
+            ->execute();
+    }
+
+    private function ensureTable(): void
+    {
+        if ($this->tableEnsured) {
+            return;
+        }
+
+        $this->database->query(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS oidc_authorization_codes (
+                code VARCHAR(128) PRIMARY KEY,
+                client_id VARCHAR(255) NOT NULL,
+                account_id VARCHAR(255) NOT NULL,
+                redirect_uri TEXT NOT NULL,
+                scopes TEXT NOT NULL,
+                code_challenge VARCHAR(128) NOT NULL,
+                code_challenge_method VARCHAR(16) NOT NULL,
+                issued_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                consumed_at INTEGER
+            )
+        SQL);
+
+        $this->database->query(
+            'CREATE INDEX IF NOT EXISTS idx_oidc_auth_codes_expires_at ON oidc_authorization_codes (expires_at)',
+        );
+        $this->database->query(
+            'CREATE INDEX IF NOT EXISTS idx_oidc_auth_codes_client_id ON oidc_authorization_codes (client_id)',
+        );
+
+        $this->tableEnsured = true;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchByCode(string $code): ?array
+    {
+        foreach ($this->database->select(self::TABLE)->condition('code', $code)->execute() as $row) {
+            return $row;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): AuthorizationCode
+    {
+        $scopes = json_decode((string) $row['scopes'], true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($scopes)) {
+            $scopes = [];
+        }
+        /** @var list<string> $scopes */
+        $scopes = array_values(array_map('strval', $scopes));
+
+        return new AuthorizationCode(
+            code: (string) $row['code'],
+            clientId: (string) $row['client_id'],
+            accountId: (string) $row['account_id'],
+            redirectUri: (string) $row['redirect_uri'],
+            scopes: $scopes,
+            codeChallenge: (string) $row['code_challenge'],
+            codeChallengeMethod: (string) $row['code_challenge_method'],
+            issuedAt: (int) $row['issued_at'],
+            expiresAt: (int) $row['expires_at'],
+            consumedAt: isset($row['consumed_at']) ? (int) $row['consumed_at'] : null,
+        );
+    }
+}

--- a/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
+++ b/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Repository;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Oidc\Repository\AuthorizationCode;
+use Waaseyaa\Oidc\Repository\DatabaseAuthorizationCodeRepository;
+
+#[CoversClass(DatabaseAuthorizationCodeRepository::class)]
+#[CoversClass(AuthorizationCode::class)]
+final class DatabaseAuthorizationCodeRepositoryTest extends TestCase
+{
+    private DBALDatabase $database;
+
+    /** @var int Fixed "now" timestamp controlled by the clock below. */
+    private int $now = 1_700_000_000;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+    }
+
+    public function testIssueReturnsCodeWithExpectedFields(): void
+    {
+        $repo = $this->buildRepo();
+
+        $code = $repo->issue(
+            clientId: 'minoo-web',
+            account: $this->account('42'),
+            redirectUri: 'https://minoo.test/callback',
+            scopes: ['openid', 'profile'],
+            codeChallenge: 'ch4lleng3',
+            codeChallengeMethod: 'S256',
+        );
+
+        self::assertNotEmpty($code->code, 'generated code must not be empty');
+        self::assertSame('minoo-web', $code->clientId);
+        self::assertSame('42', $code->accountId);
+        self::assertSame('https://minoo.test/callback', $code->redirectUri);
+        self::assertSame(['openid', 'profile'], $code->scopes);
+        self::assertSame('ch4lleng3', $code->codeChallenge);
+        self::assertSame('S256', $code->codeChallengeMethod);
+        self::assertSame($this->now, $code->issuedAt);
+        self::assertSame($this->now + 60, $code->expiresAt, 'OAuth 2.1 mandates 60 s TTL');
+        self::assertNull($code->consumedAt);
+    }
+
+    public function testIssueProducesUniqueCodesForDistinctCalls(): void
+    {
+        $repo = $this->buildRepo();
+
+        $a = $repo->issue('minoo-web', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+        $b = $repo->issue('minoo-web', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        self::assertNotSame($a->code, $b->code);
+    }
+
+    public function testConsumeReturnsIssuedCodeOnFirstCall(): void
+    {
+        $repo = $this->buildRepo();
+
+        $issued = $repo->issue(
+            clientId: 'minoo-web',
+            account: $this->account('42'),
+            redirectUri: 'https://minoo.test/callback',
+            scopes: ['openid'],
+            codeChallenge: 'ch4lleng3',
+            codeChallengeMethod: 'S256',
+        );
+
+        $consumed = $repo->consume($issued->code);
+
+        self::assertNotNull($consumed);
+        self::assertSame($issued->code, $consumed->code);
+        self::assertSame('minoo-web', $consumed->clientId);
+        self::assertSame('42', $consumed->accountId);
+        self::assertSame('https://minoo.test/callback', $consumed->redirectUri);
+        self::assertSame(['openid'], $consumed->scopes);
+        self::assertSame('ch4lleng3', $consumed->codeChallenge);
+        self::assertSame('S256', $consumed->codeChallengeMethod);
+        self::assertSame($this->now, $consumed->consumedAt);
+    }
+
+    public function testSecondConsumeReturnsNull(): void
+    {
+        $repo = $this->buildRepo();
+
+        $issued = $repo->issue('minoo-web', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        self::assertNotNull($repo->consume($issued->code));
+        self::assertNull($repo->consume($issued->code), 'single-use guarantee');
+    }
+
+    public function testConsumeReturnsNullForUnknownCode(): void
+    {
+        $repo = $this->buildRepo();
+
+        self::assertNull($repo->consume('no-such-code'));
+    }
+
+    public function testConsumeReturnsNullForExpiredCode(): void
+    {
+        $repo = $this->buildRepo();
+
+        $issued = $repo->issue('minoo-web', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        $this->now += 61;
+
+        self::assertNull($repo->consume($issued->code));
+    }
+
+    public function testPurgeExpiredRemovesOnlyExpiredRows(): void
+    {
+        $repo = $this->buildRepo();
+
+        $expired = $repo->issue('a', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        $this->now += 61;
+
+        $fresh = $repo->issue('b', $this->account('2'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        $purged = $repo->purgeExpired();
+
+        self::assertSame(1, $purged);
+        self::assertNull($repo->consume($expired->code));
+        self::assertNotNull($repo->consume($fresh->code));
+    }
+
+    public function testPurgeExpiredReturnsZeroWhenNothingToPurge(): void
+    {
+        $repo = $this->buildRepo();
+
+        $repo->issue('a', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        self::assertSame(0, $repo->purgeExpired());
+    }
+
+    private function buildRepo(): DatabaseAuthorizationCodeRepository
+    {
+        return new DatabaseAuthorizationCodeRepository(
+            database: $this->database,
+            clock: fn(): int => $this->now,
+        );
+    }
+
+    private function account(string $id): AccountInterface
+    {
+        return new class($id) implements AccountInterface {
+            public function __construct(private readonly string $id) {}
+
+            public function id(): int|string
+            {
+                return $this->id;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return false;
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/packages/oidc/tests/Unit/Repository/AuthorizationCodeTest.php
+++ b/packages/oidc/tests/Unit/Repository/AuthorizationCodeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Repository;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Oidc\Repository\AuthorizationCode;
+
+#[CoversClass(AuthorizationCode::class)]
+final class AuthorizationCodeTest extends TestCase
+{
+    public function testExposesConstructorFields(): void
+    {
+        $code = new AuthorizationCode(
+            code: 'abc123',
+            clientId: 'minoo-web',
+            accountId: '42',
+            redirectUri: 'https://minoo.test/callback',
+            scopes: ['openid', 'profile'],
+            codeChallenge: 'Ch4lleNg3',
+            codeChallengeMethod: 'S256',
+            issuedAt: 1_000_000,
+            expiresAt: 1_000_060,
+            consumedAt: null,
+        );
+
+        self::assertSame('abc123', $code->code);
+        self::assertSame('minoo-web', $code->clientId);
+        self::assertSame('42', $code->accountId);
+        self::assertSame('https://minoo.test/callback', $code->redirectUri);
+        self::assertSame(['openid', 'profile'], $code->scopes);
+        self::assertSame('Ch4lleNg3', $code->codeChallenge);
+        self::assertSame('S256', $code->codeChallengeMethod);
+        self::assertSame(1_000_000, $code->issuedAt);
+        self::assertSame(1_000_060, $code->expiresAt);
+        self::assertNull($code->consumedAt);
+    }
+
+    public function testIsExpiredReturnsFalseBeforeExpiry(): void
+    {
+        $code = $this->sample(expiresAt: 1_000_060);
+
+        self::assertFalse($code->isExpired(1_000_059));
+    }
+
+    public function testIsExpiredReturnsTrueAtExpiry(): void
+    {
+        $code = $this->sample(expiresAt: 1_000_060);
+
+        self::assertTrue($code->isExpired(1_000_060));
+    }
+
+    public function testIsExpiredReturnsTrueAfterExpiry(): void
+    {
+        $code = $this->sample(expiresAt: 1_000_060);
+
+        self::assertTrue($code->isExpired(1_000_061));
+    }
+
+    public function testIsConsumedFalseWhenNull(): void
+    {
+        $code = $this->sample(consumedAt: null);
+
+        self::assertFalse($code->isConsumed());
+    }
+
+    public function testIsConsumedTrueWhenTimestampPresent(): void
+    {
+        $code = $this->sample(consumedAt: 1_000_050);
+
+        self::assertTrue($code->isConsumed());
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    private function sample(
+        string $code = 'abc123',
+        string $clientId = 'minoo-web',
+        string $accountId = '42',
+        string $redirectUri = 'https://minoo.test/callback',
+        array $scopes = ['openid'],
+        string $codeChallenge = 'challenge',
+        string $codeChallengeMethod = 'S256',
+        int $issuedAt = 1_000_000,
+        int $expiresAt = 1_000_060,
+        ?int $consumedAt = null,
+    ): AuthorizationCode {
+        return new AuthorizationCode(
+            code: $code,
+            clientId: $clientId,
+            accountId: $accountId,
+            redirectUri: $redirectUri,
+            scopes: $scopes,
+            codeChallenge: $codeChallenge,
+            codeChallengeMethod: $codeChallengeMethod,
+            issuedAt: $issuedAt,
+            expiresAt: $expiresAt,
+            consumedAt: $consumedAt,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Short-lived, single-use authorization code storage for the OIDC authorize/token flow. Part of Track 5 (Ecosystem identity), ADR-006 §7 TDD sequence. Unblocks #1284 (`/authorize` endpoint).

## What lands

- `AuthorizationCode` final readonly value object (code, clientId, accountId, redirectUri, scopes, codeChallenge, codeChallengeMethod, issuedAt, expiresAt, consumedAt)
- `AuthorizationCodeRepositoryInterface` with `issue()`, `consume()`, `purgeExpired()` — added to `docs/public-surface-map.php`
- `DatabaseAuthorizationCodeRepository` DBAL-backed impl:
  - Single-statement atomic consume: `UPDATE ... WHERE code = ? AND consumed_at IS NULL AND expires_at > ?` with affected-rows check (see CLAUDE.md gotcha: type-hint `DBALDatabase` directly when the DBAL `Connection` is needed)
  - 60 s TTL per OAuth 2.1
  - Clock injection via `\Closure` default to `time()`, for deterministic expiry tests
  - Code generation: `bin2hex(random_bytes(32))` = 256 bits entropy
  - Scopes stored as JSON; symmetric encode/decode with `JSON_THROW_ON_ERROR`
- Provider wiring as a singleton in `OidcServiceProvider::register()` with explicit `DBALDatabase` guard
- 14 new tests (6 unit for value object, 8 integration against `DBALDatabase::createSqlite()`): issue happy path, uniqueness per call, consume happy path, double-consume returns null, unknown code returns null, expired code returns null, purgeExpired removes only expired, purgeExpired returns 0 when nothing to purge

## Design deviation to flag

Handoff suggested schema provisioning in `OidcServiceProvider::boot()` matching the `oidc_client` pattern. I used lazy `ensureTable()` inside the repo instead, matching the `DatabaseRateLimiter` precedent for non-entity helper tables. The `oidc_client` boot-time pattern exists specifically because entity tables need `SqlSchemaHandler::addFieldColumns()` for custom columns; plain tables that own their full DDL are cleaner with lazy ensure. Easy to switch if preferred — would move `CREATE TABLE`/`CREATE INDEX` statements into a new private method on the provider, tests would still pass via the repo's lazy fallback.

## Test plan

- [x] `./vendor/bin/phpunit` — 6264/6264 green (+14 from 6250 baseline), 14970 assertions
- [x] `composer phpstan` — no errors
- [x] `composer cs-check` — 0/1037 files to fix
- [x] `composer check-composer-policy` — OK
- [x] Lefthook pre-push hooks (spec-drift, phpstan, composer-policy, phpunit) — all green

## Scope boundaries

- Does NOT implement `/authorize` or `/token` endpoints (that's #1284, #next).
- Does NOT enforce PKCE method or redirect URI binding — repo stores what it's told; validation is the authorize/token endpoints' responsibility.
- Does NOT schedule `purgeExpired()` — that's a separate scheduler wiring task (framework-level, #1286/#591 adjacent).

Fixes #1283