### PR TITLE
docs: add upgrade note for shadow-collision guard

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,31 @@
+# Upgrading
+
+## 2026-04-20 - Entity-type collision guard for canonical group types
+
+Framework packages now fail loudly when a consumer re-registers an entity type id that is already owned by the framework. The registry throws `Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException` instead of a generic duplicate-registration error.
+
+### What changed
+
+- Same-class duplicate registration now fails with `[ENTITY_TYPE_DUPLICATE]`.
+- Shadow registration of a framework-owned canonical type now fails with `[ENTITY_TYPE_SHADOW_COLLISION]`.
+- The rendered message names the entity type id, the already-registered provider class, the canonical entity class, the incoming provider class, and the conflicting entity class.
+- Bundle-scoped writes now emit `[MISSING_BUNDLE_SUBTABLE]` through `LoggerInterface::notice()` when bundle-field values are present but the matching `{base}__{bundle}` subtable does not exist at save time.
+
+### How to read the collision wording
+
+- `[ENTITY_TYPE_DUPLICATE]` means the same entity type id was registered twice with the same class. Drop the duplicate registration; this is stale provider wiring, not an extension point.
+- `[ENTITY_TYPE_SHADOW_COLLISION]` means a consumer tried to register an entity type id that the framework already owns, but with a different class. Drop the shadow registration and migrate callers to the canonical framework type.
+
+### If you were shadowing `group` or `group_type`
+
+Remove the duplicate `entityType()` registration from your consumer provider instead of trying to override the framework-owned id. The canonical owners are `Waaseyaa\Groups\GroupsServiceProvider`, `Waaseyaa\Groups\Group`, and `Waaseyaa\Groups\GroupType`.
+
+If your app still has shadow classes or imports that assume consumer-owned group types, use the reconciliation ADR as the migration path:
+
+- [`docs/superpowers/specs/2026-04-19-groups-reconciliation-adr.md`](docs/superpowers/specs/2026-04-19-groups-reconciliation-adr.md)
+
+That ADR is the concrete path for the Minoo-shaped cleanup. Minoo `main` no longer carries live duplicate `group` / `group_type` registration in `AppServiceProvider`; the remaining migration case is shadow-class residue and call sites that still import those shadows. Later arc phases handle the `HasCommunityInterface` and `GroupType` key reconciliation that make those shadows removable.
+
+### If you see `[MISSING_BUNDLE_SUBTABLE]`
+
+Your app has registered bundle-scoped fields for a bundle whose storage subtable has not been materialized yet. The save path will keep the base-row write, but the bundle-field values for that write will not persist. Ship or run the schema migration / sync that creates the missing `{base}__{bundle}` subtable before saving that bundle in production.


### PR DESCRIPTION
Refs #1313
Refs #1315

Implements Phase 3 Task 3 from the merged plan.

What this PR adds:
- introduces a top-level `UPGRADING.md` entry for the new entity-type collision guard
- explains the difference between `[ENTITY_TYPE_DUPLICATE]` and `[ENTITY_TYPE_SHADOW_COLLISION]`
- points consumers shadowing `group` / `group_type` at the real reconciliation ADR path: `docs/superpowers/specs/2026-04-19-groups-reconciliation-adr.md`
- notes the adjacent `[MISSING_BUNDLE_SUBTABLE]` save-path notice so downstream operators know how to react when bundle-field writes would otherwise be dropped

Wording guardrails from the plan:
- does not claim Minoo `main` still duplicates `group` / `group_type` registration in `AppServiceProvider`
- treats the remaining Minoo-shaped migration case as shadow-class residue and stale imports/call sites
- forward-references the later `HasCommunityInterface` and `GroupType` reconciliation phases without re-planning them here

Local validation:
- `php -d extension=gmp -d extension=sodium C:\ProgramData\ComposerSetup\bin\composer.phar validate`
- `php -d extension=gmp -d extension=sodium vendor\bin\phpstan analyse --memory-limit=512M`
- `php -d extension=gmp -d extension=sodium -d extension=sqlite3 -d extension=pdo_sqlite vendor\bin\phpunit --no-coverage tests\Integration\Phase25\EntityTypeCollisionIntegrationTest.php packages\entity-storage\tests\Unit\SqlEntityStorageBundleFieldsTest.php`