### PR TITLE
test: forbid named kernel subclasses in tests/**

### DIFF
--- a/packages/entity-storage/tests/Unit/SqlSchemaHandlerRegistryFallbackTest.php
+++ b/packages/entity-storage/tests/Unit/SqlSchemaHandlerRegistryFallbackTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Field\FieldDefinitionRegistry;
+
+/**
+ * Pins the alpha.148 regression shape.
+ *
+ * The bundle-subtable materialization loop has two wire-ups that must
+ * agree:
+ *   1. shouldProcessBundles() — fieldRegistry non-null AND bundleEntityType non-null.
+ *   2. registeredBundlesFor() — falls back to FieldDefinitionRegistry::bundleNamesFor()
+ *      when the explicit bundleEnumerator is null.
+ *
+ * In alpha.148, (2) was inverted: the loop ran only when an explicit
+ * bundleEnumerator was supplied. addBundleFields()-registered bundles
+ * (which populate the registry but do not supply an enumerator) silently
+ * stopped producing subtables. This test asserts the post-fix behavior
+ * at unit level so a refactor cannot re-orphan the registry fallback
+ * without turning this test red.
+ */
+#[CoversClass(SqlSchemaHandler::class)]
+final class SqlSchemaHandlerRegistryFallbackTest extends TestCase
+{
+    #[Test]
+    public function registryPopulationDrivesSubtableMaterializationWithoutEnumerator(): void
+    {
+        $database = DBALDatabase::createSqlite(':memory:');
+        $entityType = new EntityType(
+            id: 'widget',
+            label: 'Widget',
+            class: \stdClass::class,
+            keys: ['id' => 'wid', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'],
+            bundleEntityType: 'widget_type',
+        );
+
+        $registry = new FieldDefinitionRegistry();
+        $registry->registerBundleFields('widget', 'gizmo', [
+            'gizmo_code' => new FieldDefinition(
+                name: 'gizmo_code',
+                type: 'string',
+                targetEntityTypeId: 'widget',
+                targetBundle: 'gizmo',
+            ),
+        ]);
+
+        $handler = new SqlSchemaHandler(
+            entityType: $entityType,
+            database: $database,
+            fieldRegistry: $registry,
+            bundleEnumerator: null,
+        );
+        $handler->ensureTable();
+
+        $connection = $database->getConnection();
+        $subtableExists = (int) $connection->fetchOne(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'widget__gizmo'",
+        );
+
+        self::assertSame(
+            1,
+            $subtableExists,
+            'SqlSchemaHandler must materialize bundle subtables using FieldDefinitionRegistry::bundleNamesFor() when no explicit bundleEnumerator is supplied. This is the registry-fallback branch that alpha.148 orphaned.',
+        );
+    }
+
+    #[Test]
+    public function noBundleEntityTypeSkipsBundleLoopEvenWithPopulatedRegistry(): void
+    {
+        $database = DBALDatabase::createSqlite(':memory:');
+        $entityType = new EntityType(
+            id: 'flat_thing',
+            label: 'Flat Thing',
+            class: \stdClass::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid'],
+        );
+
+        $registry = new FieldDefinitionRegistry();
+        $registry->registerBundleFields('flat_thing', 'phantom', [
+            'ghost_field' => new FieldDefinition(
+                name: 'ghost_field',
+                type: 'string',
+                targetEntityTypeId: 'flat_thing',
+                targetBundle: 'phantom',
+            ),
+        ]);
+
+        $handler = new SqlSchemaHandler(
+            entityType: $entityType,
+            database: $database,
+            fieldRegistry: $registry,
+            bundleEnumerator: null,
+        );
+        $handler->ensureTable();
+
+        $connection = $database->getConnection();
+        $unwanted = $connection->fetchAllAssociative(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'flat_thing__%'",
+        );
+
+        self::assertSame(
+            [],
+            $unwanted,
+            'shouldProcessBundles() must return false when the entity type has no bundleEntityType, regardless of registry contents.',
+        );
+    }
+
+    #[Test]
+    public function nullRegistrySkipsBundleLoopEvenWithBundleEntityType(): void
+    {
+        $database = DBALDatabase::createSqlite(':memory:');
+        $entityType = new EntityType(
+            id: 'orphan',
+            label: 'Orphan',
+            class: \stdClass::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'],
+            bundleEntityType: 'orphan_type',
+        );
+
+        $handler = new SqlSchemaHandler(
+            entityType: $entityType,
+            database: $database,
+            fieldRegistry: null,
+            bundleEnumerator: null,
+        );
+        $handler->ensureTable();
+
+        $connection = $database->getConnection();
+        $baseExists = (int) $connection->fetchOne(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'orphan'",
+        );
+        $unwanted = $connection->fetchAllAssociative(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'orphan__%'",
+        );
+
+        self::assertSame(1, $baseExists);
+        self::assertSame(
+            [],
+            $unwanted,
+            'shouldProcessBundles() must return false when fieldRegistry is null, matching pre-bundle-scoped behavior.',
+        );
+    }
+}

--- a/packages/foundation/tests/Unit/Kernel/KernelBundleSubtableMaterializationTest.php
+++ b/packages/foundation/tests/Unit/Kernel/KernelBundleSubtableMaterializationTest.php
@@ -26,6 +26,17 @@ use Waaseyaa\Foundation\Kernel\AbstractKernel;
  * Lives at this layer because the assertion is "kernel wiring delivers
  * end-to-end bundle substrate" — sibling to AbstractKernelTest /
  * HttpKernelTest, where other kernel-boot guarantees are codified.
+ *
+ * Deliberate mutation recipe (Phase 1 exit criterion 2). To prove the
+ * assertion is load-bearing, temporarily edit
+ * packages/entity-storage/src/SqlSchemaHandler.php::registeredBundlesFor()
+ * so its null-bundleEnumerator branch returns `[]` instead of calling
+ * `$this->fieldRegistry->bundleNamesFor($type->id())`. Re-run this
+ * test: `registeredBundleFieldsMaterializeSubtableViaKernelPath` must
+ * fail with "kernel_test_widget__gizmo must be materialized". This is
+ * the alpha.148 shape; a unit-level companion
+ * (SqlSchemaHandlerRegistryFallbackTest) pins the same branch so the
+ * kernel-path test is not the sole guard.
  */
 #[CoversNothing]
 final class KernelBundleSubtableMaterializationTest extends TestCase

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,9 @@
             <directory>packages/*/tests/Integration</directory>
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="Architecture">
+            <directory>tests/Architecture</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <report>

--- a/tests/Architecture/NoKernelSubclassesInTestsTest.php
+++ b/tests/Architecture/NoKernelSubclassesInTestsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Forbids named kernel subclasses under tests/**.
+ *
+ * Bootstrap-variant proliferation — parallel "kernel-ish" helpers
+ * (mocked kernel, partial boot, in-memory manifest stubs) — was the
+ * root smell that masked the alpha.148–152 adoption-chain failure.
+ * The canonical pattern for kernel-path tests is the anonymous
+ * subclass exposing publicBoot():
+ *
+ *     $kernel = new class($projectRoot) extends AbstractKernel {
+ *         public function publicBoot(): void { $this->boot(); }
+ *     };
+ *     $kernel->publicBoot();
+ *
+ * Anonymous classes are NOT matched by this guard (they appear as
+ * `new class(...) extends Foo` in source, not `class X extends Foo`).
+ * Named subclasses are — they are the drift shape this rule prevents.
+ *
+ * If you genuinely need a named subclass (e.g. a shared KernelTestCase
+ * base), place it in a non-tests/ location (packages/testing/src/ or a
+ * dedicated testing/ directory with composer autoload-dev registration)
+ * and import it. Then this guard still holds.
+ */
+#[CoversNothing]
+final class NoKernelSubclassesInTestsTest extends TestCase
+{
+    private const TESTS_ROOT = __DIR__ . '/..';
+
+    private const FORBIDDEN_PARENTS = [
+        'AbstractKernel',
+        'HttpKernel',
+        'ConsoleKernel',
+    ];
+
+    #[Test]
+    public function noNamedKernelSubclassesExistUnderTests(): void
+    {
+        $pattern = '/^\s*(?:final\s+|abstract\s+)?class\s+[A-Za-z_][A-Za-z0-9_]*\s+extends\s+(' . implode('|', self::FORBIDDEN_PARENTS) . ')\b/m';
+
+        $offenders = [];
+        foreach ($this->phpFilesUnder(self::TESTS_ROOT) as $file) {
+            if (realpath($file) === realpath(__FILE__)) {
+                continue;
+            }
+            $contents = file_get_contents($file);
+            if ($contents === false) {
+                continue;
+            }
+            if (preg_match($pattern, $contents, $matches) === 1) {
+                $offenders[] = sprintf('%s (extends %s)', $file, $matches[1]);
+            }
+        }
+
+        self::assertSame(
+            [],
+            $offenders,
+            sprintf(
+                "Found %d named kernel subclass(es) under tests/. Use the anonymous-subclass + publicBoot() pattern from KernelBundleSubtableMaterializationTest instead.\n  - %s",
+                count($offenders),
+                implode("\n  - ", $offenders),
+            ),
+        );
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function phpFilesUnder(string $dir): iterable
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                yield $file->getPathname();
+            }
+        }
+    }
+}

