### PR TITLE
feat(entity-storage,field): bundle query routing + FieldStorage hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.150] - 2026-04-19
+
+Closes the bundle-substrate four-release discovery arc: alpha.148 shipped the bundle API, alpha.149 wired `FieldDefinitionRegistry` but missed the kernel-path enumerator, the alpha.149 fix wired the enumerator but exposed a missing `getQuery()` registry forward, and this release closes query forwarding while introducing explicit storage-hint semantics. See #26 for the cross-package version-constraint tightening that would have shortened this arc.
+
+### Fixed
+
+- `entity-storage`: `SqlEntityStorage::getQuery()` now forwards `$this->fieldRegistry` into `SqlEntityQuery`. Previously the registry was silently dropped, so `getQuery()->condition($bundleField, $value)` either returned wrong rows (no JOIN) or threw `UnknownFieldException` once strict routing landed. Bundle-scoped queries on registry-aware storage now work end-to-end.
+
+### Added
+
+- `field`: `FieldStorage` backed enum (`Column`, `Data`) and `FieldDefinition::getStored()` accessor expressing the canonical persistence target for a field. `FieldDefinitionRegistry::synthesizeCoreField()` reads `'stored'` from EntityType field-definition metadata. Defaults to `FieldStorage::Column` so existing call sites are unchanged.
+- `entity-storage`: `SqlEntityQuery::routeFields()` resolves `FieldStorage::Data` core fields via `json_extract(_data, ...)` instead of throwing `UnknownFieldException`, so registry-aware queries can target `_data`-backed fields without forcing a column to exist. `SqlEntityStorage::splitForStorage()` honors the same hint on save: `FieldStorage::Data` values land in `_data` even when a legacy column happens to exist (deferred follow-up: column-vs-data drift diagnostic).
+- `entity-storage`: `SqlSchemaHandler` skips column emission for `FieldStorage::Data` fields in `buildBundleSubtableSpec()` and `ensureBundleSubtable()` so subtable layouts match the registered storage hints.
+- `groups`: `Group` now ships universal lifecycle core fields (`status`, `created_at`, `updated_at`) registered with `stored: FieldStorage::Data`. The bundle-fields surface stays consumer-defined; only the universals are pre-registered so registry-aware queries can resolve them.
+
 ## [0.1.0-alpha.149] - 2026-04-19
 
 ### Fixed

