### PR TITLE
fix(ci): replace @dev with semver in attachment + structured-import manifests

### DIFF
--- a/packages/attachment/composer.json
+++ b/packages/attachment/composer.json
@@ -27,11 +27,11 @@
     ],
     "require": {
         "php": "^8.4",
-        "waaseyaa/access": "@dev",
-        "waaseyaa/database-legacy": "@dev",
-        "waaseyaa/entity": "@dev",
-        "waaseyaa/entity-storage": "@dev",
-        "waaseyaa/foundation": "@dev"
+        "waaseyaa/access": "^0.1.0-alpha.150",
+        "waaseyaa/database-legacy": "^0.1.0-alpha.150",
+        "waaseyaa/entity": "^0.1.0-alpha.150",
+        "waaseyaa/entity-storage": "^0.1.0-alpha.150",
+        "waaseyaa/foundation": "^0.1.0-alpha.150"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/structured-import/composer.json
+++ b/packages/structured-import/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^8.4",
-        "waaseyaa/field": "@dev",
-        "waaseyaa/foundation": "@dev"
+        "waaseyaa/field": "^0.1.0-alpha.150",
+        "waaseyaa/foundation": "^0.1.0-alpha.150"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"


### PR DESCRIPTION
## Summary
- Replace `@dev` with `^0.1.0-alpha.150` in `packages/attachment/composer.json` and `packages/structured-import/composer.json` to match the convention used by sibling packages (node, taxonomy, field, entity, etc.).
- Resolves 7 CP002 violations failing the `composer-policy` CI job on `main`. Per CLAUDE.md, `@dev` is allowed only in the root aggregator manifest.
- Violations introduced in ca0ff031 (mission `single-entity-work-surface-01KQ7M1P`); unrelated to inferrer-entity-reference-compat.

## Test plan
- [x] `bash bin/check-composer-policy` reports 0 violations
- [ ] CI `composer-policy` job goes green