### PR TITLE
docs(plan): editorial pass on Phase 1 plan

### DIFF
--- a/docs/superpowers/plans/2026-04-19-phase-1-kernel-path-test.md
+++ b/docs/superpowers/plans/2026-04-19-phase-1-kernel-path-test.md
@@ -401,19 +401,13 @@ grep -rnE 'class [A-Za-z_][A-Za-z0-9_]*[[:space:]]+extends[[:space:]]+(AbstractK
 
 Expected: zero matches. This is the same anchored named-class pattern used in Task 4 Step 2, so anonymous subclasses remain intentionally out of scope.
 
-```bash
-grep -rn "extends AbstractKernel\|extends HttpKernel\|extends ConsoleKernel" tests/
-```
-
-Expected: zero matches. (Anonymous subclasses show in the source as `new class(...) extends AbstractKernel` and are fine for artefact 4's architectural guard — but the grep above only matches named `class X extends ...` forms, which should now be zero.)
-
 - [ ] **Step 5: Run the full Phase17 suite to catch collateral damage**
 
 ```bash
 ./vendor/bin/phpunit --testsuite Integration
 ```
 
-Expected: all integration tests green. If anything else imported `MinimalTestKernel`, the autoload failure surfaces here.
+Expected: all integration tests green. If anything else still references `MinimalTestKernel`, the autoload failure surfaces here.
 
 - [ ] **Step 6: Commit and push**
 
@@ -447,7 +441,7 @@ gh pr create --title "refactor(#1315): drain MinimalTestKernel to real-kernel pa
 ## Test plan
 - [ ] `./vendor/bin/phpunit tests/Integration/Phase17/KernelBootValidationTest.php` passes all six tests.
 - [ ] `./vendor/bin/phpunit --testsuite Integration` passes.
-- [ ] `grep -rn "class MinimalTestKernel" tests/ packages/` returns zero matches.
+- [ ] `grep -rnE 'class [A-Za-z_][A-Za-z0-9_]*[[:space:]]+extends[[:space:]]+(AbstractKernel|HttpKernel|ConsoleKernel)\b' tests/` returns zero matches.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF


### PR DESCRIPTION
## Summary
- remove the leftover second grep in Task 2 that still used the broad extends ... form and contradicted the anchored guidance from PR (a)
- align the sample PR body for Task 2 with the anchored named-class check so the plan's examples match its instructions
- tighten one autoload-reference sentence for clearer end-to-end reading

## Validation
- composer validate (clean schema validation, existing repo warnings only)
- phpstan analyse --memory-limit=512M
- phpunit packages/foundation/tests/Unit/Kernel/KernelBundleSubtableMaterializationTest.php tests/Integration/Phase17/KernelBootValidationTest.php

Refs #1315