### PR TITLE
fix(#1277): drop dead null-guards on non-nullable typed properties

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -107,6 +107,8 @@ AccessResult::forbidden(string $reason = ''): AccessResult
 AccessResult::unauthenticated(string $reason = ''): AccessResult
 ```
 
+`$reason` is a non-nullable string (`''` default) — callers needing a fallback message must use `!== ''` rather than `??`; the null-coalesce is dead code and PHPStan flags it as `nullCoalesce.property`.
+
 ### State Checks
 
 ```php

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -249,6 +249,8 @@ rename($tmpPath, $cachePath);
 
 This pattern is used in `PackageManifestCompiler::compileAndCache()` and must be used anywhere the cache system writes PHP files to disk.
 
+Attribute instances built via `ReflectionAttribute::newInstance()` — used throughout `PackageManifestCompiler` for `AsFormatter`, `AsMiddleware`, `AsEntityType`, etc. — reflect their constructor declarations verbatim. Required typed properties are guaranteed initialized, so `isset()` / `??` guards on them are dead code; PHPStan flags them as `isset.property` / `nullCoalesce.property`. Gate on `!== ''` (or an explicit nullability check against the declared type) instead.
+
 ## Database Layer
 
 ### DatabaseInterface

--- a/packages/access/src/Middleware/AuthorizationMiddleware.php
+++ b/packages/access/src/Middleware/AuthorizationMiddleware.php
@@ -91,7 +91,7 @@ final class AuthorizationMiddleware implements HttpMiddlewareInterface
 
         if ($result->isForbidden()) {
             if ($isRenderRoute) {
-                return $this->renderError(403, 'Forbidden', $result->reason ?? 'You do not have permission to access this page.', $request);
+                return $this->renderError(403, 'Forbidden', $result->reason !== '' ? $result->reason : 'You do not have permission to access this page.', $request);
             }
 
             return new JsonResponse([

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -105,7 +105,7 @@ final class PackageManifestCompiler
 
             foreach ($ref->getAttributes(self::FORMATTER_ATTRIBUTE) as $attr) {
                 $instance = $attr->newInstance();
-                if (isset($instance->fieldType) && is_string($instance->fieldType) && $instance->fieldType !== '') {
+                if ($instance->fieldType !== '') {
                     $formatters[$instance->fieldType] = $class;
                 }
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1170,11 +1170,6 @@ parameters:
 			count: 1
 			path: packages/foundation/src/Discovery/PackageManifestCompiler.php
 
-		-
-			message: '#^Right side of && is always true\.$#'
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: packages/foundation/src/Discovery/PackageManifestCompiler.php
 
 		-
 			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'


### PR DESCRIPTION
## Summary
- AccessResult::$reason is declared non-nullable (string default `''`) — drop `??` fallback at AuthorizationMiddleware.php:94, use `!== ''` instead.
- AsFormatter::$fieldType is a required typed property (string) on a `ReflectionAttribute::newInstance()` result — drop the `isset()`/`is_string()` guards at PackageManifestCompiler.php:108, keep only the non-empty check.
- Remove the now-orphan baseline entry for `booleanAnd.rightAlwaysTrue` in PackageManifestCompiler.
- Refresh access-control.md and infrastructure.md with the underlying typed-property invariant that justifies the fix.

Fixes #1277. Unblocks dependabot PR #1294 (phpstan 2.1.46 → 2.1.50), which surfaces these as new errors under `nullCoalesce.property` / `isset.property`.

## Test plan
- [x] `composer phpstan` — 0 errors
- [x] `./vendor/bin/phpunit` — existing tests pass
- [x] `tools/drift-detector.sh` — all affected specs OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)