### PR TITLE
fix(attachment): use iterator_to_array() for DBALSelect Generator result

### DIFF
--- a/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
+++ b/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
@@ -187,13 +187,12 @@ final class SetActiveConcurrencyTest extends TestCase
         // ── Assert invariant: exactly one active attachment ────────────────────
         $assertDb = DBALDatabase::createSqlite($this->dbPath);
 
-        $rows = $assertDb->select('attachment')
+        $rows = iterator_to_array($assertDb->select('attachment')
             ->fields('attachment', ['id'])
             ->condition('parent_entity_type', 'node')
             ->condition('parent_entity_id', '1')
             ->condition('is_active', 1)
-            ->execute()
-            ->fetchAllAssociative();
+            ->execute());
 
         self::assertCount(
             1,


### PR DESCRIPTION
## Summary
- `DBALSelect::execute()` returns `\Traversable` (a Generator), but `SetActiveConcurrencyTest` was chaining `->fetchAllAssociative()` on the result — a Doctrine DBAL `Result` method that doesn't exist on `Generator`.
- Wrap in `iterator_to_array()` to materialize rows as a plain array for `assertCount()`.

This is the last remaining error in `ci/unit-tests` after [#1359](https://github.com/waaseyaa/framework/pull/1359) fixed the `fields()` signature and Phase4 count.

## Test plan
- [ ] `ci/unit-tests` Integration step is green on Linux CI
- Local verification not possible: test is skipped on Windows (no `pcntl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)