### PR TITLE
feat(#1289): propagate nonce from /authorize through code repository into ID token

### DIFF
--- a/packages/oidc/src/Authorize/AuthorizeController.php
+++ b/packages/oidc/src/Authorize/AuthorizeController.php
@@ -80,6 +80,7 @@ final readonly class AuthorizeController
             scopes: $validated->scopes,
             codeChallenge: $validated->codeChallenge,
             codeChallengeMethod: $validated->codeChallengeMethod,
+            nonce: $validated->nonce,
         );
 
         $params = ['code' => $code->code];

--- a/packages/oidc/src/Repository/AuthorizationCode.php
+++ b/packages/oidc/src/Repository/AuthorizationCode.php
@@ -16,6 +16,9 @@ final readonly class AuthorizationCode
 {
     /**
      * @param list<string> $scopes
+     * @param ?string $nonce Verbatim copy of the OIDC `nonce` authorize param, or null.
+     *                      /token must include this in the ID token's `nonce` claim per
+     *                      OpenID Connect Core §3.1.3.6.
      */
     public function __construct(
         public string $code,
@@ -28,6 +31,7 @@ final readonly class AuthorizationCode
         public int $issuedAt,
         public int $expiresAt,
         public ?int $consumedAt = null,
+        public ?string $nonce = null,
     ) {}
 
     public function isExpired(int $now): bool

--- a/packages/oidc/src/Repository/AuthorizationCodeRepositoryInterface.php
+++ b/packages/oidc/src/Repository/AuthorizationCodeRepositoryInterface.php
@@ -23,6 +23,9 @@ interface AuthorizationCodeRepositoryInterface
      * and PKCE challenge. Returns the persisted AuthorizationCode with its generated
      * code, issuedAt, and expiresAt fields.
      *
+     * The optional OIDC `nonce` is stored verbatim and round-tripped through consume()
+     * so /token can embed it in the ID token's `nonce` claim (OIDC Core §3.1.3.6).
+     *
      * @param list<string> $scopes
      */
     public function issue(
@@ -32,6 +35,7 @@ interface AuthorizationCodeRepositoryInterface
         array $scopes,
         string $codeChallenge,
         string $codeChallengeMethod,
+        ?string $nonce = null,
     ): AuthorizationCode;
 
     /**

--- a/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
+++ b/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
@@ -43,6 +43,7 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
         array $scopes,
         string $codeChallenge,
         string $codeChallengeMethod,
+        ?string $nonce = null,
     ): AuthorizationCode {
         $this->ensureTable();
 
@@ -65,6 +66,7 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
                 'issued_at' => $now,
                 'expires_at' => $expiresAt,
                 'consumed_at' => null,
+                'nonce' => $nonce,
             ])
             ->execute();
 
@@ -79,6 +81,7 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
             issuedAt: $now,
             expiresAt: $expiresAt,
             consumedAt: null,
+            nonce: $nonce,
         );
     }
 
@@ -131,7 +134,8 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
                 code_challenge_method VARCHAR(16) NOT NULL,
                 issued_at INTEGER NOT NULL,
                 expires_at INTEGER NOT NULL,
-                consumed_at INTEGER
+                consumed_at INTEGER,
+                nonce VARCHAR(255)
             )
         SQL);
 
@@ -169,6 +173,8 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
         /** @var list<string> $scopes */
         $scopes = array_values(array_map('strval', $scopes));
 
+        $nonce = $row['nonce'] ?? null;
+
         return new AuthorizationCode(
             code: (string) $row['code'],
             clientId: (string) $row['client_id'],
@@ -180,6 +186,7 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
             issuedAt: (int) $row['issued_at'],
             expiresAt: (int) $row['expires_at'],
             consumedAt: isset($row['consumed_at']) ? (int) $row['consumed_at'] : null,
+            nonce: $nonce === null ? null : (string) $nonce,
         );
     }
 }

--- a/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
+++ b/packages/oidc/src/Repository/DatabaseAuthorizationCodeRepository.php
@@ -139,6 +139,11 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
             )
         SQL);
 
+        // Tables provisioned before #1289 lack the nonce column. Adding it lazily
+        // keeps the "one migration per schema bump" pattern and avoids a separate
+        // migration file for a single nullable column.
+        $this->ensureColumn('nonce', 'VARCHAR(255)');
+
         $this->database->query(
             'CREATE INDEX IF NOT EXISTS idx_oidc_auth_codes_expires_at ON oidc_authorization_codes (expires_at)',
         );
@@ -147,6 +152,24 @@ final class DatabaseAuthorizationCodeRepository implements AuthorizationCodeRepo
         );
 
         $this->tableEnsured = true;
