### PR TITLE
ci: add packaged-form job (informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,35 @@ jobs:
             build/logs/clover.xml
           retention-days: 30
 
+  packaged-form:
+    name: packaged-form
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_sqlite, sqlite3, mbstring, xml
+          coverage: none
+
+      - name: Cache packaged-form Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: tests/PackagedForm/skeleton/vendor
+          key: packaged-form-composer-v1-${{ hashFiles('tests/PackagedForm/skeleton/composer.lock') }}
+          restore-keys: packaged-form-composer-v1-
+
+      - name: Install packaged-form dependencies
+        working-directory: tests/PackagedForm/skeleton
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run packaged-form tests
+        working-directory: tests/PackagedForm/skeleton
+        run: ./vendor/bin/phpunit --configuration phpunit.xml.dist
+
   ci-playwright-smoke:
     name: ci/playwright-smoke
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a `packaged-form` job to the existing `CI` workflow
- install the consumer fixture from `tests/PackagedForm/skeleton/`
- keep the job informational for bring-up via job-level `continue-on-error`

## Validation
- workflow shape reviewed against `.github/workflows/ci.yml`
- fixture validated locally on the parent branch via:
  - `php -d extension=gmp -d extension=sodium -d extension=sqlite3 -d extension=pdo_sqlite C:\ProgramData\ComposerSetup\bin\composer.phar validate`
  - `php -d extension=gmp -d extension=sodium -d extension=sqlite3 -d extension=pdo_sqlite .\\vendor\\bin\\phpunit --configuration phpunit.xml.dist`

## Notes
- stacked on #1327 so the diff stays CI-only; retarget to `main` after #1327 merges
- job id: `packaged-form`
- displayed check name: `CI / packaged-form`
- informational only in this PR; do not promote to merge-blocking until the release-gated follow-up

Refs #1315