### PR TITLE
fix(tests): DBALSelect::fields() type mismatch and FieldType count drift

### DIFF
--- a/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
+++ b/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
@@ -188,7 +188,7 @@ final class SetActiveConcurrencyTest extends TestCase
         $assertDb = DBALDatabase::createSqlite($this->dbPath);
 
         $rows = $assertDb->select('attachment')
-            ->fields(['id'])
+            ->fields('attachment', ['id'])
             ->condition('parent_entity_type', 'node')
             ->condition('parent_entity_id', '1')
             ->condition('is_active', 1)

--- a/tests/Integration/Phase4/FieldTypeDiscoveryTest.php
+++ b/tests/Integration/Phase4/FieldTypeDiscoveryTest.php
@@ -58,6 +58,7 @@ final class FieldTypeDiscoveryTest extends TestCase
             'list',
             'computed',
             'json',
+            'enum',
         ];
 
         foreach ($expectedTypes as $type) {
@@ -69,9 +70,9 @@ final class FieldTypeDiscoveryTest extends TestCase
         }
 
         $this->assertCount(
-            16,
+            17,
             $definitions,
-            'All 16 built-in field types should be discovered',
+            'All 17 built-in field types should be discovered',
         );
     }
 


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main` were blocking the `ci/unit-tests` Integration step from going green. Both are in test code only — no production change.

- **`SetActiveConcurrencyTest::php:191`** — calling `DBALSelect::fields(['id'])` was a `TypeError` because the signature is `fields(string $tableAlias, array $fields = [])`. Other call sites (`DBALSelectTest`, `CostTracker`) all pass the alias explicitly. Fixed to `->fields('attachment', ['id'])`. Test was always wrong since it landed; only surfaced now because pcntl-gated, runs on Linux CI only.
- **`Phase4/FieldTypeDiscoveryTest::testAllBuiltInFieldTypesAreDiscovered`** — expected 16 built-in field types, but `EnumItem` (`#[FieldType(id: 'enum')]`) brings the count to 17. Updated the expected list and count.

Surfaced after the Vocabulary test fix (#1357) unblocked the suite. Not caused by the inferrer-entity-reference-compat mission.

## Test plan

- [x] `phpunit tests/Integration/Phase4/FieldTypeDiscoveryTest.php` passes locally
- [x] `phpunit packages/attachment/tests/Integration/` passes locally (concurrency test skipped on Windows — pcntl)
- [ ] CI `ci/unit-tests` Integration step goes green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)