### PR TITLE
feat(#1292): /token endpoint (authorization_code grant, RS256 ID token)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `oidc`: `/authorize` now propagates the OIDC `nonce` query parameter through the authorization code repository. `AuthorizationCodeRepositoryInterface::issue()` accepts `?string $nonce = null`, `AuthorizationCode` exposes it as a public field, and `DatabaseAuthorizationCodeRepository` stores it in a new nullable `nonce` column (added lazily via `ALTER TABLE` for tables provisioned before this change). Required by OIDC Core §3.1.3.6 so `/token` can embed `nonce` in the issued ID token. Closes #1289.
+- `oidc`: `POST /token` endpoint implementing the OAuth 2.1 / OIDC authorization_code grant (ADR-006 §7, OIDC Core §3.1.3). Exchanges a consumed authorization code for an RS256-signed ID token and an opaque access token. Supports public clients via PKCE S256 alone, and confidential clients via HTTP Basic or `client_secret_post` per RFC 6749 §2.3.1. Enforces byte-exact `redirect_uri` match, `client_id` binding, and PKCE verifier check (RFC 7636). ID token claims: `iss`, `sub`, `aud`, `exp` (10 min), `iat`, `auth_time`, `nonce` (when issued). Error responses follow RFC 6749 §5.2. Route is CSRF-exempt (client authentication happens inside the handler). Non-goals: refresh tokens, `/userinfo`, consent screen, `at_hash` claim, JWT access tokens. Closes #1292.
 
 ## [0.1.0-alpha.145] - 2026-04-16
 

--- a/packages/oidc/src/OidcRouteProvider.php
+++ b/packages/oidc/src/OidcRouteProvider.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Waaseyaa\Oidc;
 
 use Waaseyaa\Oidc\Authorize\AuthorizeController;
+use Waaseyaa\Oidc\Token\TokenController;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final readonly class OidcRouteProvider
 {
-    public function __construct(private ?AuthorizeController $authorizeController = null) {}
+    public function __construct(
+        private ?AuthorizeController $authorizeController = null,
+        private ?TokenController $tokenController = null,
+    ) {}
 
     public function registerRoutes(WaaseyaaRouter $router): void
     {
@@ -39,6 +43,18 @@ final readonly class OidcRouteProvider
                     ->controller($this->authorizeController)
                     ->methods('GET')
                     ->allowAll()
+                    ->build(),
+            );
+        }
+
+        if ($this->tokenController !== null) {
+            $router->addRoute(
+                'oidc.token',
+                RouteBuilder::create('/token')
+                    ->controller($this->tokenController)
+                    ->methods('POST')
+                    ->allowAll()
+                    ->csrfExempt()
                     ->build(),
             );
         }

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -22,6 +22,10 @@ use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
 use Waaseyaa\Oidc\Keys\PemFileKeyLoader;
 use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
 use Waaseyaa\Oidc\Repository\DatabaseAuthorizationCodeRepository;
+use Waaseyaa\Oidc\Token\IdTokenMinter;
+use Waaseyaa\Oidc\Token\PkceVerifier;
+use Waaseyaa\Oidc\Token\TokenController;
+use Waaseyaa\Oidc\Token\TokenRequestValidator;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
 final class OidcServiceProvider extends ServiceProvider
@@ -142,6 +146,36 @@ final class OidcServiceProvider extends ServiceProvider
                 loginPath: $this->resolveLoginPath(),
             ),
         );
+
+        $this->singleton(
+            PkceVerifier::class,
+            static fn(): PkceVerifier => new PkceVerifier(),
+        );
+
+        $this->singleton(
+            TokenRequestValidator::class,
+            static fn(): TokenRequestValidator => new TokenRequestValidator(),
+        );
+
+        $this->singleton(
+            IdTokenMinter::class,
+            fn(): IdTokenMinter => new IdTokenMinter(
+                keyLoader: $this->resolve(OidcKeyLoaderInterface::class),
+            ),
+        );
+
+        $this->singleton(
+            TokenController::class,
+            fn(): TokenController => new TokenController(
+                clientLookup: $this->resolve(OidcClientLookup::class),
+                validator: $this->resolve(TokenRequestValidator::class),
+                pkceVerifier: $this->resolve(PkceVerifier::class),
+                codeRepository: $this->resolve(AuthorizationCodeRepositoryInterface::class),
+                idTokenMinter: $this->resolve(IdTokenMinter::class),
+                issuer: $this->resolveIssuer(),
+                clock: static fn(): \DateTimeImmutable => new \DateTimeImmutable(),
+            ),
+        );
     }
 
     public function boot(): void
@@ -212,7 +246,17 @@ final class OidcServiceProvider extends ServiceProvider
             // Storage not available yet (e.g., bootstrap without entity system); skip authorize route.
         }
 
-        (new OidcRouteProvider(authorizeController: $authorizeController))->registerRoutes($router);
+        $tokenController = null;
+        try {
+            $tokenController = $this->resolve(TokenController::class);
+        } catch (\Throwable) {
+            // Storage or signing keys not available yet; skip token route.
+        }
+
+        (new OidcRouteProvider(
+            authorizeController: $authorizeController,
+            tokenController: $tokenController,
+        ))->registerRoutes($router);
     }
 
     /**

--- a/packages/oidc/src/Token/IdTokenMinter.php
+++ b/packages/oidc/src/Token/IdTokenMinter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+use DateTimeImmutable;
+use RuntimeException;
+use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
+use Waaseyaa\Oidc\Keys\SigningKey;
+
+/**
+ * Mints RS256-signed ID tokens per OIDC Core §2 and RFC 7519.
+ *
+ * Selects the first RS256 signing key that has a private key. ES256 and other
+ * algorithms are out of scope for now (ADR-006).
+ */
+final class IdTokenMinter
+{
+    private const ALGORITHM = 'RS256';
+    private const EXPIRY_SECONDS = 600;
+
+    public function __construct(private readonly OidcKeyLoaderInterface $keyLoader) {}
+
+    public function mint(
+        string $issuer,
+        string $subject,
+        string $audience,
+        ?string $nonce,
+        DateTimeImmutable $now,
+    ): string {
+        $key = $this->selectSigningKey();
+
+        $header = [
+            'alg' => self::ALGORITHM,
+            'typ' => 'JWT',
+            'kid' => $key->kid,
+        ];
+
+        $iat = $now->getTimestamp();
+        $claims = [
+            'iss' => $issuer,
+            'sub' => $subject,
+            'aud' => $audience,
+            'exp' => $iat + self::EXPIRY_SECONDS,
+            'iat' => $iat,
+            'auth_time' => $iat,
+        ];
+        if ($nonce !== null) {
+            $claims['nonce'] = $nonce;
+        }
+
+        $encodedHeader = $this->base64UrlEncode(json_encode($header, JSON_THROW_ON_ERROR));
+        $encodedPayload = $this->base64UrlEncode(json_encode($claims, JSON_THROW_ON_ERROR));
+        $signingInput = $encodedHeader . '.' . $encodedPayload;
+
+        $signature = '';
+        if (!openssl_sign($signingInput, $signature, $key->privateKeyPem, OPENSSL_ALGO_SHA256)) {
+            throw new RuntimeException('Failed to sign ID token: ' . openssl_error_string());
+        }
+
+        return $signingInput . '.' . $this->base64UrlEncode($signature);
+    }
+
+    private function selectSigningKey(): SigningKey
+    {
+        foreach ($this->keyLoader->loadSigningKeys() as $key) {
+            if ($key->algorithm === self::ALGORITHM && $key->privateKeyPem !== null) {
+                return $key;
+            }
+        }
+
+        throw new RuntimeException('No signing key with a private RS256 key is available.');
+    }
+
+    private function base64UrlEncode(string $input): string
+    {
+        return rtrim(strtr(base64_encode($input), '+/', '-_'), '=');
+    }
+}

