### PR TITLE
fix: register package migrations from migration files

### DIFF
--- a/packages/notification/composer.json
+++ b/packages/notification/composer.json
@@ -51,7 +51,7 @@
             "providers": [
                 "Waaseyaa\\Notification\\NotificationServiceProvider"
             ],
-            "migrations": "src/Migration"
+            "migrations": "migrations"
         }
     },
     "config": {

--- a/packages/notification/migrations/2026_04_24_000001_create_notification_tables.php
+++ b/packages/notification/migrations/2026_04_24_000001_create_notification_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+return new class extends Migration {
+    /** @var list<string> */
+    public array $after = ['waaseyaa/queue'];
+
+    public function up(SchemaBuilder $schema): void
+    {
+        $conn = $schema->getConnection();
+
+        $conn->executeStatement('
+            CREATE TABLE IF NOT EXISTS waaseyaa_notifications (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                type VARCHAR(255) NOT NULL,
+                notifiable_type VARCHAR(128) NOT NULL,
+                notifiable_id VARCHAR(128) NOT NULL,
+                data TEXT NOT NULL,
+                created_at VARCHAR(50) NOT NULL,
+                read_at VARCHAR(50)
+            )
+        ');
+
+        $conn->executeStatement('
+            CREATE INDEX IF NOT EXISTS idx_notifications_notifiable
+            ON waaseyaa_notifications (notifiable_type, notifiable_id)
+        ');
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $schema->dropIfExists('waaseyaa_notifications');
+    }
+};

--- a/packages/queue/composer.json
+++ b/packages/queue/composer.json
@@ -43,7 +43,7 @@
             "providers": [
                 "Waaseyaa\\Queue\\QueueServiceProvider"
             ],
-            "migrations": "src/Migration"
+            "migrations": "migrations"
         }
     },
     "config": {

--- a/packages/queue/migrations/2026_04_24_000001_create_queue_tables.php
+++ b/packages/queue/migrations/2026_04_24_000001_create_queue_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+return new class extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        $conn = $schema->getConnection();
+
+        $conn->executeStatement('
+            CREATE TABLE IF NOT EXISTS waaseyaa_queue_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue VARCHAR(255) NOT NULL,
+                payload TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                available_at INTEGER NOT NULL,
+                reserved_at INTEGER,
+                created_at INTEGER NOT NULL
+            )
+        ');
+
+        $conn->executeStatement('
+            CREATE INDEX IF NOT EXISTS idx_queue_available
+            ON waaseyaa_queue_jobs (queue, available_at)
+        ');
+
+        $conn->executeStatement('
+            CREATE TABLE IF NOT EXISTS waaseyaa_failed_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue VARCHAR(255) NOT NULL,
+                payload TEXT NOT NULL,
+                exception TEXT NOT NULL,
+                failed_at VARCHAR(50) NOT NULL,
+                retried_at VARCHAR(50)
+            )
+        ');
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $schema->dropIfExists('waaseyaa_failed_jobs');
+        $schema->dropIfExists('waaseyaa_queue_jobs');
+    }
+};

--- a/packages/scheduler/composer.json
+++ b/packages/scheduler/composer.json
@@ -47,7 +47,7 @@
             "providers": [
                 "Waaseyaa\\Scheduler\\SchedulerServiceProvider"
             ],
-            "migrations": "src/Migration"
+            "migrations": "migrations"
         }
     },
     "config": {

--- a/packages/scheduler/migrations/2026_04_24_000001_create_scheduler_tables.php
+++ b/packages/scheduler/migrations/2026_04_24_000001_create_scheduler_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+return new class extends Migration {
+    /** @var list<string> */
+    public array $after = ['waaseyaa/queue'];
+
+    public function up(SchemaBuilder $schema): void
+    {
+        $conn = $schema->getConnection();
+
+        $conn->executeStatement('
+            CREATE TABLE IF NOT EXISTS waaseyaa_schedule_locks (
+                task_name VARCHAR(255) PRIMARY KEY,
+                locked_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL
+            )
+        ');
+
+        $conn->executeStatement('
+            CREATE TABLE IF NOT EXISTS waaseyaa_schedule_state (
+                task_name VARCHAR(255) PRIMARY KEY,
+                last_run_at VARCHAR(50) NOT NULL,
+                last_result TEXT NOT NULL
+            )
+        ');
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $schema->dropIfExists('waaseyaa_schedule_state');
+        $schema->dropIfExists('waaseyaa_schedule_locks');
+    }
+};


### PR DESCRIPTION
## Summary
- point queue, notification, and scheduler at migrations/ instead of src/Migration
- add concrete migration files that return Migration instances
- keep the existing migration classes untouched for now

## Reproduction
1. Install the current framework packages in a Waaseyaa app.
2. Run php bin/waaseyaa db:init or php bin/waaseyaa migrate.
3. The migration loader reads package paths from the manifest and requires files expecting each one to return a Migration instance.
4. waaseyaa/queue, waaseyaa/notification, and waaseyaa/scheduler currently register src/Migration, which contains class definitions instead of migration-returning files, so bootstrap fails.

## Why this fix
The migration loader contract already expects migration files that eturn a Migration instance. These package registrations were the part out of sync with that contract.