### PR TITLE
fix(entity): expose isCompatible() so PHPStan sees the asymmetric scalar -> entity_reference rule

### DIFF
--- a/packages/entity/src/Attribute/FieldTypeInferrer.php
+++ b/packages/entity/src/Attribute/FieldTypeInferrer.php
@@ -193,7 +193,17 @@ final class FieldTypeInferrer
      */
     private const ENTITY_REFERENCE_COMPATIBLE_INFERRED = ['integer', 'string'];
 
-    private static function isCompatible(string $inferred, string $explicit): bool
+    /**
+     * Public seam for static analysis: returns true when an inferred field-type
+     * id may be overridden with the explicit field-type id given on the `#[Field]`
+     * attribute. Mirrors the runtime check used by {@see self::infer()}.
+     *
+     * Consumed by `FieldAttributeRule` (PHPStan extension) so the static checker
+     * and the runtime inferrer share a single source of truth — including the
+     * asymmetric `entity_reference` rule which {@see self::compatibilityGroups()}
+     * deliberately does not expose.
+     */
+    public static function isCompatible(string $inferred, string $explicit): bool
     {
         if ($inferred === $explicit) {
             return true;

--- a/packages/entity/src/PhpStan/FieldAttributeRule.php
+++ b/packages/entity/src/PhpStan/FieldAttributeRule.php
@@ -271,12 +271,9 @@ final class FieldAttributeRule implements Rule
 
     private function areCompatible(string $inferred, string $explicit): bool
     {
-        foreach (FieldTypeInferrer::compatibilityGroups() as $group) {
-            if (\in_array($inferred, $group, true) && \in_array($explicit, $group, true)) {
-                return true;
-            }
-        }
-
-        return false;
+        // Delegate to the runtime inferrer so static analysis and runtime share
+        // a single source of truth — including the asymmetric scalar →
+        // entity_reference rule, which compatibilityGroups() does not expose.
+        return FieldTypeInferrer::isCompatible($inferred, $explicit);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `ci/lint` PHPStan failures introduced by mission `inferrer-entity-reference-compat-01KQ6SC0`:

```
Conflicting field type for Waaseyaa\Node\Node::$uid: PHP type "int" infers field type "integer" but #[Field(type: "entity_reference")] was given.
Conflicting field type for Waaseyaa\Taxonomy\Term::$parent_id: PHP type "int" infers field type "integer" but #[Field(type: "entity_reference")] was given.
```

## Root cause

The mission added an **asymmetric** override rule (`?int`/`?string` → `entity_reference`) to `FieldTypeInferrer::isCompatible()`, kept deliberately outside the symmetric `compatibilityGroups()` public seam (whose contract is "either side may override the other"). But the PHPStan extension `FieldAttributeRule::areCompatible()` re-implemented the compatibility check on top of `compatibilityGroups()` only — so static analysis didn't see the new rule and continued to flag `Node.uid` / `Term.parent_id`.

## Fix

- Promote `FieldTypeInferrer::isCompatible()` from `private` to `public`. Single source of truth for runtime and static analysis.
- Delegate `FieldAttributeRule::areCompatible()` to it.
- `compatibilityGroups()` stays unchanged — its symmetric-override contract is preserved for any other callers, but it is no longer the only seam PHPStan consumes.

## Test plan

- [x] `./vendor/bin/phpunit packages/entity/tests/Unit/Attribute/FieldTypeInferrerTest.php` — 53 tests, 109 assertions, green.
- [x] `phpstan analyse packages/node/src/Node.php packages/taxonomy/src/Term.php` — `[OK] No errors` (was 2 errors).
- [ ] CI `ci/lint` job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)