### PR TITLE
feat(#1284): /authorize endpoint (authorization code flow, PKCE S256)

### DIFF
--- a/packages/oidc/src/Authorize/AuthorizationRequestException.php
+++ b/packages/oidc/src/Authorize/AuthorizationRequestException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Authorize;
+
+/**
+ * Classified authorization request rejection.
+ *
+ * When `$redirectUri` is null, the caller must render a direct error page: the
+ * client or redirect_uri is unverified and the spec forbids redirecting to an
+ * unregistered URI. When `$redirectUri` is non-null, the caller must redirect
+ * there with `error` (and `state` if present) per OAuth 2.0 §4.1.2.1.
+ */
+final class AuthorizationRequestException extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $errorCode,
+        public readonly string $errorDescription,
+        public readonly ?string $redirectUri = null,
+        public readonly ?string $state = null,
+    ) {
+        parent::__construct($errorCode . ': ' . $errorDescription);
+    }
+
+    public function canRedirect(): bool
+    {
+        return $this->redirectUri !== null;
+    }
+}

--- a/packages/oidc/src/Authorize/AuthorizationRequestValidator.php
+++ b/packages/oidc/src/Authorize/AuthorizationRequestValidator.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Authorize;
+
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+/**
+ * Validates a parsed /authorize query against a registered OIDC client.
+ *
+ * Rejection order matters: client_id and redirect_uri must pass first, because
+ * they determine whether subsequent errors can redirect back to the relying
+ * party or must render a direct error page. See OAuth 2.0 §4.1.2.1 and
+ * ADR-006 §2.5 (PKCE S256 required).
+ */
+final class AuthorizationRequestValidator
+{
+    private const REQUIRED_SCOPE = 'openid';
+    private const REQUIRED_RESPONSE_TYPE = 'code';
+    private const REQUIRED_CODE_CHALLENGE_METHOD = 'S256';
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    public function validate(OidcClient $client, array $query): ValidatedAuthorizationRequest
+    {
+        $redirectUri = $this->stringOrNull($query, 'redirect_uri');
+        if ($redirectUri === null) {
+            throw new AuthorizationRequestException(
+                errorCode: 'invalid_request',
+                errorDescription: 'Missing redirect_uri.',
+            );
+        }
+
+        if (!$client->hasRedirectUri($redirectUri)) {
+            throw new AuthorizationRequestException(
+                errorCode: 'invalid_request',
+                errorDescription: 'redirect_uri is not registered for this client.',
+            );
+        }
+
+        $state = $this->stringOrNull($query, 'state');
+
+        $responseType = $this->stringOrNull($query, 'response_type');
+        if ($responseType !== self::REQUIRED_RESPONSE_TYPE) {
+            throw new AuthorizationRequestException(
+                errorCode: 'unsupported_response_type',
+                errorDescription: 'Only response_type=code is supported.',
+                redirectUri: $redirectUri,
+                state: $state,
+            );
+        }
+
+        $scopes = $this->parseScopes($this->stringOrNull($query, 'scope'));
+        if (!\in_array(self::REQUIRED_SCOPE, $scopes, true)) {
+            throw new AuthorizationRequestException(
+                errorCode: 'invalid_scope',
+                errorDescription: "Scope must include '" . self::REQUIRED_SCOPE . "'.",
+                redirectUri: $redirectUri,
+                state: $state,
+            );
+        }
+
+        foreach ($scopes as $scope) {
+            if (!$client->hasScope($scope)) {
+                throw new AuthorizationRequestException(
+                    errorCode: 'invalid_scope',
+                    errorDescription: "Scope '$scope' is not allowed for this client.",
+                    redirectUri: $redirectUri,
+                    state: $state,
+                );
+            }
+        }
+
+        $codeChallenge = $this->stringOrNull($query, 'code_challenge');
+        if ($codeChallenge === null) {
+            throw new AuthorizationRequestException(
+                errorCode: 'invalid_request',
+                errorDescription: 'Missing code_challenge. PKCE is required.',
+                redirectUri: $redirectUri,
+                state: $state,
+            );
+        }
+
+        $codeChallengeMethod = $this->stringOrNull($query, 'code_challenge_method');
+        if ($codeChallengeMethod !== self::REQUIRED_CODE_CHALLENGE_METHOD) {
+            throw new AuthorizationRequestException(
+                errorCode: 'invalid_request',
+                errorDescription: 'code_challenge_method must be S256.',
+                redirectUri: $redirectUri,
+                state: $state,
+            );
+        }
+
+        return new ValidatedAuthorizationRequest(
+            client: $client,
+            redirectUri: $redirectUri,
+            scopes: $scopes,
+            codeChallenge: $codeChallenge,
+            codeChallengeMethod: $codeChallengeMethod,
+            state: $state,
+            nonce: $this->stringOrNull($query, 'nonce'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    private function stringOrNull(array $query, string $key): ?string
+    {
+        $value = $query[$key] ?? null;
+        if (!\is_string($value) || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function parseScopes(?string $raw): array
+    {
+        if ($raw === null) {
+            return [];
+        }
+
+        $parts = preg_split('/\s+/', trim($raw)) ?: [];
+
+        return array_values(array_filter($parts, static fn(string $s): bool => $s !== ''));
+    }
+}

--- a/packages/oidc/src/Authorize/AuthorizeController.php
+++ b/packages/oidc/src/Authorize/AuthorizeController.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Authorize;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+
+/**
+ * OAuth 2.1 / OIDC authorization code flow entry point (ADR-006 §7).
+ *
+ * Flow:
+ *   1. Anonymous caller → 302 to the login page with `return_to` preserving
+ *      the original authorize URL (query string intact).
+ *   2. Authenticated caller → look up client_id, validate the request, issue
+ *      an authorization code, and 302 back to the client's redirect_uri with
+ *      `code` (and `state` if provided).
+ *   3. Any rejection before redirect_uri is verified → direct HTML error page
+ *      (OAuth 2.0 §4.1.2.1 forbids redirecting to an unregistered URI).
+ *   4. Any rejection after redirect_uri is verified → 302 to redirect_uri with
+ *      `error`, `error_description`, and `state`.
+ *
+ * First-party clients auto-consent for now; a consent screen is a deferred
+ * follow-up (see #1284 "Non-goals").
+ */
+final readonly class AuthorizeController
+{
+    public function __construct(
+        private OidcClientLookup $clientLookup,
+        private AuthorizationRequestValidator $validator,
+        private AuthorizationCodeRepositoryInterface $codeRepository,
+        private string $loginPath = '/login',
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        $account = $request->attributes->get('_account');
+        if (!$account instanceof AccountInterface) {
+            return $this->directError(500, 'server_error', 'Session middleware did not set account.');
+        }
+
+        if (!$account->isAuthenticated()) {
+            return new RedirectResponse(
+                $this->loginPath . '?return_to=' . rawurlencode($request->getRequestUri()),
+                302,
+            );
+        }
+
+        $query = $request->query->all();
+
+        $clientId = $query['client_id'] ?? null;
+        if (!is_string($clientId) || $clientId === '') {
+            return $this->directError(400, 'invalid_request', 'Missing client_id.');
+        }
+
+        $client = $this->clientLookup->findByClientId($clientId);
+        if ($client === null) {
+            return $this->directError(400, 'invalid_request', 'Unknown client_id.');
+        }
+
+        try {
+            $validated = $this->validator->validate($client, $query);
+        } catch (AuthorizationRequestException $e) {
+            if (!$e->canRedirect()) {
+                return $this->directError(400, $e->errorCode, $e->errorDescription);
+            }
+
+            return $this->errorRedirect($e);
+        }
+
+        $code = $this->codeRepository->issue(
+            clientId: $validated->client->getClientId(),
+            account: $account,
+            redirectUri: $validated->redirectUri,
+            scopes: $validated->scopes,
+            codeChallenge: $validated->codeChallenge,
+            codeChallengeMethod: $validated->codeChallengeMethod,
+        );
+
+        $params = ['code' => $code->code];
+        if ($validated->state !== null) {
+            $params['state'] = $validated->state;
+        }
+
+        return new RedirectResponse($this->appendQuery($validated->redirectUri, $params), 302);
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function appendQuery(string $url, array $params): string
+    {
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $url . $separator . http_build_query($params);
+    }
+
+    private function errorRedirect(AuthorizationRequestException $e): RedirectResponse
+    {
+        // canRedirect() guarantees non-null redirectUri.
+        $redirectUri = $e->redirectUri ?? '';
+
+        $params = [
+            'error' => $e->errorCode,
+            'error_description' => $e->errorDescription,
+        ];
+        if ($e->state !== null) {
+            $params['state'] = $e->state;
+        }
+
+        return new RedirectResponse($this->appendQuery($redirectUri, $params), 302);
+    }
+
+    private function directError(int $status, string $code, string $description): Response
+    {
+        $body = sprintf(
+            '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Authorization Error</title></head>'
+            . '<body><h1>Authorization Error</h1>'
+            . '<p><strong>%s</strong></p><p>%s</p></body></html>',
+            htmlspecialchars($code, \ENT_QUOTES),
+            htmlspecialchars($description, \ENT_QUOTES),
+        );
+
+        return new Response($body, $status, ['Content-Type' => 'text/html; charset=utf-8']);
+    }
+}

--- a/packages/oidc/src/Authorize/ValidatedAuthorizationRequest.php
+++ b/packages/oidc/src/Authorize/ValidatedAuthorizationRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Authorize;
+
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+/**
+ * Output of AuthorizationRequestValidator. Carries every field the authorize
+ * controller needs to issue a code and redirect back to the relying party.
+ */
+final readonly class ValidatedAuthorizationRequest
+{
+    /**
+     * @param string[] $scopes
+     */
+    public function __construct(
+        public OidcClient $client,
+        public string $redirectUri,
+        public array $scopes,
+        public string $codeChallenge,
+        public string $codeChallengeMethod,
+        public ?string $state = null,
+        public ?string $nonce = null,
+    ) {}
+}

--- a/packages/oidc/src/ClientRegistry/OidcClientLookup.php
+++ b/packages/oidc/src/ClientRegistry/OidcClientLookup.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\ClientRegistry;
+
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+/**
+ * Looks up OIDC clients by their stable public `client_id` identifier.
+ *
+ * Bypasses OidcClientAccessPolicy on purpose. The access policy gates the admin
+ * CRUD surface behind `administer oidc clients`; the authorize and token flows
+ * run with an anonymous account before the user logs in, so they must read
+ * clients directly from storage without an access check.
+ */
+final class OidcClientLookup
+{
+    public function __construct(private readonly SqlEntityStorage $storage) {}
+
+    public function findByClientId(string $clientId): ?OidcClient
+    {
+        if ($clientId === '') {
+            return null;
+        }
+
+        $ids = $this->storage->getQuery()
+            ->condition('client_id', $clientId)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $entity = $this->storage->load($ids[0]);
+
+        return $entity instanceof OidcClient ? $entity : null;
+    }
+}

--- a/packages/oidc/src/OidcRouteProvider.php
+++ b/packages/oidc/src/OidcRouteProvider.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Oidc;
 
+use Waaseyaa\Oidc\Authorize\AuthorizeController;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final readonly class OidcRouteProvider
 {
+    public function __construct(private ?AuthorizeController $authorizeController = null) {}
+
     public function registerRoutes(WaaseyaaRouter $router): void
     {
         $router->addRoute(
@@ -28,5 +31,16 @@ final readonly class OidcRouteProvider
                 ->allowAll()
                 ->build(),
         );
+
+        if ($this->authorizeController !== null) {
+            $router->addRoute(
+                'oidc.authorize',
+                RouteBuilder::create('/authorize')
+                    ->controller($this->authorizeController)
+                    ->methods('GET')
+                    ->allowAll()
+                    ->build(),
+            );
+        }
     }
 }

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -11,6 +11,9 @@ use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Oidc\Authorize\AuthorizationRequestValidator;
+use Waaseyaa\Oidc\Authorize\AuthorizeController;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
 use Waaseyaa\Oidc\ClientRegistry\OidcClientSeeder;
 use Waaseyaa\Oidc\Entity\OidcClient;
 use Waaseyaa\Oidc\Http\DiscoveryController;
@@ -109,6 +112,36 @@ final class OidcServiceProvider extends ServiceProvider
                 return new DatabaseAuthorizationCodeRepository(database: $database);
             },
         );
+
+        $this->singleton(
+            OidcClientLookup::class,
+            function (): OidcClientLookup {
+                $entityTypeManager = $this->resolve(EntityTypeManager::class);
+                $storage = $entityTypeManager->getStorage('oidc_client');
+                if (!$storage instanceof SqlEntityStorage) {
+                    throw new \RuntimeException(
+                        'OIDC client lookup requires SqlEntityStorage; got ' . $storage::class . '.',
+                    );
+                }
+
+                return new OidcClientLookup($storage);
+            },
+        );
+
+        $this->singleton(
+            AuthorizationRequestValidator::class,
+            static fn(): AuthorizationRequestValidator => new AuthorizationRequestValidator(),
+        );
+
+        $this->singleton(
+            AuthorizeController::class,
+            fn(): AuthorizeController => new AuthorizeController(
+                clientLookup: $this->resolve(OidcClientLookup::class),
+                validator: $this->resolve(AuthorizationRequestValidator::class),
+                codeRepository: $this->resolve(AuthorizationCodeRepositoryInterface::class),
+                loginPath: $this->resolveLoginPath(),
+            ),
+        );
     }
 
     public function boot(): void
@@ -172,7 +205,29 @@ final class OidcServiceProvider extends ServiceProvider
 
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
     {
-        (new OidcRouteProvider())->registerRoutes($router);
+        $authorizeController = null;
+        try {
+            $authorizeController = $this->resolve(AuthorizeController::class);
+        } catch (\Throwable) {
+            // Storage not available yet (e.g., bootstrap without entity system); skip authorize route.
+        }
+
+        (new OidcRouteProvider(authorizeController: $authorizeController))->registerRoutes($router);
+    }
+
+    /**
+     * Resolve the path to the login page for anonymous authorize redirects.
+     * Defaults to `/login` (the admin SPA login route). Override via
+     * `config['oidc']['login_path']` when the login UI lives elsewhere.
+     */
+    private function resolveLoginPath(): string
+    {
+        $configured = $this->config['oidc']['login_path'] ?? null;
+        if (is_string($configured) && $configured !== '') {
+            return $configured;
+        }
+
+        return '/login';
     }
 
     /**

--- a/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
+++ b/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Authorize;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\Authorize\AuthorizationRequestValidator;
+use Waaseyaa\Oidc\Authorize\AuthorizeController;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
+use Waaseyaa\Oidc\Entity\OidcClient;
+use Waaseyaa\Oidc\Repository\AuthorizationCode;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+
+#[CoversClass(AuthorizeController::class)]
+final class AuthorizeControllerTest extends TestCase
+{
+    private SqlEntityStorage $storage;
+    private FakeCodeRepository $codeRepository;
+    private AuthorizeController $controller;
+
+    protected function setUp(): void
+    {
+        $database = DBALDatabase::createSqlite();
+
+        $entityType = new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $database);
+        $schemaHandler->ensureTable();
+        $schemaHandler->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+
+        $this->storage = new SqlEntityStorage($entityType, $database, new EventDispatcher());
+
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+            'scopes' => ['openid', 'profile', 'email'],
+            'grant_types' => ['authorization_code'],
+        ]);
+        $this->storage->save($client);
+
+        $this->codeRepository = new FakeCodeRepository();
+
+        $this->controller = new AuthorizeController(
+            clientLookup: new OidcClientLookup($this->storage),
+            validator: new AuthorizationRequestValidator(),
+            codeRepository: $this->codeRepository,
+            loginPath: '/login',
+        );
+    }
+
+    public function testAnonymousAccountRedirectsToLoginWithReturnTo(): void
+    {
+        $request = $this->makeRequest($this->validQuery(), authenticated: false);
+
+        $response = ($this->controller)($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(302, $response->getStatusCode());
+        $location = $response->headers->get('Location');
+        $this->assertNotNull($location);
+        $this->assertStringStartsWith('/login?return_to=', $location);
+        // The return_to value should be URL-encoded.
+        $this->assertStringContainsString(rawurlencode('/authorize?'), $location);
+        $this->assertStringContainsString(rawurlencode('client_id=minoo-web'), $location);
+    }
+
+    public function testMissingAccountAttributeReturns500(): void
+    {
+        $request = Request::create('/authorize', 'GET', $this->validQuery());
+
+        $response = ($this->controller)($request);
+
+        $this->assertSame(500, $response->getStatusCode());
+    }
+
+    public function testMissingClientIdReturnsDirectError(): void
+    {
+        $query = $this->validQuery();
+        unset($query['client_id']);
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertNotInstanceOf(RedirectResponse::class, $response);
+        $this->assertStringContainsString('invalid_request', (string) $response->getContent());
+    }
+
+    public function testUnknownClientIdReturnsDirectError(): void
+    {
+        $query = $this->validQuery();
+        $query['client_id'] = 'does-not-exist';
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertNotInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testUnregisteredRedirectUriReturnsDirectError(): void
+    {
+        $query = $this->validQuery();
+        $query['redirect_uri'] = 'https://evil.test/cb';
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertNotInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testRedirectableValidationErrorRedirectsToClientWithError(): void
+    {
+        $query = $this->validQuery();
+        $query['response_type'] = 'token';
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(302, $response->getStatusCode());
+        $location = $response->headers->get('Location') ?? '';
+        $this->assertStringStartsWith('https://minoo.test/callback?', $location);
+        $this->assertStringContainsString('error=unsupported_response_type', $location);
+        $this->assertStringContainsString('state=xyz-state', $location);
+    }
+
+    public function testValidRequestIssuesCodeAndRedirects(): void
+    {
+        $response = ($this->controller)($this->makeRequest($this->validQuery()));
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(302, $response->getStatusCode());
+
+        $location = $response->headers->get('Location') ?? '';
+        $this->assertStringStartsWith('https://minoo.test/callback?', $location);
+        $this->assertStringContainsString('code=issued-test-code', $location);
+        $this->assertStringContainsString('state=xyz-state', $location);
+
+        $this->assertSame('minoo-web', $this->codeRepository->lastClientId);
+        $this->assertSame('https://minoo.test/callback', $this->codeRepository->lastRedirectUri);
+        $this->assertSame(['openid', 'profile'], $this->codeRepository->lastScopes);
+        $this->assertSame('a-challenge', $this->codeRepository->lastCodeChallenge);
+        $this->assertSame('S256', $this->codeRepository->lastCodeChallengeMethod);
+    }
+
+    public function testValidRequestWithoutStateOmitsStateInRedirect(): void
+    {
+        $query = $this->validQuery();
+        unset($query['state']);
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $location = $response->headers->get('Location') ?? '';
+        $this->assertStringNotContainsString('state=', $location);
+        $this->assertStringContainsString('code=issued-test-code', $location);
+    }
+
+    public function testRedirectUriWithExistingQueryStringUsesAmpersandSeparator(): void
+    {
+        // Register a client whose redirect_uri already has a query string.
+        $client = $this->storage->create([
+            'client_id' => 'fancy-client',
+            'name' => 'Fancy',
+            'redirect_uris' => ['https://fancy.test/cb?src=oidc'],
+            'scopes' => ['openid'],
+            'grant_types' => ['authorization_code'],
+        ]);
+        $this->storage->save($client);
+
+        $query = $this->validQuery();
+        $query['client_id'] = 'fancy-client';
+        $query['redirect_uri'] = 'https://fancy.test/cb?src=oidc';
+        $query['scope'] = 'openid';
+
+        $response = ($this->controller)($this->makeRequest($query));
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $location = $response->headers->get('Location') ?? '';
+        $this->assertStringStartsWith('https://fancy.test/cb?src=oidc&', $location);
+        $this->assertStringContainsString('code=issued-test-code', $location);
+    }
+
+    public function testAuthenticatedAccountIdPassedToRepository(): void
+    {
+        $request = $this->makeRequest($this->validQuery(), authenticated: true);
+
+        ($this->controller)($request);
+
+        $this->assertSame(42, $this->codeRepository->lastAccountId);
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function makeRequest(array $query, bool $authenticated = true): Request
+    {
+        $request = Request::create('/authorize', 'GET', $query);
+
+        $account = new class ($authenticated) implements AccountInterface {
+            public function __construct(private bool $authenticated)
+            {
+            }
+
+            public function id(): int|string
+            {
+                return $this->authenticated ? 42 : 0;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return false;
+            }
+
+            public function getRoles(): array
+            {
+                return $this->authenticated ? ['authenticated'] : ['anonymous'];
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return $this->authenticated;
+            }
+        };
+
+        $request->attributes->set('_account', $account);
+
+        return $request;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validQuery(): array
+    {
+        return [
+            'client_id' => 'minoo-web',
+            'redirect_uri' => 'https://minoo.test/callback',
+            'response_type' => 'code',
+            'scope' => 'openid profile',
+            'state' => 'xyz-state',
+            'code_challenge' => 'a-challenge',
+            'code_challenge_method' => 'S256',
+        ];
+    }
+}
+
+/**
+ * Fake repository that records the most recent issue() call and returns a
+ * deterministic AuthorizationCode so the controller's redirect can be asserted.
+ */
+final class FakeCodeRepository implements AuthorizationCodeRepositoryInterface
+{
+    public ?string $lastClientId = null;
+    public int|string|null $lastAccountId = null;
+    public ?string $lastRedirectUri = null;
+    /** @var list<string>|null */
+    public ?array $lastScopes = null;
+    public ?string $lastCodeChallenge = null;
+    public ?string $lastCodeChallengeMethod = null;
+
+    public function issue(
+        string $clientId,
+        AccountInterface $account,
+        string $redirectUri,
+        array $scopes,
+        string $codeChallenge,
+        string $codeChallengeMethod,
+    ): AuthorizationCode {
+        $this->lastClientId = $clientId;
+        $this->lastAccountId = $account->id();
+        $this->lastRedirectUri = $redirectUri;
+        $this->lastScopes = $scopes;
+        $this->lastCodeChallenge = $codeChallenge;
+        $this->lastCodeChallengeMethod = $codeChallengeMethod;
+
+        return new AuthorizationCode(
+            code: 'issued-test-code',
+            clientId: $clientId,
+            accountId: (string) $account->id(),
+            redirectUri: $redirectUri,
+            scopes: $scopes,
+            codeChallenge: $codeChallenge,
+            codeChallengeMethod: $codeChallengeMethod,
+            issuedAt: 1000,
+            expiresAt: 1060,
+        );
+    }
+
+    public function consume(string $code): ?AuthorizationCode
+    {
+        return null;
+    }
+
+    public function purgeExpired(): int
+    {
+        return 0;
+    }
+}

--- a/packages/oidc/tests/Integration/ClientRegistry/OidcClientLookupTest.php
+++ b/packages/oidc/tests/Integration/ClientRegistry/OidcClientLookupTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\ClientRegistry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+#[CoversClass(OidcClientLookup::class)]
+final class OidcClientLookupTest extends TestCase
+{
+    private SqlEntityStorage $storage;
+    private OidcClientLookup $lookup;
+
+    protected function setUp(): void
+    {
+        $database = DBALDatabase::createSqlite();
+
+        $entityType = new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $database);
+        $schemaHandler->ensureTable();
+        $schemaHandler->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+
+        $this->storage = new SqlEntityStorage(
+            $entityType,
+            $database,
+            new EventDispatcher(),
+        );
+
+        $this->lookup = new OidcClientLookup($this->storage);
+    }
+
+    public function testReturnsNullWhenClientIdNotFound(): void
+    {
+        $this->assertNull($this->lookup->findByClientId('unknown-client'));
+    }
+
+    public function testReturnsClientWhenClientIdMatches(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        $this->storage->save($client);
+
+        $found = $this->lookup->findByClientId('minoo-web');
+
+        $this->assertInstanceOf(OidcClient::class, $found);
+        $this->assertSame('minoo-web', $found->getClientId());
+        $this->assertSame('Minoo', $found->getName());
+        $this->assertSame(['https://minoo.test/callback'], $found->getRedirectUris());
+    }
+
+    public function testDoesNotMatchPartialClientId(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        $this->storage->save($client);
+
+        $this->assertNull($this->lookup->findByClientId('minoo'));
+        $this->assertNull($this->lookup->findByClientId('minoo-web-extra'));
+    }
+
+    public function testReturnsFirstMatchWhenMultipleExist(): void
+    {
+        // client_id is expected to be unique, but the lookup must behave
+        // deterministically if a duplicate ever slips past uniqueness checks.
+        $first = $this->storage->create([
+            'client_id' => 'dup',
+            'name' => 'First',
+            'redirect_uris' => ['https://one.test/cb'],
+        ]);
+        $this->storage->save($first);
+
+        $second = $this->storage->create([
+            'client_id' => 'dup',
+            'name' => 'Second',
+            'redirect_uris' => ['https://two.test/cb'],
+        ]);
+        $this->storage->save($second);
+
+        $found = $this->lookup->findByClientId('dup');
+
+        $this->assertInstanceOf(OidcClient::class, $found);
+        $this->assertSame('First', $found->getName());
+    }
+
+    public function testEmptyClientIdReturnsNull(): void
+    {
+        $client = $this->storage->create([
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+        ]);
+        $this->storage->save($client);
+
+        $this->assertNull($this->lookup->findByClientId(''));
+    }
+}

--- a/packages/oidc/tests/Unit/Authorize/AuthorizationRequestValidatorTest.php
+++ b/packages/oidc/tests/Unit/Authorize/AuthorizationRequestValidatorTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Authorize;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Oidc\Authorize\AuthorizationRequestException;
+use Waaseyaa\Oidc\Authorize\AuthorizationRequestValidator;
+use Waaseyaa\Oidc\Authorize\ValidatedAuthorizationRequest;
+use Waaseyaa\Oidc\Entity\OidcClient;
+
+#[CoversClass(AuthorizationRequestValidator::class)]
+#[CoversClass(AuthorizationRequestException::class)]
+#[CoversClass(ValidatedAuthorizationRequest::class)]
+final class AuthorizationRequestValidatorTest extends TestCase
+{
+    private AuthorizationRequestValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new AuthorizationRequestValidator();
+    }
+
+    public function testReturnsValidatedRequestOnValidInput(): void
+    {
+        $result = $this->validator->validate($this->newClient(), $this->validQuery());
+
+        $this->assertInstanceOf(ValidatedAuthorizationRequest::class, $result);
+        $this->assertSame('minoo-web', $result->client->getClientId());
+        $this->assertSame('https://minoo.test/callback', $result->redirectUri);
+        $this->assertSame(['openid', 'profile'], $result->scopes);
+        $this->assertSame('xyz-state', $result->state);
+        $this->assertSame('a-challenge', $result->codeChallenge);
+        $this->assertSame('S256', $result->codeChallengeMethod);
+        $this->assertNull($result->nonce);
+    }
+
+    public function testNoncePassedThrough(): void
+    {
+        $query = $this->validQuery();
+        $query['nonce'] = 'nonce-abc';
+
+        $result = $this->validator->validate($this->newClient(), $query);
+
+        $this->assertSame('nonce-abc', $result->nonce);
+    }
+
+    public function testStateIsOptionalOnSuccess(): void
+    {
+        $query = $this->validQuery();
+        unset($query['state']);
+
+        $result = $this->validator->validate($this->newClient(), $query);
+
+        $this->assertNull($result->state);
+    }
+
+    public function testRedirectUriMissingThrowsDirectError(): void
+    {
+        $query = $this->validQuery();
+        unset($query['redirect_uri']);
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_request', $e->errorCode);
+            $this->assertNull($e->redirectUri, 'Direct error must not carry redirect_uri.');
+        }
+    }
+
+    public function testRedirectUriNotRegisteredThrowsDirectError(): void
+    {
+        $query = $this->validQuery();
+        $query['redirect_uri'] = 'https://evil.test/cb';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_request', $e->errorCode);
+            $this->assertNull($e->redirectUri);
+        }
+    }
+
+    public function testMissingResponseTypeThrowsRedirectableError(): void
+    {
+        $query = $this->validQuery();
+        unset($query['response_type']);
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('unsupported_response_type', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+            $this->assertSame('xyz-state', $e->state);
+        }
+    }
+
+    public function testUnsupportedResponseTypeThrowsRedirectableError(): void
+    {
+        $query = $this->validQuery();
+        $query['response_type'] = 'token';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('unsupported_response_type', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+        }
+    }
+
+    public function testMissingScopeThrowsInvalidScope(): void
+    {
+        $query = $this->validQuery();
+        unset($query['scope']);
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_scope', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+        }
+    }
+
+    public function testScopeWithoutOpenidThrowsInvalidScope(): void
+    {
+        $query = $this->validQuery();
+        $query['scope'] = 'profile email';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_scope', $e->errorCode);
+        }
+    }
+
+    public function testScopeWithDisallowedValueThrowsInvalidScope(): void
+    {
+        $query = $this->validQuery();
+        $query['scope'] = 'openid admin-all';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_scope', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+        }
+    }
+
+    public function testMissingCodeChallengeThrowsInvalidRequest(): void
+    {
+        $query = $this->validQuery();
+        unset($query['code_challenge']);
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_request', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+        }
+    }
+
+    public function testMissingCodeChallengeMethodThrowsInvalidRequest(): void
+    {
+        $query = $this->validQuery();
+        unset($query['code_challenge_method']);
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_request', $e->errorCode);
+        }
+    }
+
+    public function testUnsupportedCodeChallengeMethodThrowsInvalidRequest(): void
+    {
+        $query = $this->validQuery();
+        $query['code_challenge_method'] = 'plain';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('invalid_request', $e->errorCode);
+            $this->assertSame('https://minoo.test/callback', $e->redirectUri);
+        }
+    }
+
+    public function testStatePreservedOnRedirectableError(): void
+    {
+        $query = $this->validQuery();
+        $query['response_type'] = 'token';
+        $query['state'] = 'preserved-state';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertSame('preserved-state', $e->state);
+        }
+    }
+
+    public function testStateNullWhenAbsentOnRedirectableError(): void
+    {
+        $query = $this->validQuery();
+        unset($query['state']);
+        $query['response_type'] = 'token';
+
+        try {
+            $this->validator->validate($this->newClient(), $query);
+            $this->fail('Expected AuthorizationRequestException.');
+        } catch (AuthorizationRequestException $e) {
+            $this->assertNull($e->state);
+        }
+    }
+
+    private function newClient(): OidcClient
+    {
+        return new OidcClient(values: [
+            'client_id' => 'minoo-web',
+            'name' => 'Minoo',
+            'redirect_uris' => ['https://minoo.test/callback'],
+            'scopes' => ['openid', 'profile', 'email'],
+            'grant_types' => ['authorization_code'],
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validQuery(): array
+    {
+        return [
+            'client_id' => 'minoo-web',
+            'redirect_uri' => 'https://minoo.test/callback',
+            'response_type' => 'code',
+            'scope' => 'openid profile',
+            'state' => 'xyz-state',
+            'code_challenge' => 'a-challenge',
+            'code_challenge_method' => 'S256',
+        ];
+    }
+}

--- a/tests/Integration/Oidc/OidcAuthorizeIntegrationTest.php
+++ b/tests/Integration/Oidc/OidcAuthorizeIntegrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Oidc;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end wiring test for /authorize. Boots a fresh kernel in a subprocess,
+ * so the assertions cover: route registration, controller DI resolution,
+ * OidcClientLookup binding against oidc_client storage, and the anonymous →
+ * login redirect branch of AuthorizeController.
+ *
+ * The header list is asserted separately in AuthorizeControllerTest (under CLI
+ * `headers_list()` is empty, so per-request assertions stay there).
+ */
+#[CoversNothing]
+final class OidcAuthorizeIntegrationTest extends TestCase
+{
+    private string $repoRoot;
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = (string) realpath(__DIR__ . '/../../..');
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_oidc_authorize_' . uniqid();
+
+        mkdir($this->projectRoot . '/config', 0755, true);
+        mkdir($this->projectRoot . '/storage', 0755, true);
+
+        self::assertTrue(symlink($this->repoRoot . '/vendor', $this->projectRoot . '/vendor'));
+
+        file_put_contents($this->projectRoot . '/config/entity-types.php', "<?php\n\nreturn [];\n");
+        file_put_contents($this->projectRoot . '/config/waaseyaa.php', $this->buildConfigFile());
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectRoot)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                unlink($item->getPathname());
+                continue;
+            }
+            rmdir($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    #[Test]
+    public function anonymousGetAuthorizeRedirectsToLogin(): void
+    {
+        $response = $this->request(
+            '/authorize?client_id=minoo-web&redirect_uri=https%3A%2F%2Fminoo.test%2Fcallback'
+            . '&response_type=code&scope=openid%20profile&state=xyz'
+            . '&code_challenge=abc&code_challenge_method=S256',
+        );
+
+        self::assertSame(302, $response['status']);
+        // Symfony's RedirectResponse emits a meta-refresh + anchor HTML body as
+        // a fallback for clients that don't honour the Location header. That
+        // body embeds the final URL, which is all we can assert under the CLI
+        // runner (headers_list() is empty here — header assertions live in the
+        // AuthorizeController unit tests).
+        self::assertStringContainsString('/login?return_to=', $response['body']);
+        self::assertStringContainsString('client_id%3Dminoo-web', $response['body']);
+    }
+
+    /**
+     * @return array{status:int,headers:list<string>,body:string}
+     */
+    private function request(string $uri, string $method = 'GET'): array
+    {
+        $runner = $this->repoRoot . '/tests/Integration/Phase13/Fixtures/http_kernel_runner.php';
+        $command = sprintf(
+            '%s %s %s %s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($runner),
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($this->projectRoot),
+            escapeshellarg($method),
+            escapeshellarg($uri),
+        );
+
+        $output = shell_exec($command);
+        self::assertNotNull($output, 'Kernel runner produced no output.');
+
+        $lines = array_values(array_filter(
+            preg_split('/\R/', trim((string) $output)) ?: [],
+            static fn(string $line): bool => trim($line) !== '',
+        ));
+        $jsonPayload = $lines !== [] ? $lines[count($lines) - 1] : '';
+        $payload = json_decode($jsonPayload, true);
+        self::assertIsArray($payload, 'Kernel runner returned invalid JSON: ' . $output);
+
+        return [
+            'status' => (int) ($payload['status'] ?? 0),
+            'headers' => is_array($payload['headers'] ?? null) ? array_values($payload['headers']) : [],
+            'body' => (string) ($payload['body'] ?? ''),
+        ];
+    }
+
+    private function buildConfigFile(): string
+    {
+        $databasePath = $this->projectRoot . '/storage/waaseyaa.sqlite';
+
+        return <<<PHP
+<?php
+
+declare(strict_types=1);
+
+return [
+    'database' => '{$databasePath}',
+    'environment' => 'local',
+    'app' => ['url' => 'http://localhost', 'name' => 'Waaseyaa Oidc Authorize Test'],
+    'cors_origins' => ['http://localhost:3000'],
+    'oidc' => [
+        'issuer' => 'https://id.example',
+        'login_path' => '/login',
+    ],
+];
+PHP;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the OIDC authorize endpoint per ADR-006 §7. TDD order from the issue:
`OidcClientLookup` → `AuthorizationRequestValidator` → `AuthorizeController`.

- **`OidcClientLookup`** — access-bypassing lookup by `client_id`. Authorize/token flows run with anonymous accounts before the user logs in, so they read clients directly from storage without going through `OidcClientAccessPolicy`.
- **`AuthorizationRequestValidator`** — pure-function validator `(OidcClient, array $query) → ValidatedAuthorizationRequest`. Rejects in the order OAuth 2.0 §4.1.2.1 requires so `redirect_uri` errors never redirect to unverified URIs. Enforces PKCE `S256` (ADR-006 §2.5) and `openid` scope.
- **`AuthorizationRequestException`** — classifies errors as direct (pre-`redirect_uri` verification) or redirectable (post-verification), carrying `state` through in both directions.
- **`AuthorizeController`** — invokable. Anonymous → 302 to `login_path` with `return_to` preserving the full authorize URL. Authenticated → validate, issue code via `AuthorizationCodeRepositoryInterface::issue()`, 302 back to `redirect_uri` with `code` + `state`.
- Route + DI wired in `OidcServiceProvider`; `login_path` is config-overridable (defaults to `/login`).

## Test plan

- [x] `phpunit`: 6295 tests (+31 from this PR)
  - 5 integration tests for `OidcClientLookup`
  - 15 unit tests for `AuthorizationRequestValidator` (one per rejection branch + happy path + state pass-through)
  - 10 integration tests for `AuthorizeController` (fakes for code repo, real storage + lookup + validator)
  - 1 subprocess kernel integration test for end-to-end wiring (anonymous → login redirect)
- [x] `composer phpstan` clean
- [x] `composer cs-check` clean
- [x] `composer check-composer-policy` clean
- [x] `bin/check-milestones` clean
- [x] `tools/drift-detector.sh` clean

## Design notes

- **Controller signature**: the issue draft referenced `serve(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest)` but no controller in the codebase uses that form — `ControllerDispatcher` invokes callables as `$controller($request, ...$routeParams)`, and LoginController/LogoutController/MeController are all invokable with `__invoke(Request $request)` reading `_account` from request attributes. I followed the existing convention.
- **Route dependency guard**: `OidcServiceProvider::routes()` catches DI resolution failures for `AuthorizeController` and skips registering `/authorize` if the `oidc_client` storage isn't available yet. Matches the existing pattern of best-effort wiring so the kernel can boot without partial OIDC configuration.
- **Redirect URL building**: the controller uses `str_contains($url, '?') ? '&' : '?'` to handle clients whose registered `redirect_uri` already contains a query string (covered by `testRedirectUriWithExistingQueryStringUsesAmpersandSeparator`).
- **Direct error page**: plain HTML, status 400 or 500, escaped via `htmlspecialchars(…, ENT_QUOTES)`. A richer template is out of scope; the consent screen issue will likely introduce one.

## Closes

Closes #1284.

## Non-goals (per the issue)

- Consent screen (deferred)
- `prompt`, `max_age`, `id_token_hint`, `login_hint`
- Implicit / hybrid flows (ADR-006 §6)
- Response modes beyond default `query`