--- a/packages/oidc/src/Token/PkceVerifier.php
+++ b/packages/oidc/src/Token/PkceVerifier.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+/**
+ * Verifies a PKCE code_verifier against a stored code_challenge.
+ *
+ * S256 only (ADR-006 §2.5). Per RFC 7636 §4.6 the challenge is
+ * BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) with no padding, and the
+ * verifier itself must be 43–128 characters from the unreserved set
+ * [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~".
+ */
+final class PkceVerifier
+{
+    private const METHOD_S256 = 'S256';
+    private const MIN_LENGTH = 43;
+    private const MAX_LENGTH = 128;
+    private const UNRESERVED_PATTERN = '/^[A-Za-z0-9\-._~]+$/';
+
+    public function verify(string $verifier, string $challenge, string $method): bool
+    {
+        if ($method !== self::METHOD_S256) {
+            return false;
+        }
+
+        if ($challenge === '' || !$this->isValidVerifier($verifier)) {
+            return false;
+        }
+
+        $computed = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+
+        return hash_equals($challenge, $computed);
+    }
+
+    private function isValidVerifier(string $verifier): bool
+    {
+        $length = strlen($verifier);
+        if ($length < self::MIN_LENGTH || $length > self::MAX_LENGTH) {
+            return false;
+        }
+
+        return preg_match(self::UNRESERVED_PATTERN, $verifier) === 1;
+    }
+}

--- a/packages/oidc/src/Token/TokenController.php
+++ b/packages/oidc/src/Token/TokenController.php
@@ -50,9 +50,7 @@ final readonly class TokenController
         try {
             $tokenRequest = $this->validator->validate($request->request->all());
         } catch (TokenRequestException $e) {
-            $status = $e->errorCode === 'unsupported_grant_type' ? 400 : 400;
-
-            return $this->error($status, $e->errorCode, $e->errorDescription);
+            return $this->error(400, $e->errorCode, $e->errorDescription);
         }
 
         [$credClientId, $credClientSecret] = $this->extractClientCredentials($request, $tokenRequest);

--- a/packages/oidc/src/Token/TokenController.php
+++ b/packages/oidc/src/Token/TokenController.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+use Closure;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+
+/**
+ * OAuth 2.1 / OIDC token endpoint (ADR-006 §7, OIDC Core §3.1.3).
+ *
+ * Exchanges a consumed authorization code for an RS256-signed ID token and an
+ * opaque access token. Enforces PKCE S256 (ADR-006 §2.5), byte-exact
+ * redirect_uri match, and client_id binding. Confidential clients authenticate
+ * via HTTP Basic or client_secret_post (RFC 6749 §2.3.1); public clients rely
+ * on PKCE alone.
+ *
+ * Non-goals (charter #1292): refresh tokens, /userinfo, consent screen,
+ * at_hash, JWT access tokens.
+ */
+final readonly class TokenController
+{
+    private const ACCESS_TOKEN_EXPIRY = 600;
+
+    /**
+     * @param Closure(): DateTimeImmutable $clock
+     */
+    public function __construct(
+        private OidcClientLookup $clientLookup,
+        private TokenRequestValidator $validator,
+        private PkceVerifier $pkceVerifier,
+        private AuthorizationCodeRepositoryInterface $codeRepository,
+        private IdTokenMinter $idTokenMinter,
+        private string $issuer,
+        private Closure $clock,
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        if ($request->getMethod() !== 'POST') {
+            return $this->error(405, 'invalid_request', 'POST required.');
+        }
+
+        try {
+            $tokenRequest = $this->validator->validate($request->request->all());
+        } catch (TokenRequestException $e) {
+            $status = $e->errorCode === 'unsupported_grant_type' ? 400 : 400;
+
+            return $this->error($status, $e->errorCode, $e->errorDescription);
+        }
+
+        [$credClientId, $credClientSecret] = $this->extractClientCredentials($request, $tokenRequest);
+        if ($credClientId === null) {
+            return $this->error(401, 'invalid_client', 'No client credentials provided.');
+        }
+
+        $client = $this->clientLookup->findByClientId($credClientId);
+        if ($client === null) {
+            return $this->error(401, 'invalid_client', 'Unknown client_id.');
+        }
+
+        if ($client->isConfidential()) {
+            if ($credClientSecret === null) {
+                return $this->error(401, 'invalid_client', 'Client authentication required.');
+            }
+            $hash = $client->getClientSecretHash();
+            if ($hash === null || !password_verify($credClientSecret, $hash)) {
+                return $this->error(401, 'invalid_client', 'Client authentication failed.');
+            }
+        }
+
+        $stored = $this->codeRepository->consume($tokenRequest->code);
+        if ($stored === null) {
+            return $this->error(400, 'invalid_grant', 'Authorization code is invalid or expired.');
+        }
+
+        if ($stored->clientId !== $client->getClientId()) {
+            return $this->error(400, 'invalid_grant', 'Authorization code was not issued to this client.');
+        }
+
+        if ($stored->redirectUri !== $tokenRequest->redirectUri) {
+            return $this->error(400, 'invalid_grant', 'redirect_uri does not match the authorization request.');
+        }
+
+        if (!$this->pkceVerifier->verify(
+            $tokenRequest->codeVerifier,
+            $stored->codeChallenge,
+            $stored->codeChallengeMethod,
+        )) {
+            return $this->error(400, 'invalid_grant', 'PKCE verifier does not match the stored code_challenge.');
+        }
+
+        $now = ($this->clock)();
+
+        $idToken = $this->idTokenMinter->mint(
+            issuer: $this->issuer,
+            subject: $stored->accountId,
+            audience: $client->getClientId(),
+            nonce: $stored->nonce,
+            now: $now,
+        );
+
+        $accessToken = $this->generateOpaqueToken();
+
+        return $this->success([
+            'access_token' => $accessToken,
+            'token_type' => 'Bearer',
+            'expires_in' => self::ACCESS_TOKEN_EXPIRY,
+            'id_token' => $idToken,
+        ]);
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string} [client_id, client_secret]
+     */
+    private function extractClientCredentials(Request $request, TokenRequest $tokenRequest): array
+    {
+        $authHeader = $request->headers->get('Authorization');
+        if (is_string($authHeader) && stripos($authHeader, 'Basic ') === 0) {
+            $decoded = base64_decode(substr($authHeader, 6), true);
+            if (is_string($decoded) && str_contains($decoded, ':')) {
+                [$id, $secret] = explode(':', $decoded, 2);
+                if ($id !== '') {
+                    return [$id, $secret];
+                }
+            }
+        }
+
+        $bodySecret = $request->request->get('client_secret');
+        if ($tokenRequest->clientId !== null) {
+            return [
+                $tokenRequest->clientId,
+                is_string($bodySecret) && $bodySecret !== '' ? $bodySecret : null,
+            ];
+        }
+
+        return [null, null];
+    }
+
+    private function generateOpaqueToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function success(array $payload): Response
+    {
+        $response = new JsonResponse($payload, 200);
+        $response->headers->set('Cache-Control', 'no-store');
+        $response->headers->set('Pragma', 'no-cache');
+
+        return $response;
+    }
+
+    private function error(int $status, string $error, string $description): Response
+    {
+        $response = new JsonResponse([
+            'error' => $error,
+            'error_description' => $description,
+        ], $status);
+        $response->headers->set('Cache-Control', 'no-store');
+        $response->headers->set('Pragma', 'no-cache');
+
+        return $response;
+    }
+}

