### PR TITLE
fix(taxonomy): vocabulary field definitions match test expectations

### DIFF
--- a/packages/taxonomy/src/TaxonomyServiceProvider.php
+++ b/packages/taxonomy/src/TaxonomyServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Waaseyaa\Taxonomy;
 
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Field\FieldDefinition;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
 final class TaxonomyServiceProvider extends ServiceProvider
@@ -18,7 +19,8 @@ final class TaxonomyServiceProvider extends ServiceProvider
         ));
 
         // Vocabulary is a configuration entity (ConfigEntityBase). Field-attribute
-        // reflection does not apply; keep an explicit EntityType registration.
+        // reflection does not apply; declare field definitions explicitly so the
+        // admin SPA and API can render description/weight as editable fields.
         $this->entityType(new EntityType(
             id: 'taxonomy_vocabulary',
             label: 'Vocabulary',
@@ -26,6 +28,22 @@ final class TaxonomyServiceProvider extends ServiceProvider
             class: Vocabulary::class,
             keys: ['id' => 'vid', 'label' => 'name'],
             group: 'taxonomy',
+            _fieldDefinitions: [
+                'description' => new FieldDefinition(
+                    name: 'description',
+                    type: 'text',
+                    label: 'Description',
+                    description: 'A description of the vocabulary.',
+                    settings: ['weight' => 5],
+                ),
+                'weight' => new FieldDefinition(
+                    name: 'weight',
+                    type: 'integer',
+                    label: 'Weight',
+                    description: 'Sort order for this vocabulary.',
+                    settings: ['weight' => 10],
+                ),
+            ],
         ));
     }
 }


### PR DESCRIPTION
## Summary

- Vocabulary is a `ConfigEntityBase`, so `#[Field]` attribute reflection does not apply.
- `TaxonomyServiceProviderTest::vocabulary_has_field_definitions` expects `description` and `weight` to surface as field definitions so the admin SPA and API can render them as editable fields (Vocabulary exposes both with getters/setters and constructor defaults).
- Following the precedent in `GroupsServiceProvider` for `GroupType` (also `ConfigEntityBase`), declares `description` and `weight` explicitly via `_fieldDefinitions:` on the `EntityType` registration.

Pre-existing CI failure on main (unrelated to any in-flight mission). Spawned as a one-off cleanup task after the inferrer-entity-reference-compat mission.

## Test plan

- [ ] `composer phpunit packages/taxonomy/tests/` is green
- [ ] CI `ci/unit-tests` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)