--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -146,6 +146,7 @@ return [
     'Waaseyaa\Field\FieldItemInterface' => 'public',
     'Waaseyaa\Field\FieldItemListInterface' => 'public',
     'Waaseyaa\Field\FieldDefinitionInterface' => 'public',
+    'Waaseyaa\Field\FieldStorage' => 'public',
     'Waaseyaa\Field\FieldTypeInterface' => 'public',
     'Waaseyaa\Field\FieldFormatterInterface' => 'public',
     'Waaseyaa\Field\FieldTypeManagerInterface' => 'public',

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -35,7 +35,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 |---------|-------------------|
 | entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FromArrayEntityValueInterface`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
 | entity-storage | `EntityStorageDriverInterface`, `ConnectionResolverInterface` |
-| field | `FieldItemInterface`, `FieldItemListInterface`, `FieldDefinitionInterface`, `FieldTypeInterface`, `FieldFormatterInterface`, `FieldTypeManagerInterface`, `FieldItemBase`, `ViewModeConfigInterface` |
+| field | `FieldItemInterface`, `FieldItemListInterface`, `FieldDefinitionInterface`, `FieldStorage`, `FieldTypeInterface`, `FieldFormatterInterface`, `FieldTypeManagerInterface`, `FieldItemBase`, `ViewModeConfigInterface` |
 | config | `ConfigInterface`, `ConfigFactoryInterface`, `ConfigManagerInterface`, `StorageInterface`, `TranslatableConfigFactoryInterface` |
 
 **`@internal`** (implementation details, may change without notice):
@@ -1230,10 +1230,18 @@ public function __construct(
     private bool $required = false,
     private bool $readOnly = false,
     private array $constraints = [],    // Constraint[]
+    private FieldStorage $stored = FieldStorage::Column,  // see "Storage hint" below
 )
 ```
 
 `toJsonSchema()` maps types: `string` -> `{'type': 'string'}`, `integer` -> `{'type': 'integer'}`, `boolean` -> `{'type': 'boolean'}`, `float` -> `{'type': 'number'}`, `text` -> object with `value`/`format`, `entity_reference` -> object with `target_id`/`target_type`. Wraps in `{'type': 'array', 'items': ...}` when `isMultiple()`.
+
+**Storage hint.** `FieldStorage` (`packages/field/src/FieldStorage.php`, backed enum: `Column`, `Data`) tells the schema and storage layers where the field's canonical value lives:
+
+- `FieldStorage::Column` (default) — `SqlSchemaHandler` materializes a column for the field; `SqlEntityStorage::splitForStorage()` writes the value to that column; `SqlEntityQuery` resolves it as a base/subtable column reference.
+- `FieldStorage::Data` — `SqlSchemaHandler` skips column emission (both base and bundle-subtable specs); `SqlEntityStorage::splitForStorage()` routes the value into the `_data` JSON blob even when a legacy column happens to exist; `SqlEntityQuery::routeFields()` accepts the registered field as core and `resolveField()` falls back to `json_extract(_data, '$.field')`.
+
+Core `EntityType::fieldDefinitions` metadata may pass `'stored' => FieldStorage::Data` (or the string `'data'`); `FieldDefinitionRegistry::synthesizeCoreField()` reads the value into the `FieldDefinition`. The hint enables registry-aware queries like `getQuery()->condition('status', 1)` to resolve cleanly without forcing a dedicated column for low-traffic universals.
 
 ### FieldItemBase
 

--- a/packages/entity-storage/src/SqlEntityQuery.php
+++ b/packages/entity-storage/src/SqlEntityQuery.php
@@ -10,6 +10,7 @@ use Waaseyaa\Entity\Field\FieldDefinitionRegistryInterface;
 use Waaseyaa\Entity\Storage\EntityQueryInterface;
 use Waaseyaa\EntityStorage\Exception\BundleAmbiguousFieldException;
 use Waaseyaa\EntityStorage\Exception\UnknownFieldException;
+use Waaseyaa\Field\FieldStorage;
 
 /**
  * SQL-based entity query implementation.
@@ -201,6 +202,11 @@ final class SqlEntityQuery implements EntityQueryInterface
         foreach (array_keys($referenced) as $name) {
             if ($name === $this->bundleKey || \array_key_exists($name, $coreFields)) {
                 $routing[$name] = null;
+                // A core field marked FieldStorage::Data lives in the base
+                // table's `_data` JSON blob, not in a column. Resolve it via
+                // json_extract on the base alias so query routing matches the
+                // splitForStorage write path. resolveField() already handles
+                // the column-vs-data branching when the column lookup misses.
                 continue;
             }
 

--- a/packages/entity-storage/src/SqlEntityStorage.php
+++ b/packages/entity-storage/src/SqlEntityStorage.php
@@ -333,7 +333,12 @@ final class SqlEntityStorage implements EntityStorageInterface
 
     public function getQuery(): EntityQueryInterface
     {
-        return new SqlEntityQuery($this->entityType, $this->database, $this->queryResultCache);
+        return new SqlEntityQuery(
+            $this->entityType,
+            $this->database,
+            $this->queryResultCache,
+            $this->fieldRegistry,
+        );
     }
 
     public function getEntityTypeId(): string
@@ -421,11 +426,19 @@ final class SqlEntityStorage implements EntityStorageInterface
     {
         $schema = $this->database->schema();
         $jsonFields = $this->getJsonFieldNames();
+        $dataStoredFields = $this->getDataStoredCoreFieldNames();
         $dbValues = [];
         $extraData = [];
 
         foreach ($values as $key => $value) {
             if ($key === '_data') {
+                continue;
+            }
+            // Honor explicit FieldStorage::Data: route to _data even if a
+            // legacy column happens to exist. Keeps the registry's storage
+            // hint authoritative over residual schema state.
+            if (isset($dataStoredFields[$key])) {
+                $extraData[$key] = $value;
                 continue;
             }
             if ($this->columnExists($key, $schema)) {
@@ -442,6 +455,29 @@ final class SqlEntityStorage implements EntityStorageInterface
         $dbValues['_data'] = json_encode($extraData, \JSON_THROW_ON_ERROR);
 
         return $dbValues;
+    }
+
+    /**
+     * Returns the set of core field names whose registered storage hint is
+     * FieldStorage::Data. Used by splitForStorage() to keep `_data`-routed
+     * fields out of base columns even when legacy columns exist.
+     *
+     * @return array<string, true>
+     */
+    private function getDataStoredCoreFieldNames(): array
+    {
+        if ($this->fieldRegistry === null) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($this->fieldRegistry->coreFieldsFor($this->entityType->id()) as $name => $definition) {
+            if ($definition->getStored() === \Waaseyaa\Field\FieldStorage::Data) {
+                $names[$name] = true;
+            }
+        }
+
+        return $names;
     }
 
     /**

--- a/packages/entity-storage/src/SqlSchemaHandler.php
+++ b/packages/entity-storage/src/SqlSchemaHandler.php
@@ -8,6 +8,7 @@ use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\Field\FieldDefinitionRegistryInterface;
 use Waaseyaa\Field\FieldDefinitionInterface;
+use Waaseyaa\Field\FieldStorage;
 
 /**
  * Handles entity table schema creation and management.
@@ -102,6 +103,9 @@ final class SqlSchemaHandler
         }
 
         foreach ($bundleFields as $field) {
+            if ($field->getStored() === FieldStorage::Data) {
+                continue;
+            }
             $columnName = $field->getName();
             if (!$schema->fieldExists($subtableName, $columnName)) {
                 $schema->addField($subtableName, $columnName, $this->deriveColumnSpec($field));
@@ -612,6 +616,9 @@ final class SqlSchemaHandler
         }
 
         foreach ($bundleFields as $field) {
+            if ($field->getStored() === FieldStorage::Data) {
+                continue;
+            }
             $fields[$field->getName()] = $this->deriveColumnSpec($field);
         }
 

--- a/packages/entity-storage/tests/Unit/SqlEntityStorageBundleQueryRoutingTest.php
+++ b/packages/entity-storage/tests/Unit/SqlEntityStorageBundleQueryRoutingTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Exception\UnknownFieldException;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Field\FieldDefinitionRegistry;
+use Waaseyaa\Field\FieldStorage;
+
+/**
+ * Empirical gates for alpha.150's two bundle-substrate fixes:
+ *
+ *   - Bug C: SqlEntityStorage::getQuery() must forward $this->fieldRegistry
+ *     into SqlEntityQuery, otherwise bundle-scoped condition fields silently
+ *     drop the JOIN and return wrong results (or throw at resolve time).
+ *
+ *   - Gap D: a core field marked FieldStorage::Data must resolve via
+ *     json_extract(_data, ...) instead of triggering UnknownFieldException
+ *     in SqlEntityQuery::routeFields(), and SqlEntityStorage::splitForStorage
+ *     must route the value into _data on save even if a legacy column exists.
+ *
+ * Lives at the unit layer because it exercises one storage instance against
+ * an in-memory DBAL — no kernel boot needed.
+ */
+#[CoversNothing]
+final class SqlEntityStorageBundleQueryRoutingTest extends TestCase
+{
+    private DBALDatabase $database;
+    private FieldDefinitionRegistry $registry;
+    private SqlEntityStorage $storage;
+    private EntityType $entityType;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite(':memory:');
+        $this->registry = new FieldDefinitionRegistry();
+
+        $this->entityType = new EntityType(
+            id: 'widget',
+            label: 'Widget',
+            class: TestRoutingWidget::class,
+            keys: [
+                'id' => 'wid',
+                'uuid' => 'uuid',
+                'bundle' => 'type',
+                'label' => 'name',
+                'langcode' => 'langcode',
+            ],
+            bundleEntityType: 'widget_type',
+            fieldDefinitions: [
+                'status' => [
+                    'type' => 'integer',
+                    'default' => 1,
+                    'stored' => FieldStorage::Data,
+                    'label' => 'Status',
+                ],
+            ],
+        );
+
+        $this->registry->registerCoreFields(
+            $this->entityType->id(),
+            $this->entityType->getFieldDefinitions(),
+        );
+
+        $this->registry->registerBundleFields('widget', 'gizmo', [
+            'gizmo_code' => new FieldDefinition(
+                name: 'gizmo_code',
+                type: 'string',
+                targetEntityTypeId: 'widget',
+                targetBundle: 'gizmo',
+            ),
+        ]);
+
+        $schemaHandler = new SqlSchemaHandler(
+            $this->entityType,
+            $this->database,
+            $this->registry,
+        );
+        $schemaHandler->ensureTable();
+
+        $this->storage = new SqlEntityStorage(
+            $this->entityType,
+            $this->database,
+            new EventDispatcher(),
+            $this->registry,
+        );
+    }
+
+    #[Test]
+    public function getQueryForwardsFieldRegistryEnablingBundleScopedConditions(): void
+    {
+        $matching = new TestRoutingWidget([
+            'name' => 'Match',
+            'type' => 'gizmo',
+            'gizmo_code' => 'X-1',
+        ]);
+        $other = new TestRoutingWidget([
+            'name' => 'Other',
+            'type' => 'gizmo',
+            'gizmo_code' => 'Y-2',
+        ]);
+
+        $this->storage->save($matching);
+        $this->storage->save($other);
+
+        $ids = $this->storage->getQuery()
+            ->condition('gizmo_code', 'X-1')
+            ->execute();
+
+        self::assertSame([$matching->id()], $ids);
+    }
+
+    #[Test]
+    public function dataStoredCoreFieldResolvesViaJsonExtractInsteadOfThrowing(): void
+    {
+        $entity = new TestRoutingWidget([
+            'name' => 'Stored Hint',
+            'type' => 'gizmo',
+            'status' => 1,
+            'gizmo_code' => 'Z-3',
+        ]);
+        $this->storage->save($entity);
+
+        $ids = $this->storage->getQuery()
+            ->condition('status', 1)
+            ->execute();
+
+        self::assertContains($entity->id(), $ids);
+    }
+
+    #[Test]
+    public function trulyUnknownFieldStillThrowsUnknownFieldException(): void
+    {
+        $this->expectException(UnknownFieldException::class);
+
+        $this->storage->getQuery()
+            ->condition('totally_made_up_field', 'whatever')
+            ->execute();
+    }
+
+    #[Test]
+    public function dataStoredCoreFieldLandsInDataBlobNotColumn(): void
+    {
+        $entity = new TestRoutingWidget([
+            'name' => 'Persisted',
+            'type' => 'gizmo',
+            'status' => 1,
+            'gizmo_code' => 'W-9',
+        ]);
+        $this->storage->save($entity);
+
+        $row = $this->database->getConnection()->fetchAssociative(
+            'SELECT _data FROM "widget" WHERE wid = :wid',
+            ['wid' => $entity->id()],
+        );
+        self::assertIsArray($row);
+
+        $data = json_decode((string) $row['_data'], true, flags: \JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('status', $data);
+        self::assertSame(1, $data['status']);
+
+        $columns = $this->database->getConnection()->fetchAllAssociative('PRAGMA table_info("widget")');
+        $columnNames = array_column($columns, 'name');
+        self::assertNotContains('status', $columnNames, 'status must not be materialized as a base column under FieldStorage::Data.');
+    }
+}
+
+/**
+ * Test-only entity that participates in the registry routing but has no
+ * production semantics. Lives in the same file to keep the contract local.
+ */
+final class TestRoutingWidget extends ContentEntityBase
+{
+    public function __construct(array $values = [])
+    {
+        parent::__construct(
+            $values,
+            'widget',
+            [
+                'id' => 'wid',
+                'uuid' => 'uuid',
+                'bundle' => 'type',
+                'label' => 'name',
+                'langcode' => 'langcode',
+            ],
+        );
+    }
+}

--- a/packages/field/src/FieldDefinition.php
+++ b/packages/field/src/FieldDefinition.php
@@ -27,6 +27,7 @@ final readonly class FieldDefinition implements FieldDefinitionInterface
         private bool $required = false,
         private bool $readOnly = false,
         private array $constraints = [],
+        private FieldStorage $stored = FieldStorage::Column,
     ) {}
 
     public function getName(): string
