### PR TITLE
feat: add provenance-aware collision exception in the registry

### DIFF
--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -22,6 +22,7 @@
 <!-- Spec reviewed 2026-04-10 - waaseyaa/testing EntityTypeFixtureValues + EntityFactory::defineFromEntityType (#1186) -->
 <!-- Spec reviewed 2026-04-10b - P3 duplicate constructor arity contract; Hydratable scaffold; core User/Node hydration (#1188 follow-up) -->
 <!-- Spec reviewed 2026-04-16 - EntityStorageDriverInterface::write returns effective id; EntityRepository::doSave back-fills auto-increment pk before POST_SAVE (waaseyaa/giiken#57) -->
+<!-- Spec reviewed 2026-04-20 - EntityTypeManager collision guard now preserves registrant provenance, distinguishes duplicate vs shadow registration, and throws EntityTypeRegistrationCollisionException (#1313) -->
 
 Subsystem specification for the Waaseyaa entity, entity-storage, field, and config packages. Covers entity interfaces, storage implementations, query building, field definitions, config entities, and lifecycle events.
 
@@ -33,7 +34,7 @@ Authoritative dispositions are in `docs/public-surface-map.php`, verified by `Pu
 
 | Package | Interfaces/Classes |
 |---------|-------------------|
-| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FromArrayEntityValueInterface`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
+| entity | `EntityInterface`, `EntityBase`, `ContentEntityBase`, `ContentEntityInterface`, `ConfigEntityBase`, `ConfigEntityInterface`, `EntityTypeInterface`, `EntityTypeManagerInterface`, `EntityTypeRegistrationCollisionException`, `FieldableInterface`, `RevisionableInterface`, `TranslatableInterface`, `RevisionableEntityTrait`, `EntityRepositoryInterface`, `EntityEventFactoryInterface`, `EntityStorageInterface`, `RevisionableStorageInterface`, `EntityQueryInterface`, `HydratableFromStorageInterface`, `HydrationContext`, `EntityValues`, `CastDefinition`, `ValueCaster`, `CastException`, `FromArrayEntityValueInterface`, `FieldDefinitionConstraintBuilder`, `EntityTypeValidationConstraints` |
 | entity-storage | `EntityStorageDriverInterface`, `ConnectionResolverInterface` |
 | field | `FieldItemInterface`, `FieldItemListInterface`, `FieldDefinitionInterface`, `FieldStorage`, `FieldTypeInterface`, `FieldFormatterInterface`, `FieldTypeManagerInterface`, `FieldItemBase`, `ViewModeConfigInterface` |
 | config | `ConfigInterface`, `ConfigFactoryInterface`, `ConfigManagerInterface`, `StorageInterface`, `TranslatableConfigFactoryInterface` |
@@ -325,6 +326,8 @@ File: `packages/entity/src/EntityTypeManagerInterface.php`
 interface EntityTypeManagerInterface
 {
     public function getDefinition(string $entityTypeId): EntityTypeInterface;
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void;
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void;
     public function getDefinitions(): array;        // array<string, EntityTypeInterface>
     public function hasDefinition(string $entityTypeId): bool;
     public function getStorage(string $entityTypeId): EntityStorageInterface;
@@ -335,6 +338,8 @@ interface EntityTypeManagerInterface
 `getStorage()` returns the legacy `EntityStorageInterface` implementation (typically `SqlEntityStorage`) created via the optional storage factory.
 
 `getRepository()` returns `EntityRepositoryInterface` (the driver-backed repository with hydration, validation hooks, and transactional batch APIs). The kernel registers a repository factory alongside the storage factory so consumers can wrap `EntityTypeManager::getRepository($entityTypeId)` in thin domain repositories without manually assembling `SqlStorageDriver`, `RevisionableStorageDriver`, and `EntityRepository` dependencies.
+
+`registerEntityType()` and `registerCoreEntityType()` accept an optional registrant class so the registry can emit provenance-aware collision errors. When an entity type id is registered twice with the same class, the manager throws `EntityTypeRegistrationCollisionException` with the duplicate-registration message contract. When the same id is registered with a different class, the manager throws the shadow-collision variant naming the canonical and conflicting classes.
 
 ### EntityStorageInterface
 
@@ -1320,8 +1325,9 @@ final class FieldType extends WaaseyaaPlugin
 - `FieldableInterface.php` -- hasField, get, set, getFieldDefinitions
 - `EntityType.php` -- final readonly value object for entity type definitions
 - `EntityTypeInterface.php` -- entity type definition contract
-- `EntityTypeManager.php` -- registry with storage factory and optional repository factory (`getRepository()`)
-- `EntityTypeManagerInterface.php` -- manager contract
+- `EntityTypeManager.php` -- registry with provenance-aware collision detection, storage factory, and optional repository factory (`getRepository()`)
+- `EntityTypeManagerInterface.php` -- manager contract, including optional registrant provenance on registration
+- `Exception/EntityTypeRegistrationCollisionException.php` -- dedicated duplicate/shadow registration exception with migration-grade DX
 - `EntityConstants.php` -- SAVED_NEW (1), SAVED_UPDATED (2)
 - `TranslatableInterface.php` -- translation contract
 - `RevisionableInterface.php` -- revision contract

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -21,6 +21,8 @@
 <!-- Spec reviewed 2026-04-10 - inertia RootTemplateRenderer: JSON script tag uses data-page="app" (mount id) so @inertiajs/core getInitialPageFromDOM finds the initial page -->
 <!-- Spec reviewed 2026-04-09 - HttpKernel::serveHttpRequest: auth middleware short-circuit — return pipeline response whenever status !== 200 (302 login redirect, 401/403 JSON), not only when status >= 400, so unauthenticated SSR routes cannot fall through to controller dispatch -->
 
+<!-- Spec reviewed 2026-04-20 - ServiceProvider now preserves entity-type registrant provenance and ProviderRegistry rethrows entity-type collision exceptions after logging so duplicate canonical registrations fail boot deterministically (#1313) -->
+
 Specification for the foundational infrastructure layer of Waaseyaa CMS: domain events, cache system, database abstraction, query builder, migration system, kernel bootstrapping (including environment resolution and debug mode), service provider discovery, and queue workers.
 
 ## Public Surface
@@ -1430,7 +1432,7 @@ Discovery and registration follows a multi-phase process:
 1. **Instantiation**: Each provider class from `$manifest->providers` is instantiated. Missing classes are logged with actionable remediation guidance (fix `composer.json` or run `optimize:manifest`) and skipped. Non-`ServiceProvider` instances are also logged and skipped.
 2. **Context injection**: Each provider receives kernel context via `setKernelContext($projectRoot, $config, $manifest->formatters)` and a kernel resolver closure via `setKernelResolver()`. The resolver provides cross-provider DI — it resolves `EntityTypeManager`, `DatabaseInterface`, `EventDispatcherInterface`, `LoggerInterface`, and any binding registered by previously-loaded providers.
 3. **Registration**: `register()` is called on each provider, allowing them to bind interfaces to implementations.
-4. **Entity type collection**: After all providers register, entity types from `$provider->getEntityTypes()` are registered with the `EntityTypeManager`. Registration failures are logged as errors but do not halt boot.
+4. **Entity type collection**: After all providers register, entity types from `$provider->getEntityTypeRegistrations()` are registered with the `EntityTypeManager` together with the provider class that declared them. Generic registration failures are still logged as errors. `EntityTypeRegistrationCollisionException` is special-cased: the failure is logged and then rethrown so duplicate or shadow registrations stop boot deterministically.
 5. **Provider-owned surfaces**: Route and command ownership stays with the package provider or package registry that declared it. Foundation now declares only its own baseline provider (`Waaseyaa\Foundation\FoundationServiceProvider`), while package-level providers such as `ApiServiceProvider`, `UserServiceProvider`, and `McpServiceProvider` own their respective HTTP surfaces.
 
 The method returns the full list of instantiated providers. Handles instantiation failures gracefully with error logging.
@@ -1487,7 +1489,7 @@ Migration/
     MigrationResult.php          -- count + list of ran migrations
 ServiceProvider/
     ServiceProviderInterface.php -- register()/boot()/provides()/isDeferred()
-    ServiceProvider.php          -- abstract base with singleton/bind/tag helpers
+    ServiceProvider.php          -- abstract base with singleton/bind/tag helpers and provider-owned entity-type provenance capture
     ProviderDiscovery.php        -- reads composer installed.json extra.waaseyaa
     ContainerCompiler.php        -- register phase -> boot phase -> Symfony DI container
 Discovery/

--- a/docs/specs/relationship-modeling.md
+++ b/docs/specs/relationship-modeling.md
@@ -7,6 +7,8 @@
 <!-- Spec reviewed 2026-04-09k - traversal summaries, access policy, pre-save normalization, and discovery edge context use `EntityValues` / `get()` for cast-aware values (#1181 ST-8) -->
 <!-- Spec reviewed 2026-04-09 ST-9 - status/visibility diagram + cast-aware invariants cross-link (#1181) -->
 
+<!-- Spec reviewed 2026-04-20 - Package tests only: EntityTypeManagerInterface stubs now accept optional registrant provenance on registerEntityType/registerCoreEntityType; no relationship domain change (#1313) -->
+
 ## Decision
 
 Relationships are modeled as **first-class entities**.

--- a/packages/entity/src/EntityTypeManager.php
+++ b/packages/entity/src/EntityTypeManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Entity;
 
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException;
 use Waaseyaa\Entity\Field\FieldDefinitionRegistryInterface;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
@@ -23,6 +24,9 @@ class EntityTypeManager implements EntityTypeManagerInterface
      * @var array<string, EntityTypeInterface>
      */
     private array $definitions = [];
+
+    /** @var array<string, class-string|null> */
+    private array $definitionRegistrants = [];
 
     /**
      * Cached storage handler instances.
@@ -66,7 +70,7 @@ class EntityTypeManager implements EntityTypeManagerInterface
      * @throws \DomainException        If the entity type ID uses the reserved `core.` namespace.
      * @throws \InvalidArgumentException If an entity type with the same ID is already registered.
      */
-    public function registerEntityType(EntityTypeInterface $type): void
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         if (str_starts_with($type->id(), 'core.')) {
             throw new \DomainException(\sprintf(
@@ -77,7 +81,7 @@ class EntityTypeManager implements EntityTypeManagerInterface
             ));
         }
 
-        $this->persistDefinition($type);
+        $this->persistDefinition($type, $registrant);
     }
 
     /**
@@ -87,21 +91,38 @@ class EntityTypeManager implements EntityTypeManagerInterface
      *
      * @throws \InvalidArgumentException If an entity type with the same ID is already registered.
      */
-    public function registerCoreEntityType(EntityTypeInterface $type): void
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
-        $this->persistDefinition($type);
+        $this->persistDefinition($type, $registrant);
     }
 
-    private function persistDefinition(EntityTypeInterface $type): void
+    private function persistDefinition(EntityTypeInterface $type, ?string $registrant = null): void
     {
         if (isset($this->definitions[$type->id()])) {
-            throw new \InvalidArgumentException(\sprintf(
-                'Entity type "%s" is already registered.',
+            $existingDefinition = $this->definitions[$type->id()];
+            $existingRegistrant = $this->definitionRegistrants[$type->id()] ?? null;
+
+            if ($existingDefinition->getClass() === $type->getClass()) {
+                throw EntityTypeRegistrationCollisionException::duplicate(
+                    $type->id(),
+                    $existingRegistrant,
+                    $existingDefinition->getClass(),
+                    $registrant,
+                    $type->getClass(),
+                );
+            }
+
+            throw EntityTypeRegistrationCollisionException::shadowCollision(
                 $type->id(),
-            ));
+                $existingRegistrant,
+                $existingDefinition->getClass(),
+                $registrant,
+                $type->getClass(),
+            );
         }
 
         $this->definitions[$type->id()] = $type;
+        $this->definitionRegistrants[$type->id()] = $registrant;
 
         $this->fieldRegistry?->registerCoreFields($type->id(), $type->getFieldDefinitions());
     }

--- a/packages/entity/src/EntityTypeManagerInterface.php
+++ b/packages/entity/src/EntityTypeManagerInterface.php
@@ -11,9 +11,9 @@ interface EntityTypeManagerInterface
     public function getDefinition(string $entityTypeId): EntityTypeInterface;
 
     /** @throws \DomainException If the entity type ID uses the reserved `core.` namespace. */
-    public function registerEntityType(EntityTypeInterface $type): void;
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void;
 
-    public function registerCoreEntityType(EntityTypeInterface $type): void;
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void;
 
     /** @return array<string, EntityTypeInterface> */
     public function getDefinitions(): array;

--- a/packages/entity/src/Exception/EntityTypeRegistrationCollisionException.php
+++ b/packages/entity/src/Exception/EntityTypeRegistrationCollisionException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity\Exception;
+
+final class EntityTypeRegistrationCollisionException extends \InvalidArgumentException
+{
+    public static function duplicate(
+        string $entityTypeId,
+        ?string $existingRegistrant,
+        string $existingEntityClass,
+        ?string $incomingRegistrant,
+        string $incomingEntityClass,
+    ): self {
+        return new self(\sprintf(
+            '[ENTITY_TYPE_DUPLICATE] Entity type "%s" is already registered by %s using %s. '
+            . 'Duplicate registration attempted by %s using the same class %s. '
+            . 'Drop the duplicate registration.',
+            $entityTypeId,
+            self::registrantLabel($existingRegistrant),
+            $existingEntityClass,
+            self::registrantLabel($incomingRegistrant),
+            $incomingEntityClass,
+        ));
+    }
+
+    public static function shadowCollision(
+        string $entityTypeId,
+        ?string $existingRegistrant,
+        string $existingEntityClass,
+        ?string $incomingRegistrant,
+        string $incomingEntityClass,
+    ): self {
+        return new self(\sprintf(
+            '[ENTITY_TYPE_SHADOW_COLLISION] Entity type "%s" is already registered by %s using canonical class %s. '
+            . 'Conflicting registration attempted by %s using %s. '
+            . 'If this was a consumer shadow, drop the registration and migrate callers to the canonical type; '
+            . 'see docs/superpowers/specs/2026-04-19-groups-reconciliation-adr.md.',
+            $entityTypeId,
+            self::registrantLabel($existingRegistrant),
+            $existingEntityClass,
+            self::registrantLabel($incomingRegistrant),
+            $incomingEntityClass,
+        ));
+    }
+
+    private static function registrantLabel(?string $registrant): string
+    {
+        return $registrant ?? 'an unknown registrant';
+    }
+}

--- a/packages/entity/tests/Unit/EntityTypeManagerTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerTest.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Entity\Tests\Unit;
 
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
@@ -80,13 +81,45 @@ class EntityTypeManagerTest extends TestCase
         $this->manager->getDefinition('unknown');
     }
 
-    public function testRegisterDuplicateThrows(): void
+    public function testRegisterDuplicateThrowsCollisionExceptionForSameClassWithRegistrants(): void
+    {
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $this->manager->registerEntityType($type, ExistingRegistrant::class);
+
+        $this->expectException(EntityTypeRegistrationCollisionException::class);
+        $this->expectExceptionMessage('[ENTITY_TYPE_DUPLICATE]');
+        $this->expectExceptionMessage(ExistingRegistrant::class);
+        $this->expectExceptionMessage(IncomingRegistrant::class);
+        $this->expectExceptionMessage(TestEntity::class);
+
+        $duplicate = new EntityType(id: 'node', label: 'Content v2', class: TestEntity::class);
+        $this->manager->registerEntityType($duplicate, IncomingRegistrant::class);
+    }
+
+    public function testRegisterDuplicateThrowsShadowCollisionForDifferentClass(): void
+    {
+        $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
+        $this->manager->registerEntityType($type, ExistingRegistrant::class);
+
+        $this->expectException(EntityTypeRegistrationCollisionException::class);
+        $this->expectExceptionMessage('[ENTITY_TYPE_SHADOW_COLLISION]');
+        $this->expectExceptionMessage('node');
+        $this->expectExceptionMessage(ExistingRegistrant::class);
+        $this->expectExceptionMessage(IncomingRegistrant::class);
+        $this->expectExceptionMessage(TestEntity::class);
+        $this->expectExceptionMessage(ShadowEntity::class);
+
+        $duplicate = new EntityType(id: 'node', label: 'Content v2', class: ShadowEntity::class);
+        $this->manager->registerEntityType($duplicate, IncomingRegistrant::class);
+    }
+
+    public function testRegisterDuplicateFallsBackToUnknownRegistrantWhenProvenanceMissing(): void
     {
         $type = new EntityType(id: 'node', label: 'Content', class: TestEntity::class);
         $this->manager->registerEntityType($type);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Entity type "node" is already registered.');
+        $this->expectException(EntityTypeRegistrationCollisionException::class);
+        $this->expectExceptionMessage('an unknown registrant');
 
         $duplicate = new EntityType(id: 'node', label: 'Content v2', class: TestEntity::class);
         $this->manager->registerEntityType($duplicate);
@@ -289,9 +322,15 @@ class EntityTypeManagerTest extends TestCase
         $type = new EntityType(id: 'core.note', label: 'Note', class: TestEntity::class);
         $this->manager->registerCoreEntityType($type);
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(EntityTypeRegistrationCollisionException::class);
 
         $duplicate = new EntityType(id: 'core.note', label: 'Note v2', class: TestEntity::class);
         $this->manager->registerCoreEntityType($duplicate);
     }
 }
+
+final class ExistingRegistrant {}
+
+final class IncomingRegistrant {}
+
+final class ShadowEntity {}

--- a/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
+++ b/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
@@ -7,6 +7,7 @@ namespace Waaseyaa\Foundation\Kernel\Bootstrap;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -89,9 +90,19 @@ final class ProviderRegistry
         }
 
         foreach ($this->providers as $provider) {
-            foreach ($provider->getEntityTypes() as $entityType) {
+            foreach ($provider->getEntityTypeRegistrations() as $registration) {
+                $entityType = $registration['entityType'];
                 try {
-                    $entityTypeManager->registerEntityType($entityType);
+                    $entityTypeManager->registerEntityType($entityType, $registration['registrant']);
+                } catch (EntityTypeRegistrationCollisionException $e) {
+                    $this->logger->error(sprintf(
+                        'Failed to register entity type "%s" from %s: %s',
+                        $entityType->id(),
+                        $provider::class,
+                        $e->getMessage(),
+                    ));
+
+                    throw $e;
                 } catch (\RuntimeException | \InvalidArgumentException $e) {
                     $this->logger->error(sprintf(
                         'Failed to register entity type "%s" from %s: %s',

--- a/packages/foundation/src/ServiceProvider/ServiceProvider.php
+++ b/packages/foundation/src/ServiceProvider/ServiceProvider.php
@@ -205,7 +205,7 @@ abstract class ServiceProvider implements ServiceProviderInterface
     public function getEntityTypes(): array
     {
         return array_map(
-            static fn (array $registration): \Waaseyaa\Entity\EntityTypeInterface => $registration['entityType'],
+            static fn(array $registration): \Waaseyaa\Entity\EntityTypeInterface => $registration['entityType'],
             $this->entityTypeRegistrations,
         );
     }

--- a/packages/foundation/src/ServiceProvider/ServiceProvider.php
+++ b/packages/foundation/src/ServiceProvider/ServiceProvider.php
@@ -27,8 +27,8 @@ abstract class ServiceProvider implements ServiceProviderInterface
     /** @var array<string, list<string>> */
     private array $tags = [];
 
-    /** @var list<\Waaseyaa\Entity\EntityTypeInterface> */
-    private array $entityTypes = [];
+    /** @var list<array{entityType: \Waaseyaa\Entity\EntityTypeInterface, registrant: class-string}> */
+    private array $entityTypeRegistrations = [];
 
     /** @var (\Closure(string): ?object)|null */
     private ?\Closure $kernelResolver = null;
@@ -183,7 +183,10 @@ abstract class ServiceProvider implements ServiceProviderInterface
 
     protected function entityType(\Waaseyaa\Entity\EntityTypeInterface $entityType): void
     {
-        $this->entityTypes[] = $entityType;
+        $this->entityTypeRegistrations[] = [
+            'entityType' => $entityType,
+            'registrant' => static::class,
+        ];
     }
 
     /** @return array<string, array{concrete: string|callable, shared: bool}> */
@@ -201,6 +204,15 @@ abstract class ServiceProvider implements ServiceProviderInterface
     /** @return list<\Waaseyaa\Entity\EntityTypeInterface> */
     public function getEntityTypes(): array
     {
-        return $this->entityTypes;
+        return array_map(
+            static fn (array $registration): \Waaseyaa\Entity\EntityTypeInterface => $registration['entityType'],
+            $this->entityTypeRegistrations,
+        );
+    }
+
+    /** @return list<array{entityType: \Waaseyaa\Entity\EntityTypeInterface, registrant: class-string}> */
+    public function getEntityTypeRegistrations(): array
+    {
+        return $this->entityTypeRegistrations;
     }
 }

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException;
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistry;
 use Waaseyaa\Foundation\Log\LoggerInterface;
@@ -33,7 +35,6 @@ final class ProviderRegistryTest extends TestCase
         $dispatcher = new EventDispatcher();
         $entityTypeManager = new EntityTypeManager($dispatcher);
 
-        // Use a concrete provider class defined below that resolves EntityTypeManager
         $manifest = new PackageManifest(
             providers: [KernelResolverTestProvider::class],
         );
@@ -49,7 +50,6 @@ final class ProviderRegistryTest extends TestCase
 
         $this->assertCount(1, $providers);
 
-        // The provider's register() resolves EntityTypeManager via kernel resolver
         $resolved = $providers[0]->resolve(EntityTypeManager::class);
         $this->assertSame($entityTypeManager, $resolved);
     }
@@ -80,11 +80,11 @@ final class ProviderRegistryTest extends TestCase
 
         $this->assertCount(2, $providers);
 
-        // Consumer provider resolves a binding registered by the source provider
         $resolved = $providers[1]->resolve('test.cross_provider_service');
         $this->assertInstanceOf(\stdClass::class, $resolved);
         $this->assertSame('from-source', $resolved->origin);
     }
+
     #[Test]
     public function missing_provider_warning_includes_remediation_guidance(): void
     {
@@ -118,7 +118,7 @@ final class ProviderRegistryTest extends TestCase
             dispatcher: $dispatcher,
         );
 
-        $warnings = array_filter($logger->messages, fn($m) => $m['level'] === LogLevel::WARNING);
+        $warnings = array_filter($logger->messages, fn ($message) => $message['level'] === LogLevel::WARNING);
         $this->assertNotEmpty($warnings);
 
         $warning = array_values($warnings)[0]['message'];
@@ -126,21 +126,52 @@ final class ProviderRegistryTest extends TestCase
         $this->assertStringContainsString('optimize:manifest', $warning);
         $this->assertStringContainsString('composer.json', $warning);
     }
+
+    #[Test]
+    public function duplicate_entity_type_registration_throws_collision_exception_and_stops_boot(): void
+    {
+        $registry = new ProviderRegistry(new NullLogger());
+        $database = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+
+        $manifest = new PackageManifest(
+            providers: [
+                DuplicateEntityTypeSourceProvider::class,
+                DuplicateEntityTypeConsumerProvider::class,
+            ],
+        );
+
+        $this->expectException(EntityTypeRegistrationCollisionException::class);
+        $this->expectExceptionMessage('[ENTITY_TYPE_DUPLICATE]');
+        $this->expectExceptionMessage(DuplicateEntityTypeSourceProvider::class);
+        $this->expectExceptionMessage(DuplicateEntityTypeConsumerProvider::class);
+        $this->expectExceptionMessage(EntityTypeFixture::class);
+
+        $registry->discoverAndRegister(
+            manifest: $manifest,
+            projectRoot: sys_get_temp_dir(),
+            config: [],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+    }
 }
 
 /**
- * @internal Test fixture ��� provider that resolves EntityTypeManager from kernel.
+ * @internal Test fixture provider that resolves EntityTypeManager from kernel.
  */
 final class KernelResolverTestProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // No local bindings — EntityTypeManager must come from kernel resolver.
+        // No local bindings; EntityTypeManager must come from kernel resolver.
     }
 }
 
 /**
- * @internal Test fixture — provider that registers a binding for cross-provider resolution.
+ * @internal Test fixture provider that registers a binding for cross-provider resolution.
  */
 final class CrossProviderSourceProvider extends ServiceProvider
 {
@@ -156,12 +187,38 @@ final class CrossProviderSourceProvider extends ServiceProvider
 }
 
 /**
- * @internal Test fixture — provider that consumes a binding from another provider.
+ * @internal Test fixture provider that consumes a binding from another provider.
  */
 final class CrossProviderConsumerProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // No local bindings — depends on CrossProviderSourceProvider's binding.
+        // No local bindings; depends on CrossProviderSourceProvider's binding.
     }
 }
+
+final class DuplicateEntityTypeSourceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: 'group',
+            label: 'Group',
+            class: EntityTypeFixture::class,
+        ));
+    }
+}
+
+final class DuplicateEntityTypeConsumerProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: 'group',
+            label: 'Group duplicate',
+            class: EntityTypeFixture::class,
+        ));
+    }
+}
+
+final class EntityTypeFixture {}