--- a/packages/oidc/src/Token/TokenRequest.php
+++ b/packages/oidc/src/Token/TokenRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+/**
+ * A validated /token request body (authorization_code grant).
+ *
+ * clientId is nullable because a confidential client may authenticate via
+ * HTTP Basic instead of sending client_id in the form body (RFC 6749 §2.3.1).
+ * The controller reconciles the two sources.
+ */
+final class TokenRequest
+{
+    public function __construct(
+        public readonly string $code,
+        public readonly string $redirectUri,
+        public readonly string $codeVerifier,
+        public readonly ?string $clientId,
+    ) {}
+}

--- a/packages/oidc/src/Token/TokenRequestException.php
+++ b/packages/oidc/src/Token/TokenRequestException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+use RuntimeException;
+
+/**
+ * Thrown when a /token request fails validation.
+ *
+ * errorCode values come from RFC 6749 §5.2: invalid_request, invalid_client,
+ * invalid_grant, unauthorized_client, unsupported_grant_type, invalid_scope.
+ */
+final class TokenRequestException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $errorCode,
+        public readonly string $errorDescription,
+    ) {
+        parent::__construct($errorDescription);
+    }
+}

--- a/packages/oidc/src/Token/TokenRequestValidator.php
+++ b/packages/oidc/src/Token/TokenRequestValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Token;
+
+/**
+ * Validates a POST /token form body for the authorization_code grant.
+ *
+ * Per RFC 6749 §4.1.3 and RFC 7636 §4.5. Client authentication (Basic vs
+ * client_secret_post vs PKCE-only for public clients) is handled upstream by
+ * the controller; this validator only checks structural correctness of the
+ * form body and resolves the TokenRequest value object.
+ */
+final class TokenRequestValidator
+{
+    private const SUPPORTED_GRANT_TYPE = 'authorization_code';
+
+    /**
+     * @param array<string, mixed> $form
+     */
+    public function validate(array $form): TokenRequest
+    {
+        $grantType = $this->stringOrNull($form, 'grant_type');
+        if ($grantType === null) {
+            throw new TokenRequestException('invalid_request', 'Missing grant_type.');
+        }
+
+        if ($grantType !== self::SUPPORTED_GRANT_TYPE) {
+            throw new TokenRequestException(
+                'unsupported_grant_type',
+                'Only grant_type=authorization_code is supported.',
+            );
+        }
+
+        $code = $this->stringOrNull($form, 'code');
+        if ($code === null) {
+            throw new TokenRequestException('invalid_request', 'Missing code.');
+        }
+
+        $redirectUri = $this->stringOrNull($form, 'redirect_uri');
+        if ($redirectUri === null) {
+            throw new TokenRequestException('invalid_request', 'Missing redirect_uri.');
+        }
+
+        $codeVerifier = $this->stringOrNull($form, 'code_verifier');
+        if ($codeVerifier === null) {
+            throw new TokenRequestException('invalid_request', 'Missing code_verifier.');
+        }
+
+        return new TokenRequest(
+            code: $code,
+            redirectUri: $redirectUri,
+            codeVerifier: $codeVerifier,
+            clientId: $this->stringOrNull($form, 'client_id'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $form
+     */
+    private function stringOrNull(array $form, string $key): ?string
+    {
+        $value = $form[$key] ?? null;
+        if (!\is_string($value) || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/packages/oidc/tests/Integration/Token/TokenControllerTest.php
+++ b/packages/oidc/tests/Integration/Token/TokenControllerTest.php
@@ -1,0 +1,475 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Token;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\ClientRegistry\OidcClientLookup;
+use Waaseyaa\Oidc\Entity\OidcClient;
+use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
+use Waaseyaa\Oidc\Keys\SigningKey;
+use Waaseyaa\Oidc\Repository\AuthorizationCode;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+use Waaseyaa\Oidc\Token\IdTokenMinter;
+use Waaseyaa\Oidc\Token\PkceVerifier;
+use Waaseyaa\Oidc\Token\TokenController;
+use Waaseyaa\Oidc\Token\TokenRequestValidator;
+
+#[CoversClass(TokenController::class)]
+final class TokenControllerTest extends TestCase
+{
+    private const ISSUER = 'https://idp.example';
+    private const REDIRECT_URI = 'https://app.example/callback';
+    private const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    private const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+    private string $privateKeyPem;
+    private string $publicKeyPem;
+    private SqlEntityStorage $storage;
+
+    protected function setUp(): void
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        self::assertNotFalse($resource);
+
+        $private = '';
+        openssl_pkey_export($resource, $private);
+        $details = openssl_pkey_get_details($resource);
+        self::assertIsArray($details);
+
+        $this->privateKeyPem = $private;
+        $this->publicKeyPem = $details['key'];
+
+        $database = DBALDatabase::createSqlite();
+
+        $entityType = new EntityType(
+            id: 'oidc_client',
+            label: 'OIDC Client',
+            class: OidcClient::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $database);
+        $schemaHandler->ensureTable();
+        $schemaHandler->addFieldColumns([
+            'client_id' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            'is_confidential' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'client_secret_hash' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+        ]);
+
+        $this->storage = new SqlEntityStorage($entityType, $database, new EventDispatcher());
+    }
+
+    #[Test]
+    public function happyPathPublicClientReturnsTokenJson(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1')],
+            codes: [$this->seedCode('code-ok', 'spa-1', nonce: 'nonce-abc')],
+        );
+
+        $response = ($controller)($this->postForm([
+            'grant_type' => 'authorization_code',
+            'code' => 'code-ok',
+            'redirect_uri' => self::REDIRECT_URI,
+            'code_verifier' => self::VERIFIER,
+            'client_id' => 'spa-1',
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json', $response->headers->get('Content-Type'));
+        self::assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+        self::assertSame('no-cache', $response->headers->get('Pragma'));
+
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($payload);
+        self::assertSame('Bearer', $payload['token_type']);
+        self::assertSame(600, $payload['expires_in']);
+        self::assertIsString($payload['access_token']);
+        self::assertNotEmpty($payload['access_token']);
+        self::assertIsString($payload['id_token']);
+
+        $claims = $this->decodeIdTokenClaims($payload['id_token']);
+        self::assertSame(self::ISSUER, $claims['iss']);
+        self::assertSame('spa-1', $claims['aud']);
+        self::assertSame('nonce-abc', $claims['nonce']);
+    }
+
+    #[Test]
+    public function idTokenOmitsNonceClaimWhenCodeHasNoNonce(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1')],
+            codes: [$this->seedCode('code-no-nonce', 'spa-1', nonce: null)],
+        );
+
+        $response = ($controller)($this->postForm($this->validForm('code-no-nonce', 'spa-1')));
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true);
+        $claims = $this->decodeIdTokenClaims($payload['id_token']);
+        self::assertArrayNotHasKey('nonce', $claims);
+    }
+
+    #[Test]
+    public function rejectsNonPostWith405(): void
+    {
+        $controller = $this->controller();
+
+        $response = ($controller)(Request::create('/token', 'GET'));
+
+        self::assertSame(405, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsMissingGrantTypeWith400InvalidRequest(): void
+    {
+        $controller = $this->controller();
+
+        $form = $this->validForm('code-ok', 'spa-1');
+        unset($form['grant_type']);
+
+        $response = ($controller)($this->postForm($form));
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('invalid_request', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function unknownClientIdReturns401InvalidClient(): void
+    {
+        $controller = $this->controller(clients: []);
+
+        $response = ($controller)($this->postForm($this->validForm('code-ok', 'ghost')));
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_client', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function missingClientIdAndNoBasicAuthReturns401InvalidClient(): void
+    {
+        $controller = $this->controller();
+
+        $form = $this->validForm('code-ok', 'spa-1');
+        unset($form['client_id']);
+
+        $response = ($controller)($this->postForm($form));
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_client', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function unknownOrExpiredCodeReturns400InvalidGrant(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1')],
+            codes: [],
+        );
+
+        $response = ($controller)($this->postForm($this->validForm('missing-code', 'spa-1')));
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('invalid_grant', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function codeIssuedToDifferentClientReturns400InvalidGrant(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1'), $this->publicClient('spa-2')],
+            codes: [$this->seedCode('code-for-spa1', 'spa-1')],
+        );
+
+        $response = ($controller)($this->postForm($this->validForm('code-for-spa1', 'spa-2')));
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('invalid_grant', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function redirectUriMismatchReturns400InvalidGrant(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1')],
+            codes: [$this->seedCode('code-ok', 'spa-1')],
+        );
+
+        $form = $this->validForm('code-ok', 'spa-1');
+        $form['redirect_uri'] = 'https://app.example/OTHER';
+
+        $response = ($controller)($this->postForm($form));
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('invalid_grant', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function pkceVerifierMismatchReturns400InvalidGrant(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->publicClient('spa-1')],
+            codes: [$this->seedCode('code-ok', 'spa-1')],
+        );
+
+        $form = $this->validForm('code-ok', 'spa-1');
+        $form['code_verifier'] = str_repeat('x', 43);
+
+        $response = ($controller)($this->postForm($form));
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('invalid_grant', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function confidentialClientWithoutAuthReturns401InvalidClient(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->confidentialClient('conf-1', 'shhh')],
+            codes: [$this->seedCode('code-ok', 'conf-1')],
+        );
+
+        $response = ($controller)($this->postForm($this->validForm('code-ok', 'conf-1')));
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_client', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function confidentialClientWithWrongSecretReturns401InvalidClient(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->confidentialClient('conf-1', 'correct-secret')],
+            codes: [$this->seedCode('code-ok', 'conf-1')],
+        );
+
+        $request = $this->postForm($this->validForm('code-ok', 'conf-1'));
+        $request->headers->set('Authorization', 'Basic ' . base64_encode('conf-1:WRONG'));
+
+        $response = ($controller)($request);
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_client', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function confidentialClientWithBasicAuthSucceeds(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->confidentialClient('conf-1', 'correct-secret')],
+            codes: [$this->seedCode('code-ok', 'conf-1')],
+        );
+
+        $form = $this->validForm('code-ok', 'conf-1');
+        unset($form['client_id']);
+        $request = $this->postForm($form);
+        $request->headers->set('Authorization', 'Basic ' . base64_encode('conf-1:correct-secret'));
+
+        $response = ($controller)($request);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function confidentialClientWithClientSecretPostSucceeds(): void
+    {
+        $controller = $this->controller(
+            clients: [$this->confidentialClient('conf-1', 'correct-secret')],
+            codes: [$this->seedCode('code-ok', 'conf-1')],
+        );
+
+        $form = $this->validForm('code-ok', 'conf-1');
+        $form['client_secret'] = 'correct-secret';
+
+        $response = ($controller)($this->postForm($form));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string> $form
+     */
+    private function postForm(array $form): Request
+    {
+        $request = Request::create('/token', 'POST', $form);
+        $request->headers->set('Content-Type', 'application/x-www-form-urlencoded');
+
+        return $request;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validForm(string $code, string $clientId): array
+    {
+        return [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => self::REDIRECT_URI,
+            'code_verifier' => self::VERIFIER,
+            'client_id' => $clientId,
+        ];
+    }
+
+    /**
+     * @param list<OidcClient> $clients
+     * @param list<AuthorizationCode> $codes
+     */
+    private function controller(array $clients = [], array $codes = []): TokenController
+    {
+        foreach ($clients as $client) {
+            $this->storage->save($client);
+        }
+
+        return new TokenController(
+            clientLookup: new OidcClientLookup($this->storage),
+            validator: new TokenRequestValidator(),
+            pkceVerifier: new PkceVerifier(),
+            codeRepository: $this->fakeCodeRepository($codes),
+            idTokenMinter: new IdTokenMinter($this->keyLoader()),
+            issuer: self::ISSUER,
+            clock: fn (): DateTimeImmutable => new DateTimeImmutable('2026-04-18T12:00:00Z'),
+        );
+    }
+
+    private function publicClient(string $clientId): OidcClient
+    {
+        /** @var OidcClient $client */
+        $client = $this->storage->create([
+            'client_id' => $clientId,
+            'name' => $clientId,
+            'redirect_uris' => [self::REDIRECT_URI],
+            'scopes' => ['openid'],
+            'grant_types' => ['authorization_code'],
+            'is_confidential' => false,
+        ]);
+
+        return $client;
+    }
+
+    private function confidentialClient(string $clientId, string $plainSecret): OidcClient
+    {
+        $hash = password_hash($plainSecret, PASSWORD_BCRYPT);
+        self::assertIsString($hash);
+
+        /** @var OidcClient $client */
+        $client = $this->storage->create([
+            'client_id' => $clientId,
+            'name' => $clientId,
+            'redirect_uris' => [self::REDIRECT_URI],
+            'scopes' => ['openid'],
+            'grant_types' => ['authorization_code'],
+            'is_confidential' => true,
+            'client_secret_hash' => $hash,
+        ]);
+
+        return $client;
+    }
+
+    private function seedCode(string $code, string $clientId, ?string $nonce = null): AuthorizationCode
+    {
+        $now = (new DateTimeImmutable('2026-04-18T12:00:00Z'))->getTimestamp();
+
+        return new AuthorizationCode(
+            code: $code,
+            clientId: $clientId,
+            accountId: '42',
+            redirectUri: self::REDIRECT_URI,
+            scopes: ['openid'],
+            codeChallenge: self::CHALLENGE,
+            codeChallengeMethod: 'S256',
+            issuedAt: $now,
+            expiresAt: $now + 60,
+            consumedAt: null,
+            nonce: $nonce,
+        );
+    }
+
+    /**
+     * @param list<AuthorizationCode> $codes
+     */
+    private function fakeCodeRepository(array $codes): AuthorizationCodeRepositoryInterface
+    {
+        return new class ($codes) implements AuthorizationCodeRepositoryInterface {
+            /** @var array<string, AuthorizationCode> */
+            private array $by_code;
+
+            /** @param list<AuthorizationCode> $codes */
+            public function __construct(array $codes)
+            {
+                $this->by_code = [];
+                foreach ($codes as $code) {
+                    $this->by_code[$code->code] = $code;
+                }
+            }
+
+            public function issue(
+                string $clientId,
+                AccountInterface $account,
+                string $redirectUri,
+                array $scopes,
+                string $codeChallenge,
+                string $codeChallengeMethod,
+                ?string $nonce = null,
+            ): AuthorizationCode {
+                throw new \RuntimeException('issue() not used in these tests');
+            }
+
+            public function consume(string $code): ?AuthorizationCode
+            {
+                $stored = $this->by_code[$code] ?? null;
+                if ($stored === null) {
+                    return null;
+                }
+                unset($this->by_code[$code]);
+
+                return $stored;
+            }
+
+            public function purgeExpired(): int
+            {
+                return 0;
+            }
+        };
+    }
+
+    private function keyLoader(): OidcKeyLoaderInterface
+    {
+        return new class ($this->privateKeyPem, $this->publicKeyPem) implements OidcKeyLoaderInterface {
+            public function __construct(private string $private_pem, private string $public_pem)
+            {
+            }
+
+            public function loadSigningKeys(): array
+            {
+                return [new SigningKey('test-kid', 'RS256', $this->public_pem, $this->private_pem)];
+            }
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeIdTokenClaims(string $jwt): array
+    {
+        $parts = explode('.', $jwt);
+        $padded = str_pad($parts[1], (int) (ceil(strlen($parts[1]) / 4) * 4), '=', STR_PAD_RIGHT);
+        $claims = json_decode(base64_decode(strtr($padded, '-_', '+/'), true) ?: '', true);
+        self::assertIsArray($claims);
+
+        return $claims;
+    }
+
+    private function jsonError(\Symfony\Component\HttpFoundation\Response $response): string
+    {
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($payload);
+
+        return (string) ($payload['error'] ?? '');
+    }
+}

--- a/packages/oidc/tests/Unit/OidcRouteProviderTest.php
+++ b/packages/oidc/tests/Unit/OidcRouteProviderTest.php
@@ -48,4 +48,13 @@ final class OidcRouteProviderTest extends TestCase
             $route->getDefault('_controller'),
         );
     }
+
+    #[Test]
+    public function registerRoutesSkipsTokenRouteWhenControllerNotProvided(): void
+    {
+        $router = new WaaseyaaRouter();
+        (new OidcRouteProvider())->registerRoutes($router);
+
+        self::assertNull($router->getRouteCollection()->get('oidc.token'));
+    }
 }

--- a/packages/oidc/tests/Unit/Token/IdTokenMinterTest.php
+++ b/packages/oidc/tests/Unit/Token/IdTokenMinterTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Token;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Waaseyaa\Oidc\Keys\OidcKeyLoaderInterface;
+use Waaseyaa\Oidc\Keys\SigningKey;
+use Waaseyaa\Oidc\Token\IdTokenMinter;
+
+#[CoversClass(IdTokenMinter::class)]
+final class IdTokenMinterTest extends TestCase
+{
+    private string $privateKeyPem;
+    private string $publicKeyPem;
+
+    protected function setUp(): void
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        self::assertNotFalse($resource);
+
+        $private = '';
+        openssl_pkey_export($resource, $private);
+        $details = openssl_pkey_get_details($resource);
+        self::assertIsArray($details);
+
+        $this->privateKeyPem = $private;
+        $this->publicKeyPem = $details['key'];
+    }
+
+    #[Test]
+    public function mintsSignedJwtThatVerifiesAgainstPublicKey(): void
+    {
+        $minter = new IdTokenMinter($this->keyLoader('key-1'));
+        $now = new DateTimeImmutable('2026-04-18T12:00:00Z');
+
+        $jwt = $minter->mint(
+            issuer: 'https://idp.example',
+            subject: '42',
+            audience: 'client-1',
+            nonce: null,
+            now: $now,
+        );
+
+        [$encodedHeader, $encodedPayload, $encodedSignature] = explode('.', $jwt);
+        $signingInput = $encodedHeader . '.' . $encodedPayload;
+        $signature = $this->base64UrlDecode($encodedSignature);
+
+        self::assertSame(
+            1,
+            openssl_verify($signingInput, $signature, $this->publicKeyPem, OPENSSL_ALGO_SHA256),
+        );
+    }
+
+    #[Test]
+    public function headerContainsAlgRs256AndKid(): void
+    {
+        $minter = new IdTokenMinter($this->keyLoader('my-kid'));
+        $jwt = $minter->mint('https://idp.example', '42', 'client-1', null, new DateTimeImmutable());
+
+        [$encodedHeader] = explode('.', $jwt);
+        $header = json_decode($this->base64UrlDecode($encodedHeader), true);
+
+        self::assertSame('RS256', $header['alg']);
+        self::assertSame('JWT', $header['typ']);
+        self::assertSame('my-kid', $header['kid']);
+    }
+
+    #[Test]
+    public function payloadContainsRequiredClaims(): void
+    {
+        $minter = new IdTokenMinter($this->keyLoader('key-1'));
+        $now = new DateTimeImmutable('2026-04-18T12:00:00Z');
+
+        $jwt = $minter->mint('https://idp.example', '42', 'client-1', null, $now);
+
+        $claims = $this->decodeClaims($jwt);
+        self::assertSame('https://idp.example', $claims['iss']);
+        self::assertSame('42', $claims['sub']);
+        self::assertSame('client-1', $claims['aud']);
+        self::assertSame($now->getTimestamp(), $claims['iat']);
+        self::assertSame($now->getTimestamp(), $claims['auth_time']);
+        self::assertSame($now->getTimestamp() + 600, $claims['exp']);
+        self::assertArrayNotHasKey('nonce', $claims);
+    }
+
+    #[Test]
+    public function includesNonceClaimWhenProvided(): void
+    {
+        $minter = new IdTokenMinter($this->keyLoader('key-1'));
+
+        $jwt = $minter->mint(
+            'https://idp.example',
+            '42',
+            'client-1',
+            'nonce-abc-123',
+            new DateTimeImmutable(),
+        );
+
+        $claims = $this->decodeClaims($jwt);
+        self::assertSame('nonce-abc-123', $claims['nonce']);
+    }
+
+    #[Test]
+    public function throwsWhenNoSigningKeyHasPrivateKey(): void
+    {
+        $loader = new class () implements OidcKeyLoaderInterface {
+            public function loadSigningKeys(): array
+            {
+                return [new SigningKey('key-1', 'RS256', 'dummy-public-pem', null)];
+            }
+        };
+
+        $minter = new IdTokenMinter($loader);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No signing key');
+
+        $minter->mint('https://idp.example', '42', 'client-1', null, new DateTimeImmutable());
+    }
+
+    #[Test]
+    public function throwsWhenNoRs256KeyAvailable(): void
+    {
+        $loader = new class ($this->privateKeyPem, $this->publicKeyPem) implements OidcKeyLoaderInterface {
+            public function __construct(private string $private_pem, private string $public_pem)
+            {
+            }
+
+            public function loadSigningKeys(): array
+            {
+                return [new SigningKey('key-1', 'ES256', $this->public_pem, $this->private_pem)];
+            }
+        };
+
+        $minter = new IdTokenMinter($loader);
+
+        $this->expectException(RuntimeException::class);
+
+        $minter->mint('https://idp.example', '42', 'client-1', null, new DateTimeImmutable());
+    }
+
+    private function keyLoader(string $kid): OidcKeyLoaderInterface
+    {
+        return new class ($kid, $this->privateKeyPem, $this->publicKeyPem) implements OidcKeyLoaderInterface {
+            public function __construct(
+                private string $key_id,
+                private string $private_pem,
+                private string $public_pem,
+            ) {
+            }
+
+            public function loadSigningKeys(): array
+            {
+                return [new SigningKey($this->key_id, 'RS256', $this->public_pem, $this->private_pem)];
+            }
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeClaims(string $jwt): array
+    {
+        $parts = explode('.', $jwt);
+        $decoded = json_decode($this->base64UrlDecode($parts[1]), true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function base64UrlDecode(string $encoded): string
+    {
+        $padded = str_pad($encoded, (int) (ceil(strlen($encoded) / 4) * 4), '=', STR_PAD_RIGHT);
+        $decoded = base64_decode(strtr($padded, '-_', '+/'), true);
+        self::assertIsString($decoded);
+
+        return $decoded;
+    }
+}

--- a/packages/oidc/tests/Unit/Token/PkceVerifierTest.php
+++ b/packages/oidc/tests/Unit/Token/PkceVerifierTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Token;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Oidc\Token\PkceVerifier;
+
+#[CoversClass(PkceVerifier::class)]
+final class PkceVerifierTest extends TestCase
+{
+    // RFC 7636 §4.6 example pair.
+    private const RFC_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    private const RFC_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+    #[Test]
+    public function verifiesMatchingS256Pair(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertTrue($verifier->verify(self::RFC_VERIFIER, self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsMismatchedChallenge(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertFalse($verifier->verify(self::RFC_VERIFIER, 'wrong-challenge-value', 'S256'));
+    }
+
+    #[Test]
+    public function rejectsMismatchedVerifier(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // Valid-length verifier but wrong content.
+        $wrong = str_repeat('a', 43);
+
+        self::assertFalse($verifier->verify($wrong, self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsPlainMethod(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // Even if verifier == challenge, plain method is not supported.
+        self::assertFalse($verifier->verify(self::RFC_VERIFIER, self::RFC_VERIFIER, 'plain'));
+    }
+
+    #[Test]
+    public function rejectsUnknownMethod(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertFalse($verifier->verify(self::RFC_VERIFIER, self::RFC_CHALLENGE, 'S384'));
+    }
+
+    #[Test]
+    public function rejectsEmptyMethod(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertFalse($verifier->verify(self::RFC_VERIFIER, self::RFC_CHALLENGE, ''));
+    }
+
+    #[Test]
+    public function rejectsVerifierTooShort(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // 42 chars — one below RFC 7636 minimum of 43.
+        $short = str_repeat('a', 42);
+
+        self::assertFalse($verifier->verify($short, self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsVerifierTooLong(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // 129 chars — one above RFC 7636 maximum of 128.
+        $long = str_repeat('a', 129);
+
+        self::assertFalse($verifier->verify($long, self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function acceptsVerifierAtMinLength(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // 43 chars of 'a' — valid format, mismatched challenge (we're testing length boundary only).
+        $minVerifier = str_repeat('a', 43);
+        $minChallenge = $this->computeS256Challenge($minVerifier);
+
+        self::assertTrue($verifier->verify($minVerifier, $minChallenge, 'S256'));
+    }
+
+    #[Test]
+    public function acceptsVerifierAtMaxLength(): void
+    {
+        $verifier = new PkceVerifier();
+
+        $maxVerifier = str_repeat('a', 128);
+        $maxChallenge = $this->computeS256Challenge($maxVerifier);
+
+        self::assertTrue($verifier->verify($maxVerifier, $maxChallenge, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsVerifierWithInvalidCharacters(): void
+    {
+        $verifier = new PkceVerifier();
+
+        // 43 chars but contains a '+' — outside RFC 7636 unreserved set [A-Z][a-z][0-9]-._~
+        $invalid = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEj+k';
+        self::assertSame(43, strlen($invalid));
+
+        self::assertFalse($verifier->verify($invalid, self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsEmptyVerifier(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertFalse($verifier->verify('', self::RFC_CHALLENGE, 'S256'));
+    }
+
+    #[Test]
+    public function rejectsEmptyChallenge(): void
+    {
+        $verifier = new PkceVerifier();
+
+        self::assertFalse($verifier->verify(self::RFC_VERIFIER, '', 'S256'));
+    }
+
+    private function computeS256Challenge(string $verifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    }
+}

--- a/packages/oidc/tests/Unit/Token/TokenRequestValidatorTest.php
+++ b/packages/oidc/tests/Unit/Token/TokenRequestValidatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Unit\Token;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Oidc\Token\TokenRequestException;
+use Waaseyaa\Oidc\Token\TokenRequestValidator;
+
+#[CoversClass(TokenRequestValidator::class)]
+#[CoversClass(TokenRequestException::class)]
+final class TokenRequestValidatorTest extends TestCase
+{
+    private const VALID_FORM = [
+        'grant_type' => 'authorization_code',
+        'code' => 'abc123',
+        'redirect_uri' => 'https://app.example/callback',
+        'code_verifier' => 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+        'client_id' => 'first-party-spa',
+    ];
+
+    #[Test]
+    public function acceptsWellFormedRequest(): void
+    {
+        $validator = new TokenRequestValidator();
+
+        $request = $validator->validate(self::VALID_FORM);
+
+        self::assertSame('abc123', $request->code);
+        self::assertSame('https://app.example/callback', $request->redirectUri);
+        self::assertSame('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', $request->codeVerifier);
+        self::assertSame('first-party-spa', $request->clientId);
+    }
+
+    #[Test]
+    public function clientIdIsOptionalForBasicAuthPath(): void
+    {
+        $validator = new TokenRequestValidator();
+
+        $form = self::VALID_FORM;
+        unset($form['client_id']);
+
+        $request = $validator->validate($form);
+
+        self::assertNull($request->clientId);
+    }
+
+    #[Test]
+    public function rejectsMissingGrantType(): void
+    {
+        $form = self::VALID_FORM;
+        unset($form['grant_type']);
+
+        $this->expectValidation('invalid_request', 'grant_type', $form);
+    }
+
+    #[Test]
+    public function rejectsUnsupportedGrantType(): void
+    {
+        $form = self::VALID_FORM;
+        $form['grant_type'] = 'client_credentials';
+
+        $this->expectValidation('unsupported_grant_type', 'authorization_code', $form);
+    }
+
+    #[Test]
+    public function rejectsMissingCode(): void
+    {
+        $form = self::VALID_FORM;
+        unset($form['code']);
+
+        $this->expectValidation('invalid_request', 'code', $form);
+    }
+
+    #[Test]
+    public function rejectsEmptyCode(): void
+    {
+        $form = self::VALID_FORM;
+        $form['code'] = '';
+
+        $this->expectValidation('invalid_request', 'code', $form);
+    }
+
+    #[Test]
+    public function rejectsMissingRedirectUri(): void
+    {
+        $form = self::VALID_FORM;
+        unset($form['redirect_uri']);
+
+        $this->expectValidation('invalid_request', 'redirect_uri', $form);
+    }
+
+    #[Test]
+    public function rejectsMissingCodeVerifier(): void
+    {
+        $form = self::VALID_FORM;
+        unset($form['code_verifier']);
+
+        $this->expectValidation('invalid_request', 'code_verifier', $form);
+    }
+
+    #[Test]
+    public function rejectsNonStringValues(): void
+    {
+        $form = self::VALID_FORM;
+        $form['code'] = ['array', 'not', 'string'];
+
+        $this->expectValidation('invalid_request', 'code', $form);
+    }
+
+    /**
+     * @param array<string, mixed> $form
+     */
+    private function expectValidation(string $errorCode, string $mustContain, array $form): void
+    {
+        try {
+            (new TokenRequestValidator())->validate($form);
+            self::fail('Expected TokenRequestException');
+        } catch (TokenRequestException $e) {
+            self::assertSame($errorCode, $e->errorCode);
+            self::assertStringContainsString($mustContain, $e->errorDescription);
+        }
+    }
+}

--- a/tests/Integration/Oidc/Fixtures/token_flow_runner.php
+++ b/tests/Integration/Oidc/Fixtures/token_flow_runner.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
+use Waaseyaa\User\DevAdminAccount;
+
+/**
+ * Exercises the /token flow end-to-end in a subprocess.
+ *
+ * Phase 1: boot the kernel (via reflection since boot() is protected), then
+ * resolve AuthorizationCodeRepositoryInterface and issue a code bound to the
+ * passed client_id, redirect_uri, and challenge.
+ *
+ * Phase 2: populate globals to look like POST /token with the freshly issued
+ * code + matching verifier, call handle(), and emit the resulting response as
+ * JSON on stdout for the PHPUnit test to assert against.
+ */
+if ($argc < 7) {
+    fwrite(STDERR, "Usage: php token_flow_runner.php <repo_root> <project_root> <client_id> <redirect_uri> <code_challenge> <code_verifier> [nonce]\n");
+    exit(1);
+}
+
+$repoRoot = (string) $argv[1];
+$projectRoot = (string) $argv[2];
+$clientId = (string) $argv[3];
+$redirectUri = (string) $argv[4];
+$codeChallenge = (string) $argv[5];
+$codeVerifier = (string) $argv[6];
+$nonce = isset($argv[7]) && $argv[7] !== '' ? (string) $argv[7] : null;
+
+require $repoRoot . '/vendor/autoload.php';
+
+$kernel = new HttpKernel($projectRoot);
+
+$bootMethod = (new ReflectionClass(HttpKernel::class))->getMethod('boot');
+$bootMethod->invoke($kernel);
+
+$resolver = $kernel->getHttpServiceResolver();
+$codeRepository = $resolver(AuthorizationCodeRepositoryInterface::class);
+if (!$codeRepository instanceof AuthorizationCodeRepositoryInterface) {
+    fwrite(STDERR, "Failed to resolve AuthorizationCodeRepositoryInterface\n");
+    exit(1);
+}
+
+$issued = $codeRepository->issue(
+    clientId: $clientId,
+    account: new DevAdminAccount(),
+    redirectUri: $redirectUri,
+    scopes: ['openid'],
+    codeChallenge: $codeChallenge,
+    codeChallengeMethod: 'S256',
+    nonce: $nonce,
+);
+
+// Phase 2: set globals to simulate POST /token and dispatch through kernel.
+$_GET = [];
+$_POST = [
+    'grant_type' => 'authorization_code',
+    'code' => $issued->code,
+    'redirect_uri' => $redirectUri,
+    'code_verifier' => $codeVerifier,
+    'client_id' => $clientId,
+];
+$_COOKIE = [];
+$_FILES = [];
+$_REQUEST = $_POST;
+$_SERVER = [
+    'REQUEST_METHOD' => 'POST',
+    'REQUEST_URI' => '/token',
+    'QUERY_STRING' => '',
+    'HTTP_HOST' => 'localhost',
+    'SERVER_NAME' => 'localhost',
+    'SERVER_PORT' => '80',
+    'HTTPS' => 'off',
+    'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+];
+
+$response = $kernel->handle();
+
+echo json_encode([
+    'status' => $response->getStatusCode(),
+    'headers' => [
+        'content-type' => (string) $response->headers->get('Content-Type'),
+        'cache-control' => (string) $response->headers->get('Cache-Control'),
+        'pragma' => (string) $response->headers->get('Pragma'),
+    ],
+    'body' => (string) $response->getContent(),
+], JSON_THROW_ON_ERROR);

--- a/tests/Integration/Oidc/OidcTokenIntegrationTest.php
+++ b/tests/Integration/Oidc/OidcTokenIntegrationTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Oidc;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end wiring test for /token. Boots a fresh kernel in a subprocess:
+ *
+ *   1. Issues an authorization code via the real DatabaseAuthorizationCodeRepository.
+ *   2. Dispatches POST /token through the full middleware pipeline.
+ *   3. Asserts the JSON response carries id_token, access_token, token_type,
+ *      expires_in, and that the ID token signature verifies against the
+ *      configured RS256 public key.
+ *
+ * The PKCE verification, client authentication, and error branches are covered
+ * in detail by TokenControllerTest; this test proves the pieces are wired in
+ * the kernel.
+ */
+#[CoversNothing]
+final class OidcTokenIntegrationTest extends TestCase
+{
+    private const CLIENT_ID = 'minoo-web';
+    private const REDIRECT_URI = 'https://minoo.test/callback';
+    private const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    private const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    private const ISSUER = 'https://id.example';
+
+    private string $repoRoot;
+    private string $projectRoot;
+    private string $publicKeyPem;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = (string) realpath(__DIR__ . '/../../..');
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_oidc_token_' . uniqid();
+
+        mkdir($this->projectRoot . '/config', 0755, true);
+        mkdir($this->projectRoot . '/storage', 0755, true);
+        mkdir($this->projectRoot . '/keys', 0755, true);
+
+        self::assertTrue(symlink($this->repoRoot . '/vendor', $this->projectRoot . '/vendor'));
+
+        [$privatePem, $publicPem] = $this->generateRsaKeypair();
+        $this->publicKeyPem = $publicPem;
+        file_put_contents($this->projectRoot . '/keys/signing.key', $privatePem);
+        file_put_contents($this->projectRoot . '/keys/signing.pub', $publicPem);
+
+        file_put_contents($this->projectRoot . '/config/entity-types.php', "<?php\n\nreturn [];\n");
+        file_put_contents($this->projectRoot . '/config/waaseyaa.php', $this->buildConfigFile());
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectRoot)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                unlink($item->getPathname());
+                continue;
+            }
+            rmdir($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    #[Test]
+    public function tokenEndpointExchangesCodeForSignedIdToken(): void
+    {
+        $result = $this->runTokenFlow(nonce: 'nonce-xyz');
+
+        self::assertSame(200, $result['status'], 'Body: ' . $result['body']);
+        self::assertStringContainsString('application/json', $result['headers']['content-type']);
+        self::assertStringContainsString('no-store', $result['headers']['cache-control']);
+
+        $payload = json_decode($result['body'], true);
+        self::assertIsArray($payload);
+        self::assertSame('Bearer', $payload['token_type']);
+        self::assertSame(600, $payload['expires_in']);
+        self::assertIsString($payload['access_token']);
+        self::assertNotEmpty($payload['access_token']);
+        self::assertIsString($payload['id_token']);
+
+        $claims = $this->verifyAndDecodeIdToken($payload['id_token']);
+        self::assertSame(self::ISSUER, $claims['iss']);
+        self::assertSame(self::CLIENT_ID, $claims['aud']);
+        self::assertSame('nonce-xyz', $claims['nonce']);
+        self::assertArrayHasKey('exp', $claims);
+        self::assertArrayHasKey('iat', $claims);
+        self::assertArrayHasKey('auth_time', $claims);
+        self::assertArrayHasKey('sub', $claims);
+    }
+
+    /**
+     * @return array{status:int,headers:array<string,string>,body:string}
+     */
+    private function runTokenFlow(?string $nonce = null): array
+    {
+        $runner = $this->repoRoot . '/tests/Integration/Oidc/Fixtures/token_flow_runner.php';
+        $command = sprintf(
+            '%s %s %s %s %s %s %s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($runner),
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($this->projectRoot),
+            escapeshellarg(self::CLIENT_ID),
+            escapeshellarg(self::REDIRECT_URI),
+            escapeshellarg(self::CHALLENGE),
+            escapeshellarg(self::VERIFIER),
+            escapeshellarg((string) $nonce),
+        );
+
+        $output = shell_exec($command);
+        self::assertNotNull($output, 'Runner produced no output.');
+
+        $lines = array_values(array_filter(
+            preg_split('/\R/', trim((string) $output)) ?: [],
+            static fn(string $line): bool => trim($line) !== '',
+        ));
+        $jsonPayload = $lines !== [] ? $lines[count($lines) - 1] : '';
+        $payload = json_decode($jsonPayload, true);
+        self::assertIsArray($payload, 'Runner returned invalid JSON: ' . $output);
+
+        return [
+            'status' => (int) ($payload['status'] ?? 0),
+            'headers' => is_array($payload['headers'] ?? null) ? $payload['headers'] : [],
+            'body' => (string) ($payload['body'] ?? ''),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function verifyAndDecodeIdToken(string $jwt): array
+    {
+        $parts = explode('.', $jwt);
+        self::assertCount(3, $parts, 'ID token must have 3 segments');
+
+        $signingInput = $parts[0] . '.' . $parts[1];
+        $signature = $this->base64UrlDecode($parts[2]);
+
+        self::assertSame(
+            1,
+            openssl_verify($signingInput, $signature, $this->publicKeyPem, OPENSSL_ALGO_SHA256),
+            'ID token signature did not verify against configured public key',
+        );
+
+        $claims = json_decode($this->base64UrlDecode($parts[1]), true);
+        self::assertIsArray($claims);
+
+        return $claims;
+    }
+
+    private function base64UrlDecode(string $encoded): string
+    {
+        $padded = str_pad($encoded, (int) (ceil(strlen($encoded) / 4) * 4), '=', STR_PAD_RIGHT);
+        $decoded = base64_decode(strtr($padded, '-_', '+/'), true);
+        self::assertIsString($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array{0:string,1:string} [private pem, public pem]
+     */
+    private function generateRsaKeypair(): array
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        self::assertNotFalse($resource);
+
+        $privatePem = '';
+        openssl_pkey_export($resource, $privatePem);
+        $details = openssl_pkey_get_details($resource);
+        self::assertIsArray($details);
+
+        return [$privatePem, $details['key']];
+    }
+
+    private function buildConfigFile(): string
+    {
+        $databasePath = $this->projectRoot . '/storage/waaseyaa.sqlite';
+        $privateKeyPath = $this->projectRoot . '/keys/signing.key';
+        $publicKeyPath = $this->projectRoot . '/keys/signing.pub';
+
+        return <<<PHP
+<?php
+
+declare(strict_types=1);
+
+return [
+    'database' => '{$databasePath}',
+    'environment' => 'local',
+    'app' => ['url' => 'http://localhost', 'name' => 'Waaseyaa Oidc Token Test'],
+    'cors_origins' => ['http://localhost:3000'],
+    'oidc' => [
+        'issuer' => '{$this->issuer()}',
+        'signing_keys' => [
+            'test-kid' => [
+                'algorithm' => 'RS256',
+                'public_key_path' => '{$publicKeyPath}',
+                'private_key_path' => '{$privateKeyPath}',
+            ],
+        ],
+        'clients' => [
+            'minoo-web' => [
+                'name' => 'Minoo',
+                'redirect_uris' => ['https://minoo.test/callback'],
+                'scopes' => ['openid'],
+                'grant_types' => ['authorization_code'],
+                'is_confidential' => false,
+            ],
+        ],
+    ],
+];
+PHP;
+    }
+
+    private function issuer(): string
+    {
+        return self::ISSUER;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the OAuth 2.1 / OIDC `/token` endpoint per ADR-006 §7 and OIDC Core §3.1.3. Exchanges a consumed authorization code for an RS256-signed ID token and an opaque access token, completing the authorization code flow begun by #1284 and extended with nonce propagation in #1289.

- Public clients: PKCE S256 alone.
- Confidential clients: HTTP Basic or `client_secret_post` (RFC 6749 §2.3.1).
- Byte-exact `redirect_uri` match, `client_id` binding, PKCE verifier check (RFC 7636 format bounds, constant-time compare).
- ID token claims: `iss`, `sub`, `aud`, `exp` (10 min), `iat`, `auth_time`, `nonce` (when the code carried one — closes the loop with #1289).
- JSON response per RFC 6749 §5.1 with `Cache-Control: no-store`.
- Error responses per §5.2: `invalid_request`, `invalid_client`, `invalid_grant`, `unsupported_grant_type`.
- Minimal `openssl_sign`-based RS256 signer; no `firebase/php-jwt` dep added.
- Route is CSRF-exempt since client auth lives inside the handler.

Non-goals (from the issue charter): refresh tokens, `/userinfo`, consent screen, `at_hash`, JWT access tokens.

## Test plan

- [x] PkceVerifier unit: RFC 7636 §4.6 example pair, mismatch, plain method, unknown method, length bounds (43–128), invalid chars, empty inputs. 13 tests.
- [x] TokenRequestValidator unit: every required-field rejection, `unsupported_grant_type`, non-string values, optional `client_id` for Basic-auth path. 9 tests.
- [x] IdTokenMinter unit: ephemeral RSA keypair, verifies signed JWT against public key, header has `alg=RS256 typ=JWT kid`, payload claims, nonce inclusion/omission, error paths for missing/non-RS256 keys. 6 tests.
- [x] TokenController integration: happy paths (public + confidential via Basic, confidential via `client_secret_post`), nonce round-trip, method not allowed, missing grant_type, unknown client, code mismatch, redirect_uri mismatch, PKCE mismatch, confidential without auth, confidential with wrong secret. 14 tests.
- [x] Subprocess integration test: boots a fresh kernel, seeds a code via the real `DatabaseAuthorizationCodeRepository`, POSTs `/token`, verifies the ID token signature against the configured public key and asserts all claims.
- [x] `composer cs-check` clean, `composer phpstan` 0 errors, `composer check-composer-policy` passes.
- [x] Full suite 6344 / 15239 green (+44 tests, +172 assertions over main).

Closes #1292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)