@@ -154,5 +155,10 @@ final readonly class FieldDefinition implements FieldDefinitionInterface
     public function getConstraints(): array
     {
         return $this->constraints;
+    }
+
+    public function getStored(): FieldStorage
+    {
+        return $this->stored;
     }
 }

--- a/packages/field/src/FieldDefinitionInterface.php
+++ b/packages/field/src/FieldDefinitionInterface.php
@@ -31,4 +31,6 @@ interface FieldDefinitionInterface extends DataDefinitionInterface
     public function getDefaultValue(): mixed;
 
     public function toJsonSchema(): array;
+
+    public function getStored(): FieldStorage;
 }

--- a/packages/field/src/FieldDefinitionRegistry.php
+++ b/packages/field/src/FieldDefinitionRegistry.php
@@ -51,7 +51,7 @@ final class FieldDefinitionRegistry implements FieldDefinitionRegistryInterface
     {
         $known = ['type', 'label', 'description', 'required', 'readOnly', 'read_only',
             'cardinality', 'translatable', 'revisionable', 'default', 'defaultValue',
-            'settings', 'constraints'];
+            'settings', 'constraints', 'stored'];
 
         $settings = $meta['settings'] ?? [];
         if (!\is_array($settings)) {
@@ -61,6 +61,14 @@ final class FieldDefinitionRegistry implements FieldDefinitionRegistryInterface
             if (!\in_array($key, $known, true)) {
                 $settings[$key] = $value;
             }
+        }
+
+        $stored = $meta['stored'] ?? FieldStorage::Column;
+        if (\is_string($stored)) {
+            $stored = FieldStorage::tryFrom($stored) ?? FieldStorage::Column;
+        }
+        if (!$stored instanceof FieldStorage) {
+            $stored = FieldStorage::Column;
         }
 
         return new FieldDefinition(
@@ -78,6 +86,7 @@ final class FieldDefinitionRegistry implements FieldDefinitionRegistryInterface
             required: (bool) ($meta['required'] ?? false),
             readOnly: (bool) ($meta['readOnly'] ?? $meta['read_only'] ?? false),
             constraints: \is_array($meta['constraints'] ?? null) ? $meta['constraints'] : [],
+            stored: $stored,
         );
     }
 