--- a/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
+++ b/packages/relationship/tests/Fixtures/StubEntityTypeManager.php
@@ -71,12 +71,12 @@ class StubEntityTypeManager implements EntityTypeManagerInterface
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function registerEntityType(EntityTypeInterface $type): void
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function registerCoreEntityType(EntityTypeInterface $type): void
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \BadMethodCallException('Not implemented.');
     }

--- a/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipDiscoveryServiceTest.php
@@ -489,12 +489,12 @@ final class DiscoveryEntityTypeManager implements EntityTypeManagerInterface
         throw new \RuntimeException('Not needed in test.');
     }
 
-    public function registerEntityType(EntityTypeInterface $type): void
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \RuntimeException('Not needed in test.');
     }
 
-    public function registerCoreEntityType(EntityTypeInterface $type): void
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \RuntimeException('Not needed in test.');
     }

--- a/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
+++ b/packages/relationship/tests/Unit/RelationshipTraversalServiceTest.php
@@ -322,12 +322,12 @@ final class TraversalEntityTypeManager implements EntityTypeManagerInterface
         throw new \RuntimeException('Not needed in test.');
     }
 
-    public function registerEntityType(EntityTypeInterface $type): void
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \RuntimeException('Not needed in test.');
     }
 
-    public function registerCoreEntityType(EntityTypeInterface $type): void
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void
     {
         throw new \RuntimeException('Not needed in test.');
     }


### PR DESCRIPTION
## Summary
- carry provider provenance from ServiceProvider registration into EntityTypeManager
- add EntityTypeRegistrationCollisionException with distinct duplicate and shadow-collision messages
- make provider-driven collision failures stop the kernel path and cover the behavior in unit tests

## Validation
- php -d extension=gmp -d extension=sodium C:\ProgramData\ComposerSetup\bin\composer.phar validate
- php -d extension=gmp -d extension=sodium vendor\\bin\\phpstan analyse --memory-limit=512M
- php -d extension=gmp -d extension=sodium -d extension=sqlite3 -d extension=pdo_sqlite vendor\\bin\\phpunit --no-coverage packages\\entity\\tests\\Unit packages\\foundation\\tests\\Unit\\Kernel\\Bootstrap\\ProviderRegistryTest.php

Refs #1313
Refs #1315