### PR TITLE
fix(oidc): use appendQuery() for login redirect (closes #1290)

### DIFF
--- a/packages/oidc/src/Authorize/AuthorizeController.php
+++ b/packages/oidc/src/Authorize/AuthorizeController.php
@@ -46,7 +46,7 @@ final readonly class AuthorizeController
 
         if (!$account->isAuthenticated()) {
             return new RedirectResponse(
-                $this->loginPath . '?return_to=' . rawurlencode($request->getRequestUri()),
+                $this->appendQuery($this->loginPath, ['return_to' => $request->getRequestUri()]),
                 302,
             );
         }

--- a/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
+++ b/packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php
@@ -85,6 +85,29 @@ final class AuthorizeControllerTest extends TestCase
         $this->assertStringContainsString(rawurlencode('client_id=minoo-web'), $location);
     }
 
+    public function testAnonymousRedirectPreservesPreExistingLoginPathQueryString(): void
+    {
+        // Regression for #1290 — login_path with a pre-existing query string
+        // produced `/login?foo=bar?return_to=...` (malformed). The controller
+        // must use `&` as the separator when the path already contains `?`.
+        $controller = new AuthorizeController(
+            clientLookup: new OidcClientLookup($this->storage),
+            validator: new AuthorizationRequestValidator(),
+            codeRepository: $this->codeRepository,
+            loginPath: '/login?foo=bar',
+        );
+
+        $request = $this->makeRequest($this->validQuery(), authenticated: false);
+
+        $response = $controller($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $location = $response->headers->get('Location');
+        $this->assertNotNull($location);
+        $this->assertStringStartsWith('/login?foo=bar&return_to=', $location);
+        $this->assertStringNotContainsString('?return_to=', substr($location, strlen('/login?foo=bar')));
+    }
+
     public function testMissingAccountAttributeReturns500(): void
     {
         $request = Request::create('/authorize', 'GET', $this->validQuery());


### PR DESCRIPTION
## Summary

- `AuthorizeController::__invoke()` built the anonymous-login redirect by concatenating `?return_to=` to `loginPath`. When `loginPath` already contained a query string (e.g. `/login?foo=bar`), the result was `/login?foo=bar?return_to=...` — malformed.
- Routes the redirect through the existing private `appendQuery()` helper, which already selects `&` vs `?` correctly. Default `/login` is unchanged.
- Adds a regression test that constructs the controller with `loginPath: '/login?foo=bar'` and asserts the Location header is well-formed.

Closes #1290.

## Test plan

- [x] `./vendor/bin/phpunit packages/oidc/tests/Integration/Authorize/AuthorizeControllerTest.php` — 12/12 pass (was 11; new test is `testAnonymousRedirectPreservesPreExistingLoginPathQueryString`).
- [x] `./vendor/bin/phpunit packages/oidc/tests/` — 183/183 pass.
- [x] `composer cs-check` clean.
- [x] `composer phpstan` clean (level 5).
- [x] `tools/drift-detector.sh 5` — no specs flagged (oidc not in the spec-pattern map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)