### PR TITLE
feat(#1339): telescope agent-context telemetry and SPA-aligned codified-context JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Telescope agent-context telemetry:** Canonical Prometheus series names are now `waaseyaa_agent_context_*`; `waaseyaa_cc_*` remain as deprecated duplicates in the same scrape for dashboard migration. Admin SPA and E2E call **`/api/telescope/agent-context/…`**; legacy **`/api/telescope/codified-context/…`** HTTP routes remain registered. Telescope `record.agent_context` overrides `record.codified_context` when set. See **`docs/specs/telescope-agent-context-telemetry.md`**.
+
 - **Governance:** Document **Spec Kitty–first** workflow — missions and work packages are the primary execution ledger; GitHub is PR/CI/releases and optional issues (`docs/specs/workflow.md`, `CLAUDE.md`, `AGENTS.md`, PR template). `bin/check-milestones` remains supplementary GitHub hygiene. README **Contributing** and the PR template include an **Active Spec Kitty mission** line for traceability.
 
 - **Contributor / agent workflow:** Retired the Node MCP spec-retrieval servers (`waaseyaa_list_specs`, `waaseyaa_get_spec`, `waaseyaa_search_specs`). Subsystem context is read from `docs/specs/` directly. Adopted [Spec Kitty](https://github.com/Priivacy-ai/spec-kitty) scaffold (`.kittify/`); see `CLAUDE.md` for workflow and CLI install. Spec Kitty’s `.claude/skills/` symlinks stay local (gitignored); install the CLI and run `spec-kitty init` after clone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ When working on files matching these patterns, retrieve the spec for deep contex
 | `packages/ssr/*` | — | — |
 | `packages/error-handler/*` | — | `docs/specs/debugging-dx.md` |
 | `packages/debug/*` | — | `docs/specs/debugging-dx.md` |
-| `packages/telescope/*` | — | — |
+| `packages/telescope/*` (agent-context / codified-context telemetry, Prometheus) | — | `docs/specs/telescope-agent-context-telemetry.md`, `docs/specs/api-layer.md` |
 | `packages/workflows/*` | — | — |
 | `packages/billing/*` | — | — |
 | `packages/github/*` | — | — |

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,5 +1,6 @@
 # Admin SPA
 
+<!-- Spec reviewed 2026-04-24 - useCodifiedContext + E2E: `/api/telescope/agent-context/…` (legacy HTTP alias on server); Nuxt routes still `/telescope/codified-context/*`; cross-link telescope-agent-context-telemetry.md -->
 <!-- Spec reviewed 2026-04-21 - IngestSummaryWidget: NC sync status from `/api/staff/nc-sync-status`; dashboard link `/staff/ingestion` (staff surface, not admin SPA catch-all) -->
 <!-- Spec reviewed 2026-04-08 - normalizeAppBaseURL (ufo cleanDoubleSlashes + joinURL): shared by admin plugin and auth.global so adminPathBase matches normalized base; surface $fetch uses joinURL paths; packages/admin/app/runtime/normalizeAppBaseURL.ts -->
 <!-- Spec reviewed 2026-04-08 - Admin fetch baseURL: useRuntimeConfig().app.baseURL (trailing slash) for $fetch/apiFetch and auth.global navigateTo; plugins/admin tests stub app.baseURL (#814); ufo joinURL for path joins -->
@@ -382,7 +383,7 @@ Key categories:
 - Entity type labels: `entity_type_user`, `entity_type_node`, `entity_type_node_type`, `entity_type_taxonomy_term`, etc.
 - Field labels: `field_title`, `field_machine_name`, `field_published`, `field_description`, `field_weight`, `field_email`, etc.
 - Parameterized: `create_entity`, `edit_entity` (with `{type}` token)
-- Telescope: `telescope_codified_context`, `telescope_cc_sessions`, `telescope_cc_drift_score`, etc.
+- Telescope: `telescope_codified_context`, `telescope_cc_sessions`, `telescope_cc_drift_score`, etc. Session telemetry API calls use **`/api/telescope/agent-context/…`** (`useCodifiedContext.ts`); see **`docs/specs/telescope-agent-context-telemetry.md`**.
 
 Token replacement pattern: `t('key', { token: 'value' })` replaces `{token}` in the string.
 

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,6 +1,6 @@
 # API Layer
 
-<!-- Spec reviewed 2026-04-24 - CodifiedContextController depends only on CodifiedContextSessionStoreInterface + CodifiedContextSessionRow (packages/api); waaseyaa/telescope ships CodifiedContextSessionStoreAdapter and requires waaseyaa/api at runtime (#1339 L4/L6 boundary) -->
+<!-- Spec reviewed 2026-04-24 - CodifiedContextController + CodifiedContextApiRouter; agent-context HTTP paths; CodifiedContextSessionStoreInterface + CodifiedContextSessionRow (packages/api); telescope-agent-context-telemetry.md; waaseyaa/telescope ships CodifiedContextSessionStoreAdapter (#1339 L4/L6 boundary) -->
 <!-- Spec reviewed 2026-04-24 - Auth and OIDC HTTP route tables: AuthOidcRouteServiceProvider + OidcHttpRoutes in packages/routing (waaseyaa/routing requires auth+oidc); BuiltinRouteRegistrar still calls all providers' routes() -->
 <!-- Spec reviewed 2026-04-22 - WaaseyaaRouter: reject duplicate route names; RouteBuilder::priority + sortRoutesByPriority (_waaseyaa_priority) for deterministic ordering -->
 <!-- Spec reviewed 2026-04-22 - SchemaPresenter/ResourceSerializer consume normalized FieldDefinitionInterface contracts; legacy array inputs normalized at presenter boundary -->
@@ -29,7 +29,7 @@ Foundation still wires several shared HTTP surfaces that are not entity-package 
 
 ### Codified context session endpoints
 
-`CodifiedContextController` exposes operator JSON for codified-context **session** telemetry (for example `GET /api/telescope/codified-context/sessions`). It type-hints **`CodifiedContextSessionStoreInterface`** only; row shapes use **`CodifiedContextSessionRow`** (`packages/api/src/CodifiedContext/`). That keeps Layer 4 free of Layer 6 Telescope storage types. **`Waaseyaa\Telescope\CodifiedContext\Storage\CodifiedContextSessionStoreAdapter`** bridges Telescope’s SQLite codified-context store to the port; `waaseyaa/telescope` `require`s `waaseyaa/api` for those interfaces. Unit tests may register an in-memory or stub store without loading Telescope.
+`CodifiedContextController` exposes operator JSON for **agent-context** (codified-context) **session** telemetry. Canonical paths are under `GET /api/telescope/agent-context/sessions` (see **`docs/specs/telescope-agent-context-telemetry.md`**). **`BuiltinRouteRegistrar`** also registers legacy `/api/telescope/codified-context/…` aliases for the same controller actions. Dispatch is handled by **`Waaseyaa\Foundation\Http\Router\CodifiedContextApiRouter`**, which constructs the controller with an optional **`CodifiedContextSessionStoreInterface`** from **`HttpKernel::getCodifiedContextSessionStore()`** (defaults to null until a host wires the store via **`HttpKernel::setCodifiedContextSessionStore()`**). The controller type-hints the port only; row shapes use **`CodifiedContextSessionRow`** (`packages/api/src/CodifiedContext/`). **`Waaseyaa\Telescope\CodifiedContext\Storage\CodifiedContextSessionStoreAdapter`** bridges Telescope’s SQLite codified-context store to the port; `waaseyaa/telescope` `require`s `waaseyaa/api` for those interfaces. Unit tests may register an in-memory or stub store without loading Telescope.
 
 ### packages/api/
 

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,6 +1,6 @@
 # API Layer
 
-<!-- Spec reviewed 2026-04-24 - CodifiedContextController + CodifiedContextApiRouter; agent-context HTTP paths; CodifiedContextSessionStoreInterface + CodifiedContextSessionRow (packages/api); telescope-agent-context-telemetry.md; waaseyaa/telescope ships CodifiedContextSessionStoreAdapter (#1339 L4/L6 boundary) -->
+<!-- Spec reviewed 2026-04-24 - CodifiedContextController JSON camelCase (admin useCodifiedContext); CodifiedContextApiRouter; agent-context HTTP paths; CodifiedContextSessionStoreInterface + CodifiedContextSessionRow (packages/api); telescope-agent-context-telemetry.md; waaseyaa/telescope ships CodifiedContextSessionStoreAdapter (#1339 L4/L6 boundary) -->
 <!-- Spec reviewed 2026-04-24 - Auth and OIDC HTTP route tables: AuthOidcRouteServiceProvider + OidcHttpRoutes in packages/routing (waaseyaa/routing requires auth+oidc); BuiltinRouteRegistrar still calls all providers' routes() -->
 <!-- Spec reviewed 2026-04-22 - WaaseyaaRouter: reject duplicate route names; RouteBuilder::priority + sortRoutesByPriority (_waaseyaa_priority) for deterministic ordering -->
 <!-- Spec reviewed 2026-04-22 - SchemaPresenter/ResourceSerializer consume normalized FieldDefinitionInterface contracts; legacy array inputs normalized at presenter boundary -->
@@ -30,6 +30,8 @@ Foundation still wires several shared HTTP surfaces that are not entity-package 
 ### Codified context session endpoints
 
 `CodifiedContextController` exposes operator JSON for **agent-context** (codified-context) **session** telemetry. Canonical paths are under `GET /api/telescope/agent-context/sessions` (see **`docs/specs/telescope-agent-context-telemetry.md`**). **`BuiltinRouteRegistrar`** also registers legacy `/api/telescope/codified-context/…` aliases for the same controller actions. Dispatch is handled by **`Waaseyaa\Foundation\Http\Router\CodifiedContextApiRouter`**, which constructs the controller with an optional **`CodifiedContextSessionStoreInterface`** from **`HttpKernel::getCodifiedContextSessionStore()`** (defaults to null until a host wires the store via **`HttpKernel::setCodifiedContextSessionStore()`**). The controller type-hints the port only; row shapes use **`CodifiedContextSessionRow`** (`packages/api/src/CodifiedContext/`). **`Waaseyaa\Telescope\CodifiedContext\Storage\CodifiedContextSessionStoreAdapter`** bridges Telescope’s SQLite codified-context store to the port; `waaseyaa/telescope` `require`s `waaseyaa/api` for those interfaces. Unit tests may register an in-memory or stub store without loading Telescope.
+
+**Response JSON (admin SPA):** Successful payloads use **camelCase** keys aligned with the admin composable **`useCodifiedContext`** (`packages/admin/app/composables/useCodifiedContext.ts`): session list and `GET …/sessions/{id}` return objects with `sessionId`, `startedAt`, `endedAt`, `durationMs`, `eventCount`, `latestDriftScore`, `latestSeverity`, etc. (timestamps as ISO-8601/RFC3339 strings). `GET …/events` returns rows with `eventType` (semantic type: stored `event_type` underscores mapped to dots, e.g. `context_load` → `context.load`), `createdAt`, and `data`. `GET …/validation` returns a single flat validation object (`driftScore` as 0–100 integer, `components`, `issues`, `recommendation`, `validatedAt`) — not a nested `report` envelope.
 
 ### packages/api/
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,5 +1,6 @@
 # Infrastructure
 
+<!-- Spec reviewed 2026-04-24 - CodifiedContextApiRouter + HttpKernel codified-context store getters/setters; BuiltinRouteRegistrar telescope agent-context + codified-context HTTP routes -->
 <!-- Spec reviewed 2026-04-24 - packages/http-client StreamHttpClient; packages/inertia InertiaServiceProvider (PHPStan-only); packages/queue timestamped migrations + CreateQueueTables DDL (waaseyaa_queue_jobs / waaseyaa_failed_jobs) -->
 <!-- Spec reviewed 2026-04-24 - Layer 0 env variable contract subsection (APP_ENV, APP_DEBUG, WAASEYAA_DB, WAASEYAA_CONFIG_DIR, .env/EnvLoader) + assert/IO review note after boot guard -->
 <!-- Spec reviewed 2026-04-22 - PackageManifest: removed persisted commands/routes (ADR docs/adr/0001); legacy extra.waaseyaa.commands|routes log warning only; fromArray strips legacy cache keys; mergeRootWaaseyaa merges providers+permissions only; attributeEntityTypes; ProviderRegistry entity_auto_register; ServiceProvider::mergeChildProvider; BuiltinRouteRegistrar: MCP route owned by mcp package only, sortRoutesByPriority after provider routes; MigrationLoader InstalledVersions; queue/notification/scheduler extra.waaseyaa.migrations -->
@@ -1083,7 +1084,7 @@ interface DomainRouterInterface
 
 Deterministic chain: `HttpKernel` iterates routers in order; first `supports()` match wins.
 
-**Merge order:** Built-in foundation routers end at `McpRouter`. Each discovered `ServiceProvider` may implement `httpDomainRouters(?HttpKernel $httpKernel)` to return additional `DomainRouterInterface` instances; those run in **package manifest order** (same order as provider registration). `BroadcastRouter` is always appended last. Example contributors: `ApiServiceProvider` (`DiscoveryRouter` in `Waaseyaa\Api\Http\Router`), `MediaServiceProvider` (`MediaRouter`), `GraphQlServiceProvider` (`GraphQlRouter`, merging `graphqlMutationOverrides()` from all providers), `SsrServiceProvider` (`SsrRouter`, `AppControllerRouter`).
+**Merge order:** Built-in foundation routers (in `HttpKernel::serveHttpRequest`) run as: `JsonApiRouter`, `EntityTypeLifecycleRouter`, `SchemaRouter`, **`CodifiedContextApiRouter`**, `SearchRouter`, `McpRouter`, then each discovered `ServiceProvider::httpDomainRouters(?HttpKernel)` in **package manifest order**, then **`BroadcastRouter`** last. Example provider routers: `ApiServiceProvider` (`DiscoveryRouter` in `Waaseyaa\Api\Http\Router`), `MediaServiceProvider` (`MediaRouter`), `GraphQlServiceProvider` (`GraphQlRouter`, merging `graphqlMutationOverrides()` from all providers), `SsrServiceProvider` (`SsrRouter`, `AppControllerRouter`).
 
 **Kernel hooks:** After access policies are registered and before `$kernel->booted` is set, `HttpKernel::finalizeBoot()` prepares shared cache backends, discovery handler, MCP/render cache listeners from `EventListenerRegistrar`, per-provider `registerRenderCacheListeners()` and `configureHttpKernel()` (SSR builds `SsrPageHandler` there so `EntityAccessGate` sees a fully wired `EntityAccessHandler`).
 
@@ -1112,6 +1113,7 @@ Optional follow-ups (full header map API, lazy adapter, JSON:API adoption) are t
 | `JsonApiRouter` | `jsonapi.*` | JSON:API CRUD delegation to `JsonApiController` |
 | `EntityTypeLifecycleRouter` | `entity_types`, `entity_type.disable`, `entity_type.enable` | Entity type listing and lifecycle management |
 | `SchemaRouter` | `openapi`, `schema.*` | OpenAPI and JSON Schema endpoints |
+| `CodifiedContextApiRouter` | `Waaseyaa\Api\Controller\CodifiedContextController::*` | Telescope agent-context session JSON (`BuiltinRouteRegistrar` routes under `/api/telescope/agent-context/…` plus legacy `/api/telescope/codified-context/…`); optional `CodifiedContextSessionStoreInterface` from `HttpKernel::getCodifiedContextSessionStore()` |
 | `DiscoveryRouter` (`Waaseyaa\Api\Http\Router`) | `discovery.topic_hub`, `discovery.cluster`, `discovery.timeline`, `discovery.endpoint` | Discovery API for topic hubs, clusters, timelines (registered from `ApiServiceProvider::httpDomainRouters()`) |
 | `SearchRouter` | `search.semantic` | Semantic search via embedding storage |
 | `MediaRouter` (`Waaseyaa\Media\Http\Router`) | `media.upload` | File upload with MIME validation, size limits, sanitization, move error handling (`MediaServiceProvider`) |
@@ -1499,7 +1501,7 @@ Kernel/
     EnvLoader.php                -- .env file parser; writes to putenv(), $_ENV, and $_SERVER (each destination guarded independently — preset keys in any destination are never overwritten)
     ConfigLoader.php             -- config/waaseyaa.php loader
     EventListenerRegistrar.php   -- registers cache invalidation listeners
-    BuiltinRouteRegistrar.php    -- registers shared foundation-owned HTTP routes (schema, discovery, entity-types, SSR catch-all)
+    BuiltinRouteRegistrar.php    -- registers shared foundation-owned HTTP routes (schema, discovery, entity-types, telescope agent-context JSON, SSR catch-all)
     Bootstrap/
         DatabaseBootstrapper.php     -- creates DBALDatabase connection
         ManifestBootstrapper.php     -- loads/compiles PackageManifest

--- a/docs/specs/telescope-agent-context-telemetry.md
+++ b/docs/specs/telescope-agent-context-telemetry.md
@@ -1,0 +1,45 @@
+# Telescope agent-context telemetry
+
+<!-- Spec reviewed 2026-04-24 - Prometheus canonical waaseyaa_agent_context_* + legacy waaseyaa_cc_* mirrors; HTTP /api/telescope/agent-context/* + codified-context aliases; Telescope record.agent_context precedence -->
+
+Operator-facing **names** for Telescope’s codified-context pipeline (session/event/validation recorders, drift scoring). Storage **types** (`cc_session`, `cc_event`, `cc_validation`), SQLite table `telescope_cc_entries`, and JSONL `telescope_cc.jsonl` are **not** renamed here — they remain the durable internal representation.
+
+## Prometheus (canonical + deprecated)
+
+`Waaseyaa\Telescope\CodifiedContext\Storage\PrometheusCodifiedContextStore` exposes text exposition with:
+
+| Canonical metric | Type | Meaning |
+|------------------|------|---------|
+| `waaseyaa_agent_context_sessions_total` | counter | Distinct `session_id` values observed |
+| `waaseyaa_agent_context_events_total` | counter | `store()` invocations |
+| `waaseyaa_agent_context_drift_events_total` | counter | Drift-related / severity-flagged events (same heuristics as before) |
+| `waaseyaa_agent_context_validations_total` | counter | Validation-ish types |
+| `waaseyaa_agent_context_drift_score_avg` | gauge | Running mean of numeric `drift_score` samples |
+
+**Deprecated duplicates:** `waaseyaa_cc_*` series are emitted in the **same** scrape with identical sample values and `Deprecated:` HELP lines so existing dashboards keep working. Remove the legacy block after downstream consumers migrate.
+
+`getMetrics()` returns **both** canonical and `waaseyaa_cc_*` keys (same values) for in-process introspection.
+
+## HTTP JSON (canonical + legacy)
+
+Routes are registered in **`Waaseyaa\Foundation\Kernel\BuiltinRouteRegistrar`**. All routes require the **`admin`** role.
+
+| Action | Canonical path | Legacy alias |
+|--------|----------------|--------------|
+| List sessions | `GET /api/telescope/agent-context/sessions` | `GET /api/telescope/codified-context/sessions` |
+| Session row | `GET /api/telescope/agent-context/sessions/{sessionId}` | `…/codified-context/sessions/{sessionId}` |
+| Events | `GET …/sessions/{sessionId}/events` | same under `codified-context` |
+| Validation | `GET …/sessions/{sessionId}/validation` | same under `codified-context` |
+
+**Dispatch:** `Waaseyaa\Foundation\Http\Router\CodifiedContextApiRouter` instantiates `Waaseyaa\Api\Controller\CodifiedContextController` with **`HttpKernel::getCodifiedContextSessionStore()`** (nullable). Hosts that persist codified-context data should call **`HttpKernel::setCodifiedContextSessionStore()`** during boot (e.g. from a `ServiceProvider::configureHttpKernel()` hook) with an adapter such as **`CodifiedContextSessionStoreAdapter`**.
+
+## Telescope config toggle
+
+Under `telescope.record`:
+
+- **`agent_context`** — when this key **exists** (even `false`), it alone controls the codified-context observer (`CodifiedContextObserver`).
+- **`codified_context`** — used only when `agent_context` is **absent** (legacy behaviour).
+
+## Admin SPA
+
+The Nuxt dev pages may keep the historical route path **`/telescope/codified-context`** for navigation; API calls target **`/api/telescope/agent-context/…`** (see `packages/admin/app/composables/useCodifiedContext.ts`).

--- a/packages/admin/app/composables/useCodifiedContext.ts
+++ b/packages/admin/app/composables/useCodifiedContext.ts
@@ -45,7 +45,7 @@ export function useCodifiedContext() {
     error.value = null
     try {
       const response = await apiFetch<{ data: CodifiedContextSession[] }>(
-        `/api/telescope/codified-context/sessions?limit=${limit}`,
+        `/api/telescope/agent-context/sessions?limit=${limit}`,
       )
       sessions.value = response.data ?? []
     } catch (e: any) {
@@ -60,7 +60,7 @@ export function useCodifiedContext() {
     error.value = null
     try {
       const response = await apiFetch<{ data: CodifiedContextSession }>(
-        `/api/telescope/codified-context/sessions/${id}`,
+        `/api/telescope/agent-context/sessions/${id}`,
       )
       currentSession.value = response.data ?? null
     } catch (e: any) {
@@ -75,7 +75,7 @@ export function useCodifiedContext() {
     error.value = null
     try {
       const response = await apiFetch<{ data: CodifiedContextEvent[] }>(
-        `/api/telescope/codified-context/sessions/${id}/events`,
+        `/api/telescope/agent-context/sessions/${id}/events`,
       )
       events.value = response.data ?? []
     } catch (e: any) {
@@ -90,7 +90,7 @@ export function useCodifiedContext() {
     error.value = null
     try {
       const response = await apiFetch<{ data: ValidationReport }>(
-        `/api/telescope/codified-context/sessions/${id}/validation`,
+        `/api/telescope/agent-context/sessions/${id}/validation`,
       )
       validationReport.value = response.data ?? null
     } catch (e: any) {

--- a/packages/admin/e2e/telescope-codified-context.spec.ts
+++ b/packages/admin/e2e/telescope-codified-context.spec.ts
@@ -60,7 +60,7 @@ const mockValidation = {
 }
 
 async function mockAllRoutes(page: import('@playwright/test').Page) {
-  await page.route('**/api/telescope/codified-context/sessions**', (route) => {
+  await page.route('**/api/telescope/agent-context/sessions**', (route) => {
     const url = route.request().url()
     // Session detail
     if (url.includes('/sessions/sess-abcdef12/events')) {
@@ -139,7 +139,7 @@ test.describe('Telescope: Codified Context', () => {
   })
 
   test('empty state shown when no sessions', async ({ page }) => {
-    await page.route('**/api/telescope/codified-context/sessions**', (route) =>
+    await page.route('**/api/telescope/agent-context/sessions**', (route) =>
       route.fulfill({ json: { data: [] } }),
     )
     await page.goto('/telescope/codified-context')

--- a/packages/api/src/Controller/CodifiedContextController.php
+++ b/packages/api/src/Controller/CodifiedContextController.php
@@ -14,7 +14,7 @@ final class CodifiedContextController
     public function __construct(private readonly ?CodifiedContextSessionStoreInterface $store = null) {}
 
     /**
-     * GET /api/telescope/codified-context/sessions
+     * GET /api/telescope/agent-context/sessions (legacy alias: /api/telescope/codified-context/sessions)
      *
      * Groups cc_session entries by session_id, merges start/end, enriches with latest drift scores.
      *
@@ -65,7 +65,7 @@ final class CodifiedContextController
     }
 
     /**
-     * GET /api/telescope/codified-context/sessions/{sessionId}
+     * GET /api/telescope/agent-context/sessions/{sessionId} (legacy: …/codified-context/…)
      *
      * @return array{data: array<string, mixed>|null}
      */
@@ -93,7 +93,7 @@ final class CodifiedContextController
     }
 
     /**
-     * GET /api/telescope/codified-context/sessions/{sessionId}/events
+     * GET /api/telescope/agent-context/sessions/{sessionId}/events (legacy: …/codified-context/…)
      *
      * Returns only cc_event type entries for the session.
      *
@@ -124,7 +124,7 @@ final class CodifiedContextController
     }
 
     /**
-     * GET /api/telescope/codified-context/sessions/{sessionId}/validation
+     * GET /api/telescope/agent-context/sessions/{sessionId}/validation (legacy: …/codified-context/…)
      *
      * Returns latest cc_validation entry for the session.
      *

--- a/packages/api/src/Controller/CodifiedContextController.php
+++ b/packages/api/src/Controller/CodifiedContextController.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Api\Controller;
 
+use Waaseyaa\Api\CodifiedContext\CodifiedContextSessionRow;
 use Waaseyaa\Api\CodifiedContext\CodifiedContextSessionStoreInterface;
 
 /**
  * API controller for codified context session data.
+ *
+ * JSON payloads use camelCase keys aligned with the admin SPA TypeScript types
+ * ({@see useCodifiedContext}).
  */
 final class CodifiedContextController
 {
@@ -16,7 +20,7 @@ final class CodifiedContextController
     /**
      * GET /api/telescope/agent-context/sessions (legacy alias: /api/telescope/codified-context/sessions)
      *
-     * Groups cc_session entries by session_id, merges start/end, enriches with latest drift scores.
+     * Groups cc_session entries by session_id, merges start/end, enriches with drift scores and event counts.
      *
      * @param array<string, mixed> $query
      * @return array{data: array<int, array<string, mixed>>}
@@ -27,41 +31,101 @@ final class CodifiedContextController
             return ['data' => []];
         }
 
-        $sessionEntries = $this->store->queryByEventType('cc_session', limit: 500);
+        $sessionRows = $this->store->queryByEventType('cc_session', limit: 500);
+        $eventRows = $this->store->queryByEventType('cc_event', limit: 2000);
+        $eventCounts = $this->countEventsBySession($eventRows);
 
-        $sessions = [];
-        foreach ($sessionEntries as $entry) {
-            $sessionId = $entry->sessionId;
-            if (!isset($sessions[$sessionId])) {
-                $sessions[$sessionId] = [
-                    'session_id' => $sessionId,
-                    'started_at' => $entry->createdAt->format('Y-m-d H:i:s.u'),
-                    'ended_at' => null,
-                    'drift_score' => null,
+        $aggregates = [];
+        foreach ($sessionRows as $row) {
+            $sessionId = $row->sessionId;
+            $data = $row->data;
+            if (!isset($aggregates[$sessionId])) {
+                $aggregates[$sessionId] = [
+                    'sessionId' => $sessionId,
+                    'repoHash' => '',
+                    'startedAt' => null,
+                    'endedAt' => null,
+                    'durationMs' => null,
+                    'eventCount' => $eventCounts[$sessionId] ?? 0,
+                    'latestDriftScore' => null,
+                    'latestSeverity' => null,
                 ];
             }
 
-            $data = $entry->data;
-            $phase = $data['phase'] ?? null;
-            if ($phase === 'end') {
-                $sessions[$sessionId]['ended_at'] = $entry->createdAt->format('Y-m-d H:i:s.u');
+            if ($this->isSessionStartRow($data)) {
+                $repo = $data['repo_hash'] ?? $data['repoHash'] ?? '';
+                if (is_string($repo) && $repo !== '') {
+                    $aggregates[$sessionId]['repoHash'] = $repo;
+                }
+                $started = self::createdAtAtom($row->createdAt);
+                $prevStart = $aggregates[$sessionId]['startedAt'];
+                if ($prevStart === null || $started < $prevStart) {
+                    $aggregates[$sessionId]['startedAt'] = $started;
+                }
             }
+
+            if ($this->isSessionEndRow($data)) {
+                $aggregates[$sessionId]['endedAt'] = self::createdAtAtom($row->createdAt);
+                if (isset($data['duration_ms']) && is_numeric($data['duration_ms'])) {
+                    $aggregates[$sessionId]['durationMs'] = (int) $data['duration_ms'];
+                }
+                if (isset($data['event_count']) && is_numeric($data['event_count'])) {
+                    $aggregates[$sessionId]['eventCount'] = (int) $data['event_count'];
+                }
+            }
+
             if (isset($data['drift_score'])) {
-                $sessions[$sessionId]['drift_score'] = $data['drift_score'];
+                $aggregates[$sessionId]['latestDriftScore'] = self::normalizeDriftScoreInt($data['drift_score']);
+            }
+            if (isset($data['severity']) && is_string($data['severity'])) {
+                $aggregates[$sessionId]['latestSeverity'] = $data['severity'];
             }
         }
 
-        // Enrich with latest validation drift scores.
-        foreach (array_keys($sessions) as $sessionId) {
-            $validations = $this->store->queryBySession($sessionId, limit: 1);
+        $earliestSessionCreated = [];
+        foreach ($sessionRows as $row) {
+            $atom = self::createdAtAtom($row->createdAt);
+            $sid = $row->sessionId;
+            if (!isset($earliestSessionCreated[$sid]) || $atom < $earliestSessionCreated[$sid]) {
+                $earliestSessionCreated[$sid] = $atom;
+            }
+        }
+
+        foreach (array_keys($aggregates) as $sessionId) {
+            $validations = $this->store->queryBySession($sessionId, limit: 50);
             foreach ($validations as $entry) {
-                if ($entry->type === 'cc_validation' && isset($entry->data['drift_score'])) {
-                    $sessions[$sessionId]['drift_score'] = $entry->data['drift_score'];
+                if ($entry->type !== 'cc_validation') {
+                    continue;
+                }
+                $vd = $entry->data;
+                if (isset($vd['drift_score'])) {
+                    $aggregates[$sessionId]['latestDriftScore'] = self::normalizeDriftScoreInt($vd['drift_score']);
+                }
+                if (isset($vd['severity']) && is_string($vd['severity'])) {
+                    $aggregates[$sessionId]['latestSeverity'] = $vd['severity'];
                 }
             }
         }
 
-        return ['data' => array_values($sessions)];
+        $out = [];
+        foreach ($aggregates as $sessionId => $row) {
+            $startedAt = $row['startedAt'] ?? $earliestSessionCreated[$sessionId] ?? self::epochAtom();
+            $fromEnd = $row['eventCount'];
+            $fromScan = $eventCounts[$sessionId] ?? 0;
+            $out[] = [
+                'id' => $sessionId,
+                'sessionId' => $sessionId,
+                'repoHash' => $row['repoHash'],
+                'startedAt' => $startedAt,
+                'endedAt' => $row['endedAt'],
+                'durationMs' => $row['durationMs'],
+                'eventCount' => max($fromEnd, $fromScan),
+                'latestDriftScore' => $row['latestDriftScore'],
+                'latestSeverity' => $row['latestSeverity'],
+            ];
+        }
+
+        return ['data' => $out];
     }
 
     /**
@@ -75,21 +139,14 @@ final class CodifiedContextController
             return ['data' => null];
         }
 
-        $entries = $this->store->queryBySession($sessionId, limit: 1);
-        if ($entries === []) {
-            return ['data' => null];
+        $list = $this->listSessions();
+        foreach ($list['data'] as $row) {
+            if (($row['sessionId'] ?? '') === $sessionId) {
+                return ['data' => $row];
+            }
         }
 
-        $entry = $entries[0];
-
-        return [
-            'data' => [
-                'session_id' => $entry->sessionId,
-                'type' => $entry->type,
-                'created_at' => $entry->createdAt->format('Y-m-d H:i:s.u'),
-                'data' => $entry->data,
-            ],
-        ];
+        return ['data' => null];
     }
 
     /**
@@ -109,15 +166,23 @@ final class CodifiedContextController
         $events = [];
 
         foreach ($allEntries as $entry) {
-            if ($entry->type === 'cc_event') {
-                $events[] = [
-                    'id' => $entry->id,
-                    'session_id' => $entry->sessionId,
-                    'type' => $entry->type,
-                    'created_at' => $entry->createdAt->format('Y-m-d H:i:s.u'),
-                    'data' => $entry->data,
-                ];
+            if ($entry->type !== 'cc_event') {
+                continue;
             }
+
+            $data = $entry->data;
+            $semantic = $data['event_type'] ?? '';
+            $eventType = is_string($semantic) && $semantic !== ''
+                ? str_replace('_', '.', $semantic)
+                : $entry->type;
+
+            $events[] = [
+                'id' => $entry->id,
+                'sessionId' => $entry->sessionId,
+                'eventType' => $eventType,
+                'createdAt' => self::createdAtAtom($entry->createdAt),
+                'data' => $data,
+            ];
         }
 
         return ['data' => $events];
@@ -126,7 +191,7 @@ final class CodifiedContextController
     /**
      * GET /api/telescope/agent-context/sessions/{sessionId}/validation (legacy: …/codified-context/…)
      *
-     * Returns latest cc_validation entry for the session.
+     * Returns latest cc_validation payload as a {@see ValidationReport}-shaped object (camelCase).
      *
      * @return array{data: array<string, mixed>|null}
      */
@@ -139,18 +204,126 @@ final class CodifiedContextController
         $allEntries = $this->store->queryBySession($sessionId, limit: 100);
 
         foreach ($allEntries as $entry) {
-            if ($entry->type === 'cc_validation') {
-                return [
-                    'data' => [
-                        'id' => $entry->id,
-                        'session_id' => $entry->sessionId,
-                        'created_at' => $entry->createdAt->format('Y-m-d H:i:s.u'),
-                        'report' => $entry->data,
-                    ],
-                ];
+            if ($entry->type !== 'cc_validation') {
+                continue;
             }
+
+            return ['data' => self::mapValidationReportCamel($sessionId, $entry)];
         }
 
         return ['data' => null];
+    }
+
+    /**
+     * @param list<CodifiedContextSessionRow> $eventRows
+     * @return array<string, int>
+     */
+    private function countEventsBySession(array $eventRows): array
+    {
+        $counts = [];
+        foreach ($eventRows as $row) {
+            if ($row->type !== 'cc_event') {
+                continue;
+            }
+            $sid = $row->sessionId;
+            $counts[$sid] = ($counts[$sid] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function isSessionStartRow(array $data): bool
+    {
+        $phase = $data['phase'] ?? null;
+        $eventType = $data['event_type'] ?? null;
+
+        return $phase === 'start' || $eventType === 'session_start';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function isSessionEndRow(array $data): bool
+    {
+        $phase = $data['phase'] ?? null;
+        $eventType = $data['event_type'] ?? null;
+
+        return $phase === 'end' || $eventType === 'session_end';
+    }
+
+    private static function createdAtAtom(\DateTimeImmutable $at): string
+    {
+        return $at->format(\DateTimeInterface::ATOM);
+    }
+
+    private static function epochAtom(): string
+    {
+        return (new \DateTimeImmutable('@0'))->format(\DateTimeInterface::ATOM);
+    }
+
+    private static function normalizeDriftScoreInt(mixed $value): ?int
+    {
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $f = (float) $value;
+        if ($f > 0.0 && $f <= 1.0) {
+            return (int) round($f * 100.0);
+        }
+
+        return (int) round($f);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function mapValidationReportCamel(string $sessionId, CodifiedContextSessionRow $entry): array
+    {
+        $d = $entry->data;
+        $componentsIn = $d['components'] ?? [];
+        $componentsIn = is_array($componentsIn) ? $componentsIn : [];
+
+        $semantic = $componentsIn['semantic_alignment'] ?? $componentsIn['semanticAlignment'] ?? 0;
+        $structural = $componentsIn['structural_score'] ?? $componentsIn['structural_checks'] ?? $componentsIn['structuralChecks'] ?? 0;
+        $contradiction = $componentsIn['contradiction_score'] ?? $componentsIn['contradiction_checks'] ?? $componentsIn['contradictionChecks'] ?? 0;
+
+        $issuesOut = [];
+        $issuesIn = $d['issues'] ?? [];
+        if (is_array($issuesIn)) {
+            foreach ($issuesIn as $issue) {
+                if (is_string($issue)) {
+                    $issuesOut[] = [
+                        'type' => 'issue',
+                        'message' => $issue,
+                        'severity' => 'low',
+                    ];
+                } elseif (is_array($issue)) {
+                    $issuesOut[] = [
+                        'type' => (string) ($issue['type'] ?? 'issue'),
+                        'message' => (string) ($issue['message'] ?? ''),
+                        'severity' => (string) ($issue['severity'] ?? 'low'),
+                    ];
+                }
+            }
+        }
+
+        $drift = $d['drift_score'] ?? $d['driftScore'] ?? null;
+
+        return [
+            'sessionId' => $sessionId,
+            'driftScore' => self::normalizeDriftScoreInt($drift) ?? 0,
+            'components' => [
+                'semantic_alignment' => is_numeric($semantic) ? (int) round((float) $semantic) : 0,
+                'structural_checks' => is_numeric($structural) ? (int) round((float) $structural) : 0,
+                'contradiction_checks' => is_numeric($contradiction) ? (int) round((float) $contradiction) : 0,
+            ],
+            'issues' => $issuesOut,
+            'recommendation' => (string) ($d['recommendation'] ?? ''),
+            'validatedAt' => self::createdAtAtom($entry->createdAt),
+        ];
     }
 }

--- a/packages/api/tests/Unit/Controller/CodifiedContextControllerTest.php
+++ b/packages/api/tests/Unit/Controller/CodifiedContextControllerTest.php
@@ -75,7 +75,7 @@ final class CodifiedContextControllerTest extends TestCase
         $result = $controller->listSessions();
 
         $this->assertCount(2, $result['data']);
-        $sessionIds = array_column($result['data'], 'session_id');
+        $sessionIds = array_column($result['data'], 'sessionId');
         $this->assertContains('sess-A', $sessionIds);
         $this->assertContains('sess-B', $sessionIds);
     }
@@ -106,7 +106,7 @@ final class CodifiedContextControllerTest extends TestCase
         $result = $controller->getSession('sess-X');
 
         $this->assertNotNull($result['data']);
-        $this->assertSame('sess-X', $result['data']['session_id']);
+        $this->assertSame('sess-X', $result['data']['sessionId']);
     }
 
     #[Test]
@@ -120,7 +120,7 @@ final class CodifiedContextControllerTest extends TestCase
         ]);
         $inner->store('cc_event', [
             'session_id' => 'sess-Y',
-            'event_type' => 'cc_event',
+            'event_type' => 'context_load',
             'action' => 'load_spec',
         ]);
         $inner->store('cc_validation', [
@@ -134,7 +134,8 @@ final class CodifiedContextControllerTest extends TestCase
         $result = $controller->getSessionEvents('sess-Y');
 
         $this->assertCount(1, $result['data']);
-        $this->assertSame('cc_event', $result['data'][0]['type']);
+        $this->assertSame('context.load', $result['data'][0]['eventType']);
+        $this->assertArrayHasKey('createdAt', $result['data'][0]);
     }
 
     #[Test]
@@ -170,8 +171,9 @@ final class CodifiedContextControllerTest extends TestCase
         $result = $controller->getSessionValidation('sess-V');
 
         $this->assertNotNull($result['data']);
-        $this->assertSame('sess-V', $result['data']['session_id']);
-        $this->assertArrayHasKey('report', $result['data']);
-        $this->assertSame(0.85, $result['data']['report']['drift_score']);
+        $this->assertSame('sess-V', $result['data']['sessionId']);
+        $this->assertSame(85, $result['data']['driftScore']);
+        $this->assertArrayHasKey('components', $result['data']);
+        $this->assertArrayHasKey('issues', $result['data']);
     }
 }

--- a/packages/foundation/src/Http/Router/CodifiedContextApiRouter.php
+++ b/packages/foundation/src/Http/Router/CodifiedContextApiRouter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Http\Router;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Api\CodifiedContext\CodifiedContextSessionStoreInterface;
+use Waaseyaa\Api\Controller\CodifiedContextController;
+use Waaseyaa\Foundation\Http\JsonApiResponseTrait;
+
+/**
+ * Dispatches Telescope agent-context (codified-context) session JSON endpoints.
+ */
+final class CodifiedContextApiRouter implements DomainRouterInterface
+{
+    use JsonApiResponseTrait;
+
+    public function __construct(
+        private readonly ?CodifiedContextSessionStoreInterface $sessionStore = null,
+    ) {}
+
+    public function supports(Request $request): bool
+    {
+        $controller = $request->attributes->get('_controller', '');
+
+        return is_string($controller) && str_contains($controller, 'CodifiedContextController::');
+    }
+
+    public function handle(Request $request): Response
+    {
+        $controllerRef = $request->attributes->get('_controller', '');
+        if (!is_string($controllerRef) || !str_contains($controllerRef, '::')) {
+            return $this->jsonApiResponse(500, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Invalid codified context controller reference.']],
+            ]);
+        }
+
+        [, $action] = explode('::', $controllerRef, 2);
+        $ctx = WaaseyaaContext::fromRequest($request);
+        $apiController = new CodifiedContextController($this->sessionStore);
+
+        $params = $request->attributes->all();
+        $sessionId = isset($params['sessionId']) && is_scalar($params['sessionId'])
+            ? (string) $params['sessionId']
+            : '';
+
+        $payload = match ($action) {
+            'listSessions' => $apiController->listSessions($ctx->query),
+            'getSession' => $apiController->getSession($sessionId),
+            'getSessionEvents' => $apiController->getSessionEvents($sessionId),
+            'getSessionValidation' => $apiController->getSessionValidation($sessionId),
+            default => null,
+        };
+
+        if ($payload === null) {
+            return $this->jsonApiResponse(404, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [['status' => '404', 'title' => 'Not Found', 'detail' => sprintf('Unknown codified context action: %s', $action)]],
+            ]);
+        }
+
+        return $this->jsonApiResponse(200, $payload);
+    }
+}

--- a/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
+++ b/packages/foundation/src/Kernel/BuiltinRouteRegistrar.php
@@ -13,7 +13,8 @@ use Waaseyaa\Routing\WaaseyaaRouter;
  * Registers all built-in HTTP routes on the router.
  *
  * Handles JSON:API entity routes, schema, OpenAPI, discovery endpoints,
- * media upload, SSR page rendering, and app-level provider routes.
+ * media upload, Telescope agent-context (codified-context) JSON routes,
+ * SSR page rendering, and app-level provider routes.
  */
 final class BuiltinRouteRegistrar
 {
@@ -127,6 +128,73 @@ final class BuiltinRouteRegistrar
             RouteBuilder::create('/api/discovery/endpoint/{entity_type}/{id}')
                 ->controller('discovery.endpoint')
                 ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $ccController = 'Waaseyaa\\Api\\Controller\\CodifiedContextController';
+        $router->addRoute(
+            'api.telescope.agent_context.sessions',
+            RouteBuilder::create('/api/telescope/agent-context/sessions')
+                ->controller($ccController . '::listSessions')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.agent_context.session',
+            RouteBuilder::create('/api/telescope/agent-context/sessions/{sessionId}')
+                ->controller($ccController . '::getSession')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.agent_context.session_events',
+            RouteBuilder::create('/api/telescope/agent-context/sessions/{sessionId}/events')
+                ->controller($ccController . '::getSessionEvents')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.agent_context.session_validation',
+            RouteBuilder::create('/api/telescope/agent-context/sessions/{sessionId}/validation')
+                ->controller($ccController . '::getSessionValidation')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'api.telescope.codified_context.sessions',
+            RouteBuilder::create('/api/telescope/codified-context/sessions')
+                ->controller($ccController . '::listSessions')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.codified_context.session',
+            RouteBuilder::create('/api/telescope/codified-context/sessions/{sessionId}')
+                ->controller($ccController . '::getSession')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.codified_context.session_events',
+            RouteBuilder::create('/api/telescope/codified-context/sessions/{sessionId}/events')
+                ->controller($ccController . '::getSessionEvents')
+                ->requireRole('admin')
+                ->methods('GET')
+                ->build(),
+        );
+        $router->addRoute(
+            'api.telescope.codified_context.session_validation',
+            RouteBuilder::create('/api/telescope/codified-context/sessions/{sessionId}/validation')
+                ->controller($ccController . '::getSessionValidation')
+                ->requireRole('admin')
                 ->methods('GET')
                 ->build(),
         );

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -12,6 +12,7 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Access\ErrorPageRendererInterface;
 use Waaseyaa\Access\Gate\EntityAccessGate;
 use Waaseyaa\Access\Middleware\AuthorizationMiddleware;
+use Waaseyaa\Api\CodifiedContext\CodifiedContextSessionStoreInterface;
 use Waaseyaa\Api\Controller\BroadcastStorage;
 use Waaseyaa\Api\Http\DiscoveryApiHandler;
 use Waaseyaa\Cache\Backend\DatabaseBackend;
@@ -55,6 +56,8 @@ final class HttpKernel extends AbstractKernel
     private ?CacheBackendInterface $discoveryCache = null;
     private ?CacheBackendInterface $mcpReadCache = null;
     private ?DiscoveryApiHandler $discoveryHandler = null;
+
+    private ?CodifiedContextSessionStoreInterface $codifiedContextSessionStore = null;
 
     public function handle(): HttpResponse
     {
@@ -140,6 +143,16 @@ final class HttpKernel extends AbstractKernel
     public function getInertiaFullPageRenderer(): ?InertiaFullPageRendererInterface
     {
         return $this->resolveInertiaFullPageRenderer();
+    }
+
+    public function getCodifiedContextSessionStore(): ?CodifiedContextSessionStoreInterface
+    {
+        return $this->codifiedContextSessionStore;
+    }
+
+    public function setCodifiedContextSessionStore(?CodifiedContextSessionStoreInterface $store): void
+    {
+        $this->codifiedContextSessionStore = $store;
     }
 
     /**
@@ -361,6 +374,7 @@ final class HttpKernel extends AbstractKernel
             new HttpRouter\JsonApiRouter($this->entityTypeManager, $this->accessHandler),
             new HttpRouter\EntityTypeLifecycleRouter($this->entityTypeManager, $this->lifecycleManager),
             new HttpRouter\SchemaRouter($this->entityTypeManager, $this->accessHandler),
+            new HttpRouter\CodifiedContextApiRouter($this->codifiedContextSessionStore),
             new HttpRouter\SearchRouter($this->config, $this->database, $this->entityTypeManager),
             new HttpRouter\McpRouter($this->entityTypeManager, $this->accessHandler, $this->database, $this->config, $this->mcpReadCache),
         ];

--- a/packages/foundation/tests/Unit/Http/Router/CodifiedContextApiRouterTest.php
+++ b/packages/foundation/tests/Unit/Http/Router/CodifiedContextApiRouterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Http\Router;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Api\Controller\BroadcastStorage;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Foundation\Http\Router\CodifiedContextApiRouter;
+
+#[CoversClass(CodifiedContextApiRouter::class)]
+final class CodifiedContextApiRouterTest extends TestCase
+{
+    private function requestWithContext(string $controller, array $routeDefaults = []): Request
+    {
+        $db = DBALDatabase::createSqlite();
+        $request = Request::create('/api/telescope/agent-context/sessions');
+        $request->attributes->set('_controller', $controller);
+        $request->attributes->set('_account', $this->createStub(\Waaseyaa\Access\AccountInterface::class));
+        $request->attributes->set('_broadcast_storage', new BroadcastStorage($db));
+        $request->attributes->set('_parsed_body', null);
+        foreach ($routeDefaults as $k => $v) {
+            $request->attributes->set($k, $v);
+        }
+
+        return $request;
+    }
+
+    #[Test]
+    public function supports_codified_context_controller_actions(): void
+    {
+        $router = new CodifiedContextApiRouter();
+        $request = $this->requestWithContext('Waaseyaa\\Api\\Controller\\CodifiedContextController::listSessions');
+
+        self::assertTrue($router->supports($request));
+    }
+
+    #[Test]
+    public function does_not_support_unrelated_controller(): void
+    {
+        $router = new CodifiedContextApiRouter();
+        $request = $this->requestWithContext('Waaseyaa\\Api\\JsonApiController::index');
+
+        self::assertFalse($router->supports($request));
+    }
+
+    #[Test]
+    public function list_sessions_returns_empty_data_without_store(): void
+    {
+        $router = new CodifiedContextApiRouter();
+        $request = $this->requestWithContext('Waaseyaa\\Api\\Controller\\CodifiedContextController::listSessions');
+
+        $response = $router->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $decoded = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['data' => []], $decoded);
+    }
+
+    #[Test]
+    public function unknown_action_returns_404(): void
+    {
+        $router = new CodifiedContextApiRouter();
+        $request = $this->requestWithContext('Waaseyaa\\Api\\Controller\\CodifiedContextController::missing');
+
+        $response = $router->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/packages/telescope/src/CodifiedContext/Storage/PrometheusCodifiedContextStore.php
+++ b/packages/telescope/src/CodifiedContext/Storage/PrometheusCodifiedContextStore.php
@@ -120,18 +120,28 @@ final class PrometheusCodifiedContextStore implements CodifiedContextStoreInterf
     /**
      * Get all tracked metric values.
      *
+     * Canonical series use the `waaseyaa_agent_context_*` prefix. The legacy
+     * `waaseyaa_cc_*` keys mirror the same values for transitional dashboards.
+     *
      * @return array<string, int|float>
      */
     public function getMetrics(): array
     {
+        $driftAvg = $this->driftScoreCount > 0
+            ? $this->driftScoreSum / $this->driftScoreCount
+            : 0.0;
+
         return [
+            'waaseyaa_agent_context_sessions_total' => $this->sessionsTotal,
+            'waaseyaa_agent_context_events_total' => $this->eventsTotal,
+            'waaseyaa_agent_context_drift_events_total' => $this->driftEventsTotal,
+            'waaseyaa_agent_context_validations_total' => $this->validationsTotal,
+            'waaseyaa_agent_context_drift_score_avg' => $driftAvg,
             'waaseyaa_cc_sessions_total' => $this->sessionsTotal,
             'waaseyaa_cc_events_total' => $this->eventsTotal,
             'waaseyaa_cc_drift_events_total' => $this->driftEventsTotal,
             'waaseyaa_cc_validations_total' => $this->validationsTotal,
-            'waaseyaa_cc_drift_score_avg' => $this->driftScoreCount > 0
-                ? $this->driftScoreSum / $this->driftScoreCount
-                : 0.0,
+            'waaseyaa_cc_drift_score_avg' => $driftAvg,
         ];
     }
 
@@ -144,23 +154,45 @@ final class PrometheusCodifiedContextStore implements CodifiedContextStoreInterf
 
         $lines = [];
 
-        $lines[] = '# HELP waaseyaa_cc_sessions_total Total number of unique codified context sessions observed.';
+        $lines[] = '# HELP waaseyaa_agent_context_sessions_total Total number of unique agent-context (codified-context) sessions observed.';
+        $lines[] = '# TYPE waaseyaa_agent_context_sessions_total counter';
+        $lines[] = 'waaseyaa_agent_context_sessions_total ' . $metrics['waaseyaa_agent_context_sessions_total'];
+
+        $lines[] = '# HELP waaseyaa_agent_context_events_total Total number of agent-context events stored.';
+        $lines[] = '# TYPE waaseyaa_agent_context_events_total counter';
+        $lines[] = 'waaseyaa_agent_context_events_total ' . $metrics['waaseyaa_agent_context_events_total'];
+
+        $lines[] = '# HELP waaseyaa_agent_context_drift_events_total Total number of drift-related agent-context events observed.';
+        $lines[] = '# TYPE waaseyaa_agent_context_drift_events_total counter';
+        $lines[] = 'waaseyaa_agent_context_drift_events_total ' . $metrics['waaseyaa_agent_context_drift_events_total'];
+
+        $lines[] = '# HELP waaseyaa_agent_context_validations_total Total number of agent-context validation events observed.';
+        $lines[] = '# TYPE waaseyaa_agent_context_validations_total counter';
+        $lines[] = 'waaseyaa_agent_context_validations_total ' . $metrics['waaseyaa_agent_context_validations_total'];
+
+        $lines[] = '# HELP waaseyaa_agent_context_drift_score_avg Running average of drift scores for agent-context telemetry.';
+        $lines[] = '# TYPE waaseyaa_agent_context_drift_score_avg gauge';
+        $lines[] = 'waaseyaa_agent_context_drift_score_avg ' . $metrics['waaseyaa_agent_context_drift_score_avg'];
+
+        $lines[] = '# waaseyaa_cc_* metrics below are deprecated duplicates of waaseyaa_agent_context_*; remove after downstream dashboards migrate.';
+
+        $lines[] = '# HELP waaseyaa_cc_sessions_total Deprecated: use waaseyaa_agent_context_sessions_total.';
         $lines[] = '# TYPE waaseyaa_cc_sessions_total counter';
         $lines[] = 'waaseyaa_cc_sessions_total ' . $metrics['waaseyaa_cc_sessions_total'];
 
-        $lines[] = '# HELP waaseyaa_cc_events_total Total number of codified context events stored.';
+        $lines[] = '# HELP waaseyaa_cc_events_total Deprecated: use waaseyaa_agent_context_events_total.';
         $lines[] = '# TYPE waaseyaa_cc_events_total counter';
         $lines[] = 'waaseyaa_cc_events_total ' . $metrics['waaseyaa_cc_events_total'];
 
-        $lines[] = '# HELP waaseyaa_cc_drift_events_total Total number of drift-related events observed.';
+        $lines[] = '# HELP waaseyaa_cc_drift_events_total Deprecated: use waaseyaa_agent_context_drift_events_total.';
         $lines[] = '# TYPE waaseyaa_cc_drift_events_total counter';
         $lines[] = 'waaseyaa_cc_drift_events_total ' . $metrics['waaseyaa_cc_drift_events_total'];
 
-        $lines[] = '# HELP waaseyaa_cc_validations_total Total number of validation events observed.';
+        $lines[] = '# HELP waaseyaa_cc_validations_total Deprecated: use waaseyaa_agent_context_validations_total.';
         $lines[] = '# TYPE waaseyaa_cc_validations_total counter';
         $lines[] = 'waaseyaa_cc_validations_total ' . $metrics['waaseyaa_cc_validations_total'];
 
-        $lines[] = '# HELP waaseyaa_cc_drift_score_avg Running average of drift scores.';
+        $lines[] = '# HELP waaseyaa_cc_drift_score_avg Deprecated: use waaseyaa_agent_context_drift_score_avg.';
         $lines[] = '# TYPE waaseyaa_cc_drift_score_avg gauge';
         $lines[] = 'waaseyaa_cc_drift_score_avg ' . $metrics['waaseyaa_cc_drift_score_avg'];
 

--- a/packages/telescope/src/TelescopeServiceProvider.php
+++ b/packages/telescope/src/TelescopeServiceProvider.php
@@ -128,7 +128,7 @@ final class TelescopeServiceProvider
             return null;
         }
 
-        if (!$this->isRecordingEnabled('codified_context')) {
+        if (!$this->isAgentContextRecordingEnabled()) {
             return null;
         }
 
@@ -142,6 +142,26 @@ final class TelescopeServiceProvider
     private function isRecordingEnabled(string $recorder): bool
     {
         return (bool) ($this->config['record'][$recorder] ?? true);
+    }
+
+    /**
+     * Agent-context (codified-context) observer toggle.
+     *
+     * When `record.agent_context` is present it wins; otherwise the legacy
+     * `record.codified_context` key is consulted.
+     */
+    private function isAgentContextRecordingEnabled(): bool
+    {
+        $record = $this->config['record'] ?? [];
+        if (!is_array($record)) {
+            return true;
+        }
+
+        if (array_key_exists('agent_context', $record)) {
+            return (bool) $record['agent_context'];
+        }
+
+        return (bool) ($record['codified_context'] ?? true);
     }
 
     private function createDefaultStore(): TelescopeStoreInterface

--- a/packages/telescope/tests/Unit/CodifiedContext/Storage/PrometheusCodifiedContextStoreTest.php
+++ b/packages/telescope/tests/Unit/CodifiedContext/Storage/PrometheusCodifiedContextStoreTest.php
@@ -32,11 +32,13 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
     {
         $metrics = $this->store->getMetrics();
 
-        $this->assertSame(0, $metrics['waaseyaa_cc_sessions_total']);
-        $this->assertSame(0, $metrics['waaseyaa_cc_events_total']);
-        $this->assertSame(0, $metrics['waaseyaa_cc_drift_events_total']);
-        $this->assertSame(0, $metrics['waaseyaa_cc_validations_total']);
-        $this->assertSame(0.0, $metrics['waaseyaa_cc_drift_score_avg']);
+        $this->assertSame(0, $metrics['waaseyaa_agent_context_sessions_total']);
+        $this->assertSame(0, $metrics['waaseyaa_agent_context_events_total']);
+        $this->assertSame(0, $metrics['waaseyaa_agent_context_drift_events_total']);
+        $this->assertSame(0, $metrics['waaseyaa_agent_context_validations_total']);
+        $this->assertSame(0.0, $metrics['waaseyaa_agent_context_drift_score_avg']);
+        $this->assertSame($metrics['waaseyaa_agent_context_sessions_total'], $metrics['waaseyaa_cc_sessions_total']);
+        $this->assertSame($metrics['waaseyaa_agent_context_events_total'], $metrics['waaseyaa_cc_events_total']);
     }
 
     #[Test]
@@ -45,7 +47,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $this->store->store('some_event', ['session_id' => 'sess-1']);
         $this->store->store('some_event', ['session_id' => 'sess-2']);
 
-        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_cc_events_total']);
+        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_agent_context_events_total']);
     }
 
     #[Test]
@@ -55,8 +57,8 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $this->store->store('event', ['session_id' => 'sess-A']); // Same session.
         $this->store->store('event', ['session_id' => 'sess-B']);
 
-        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_cc_sessions_total']);
-        $this->assertSame(3, $this->store->getMetrics()['waaseyaa_cc_events_total']);
+        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_agent_context_sessions_total']);
+        $this->assertSame(3, $this->store->getMetrics()['waaseyaa_agent_context_events_total']);
     }
 
     #[Test]
@@ -66,7 +68,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $this->store->store('validation', ['session_id' => 'sess-1']);
         $this->store->store('drift_corrected', ['session_id' => 'sess-1']);
 
-        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_cc_drift_events_total']);
+        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_agent_context_drift_events_total']);
     }
 
     #[Test]
@@ -74,7 +76,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
     {
         $this->store->store('some_event', ['session_id' => 'sess-1', 'severity' => 'high']);
 
-        $this->assertSame(1, $this->store->getMetrics()['waaseyaa_cc_drift_events_total']);
+        $this->assertSame(1, $this->store->getMetrics()['waaseyaa_agent_context_drift_events_total']);
     }
 
     #[Test]
@@ -84,7 +86,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $this->store->store('validate_schema', ['session_id' => 'sess-2']);
         $this->store->store('drift_detected', ['session_id' => 'sess-3']);
 
-        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_cc_validations_total']);
+        $this->assertSame(2, $this->store->getMetrics()['waaseyaa_agent_context_validations_total']);
     }
 
     #[Test]
@@ -93,7 +95,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $this->store->store('drift', ['session_id' => 's1', 'drift_score' => 0.4]);
         $this->store->store('drift', ['session_id' => 's2', 'drift_score' => 0.6]);
 
-        $avg = $this->store->getMetrics()['waaseyaa_cc_drift_score_avg'];
+        $avg = $this->store->getMetrics()['waaseyaa_agent_context_drift_score_avg'];
 
         $this->assertEqualsWithDelta(0.5, $avg, 0.0001);
     }
@@ -103,7 +105,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
     {
         $this->store->store('event', ['session_id' => 'sess-1']);
 
-        $this->assertSame(0.0, $this->store->getMetrics()['waaseyaa_cc_drift_score_avg']);
+        $this->assertSame(0.0, $this->store->getMetrics()['waaseyaa_agent_context_drift_score_avg']);
     }
 
     #[Test]
@@ -156,7 +158,7 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
         $store->store('event', ['session_id' => 'sess-1']);
 
         // Metrics tracked.
-        $this->assertSame(1, $store->getMetrics()['waaseyaa_cc_events_total']);
+        $this->assertSame(1, $store->getMetrics()['waaseyaa_agent_context_events_total']);
 
         // Also written to inner store.
         $entries = $store->query('event');
@@ -184,25 +186,28 @@ final class PrometheusCodifiedContextStoreTest extends TestCase
 
         $output = $this->store->renderPrometheusOutput();
 
-        $this->assertStringContainsString('# HELP waaseyaa_cc_sessions_total', $output);
-        $this->assertStringContainsString('# TYPE waaseyaa_cc_sessions_total counter', $output);
+        $this->assertStringContainsString('# HELP waaseyaa_agent_context_sessions_total', $output);
+        $this->assertStringContainsString('# TYPE waaseyaa_agent_context_sessions_total counter', $output);
+        $this->assertStringContainsString('waaseyaa_agent_context_sessions_total 2', $output);
+
+        $this->assertStringContainsString('# HELP waaseyaa_agent_context_events_total', $output);
+        $this->assertStringContainsString('# TYPE waaseyaa_agent_context_events_total counter', $output);
+        $this->assertStringContainsString('waaseyaa_agent_context_events_total 2', $output);
+
+        $this->assertStringContainsString('# HELP waaseyaa_agent_context_drift_events_total', $output);
+        $this->assertStringContainsString('# TYPE waaseyaa_agent_context_drift_events_total counter', $output);
+        $this->assertStringContainsString('waaseyaa_agent_context_drift_events_total 1', $output);
+
+        $this->assertStringContainsString('# HELP waaseyaa_agent_context_validations_total', $output);
+        $this->assertStringContainsString('# TYPE waaseyaa_agent_context_validations_total counter', $output);
+        $this->assertStringContainsString('waaseyaa_agent_context_validations_total 1', $output);
+
+        $this->assertStringContainsString('# HELP waaseyaa_agent_context_drift_score_avg', $output);
+        $this->assertStringContainsString('# TYPE waaseyaa_agent_context_drift_score_avg gauge', $output);
+        $this->assertStringContainsString('waaseyaa_agent_context_drift_score_avg', $output);
+
         $this->assertStringContainsString('waaseyaa_cc_sessions_total 2', $output);
-
-        $this->assertStringContainsString('# HELP waaseyaa_cc_events_total', $output);
-        $this->assertStringContainsString('# TYPE waaseyaa_cc_events_total counter', $output);
         $this->assertStringContainsString('waaseyaa_cc_events_total 2', $output);
-
-        $this->assertStringContainsString('# HELP waaseyaa_cc_drift_events_total', $output);
-        $this->assertStringContainsString('# TYPE waaseyaa_cc_drift_events_total counter', $output);
-        $this->assertStringContainsString('waaseyaa_cc_drift_events_total 1', $output);
-
-        $this->assertStringContainsString('# HELP waaseyaa_cc_validations_total', $output);
-        $this->assertStringContainsString('# TYPE waaseyaa_cc_validations_total counter', $output);
-        $this->assertStringContainsString('waaseyaa_cc_validations_total 1', $output);
-
-        $this->assertStringContainsString('# HELP waaseyaa_cc_drift_score_avg', $output);
-        $this->assertStringContainsString('# TYPE waaseyaa_cc_drift_score_avg gauge', $output);
-        $this->assertStringContainsString('waaseyaa_cc_drift_score_avg', $output);
     }
 
     #[Test]

--- a/packages/telescope/tests/Unit/TelescopeServiceProviderTest.php
+++ b/packages/telescope/tests/Unit/TelescopeServiceProviderTest.php
@@ -216,6 +216,26 @@ final class TelescopeServiceProviderTest extends TestCase
     }
 
     #[Test]
+    public function agent_context_record_key_takes_precedence_when_present(): void
+    {
+        $provider = new TelescopeServiceProvider(config: [
+            'record' => ['agent_context' => false, 'codified_context' => true],
+        ]);
+
+        $this->assertNull($provider->getCodifiedContextObserver());
+    }
+
+    #[Test]
+    public function agent_context_true_enables_observer_even_when_codified_context_false(): void
+    {
+        $provider = new TelescopeServiceProvider(config: [
+            'record' => ['agent_context' => true, 'codified_context' => false],
+        ]);
+
+        $this->assertNotNull($provider->getCodifiedContextObserver());
+    }
+
+    #[Test]
     public function returnsSameRecorderInstanceOnMultipleCalls(): void
     {
         $provider = new TelescopeServiceProvider();


### PR DESCRIPTION
## Summary

- **Agent-context HTTP surface:** canonical `/api/telescope/agent-context/sessions` routes (legacy `/codified-context/` aliases), `CodifiedContextApiRouter`, kernel wiring for optional `CodifiedContextSessionStoreInterface` (L4 uses the port, not L6 Telescope types).
- **Admin alignment:** `CodifiedContextController` returns **camelCase** JSON matching `useCodifiedContext.ts` (sessions, events with `eventType`, flat validation report with 0–100 `driftScore`). Unit tests and `docs/specs/api-layer.md` updated.

Ref #1339 (L4 codified-context coupling and operator telemetry; does not claim full closure of every audit bullet).

## Checklist

- [x] **Traceability:** Ref #1339 above
- [ ] If this PR closes a **GitHub issue**, that issue is assigned to a Track milestone — **n/a** (ref only)
- [x] PR title includes `#1339` per `docs/specs/workflow.md`