+    }
+
+    private function ensureColumn(string $column, string $definition): void
+    {
+        $columns = $this->database->getConnection()
+            ->createSchemaManager()
+            ->listTableColumns(self::TABLE);
+
+        if (isset($columns[$column])) {
+            return;
+        }
+
+        $this->database->query(sprintf(
+            'ALTER TABLE %s ADD COLUMN %s %s',
+            self::TABLE,
+            $column,
+            $definition,
+        ));
     }
 
     /**

--- a/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
+++ b/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
@@ -160,6 +160,17 @@ final class AuthorizeControllerTest extends TestCase
         $this->assertSame(['openid', 'profile'], $this->codeRepository->lastScopes);
         $this->assertSame('a-challenge', $this->codeRepository->lastCodeChallenge);
         $this->assertSame('S256', $this->codeRepository->lastCodeChallengeMethod);
+        $this->assertNull($this->codeRepository->lastNonce, 'nonce omitted in /authorize query must reach repo as null');
+    }
+
+    public function testNonceFromQueryIsPassedToRepository(): void
+    {
+        $query = $this->validQuery();
+        $query['nonce'] = 'n-0S6_WzA2Mj';
+
+        ($this->controller)($this->makeRequest($query));
+
+        $this->assertSame('n-0S6_WzA2Mj', $this->codeRepository->lastNonce);
     }
 
     public function testValidRequestWithoutStateOmitsStateInRedirect(): void
@@ -277,6 +288,7 @@ final class FakeCodeRepository implements AuthorizationCodeRepositoryInterface
     public ?array $lastScopes = null;
     public ?string $lastCodeChallenge = null;
     public ?string $lastCodeChallengeMethod = null;
+    public ?string $lastNonce = null;
 
     public function issue(
         string $clientId,
@@ -285,6 +297,7 @@ final class FakeCodeRepository implements AuthorizationCodeRepositoryInterface
         array $scopes,
         string $codeChallenge,
         string $codeChallengeMethod,
+        ?string $nonce = null,
     ): AuthorizationCode {
         $this->lastClientId = $clientId;
         $this->lastAccountId = $account->id();
@@ -292,6 +305,7 @@ final class FakeCodeRepository implements AuthorizationCodeRepositoryInterface
         $this->lastScopes = $scopes;
         $this->lastCodeChallenge = $codeChallenge;
         $this->lastCodeChallengeMethod = $codeChallengeMethod;
+        $this->lastNonce = $nonce;
 
         return new AuthorizationCode(
             code: 'issued-test-code',
@@ -303,6 +317,7 @@ final class FakeCodeRepository implements AuthorizationCodeRepositoryInterface
             codeChallengeMethod: $codeChallengeMethod,
             issuedAt: 1000,
             expiresAt: 1060,
+            nonce: $nonce,
         );
     }
 

--- a/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
+++ b/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
@@ -175,6 +175,42 @@ final class DatabaseAuthorizationCodeRepositoryTest extends TestCase
         self::assertSame(0, $repo->purgeExpired());
     }
 
+    public function testEnsureTableAddsNonceColumnToLegacySchema(): void
+    {
+        // Simulate a table provisioned by #1283 before nonce was introduced.
+        $this->database->query(<<<'SQL'
+            CREATE TABLE oidc_authorization_codes (
+                code VARCHAR(128) PRIMARY KEY,
+                client_id VARCHAR(255) NOT NULL,
+                account_id VARCHAR(255) NOT NULL,
+                redirect_uri TEXT NOT NULL,
+                scopes TEXT NOT NULL,
+                code_challenge VARCHAR(128) NOT NULL,
+                code_challenge_method VARCHAR(16) NOT NULL,
+                issued_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                consumed_at INTEGER
+            )
+        SQL);
+
+        $repo = $this->buildRepo();
+
+        $issued = $repo->issue(
+            clientId: 'minoo-web',
+            account: $this->account('42'),
+            redirectUri: 'https://minoo.test/callback',
+            scopes: ['openid'],
+            codeChallenge: 'ch4lleng3',
+            codeChallengeMethod: 'S256',
+            nonce: 'n-migrated',
+        );
+
+        self::assertSame('n-migrated', $issued->nonce);
+        $consumed = $repo->consume($issued->code);
+        self::assertNotNull($consumed);
+        self::assertSame('n-migrated', $consumed->nonce);
+    }
+
     private function buildRepo(): DatabaseAuthorizationCodeRepository
     {
         return new DatabaseAuthorizationCodeRepository(

--- a/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
+++ b/packages/oidc/tests/Integration/Repository/DatabaseAuthorizationCodeRepositoryTest.php
@@ -48,6 +48,40 @@ final class DatabaseAuthorizationCodeRepositoryTest extends TestCase
         self::assertSame($this->now, $code->issuedAt);
         self::assertSame($this->now + 60, $code->expiresAt, 'OAuth 2.1 mandates 60 s TTL');
         self::assertNull($code->consumedAt);
+        self::assertNull($code->nonce, 'nonce defaults to null when not supplied');
+    }
+
+    public function testIssueStoresNonceWhenProvided(): void
+    {
+        $repo = $this->buildRepo();
+
+        $code = $repo->issue(
+            clientId: 'minoo-web',
+            account: $this->account('42'),
+            redirectUri: 'https://minoo.test/callback',
+            scopes: ['openid'],
+            codeChallenge: 'ch4lleng3',
+            codeChallengeMethod: 'S256',
+            nonce: 'n-0S6_WzA2Mj',
+        );
+
+        self::assertSame('n-0S6_WzA2Mj', $code->nonce);
+
+        $consumed = $repo->consume($code->code);
+        self::assertNotNull($consumed);
+        self::assertSame('n-0S6_WzA2Mj', $consumed->nonce, 'nonce must survive consume() round-trip');
+    }
+
+    public function testConsumeReturnsNullNonceWhenIssuedWithoutNonce(): void
+    {
+        $repo = $this->buildRepo();
+
+        $issued = $repo->issue('minoo-web', $this->account('1'), 'https://x/y', ['openid'], 'c', 'S256');
+
+        $consumed = $repo->consume($issued->code);
+
+        self::assertNotNull($consumed);
+        self::assertNull($consumed->nonce);
     }
 
     public function testIssueProducesUniqueCodesForDistinctCalls(): void
@@ -84,6 +118,7 @@ final class DatabaseAuthorizationCodeRepositoryTest extends TestCase
         self::assertSame('ch4lleng3', $consumed->codeChallenge);
         self::assertSame('S256', $consumed->codeChallengeMethod);
         self::assertSame($this->now, $consumed->consumedAt);
+        self::assertNull($consumed->nonce);
     }
 
     public function testSecondConsumeReturnsNull(): void

--- a/packages/oidc/tests/Unit/Repository/AuthorizationCodeTest.php
+++ b/packages/oidc/tests/Unit/Repository/AuthorizationCodeTest.php
@@ -24,6 +24,7 @@ final class AuthorizationCodeTest extends TestCase
             issuedAt: 1_000_000,
             expiresAt: 1_000_060,
             consumedAt: null,
+            nonce: 'n-0S6_WzA2Mj',
         );
 
         self::assertSame('abc123', $code->code);
@@ -36,6 +37,14 @@ final class AuthorizationCodeTest extends TestCase
         self::assertSame(1_000_000, $code->issuedAt);
         self::assertSame(1_000_060, $code->expiresAt);
         self::assertNull($code->consumedAt);
+        self::assertSame('n-0S6_WzA2Mj', $code->nonce);
+    }
+
+    public function testNonceDefaultsToNull(): void
+    {
+        $code = $this->sample();
+
+        self::assertNull($code->nonce);
     }
 
     public function testIsExpiredReturnsFalseBeforeExpiry(): void


### PR DESCRIPTION
## Summary

- `AuthorizationCodeRepositoryInterface::issue()` takes `?string $nonce = null`; `AuthorizationCode` exposes a matching nullable public property
- `DatabaseAuthorizationCodeRepository` evolves its schema with a nullable `nonce VARCHAR(255)` column (lazy `ensureTable()`), stores on insert, hydrates on consume with `$row['nonce'] ?? null`
- `AuthorizeController` passes `$validated->nonce` through to `issue()`

Wires the OIDC nonce from the authorize query all the way through the code repository so `/token` can embed it in the ID token `nonce` claim (OIDC Core §3.1.3.6). Closes #1289.

Blocks /token: until nonce survives the full authorize → consume round-trip, `/token` cannot mint OIDC-compliant ID tokens.

## Test plan

- [x] `AuthorizationCodeTest` — asserts nonce round-trips through the constructor and defaults to null
- [x] `DatabaseAuthorizationCodeRepositoryTest` — asserts `issue(nonce: 'n-...')` stores, `consume()` rehydrates, omitted nonce stays null
- [x] `AuthorizeControllerTest` — `FakeCodeRepository` records nonce, asserts controller passes `$validated->nonce` through; null when query omits it
- [x] Full phpunit suite: 6299 tests / 15064 assertions green
- [x] `composer cs-fix` — no changes
- [x] `composer phpstan` — 774 files, no errors
- [x] `composer check-composer-policy` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)