--- a/packages/field/src/FieldStorage.php
+++ b/packages/field/src/FieldStorage.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Field;
+
+/**
+ * Storage hint for a FieldDefinition.
+ *
+ * Tells the schema handler whether to materialize a dedicated column for the
+ * field, and tells query routing whether to read it from a column or from the
+ * `_data` JSON blob. Defaults to {@see self::Column} so existing call sites
+ * keep their pre-hint semantics.
+ *
+ * Some entity types declare core fields whose canonical persistence is the
+ * `_data` blob (e.g. low-traffic universals like `created_at` on a small
+ * config entity). Marking those as {@see self::Data} keeps the registry
+ * aware of the field — so `getQuery()->condition($field, ...)` resolves
+ * cleanly via `json_extract` instead of throwing UnknownFieldException —
+ * without forcing a column to exist on disk.
+ */
+enum FieldStorage: string
+{
+    case Column = 'column';
+    case Data = 'data';
+}

--- a/packages/groups/src/GroupsServiceProvider.php
+++ b/packages/groups/src/GroupsServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Groups;
 
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Field\FieldStorage;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
 /**
@@ -33,6 +34,25 @@ final class GroupsServiceProvider extends ServiceProvider
             ],
             bundleEntityType: 'group_type',
             group: 'groups',
+            fieldDefinitions: [
+                'status' => [
+                    'type' => 'integer',
+                    'default' => 1,
+                    'stored' => FieldStorage::Data,
+                    'label' => 'Status',
+                    'description' => 'Whether the group is published.',
+                ],
+                'created_at' => [
+                    'type' => 'integer',
+                    'stored' => FieldStorage::Data,
+                    'label' => 'Created at',
+                ],
+                'updated_at' => [
+                    'type' => 'integer',
+                    'stored' => FieldStorage::Data,
+                    'label' => 'Updated at',
+                ],
+            ],
         ));
 
         $this->entityType(new EntityType(

--- a/packages/groups/tests/Unit/GroupsServiceProviderTest.php
+++ b/packages/groups/tests/Unit/GroupsServiceProviderTest.php
@@ -61,7 +61,7 @@ final class GroupsServiceProviderTest extends TestCase
     }
 
     #[Test]
-    public function groupShipsWithZeroPreRegisteredBundleFields(): void
+    public function groupShipsWithUniversalDataStoredCoreFieldsOnly(): void
     {
         $provider = new GroupsServiceProvider();
         $provider->register();
@@ -74,8 +74,15 @@ final class GroupsServiceProviderTest extends TestCase
             }
         }
         self::assertNotNull($group);
-        // Core field-definition map is empty; bundle fields are registered by
-        // consumers via EntityTypeManager::addBundleFields().
-        self::assertSame([], $group->getFieldDefinitions());
+
+        // Bundle fields are still 100% consumer-defined via
+        // EntityTypeManager::addBundleFields(); the only core fields shipped
+        // are the FieldStorage::Data universals so registry-aware queries can
+        // resolve `status`/`created_at`/`updated_at` via json_extract.
+        $fieldDefs = $group->getFieldDefinitions();
+        self::assertSame(['status', 'created_at', 'updated_at'], array_keys($fieldDefs));
+        foreach ($fieldDefs as $def) {
+            self::assertSame(\Waaseyaa\Field\FieldStorage::Data, $def['stored']);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the bundle-substrate four-release discovery arc:

- **alpha.148** shipped the bundle API (`addBundleFields`, per-bundle subtables).
- **alpha.149** wired `FieldDefinitionRegistry` into `SqlSchemaHandler` but missed the kernel-path enumerator, so registered bundles silently skipped subtable creation.
- **alpha.149 fix** (PR #1306) wired the enumerator with a registry fallback — but exposed a missing `getQuery()` registry forward.
- **This PR** closes query forwarding and introduces explicit storage-hint semantics so registry-aware queries on `_data`-backed core fields stop throwing `UnknownFieldException`.

The cross-package version-constraint tightening tracked in #26 would have caught the alpha.149 gap before propagation. Discovery cost on this arc adds weight to that follow-up.

### What's in this PR

**Bug C — `SqlEntityStorage::getQuery()` now forwards `$this->fieldRegistry`.**
Without it, registry-aware bundle conditions silently dropped the JOIN (returning wrong rows) or — once strict routing landed — threw `UnknownFieldException`. End-to-end bundle queries on registry-aware storage now work.

**Gap D — `FieldStorage` enum + storage-hint plumbing.**
New backed enum `Waaseyaa\Field\FieldStorage` (`Column` default, `Data`) appended as the 15th constructor parameter on `FieldDefinition`. `FieldDefinitionRegistry::synthesizeCoreField()` reads `'stored'` from `EntityType::fieldDefinitions` metadata. Three downstream layers honor the hint:

- `SqlEntityQuery::routeFields()` — a `FieldStorage::Data` core field resolves via `json_extract(_data, ...)` instead of throwing `UnknownFieldException`.
- `SqlEntityStorage::splitForStorage()` — `FieldStorage::Data` values land in `_data` even when a legacy column happens to exist (the symmetric query-side drift handling is filed as a follow-up).
- `SqlSchemaHandler` — skips column emission for `FieldStorage::Data` fields in both `buildBundleSubtableSpec` and `ensureBundleSubtable`.

**`Waaseyaa\Groups\Group`** registers `status`, `created_at`, `updated_at` as core fields with `stored: FieldStorage::Data`. Bundle surface stays 100% consumer-defined via `addBundleFields()`; only the universals are pre-registered so registry-aware queries can resolve them via `_data`.

## Test plan

- [x] `SqlEntityStorageBundleQueryRoutingTest` (4 tests, 7 assertions) — empirical gates for Bug C, Gap D query path, the strict-unknown-field path, and the save-side `_data` routing.
- [x] Updated `GroupsServiceProviderTest` to assert the new universal-fields shape rather than the now-stale empty-fieldDefinitions shape.
- [x] Full framework test suite green: 6454 tests / 15498 assertions.
- [x] PHPStan clean (0 errors).
- [x] PHP-CS-Fixer clean.
- [x] `tools/drift-detector.sh` clean — source + spec + CHANGELOG bundled in this PR.

## Follow-ups filed separately

- Save-path symmetric strict handling (query side honoring the hint when a legacy column exists).
- Column-vs-data drift diagnostic (operator-facing detection of the asymmetry above).
- #26 — tighten inter-package version constraints to shorten arcs like this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)