--- a/tests/Integration/Phase17/KernelBootValidationTest.php
+++ b/tests/Integration/Phase17/KernelBootValidationTest.php
@@ -7,152 +7,164 @@ namespace Waaseyaa\Tests\Integration\Phase17;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\ContentEntityBase;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
-use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\Kernel\AbstractKernel;
-use Waaseyaa\Note\Note;
 
+/**
+ * Validates the content-type guard in AbstractKernel::boot() via the real
+ * kernel path. Each test writes a real `config/entity-types.php` under a
+ * temp projectRoot, instantiates an anonymous subclass of AbstractKernel
+ * exposing publicBoot(), and calls boot() — no MinimalTestKernel, no
+ * partial boot(), no hand-wired EntityTypeManager.
+ *
+ * Bootstrap-variant policy: this file must use the anonymous-subclass +
+ * real-projectRoot pattern codified in KernelBundleSubtableMaterializationTest.
+ * See tests/Architecture/NoKernelSubclassesInTestsTest for enforcement.
+ */
 #[CoversClass(AbstractKernel::class)]
 final class KernelBootValidationTest extends TestCase
 {
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_boot_validation_' . uniqid();
+        mkdir($this->projectRoot . '/config', 0755, true);
+        mkdir($this->projectRoot . '/storage/framework', 0755, true);
+
+        file_put_contents(
+            $this->projectRoot . '/config/waaseyaa.php',
+            "<?php return ['database' => ':memory:'];",
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $registryProperty = new \ReflectionProperty(ContentEntityBase::class, 'fieldRegistry');
+        $registryProperty->setValue(null, null);
+
+        if (!is_dir($this->projectRoot)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    private function writeEntityTypes(string $body): void
+    {
+        file_put_contents($this->projectRoot . '/config/entity-types.php', "<?php\nreturn {$body};\n");
+    }
+
+    private function newKernel(): AbstractKernel
+    {
+        return new class($this->projectRoot) extends AbstractKernel {
+            public function publicBoot(): void
+            {
+                $this->boot();
+            }
+        };
+    }
+
     #[Test]
     public function bootHaltsWithDefaultTypeMissingWhenNoTypesRegistered(): void
     {
-        $kernel = new MinimalTestKernel(types: []);
+        $this->writeEntityTypes('[]');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/DEFAULT_TYPE_MISSING/');
 
-        $kernel->bootForTest();
+        $this->newKernel()->publicBoot();
     }
 
     #[Test]
     public function exceptionIncludesRemediationMessage(): void
     {
-        $kernel = new MinimalTestKernel(types: []);
+        $this->writeEntityTypes('[]');
 
         try {
-            $kernel->bootForTest();
+            $this->newKernel()->publicBoot();
             $this->fail('Expected RuntimeException was not thrown.');
         } catch (\RuntimeException $e) {
-            $this->assertStringContainsString('DEFAULT_TYPE_MISSING', $e->getMessage());
-            $this->assertStringContainsString('content type', $e->getMessage());
+            self::assertStringContainsString('DEFAULT_TYPE_MISSING', $e->getMessage());
+            self::assertStringContainsString('content type', $e->getMessage());
         }
     }
 
     #[Test]
     public function bootSucceedsWithOneRegisteredContentType(): void
     {
-        $kernel = new MinimalTestKernel(types: [
-            new EntityType(
-                id: 'note',
-                label: 'Note',
-                class: Note::class,
-                keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
-            ),
-        ]);
+        $this->writeEntityTypes(<<<'PHP'
+[
+    new \Waaseyaa\Entity\EntityType(
+        id: 'note',
+        label: 'Note',
+        class: \Waaseyaa\Note\Note::class,
+        keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+    ),
+]
+PHP);
 
-        // Should not throw.
-        $kernel->bootForTest();
+        $kernel = $this->newKernel();
+        $kernel->publicBoot();
 
-        $this->assertTrue($kernel->getEntityTypeManager()->hasDefinition('note'));
+        self::assertTrue($kernel->getEntityTypeManager()->hasDefinition('note'));
     }
 
     #[Test]
     public function bootSucceedsWithMultipleContentTypes(): void
     {
-        $kernel = new MinimalTestKernel(types: [
-            new EntityType(id: 'note', label: 'Note', class: Note::class, keys: ['id' => 'id']),
-            new EntityType(id: 'article', label: 'Article', class: Note::class, keys: ['id' => 'id']),
-        ]);
+        $this->writeEntityTypes(<<<'PHP'
+[
+    new \Waaseyaa\Entity\EntityType(id: 'note', label: 'Note', class: \Waaseyaa\Note\Note::class, keys: ['id' => 'id']),
+    new \Waaseyaa\Entity\EntityType(id: 'article', label: 'Article', class: \Waaseyaa\Note\Note::class, keys: ['id' => 'id']),
+]
+PHP);
 
-        $kernel->bootForTest();
+        $kernel = $this->newKernel();
+        $kernel->publicBoot();
 
-        $this->assertCount(2, $kernel->getEntityTypeManager()->getDefinitions());
+        self::assertCount(2, $kernel->getEntityTypeManager()->getDefinitions());
     }
 
     #[Test]
     public function bootHaltsWithDefaultTypeDisabledWhenAllTypesDisabled(): void
     {
-        $tempDir = sys_get_temp_dir() . '/waaseyaa_disabled_test_' . uniqid();
-        mkdir($tempDir . '/storage/framework', 0755, true);
+        $this->writeEntityTypes(<<<'PHP'
+[
+    new \Waaseyaa\Entity\EntityType(id: 'note', label: 'Note', class: \Waaseyaa\Note\Note::class, keys: ['id' => 'id']),
+]
+PHP);
 
-        $lifecycleManager = new EntityTypeLifecycleManager($tempDir);
-        $lifecycleManager->disable('note', 'test');
-
-        $kernel = new MinimalTestKernel(types: [
-            new EntityType(id: 'note', label: 'Note', class: Note::class, keys: ['id' => 'id']),
-        ]);
+        (new EntityTypeLifecycleManager($this->projectRoot))->disable('note', 'test');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/DEFAULT_TYPE_DISABLED/');
 
-        try {
-            $kernel->bootForTest($lifecycleManager);
-        } finally {
-            array_map('unlink', glob($tempDir . '/storage/framework/*') ?: []);
-            @rmdir($tempDir . '/storage/framework');
-            @rmdir($tempDir . '/storage');
-            @rmdir($tempDir);
-        }
+        $this->newKernel()->publicBoot();
     }
 
     #[Test]
     public function bootSucceedsWhenOnlyOneOfTwoTypesIsDisabled(): void
     {
-        $tempDir = sys_get_temp_dir() . '/waaseyaa_partial_disabled_test_' . uniqid();
-        mkdir($tempDir . '/storage/framework', 0755, true);
+        $this->writeEntityTypes(<<<'PHP'
+[
+    new \Waaseyaa\Entity\EntityType(id: 'note', label: 'Note', class: \Waaseyaa\Note\Note::class, keys: ['id' => 'id']),
+    new \Waaseyaa\Entity\EntityType(id: 'article', label: 'Article', class: \Waaseyaa\Note\Note::class, keys: ['id' => 'id']),
+]
+PHP);
 
-        $lifecycleManager = new EntityTypeLifecycleManager($tempDir);
-        $lifecycleManager->disable('article', 'test');
+        (new EntityTypeLifecycleManager($this->projectRoot))->disable('article', 'test');
 
-        $kernel = new MinimalTestKernel(types: [
-            new EntityType(id: 'note', label: 'Note', class: Note::class, keys: ['id' => 'id']),
-            new EntityType(id: 'article', label: 'Article', class: Note::class, keys: ['id' => 'id']),
-        ]);
+        $kernel = $this->newKernel();
+        $kernel->publicBoot();
 
-        // Should not throw — 'note' is still enabled.
-        $kernel->bootForTest($lifecycleManager);
-
-        array_map('unlink', glob($tempDir . '/storage/framework/*') ?: []);
-        @rmdir($tempDir . '/storage/framework');
-        @rmdir($tempDir . '/storage');
-        @rmdir($tempDir);
-
-        $this->assertTrue(true); // boot succeeded
-    }
-}
-
-/**
- * Minimal AbstractKernel subclass for testing boot validation in isolation.
- *
- * Skips database, manifest, providers, access policies, and extensions.
- * Only exercises the entity type registration + content type validation path.
- */
-class MinimalTestKernel extends AbstractKernel
-{
-    /** @param \Waaseyaa\Entity\EntityTypeInterface[] $types */
-    public function __construct(
-        private readonly array $types,
-    ) {
-        parent::__construct(projectRoot: sys_get_temp_dir());
-    }
-
-    /**
-     * Runs only the entity type registration + validation portion of boot.
-     */
-    public function bootForTest(?EntityTypeLifecycleManager $lifecycleManager = null): void
-    {
-        $this->dispatcher = new EventDispatcher();
-        $this->entityTypeManager = new EntityTypeManager($this->dispatcher);
-        $this->lifecycleManager = $lifecycleManager ?? new EntityTypeLifecycleManager(sys_get_temp_dir());
-
-        foreach ($this->types as $type) {
-            $this->entityTypeManager->registerEntityType($type);
-        }
-
-        $this->validateContentTypes();
+        self::assertTrue($kernel->getEntityTypeManager()->hasDefinition('note'));
     }
 }


### PR DESCRIPTION
## Summary
- add an architectural test that scans 	ests/** for named class X extends AbstractKernel|HttpKernel|ConsoleKernel
- intentionally use the anchored named-class pattern from the amended plan so anonymous 
ew class(...) extends ... test kernels remain allowed
- wire 	ests/Architecture into phpunit.xml.dist and verify the guard fails loudly when a scratch named subclass is planted

## Validation
- composer validate (clean schema validation, existing repo warnings only)
- phpstan analyse --memory-limit=512M
- phpunit tests/Architecture/NoKernelSubclassesInTestsTest.php
- phpunit --testsuite Architecture
- planted 	ests/_scratch/ScratchKernel.php made the guard fail, then removing it restored green

Refs #1315