### PR TITLE
feat(diagnostic): detect column-vs-_data storage drift (closes #1309)

### DIFF
--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,5 +1,6 @@
 # Infrastructure
 
+<!-- Spec reviewed 2026-05-04b - issue #1309: added `COLUMN_DATA_STORAGE_DRIFT` to the DiagnosticCode table. HealthChecker gained `checkColumnDataStorageDrift()` (called from `checkRuntime()`), which warns when a field registered with `FieldStorage::Data` still has a backing column on the base table or a registered bundle subtable. Severity: warning. -->
 <!-- Spec reviewed 2026-05-04 - cs-fixer sweep applied to AbstractKernel.php (alphabetical import sort only, no behavior change). Spec contents verified accurate; no infrastructure-spec contract changed. -->
 <!-- Spec reviewed 2026-05-02b - mission #1257 WP10 review hardening (PR #1367): `AbstractKernel::resolveCommunityScope()` no longer falls back to a null scope unconditionally when tenancy is declared but no `CommunityContextInterface` is bound. In production (any environment NOT in {local, dev, development, testing}), missing context throws `[TENANCY_MISCONFIGURED] RuntimeException` — silent disablement of community isolation in production is a data-leak posture, not a tolerable misconfiguration. In development the prior log-once + null-scope path stays so tests / CLI / bare bootstrap don't crash. -->
 <!-- Spec reviewed 2026-05-02 - mission #1257 WP10: AbstractKernel gained `setCommunityContext(?CommunityContextInterface)` plus a private `resolveCommunityScope(EntityTypeInterface)` helper that the EntityRepository factory uses to inject CommunityScope into SqlStorageDriver when the EntityType declares `tenancy: ['scope' => 'community']`. When tenancy is declared but no context is bound, the kernel logs a once-per-type warning and falls back to a null scope (no boot crash; superseded by the 2026-05-02b production-throw guard above). EntityTypeManager now also receives the kernel logger so it can emit the C1 deprecation warning. Wiring contract details live in docs/specs/entity-system.md §C1 / §Community Scoping; no infrastructure-spec contract changed. -->
@@ -1323,8 +1324,9 @@ String-backed enum of operator-facing error codes:
 | `CACHE_DIRECTORY_UNWRITABLE` | Cache directory not writable |
 | `INGESTION_LOG_OVERSIZED` | Ingestion log exceeds retention threshold |
 | `INGESTION_RECENT_FAILURES` | High ingestion failure rate |
+| `COLUMN_DATA_STORAGE_DRIFT` | A field registered with `FieldStorage::Data` still has a backing column on the base table or a bundle subtable (new writes go to `_data`; the column holds stale values) |
 
-Each code has a `defaultMessage()` method for human-readable descriptions. Severity: `MISSING_BUNDLE_SUBTABLE` and `FK_ENFORCEMENT_DISABLED` are errors; `ORPHAN_BUNDLE_SUBTABLE` is a warning (the base row is still reachable, the subtable is merely stale).
+Each code has a `defaultMessage()` method for human-readable descriptions. Severity: `MISSING_BUNDLE_SUBTABLE` and `FK_ENFORCEMENT_DISABLED` are errors; `ORPHAN_BUNDLE_SUBTABLE` and `COLUMN_DATA_STORAGE_DRIFT` are warnings (the base row is still reachable, the lingering surface is merely stale).
 
 ### DiagnosticEmitter
 

--- a/docs/specs/operator-diagnostics.md
+++ b/docs/specs/operator-diagnostics.md
@@ -54,6 +54,7 @@ BootDiagnosticReport ─→ HealthChecker ─→ HealthCheckResult[] ─→ CLI 
 | `STORAGE_DIRECTORY_MISSING` | warning | `storage/framework/` does not exist |
 | `INGESTION_LOG_OVERSIZED` | warning | Ingestion log exceeds 10,000 entries |
 | `INGESTION_RECENT_FAILURES` | warning | >25% of ingestion attempts rejected |
+| `COLUMN_DATA_STORAGE_DRIFT` | warning | A field registered with `FieldStorage::Data` still has a backing column on the base table or a registered bundle subtable. New writes go to `_data`; the column holds stale values. Author a migration to drop the column or revert the storage hint. |
 
 ### Code Structure
 
@@ -75,6 +76,7 @@ Each `DiagnosticCode` case provides:
 
 - **Database** — `SELECT 1` connectivity test via `DBALDatabase::query()`
 - **Schema drift** — compares `PRAGMA table_info()` against `SqlSchemaHandler.buildTableSpec()` expected columns for each registered entity type. Multi-bundle types additionally enumerate their `{base_table}__{bundle}` subtables (see below).
+- **Column-vs-data storage drift** — for each entity type with a registered `FieldStorage::Data` field, probes `PRAGMA table_info()` for a column whose name matches the field on the base table (core fields) or the matching `{base_table}__{bundle}` subtable (bundle fields). Emits `COLUMN_DATA_STORAGE_DRIFT` per occurrence. Skipped silently when no `FieldDefinitionRegistry` is injected. SQLite-only at present (mirrors the orphan-detection path in #1301).
 - **Foreign key enforcement** — SQLite only: checks `PRAGMA foreign_keys`; emits `FK_ENFORCEMENT_DISABLED` when off. Skipped for dialects with default-on enforcement.
 - **Storage directory** — `storage/framework/` existence check
 - **Cache directory** — `storage/framework/` writability check

--- a/packages/foundation/src/Diagnostic/DiagnosticCode.php
+++ b/packages/foundation/src/Diagnostic/DiagnosticCode.php
@@ -31,6 +31,7 @@ enum DiagnosticCode: string
     case STORAGE_DIRECTORY_MISSING   = 'STORAGE_DIRECTORY_MISSING';
     case INGESTION_LOG_OVERSIZED     = 'INGESTION_LOG_OVERSIZED';
     case INGESTION_RECENT_FAILURES   = 'INGESTION_RECENT_FAILURES';
+    case COLUMN_DATA_STORAGE_DRIFT   = 'COLUMN_DATA_STORAGE_DRIFT';
 
     // --- Schema-evolution v2 codes (mission #529) ---
     case CHECKSUM_MISMATCH           = 'CHECKSUM_MISMATCH';
@@ -72,6 +73,8 @@ enum DiagnosticCode: string
                 'The ingestion log file exceeds the expected size for the retention window. Run pruning.',
             self::INGESTION_RECENT_FAILURES =>
                 'A high proportion of recent ingestion attempts have failed.',
+            self::COLUMN_DATA_STORAGE_DRIFT =>
+                'A field is registered with FieldStorage::Data but a column for the field still exists in storage. New writes go to the _data JSON blob; the column holds stale values that reads will silently skip once query routing is symmetric.',
             self::CHECKSUM_MISMATCH =>
                 'A v2 migration was re-applied with a different source checksum than the one recorded in the ledger. Production refuses silent re-apply; the same migration_id cannot mean two different structural intents.',
             self::LEDGER_ORPHAN =>
@@ -118,6 +121,8 @@ enum DiagnosticCode: string
                 'Run `waaseyaa health:check` to review log size, then prune old entries or increase the retention window.',
             self::INGESTION_RECENT_FAILURES =>
                 'Review recent ingestion errors in storage/framework/ingestion.jsonl. Check envelope format and payload schemas.',
+            self::COLUMN_DATA_STORAGE_DRIFT =>
+                'Author a migration to drop the lingering column once any data has been backfilled into _data, or revert the FieldStorage::Data hint if the column should remain canonical. Auto-drop is never performed.',
             self::CHECKSUM_MISMATCH =>
                 'Either revert the source change so the canonical SchemaDiff matches the stored checksum, or author a new migration_id (Q1 — migration_id is the canonical key).',
             self::LEDGER_ORPHAN =>
@@ -148,7 +153,8 @@ enum DiagnosticCode: string
             self::TAG_QUARANTINE_DETECTED,
             self::INGESTION_RECENT_FAILURES,
             self::CACHE_DIRECTORY_UNWRITABLE,
-            self::ORPHAN_BUNDLE_SUBTABLE => 'warning',
+            self::ORPHAN_BUNDLE_SUBTABLE,
+            self::COLUMN_DATA_STORAGE_DRIFT => 'warning',
 
             self::MANIFEST_VERSIONING_MISSING,
             self::NAMESPACE_RESERVED,

--- a/packages/foundation/src/Diagnostic/HealthChecker.php
+++ b/packages/foundation/src/Diagnostic/HealthChecker.php
@@ -9,6 +9,7 @@ use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Field\FieldDefinitionRegistryInterface;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Field\FieldStorage;
 use Waaseyaa\Foundation\Ingestion\IngestionLogger;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
@@ -93,6 +94,11 @@ final class HealthChecker implements HealthCheckerInterface
         // Schema drift.
         $driftResults = $this->checkSchemaDrift();
         array_push($results, ...$driftResults);
+
+        // Column-vs-data storage drift (FieldStorage::Data fields with a
+        // lingering column on disk).
+        $columnDataDrift = $this->checkColumnDataStorageDrift();
+        array_push($results, ...$columnDataDrift);
 
         // Storage directory.
         $results[] = $this->checkStorageDirectory();
@@ -227,6 +233,120 @@ final class HealthChecker implements HealthCheckerInterface
         }
 
         return $results;
+    }
+
+    /**
+     * Detect column-vs-_data storage drift: fields registered with
+     * `FieldStorage::Data` whose name still has a backing column on the base
+     * table or a registered bundle subtable. Such columns hold stale data
+     * (new writes go to the `_data` JSON blob) and reads silently skip them
+     * once query routing is symmetric.
+     *
+     * Skipped silently when no FieldDefinitionRegistry was injected — the
+     * registry is the source of truth for the storage hint.
+     *
+     * @return list<HealthCheckResult>
+     */
+    public function checkColumnDataStorageDrift(): array
+    {
+        if ($this->fieldRegistry === null) {
+            return [];
+        }
+
+        $results = [];
+        $schema = $this->database->schema();
+
+        foreach (array_keys($this->entityTypeManager->getDefinitions()) as $entityId) {
+            $baseTable = $entityId;
+
+            // Core fields land on the base table.
+            if ($schema->tableExists($baseTable)) {
+                foreach ($this->fieldRegistry->coreFieldsFor($entityId) as $field) {
+                    if (!$this->fieldIsDataStored($field)) {
+                        continue;
+                    }
+                    $fieldName = $field->getName();
+                    if ($this->columnExists($baseTable, $fieldName)) {
+                        $results[] = $this->columnDataDriftResult($entityId, $baseTable, $fieldName, bundle: null);
+                    }
+                }
+            }
+
+            // Bundle fields land on the per-bundle subtable.
+            foreach ($this->fieldRegistry->bundleNamesFor($entityId) as $bundle) {
+                $subtable = $baseTable . '__' . $bundle;
+                if (!$schema->tableExists($subtable)) {
+                    continue;
+                }
+
+                foreach ($this->fieldRegistry->bundleFieldsFor($entityId, $bundle) as $field) {
+                    if (!$this->fieldIsDataStored($field)) {
+                        continue;
+                    }
+                    $fieldName = $field->getName();
+                    if ($this->columnExists($subtable, $fieldName)) {
+                        $results[] = $this->columnDataDriftResult($entityId, $subtable, $fieldName, bundle: $bundle);
+                    }
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    private function fieldIsDataStored(object $field): bool
+    {
+        return method_exists($field, 'getStored') && $field->getStored() === FieldStorage::Data;
+    }
+
+    /**
+     * SQLite-only PRAGMA column existence probe. On non-SQLite drivers the
+     * query throws; treat that as "no drift" and skip silently — portable
+     * column enumeration is tracked separately under #1301.
+     */
+    private function columnExists(string $tableName, string $columnName): bool
+    {
+        try {
+            foreach ($this->database->query("PRAGMA table_info(\"{$tableName}\")", []) as $row) {
+                if (($row['name'] ?? null) === $columnName) {
+                    return true;
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->info(sprintf(
+                'Column-data drift detection skipped for %s.%s: %s',
+                $tableName,
+                $columnName,
+                $e->getMessage(),
+            ));
+        }
+        return false;
+    }
+
+    private function columnDataDriftResult(string $entityId, string $tableName, string $columnName, ?string $bundle): HealthCheckResult
+    {
+        $context = [
+            'entity_type' => $entityId,
+            'table' => $tableName,
+            'column' => $columnName,
+            'field' => $columnName,
+        ];
+        if ($bundle !== null) {
+            $context['bundle'] = $bundle;
+        }
+
+        return HealthCheckResult::warn(
+            "Storage drift: {$tableName}.{$columnName}",
+            DiagnosticCode::COLUMN_DATA_STORAGE_DRIFT,
+            sprintf(
+                'Field "%s" on entity type "%s" is registered with FieldStorage::Data but column "%s" still exists on table "%s". New writes go to _data; the column holds stale data.',
+                $columnName,
+                $entityId,
+                $columnName,
+                $tableName,
+            ),
+            context: $context,
+        );
     }
 
     /**

--- a/packages/foundation/tests/Unit/Diagnostic/HealthCheckerColumnDataDriftTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/HealthCheckerColumnDataDriftTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Unit\Diagnostic;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Field\FieldDefinitionRegistryInterface;
+use Waaseyaa\Field\FieldStorage;
+use Waaseyaa\Foundation\Diagnostic\BootDiagnosticReport;
+use Waaseyaa\Foundation\Diagnostic\DiagnosticCode;
+use Waaseyaa\Foundation\Diagnostic\HealthChecker;
+use Waaseyaa\Foundation\Diagnostic\HealthCheckResult;
+
+/**
+ * Regression tests for #1309 — column-vs-_data storage drift detection.
+ *
+ * A field registered with FieldStorage::Data must NOT have a backing column
+ * on disk. When it does, new writes route to the _data JSON blob while old
+ * data lingers in the column — the column wins for column-existence-based
+ * reads until query routing becomes symmetric (mission #1257 WP04 / WP05),
+ * and stays silently stale afterward.
+ */
+#[CoversClass(HealthChecker::class)]
+final class HealthCheckerColumnDataDriftTest extends TestCase
+{
+    private DBALDatabase $database;
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_column_data_drift_' . uniqid();
+        mkdir($this->projectRoot . '/storage/framework', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->projectRoot);
+    }
+
+    #[Test]
+    public function coreFieldWithDataStorageButLingeringColumnIsReportedAsWarning(): void
+    {
+        $type = $this->singleBundleType();
+        // 'status' is registered with FieldStorage::Data but the base table
+        // still has a 'status' column — that's drift.
+        $this->createBaseTable('thing', extraColumns: ['status']);
+        $registry = $this->registry(coreFields: ['status' => FieldStorage::Data]);
+
+        $results = $this->checker($type, $registry)->checkColumnDataStorageDrift();
+
+        $drift = $this->findByCode($results, DiagnosticCode::COLUMN_DATA_STORAGE_DRIFT);
+        self::assertNotNull($drift, 'Expected a COLUMN_DATA_STORAGE_DRIFT result.');
+        self::assertSame('warn', $drift->status);
+        self::assertSame('thing', $drift->context['entity_type'] ?? null);
+        self::assertSame('thing', $drift->context['table'] ?? null);
+        self::assertSame('status', $drift->context['column'] ?? null);
+        self::assertArrayNotHasKey('bundle', $drift->context);
+    }
+
+    #[Test]
+    public function coreFieldWithDataStorageAndNoColumnIsClean(): void
+    {
+        $type = $this->singleBundleType();
+        // Base table has no 'status' column — registering 'status' as Data is fine.
+        $this->createBaseTable('thing');
+        $registry = $this->registry(coreFields: ['status' => FieldStorage::Data]);
+
+        $results = $this->checker($type, $registry)->checkColumnDataStorageDrift();
+
+        self::assertSame([], $results, 'No drift expected when no backing column exists.');
+    }
+
+    #[Test]
+    public function coreColumnFieldWithBackingColumnIsClean(): void
+    {
+        $type = $this->singleBundleType();
+        $this->createBaseTable('thing', extraColumns: ['status']);
+        // Field is FieldStorage::Column — column is expected, no drift.
+        $registry = $this->registry(coreFields: ['status' => FieldStorage::Column]);
+
+        $results = $this->checker($type, $registry)->checkColumnDataStorageDrift();
+
+        self::assertSame([], $results, 'Column-stored fields with backing columns are not drift.');
+    }
+
+    #[Test]
+    public function bundleFieldWithDataStorageButLingeringColumnIsReportedWithBundle(): void
+    {
+        $type = $this->multiBundleType();
+        $this->createBaseTable('group');
+        // Subtable has a lingering 'tagline' column even though the field is Data-stored.
+        $this->createSubtable('group__business', ['tagline']);
+        $registry = $this->registry(
+            coreFields: [],
+            bundleFields: ['business' => ['tagline' => FieldStorage::Data]],
+        );
+
+        $results = $this->checker($type, $registry)->checkColumnDataStorageDrift();
+
+        $drift = $this->findByCode($results, DiagnosticCode::COLUMN_DATA_STORAGE_DRIFT);
+        self::assertNotNull($drift, 'Expected a COLUMN_DATA_STORAGE_DRIFT result for the bundle field.');
+        self::assertSame('group__business', $drift->context['table'] ?? null);
+        self::assertSame('tagline', $drift->context['column'] ?? null);
+        self::assertSame('business', $drift->context['bundle'] ?? null);
+    }
+
+    #[Test]
+    public function missingFieldRegistryIsSkippedSilently(): void
+    {
+        $type = $this->singleBundleType();
+        $this->createBaseTable('thing', extraColumns: ['status']);
+
+        // No registry — checker constructed with $fieldRegistry === null.
+        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
+        $checker = new HealthChecker(
+            bootReport: new BootDiagnosticReport(
+                registeredTypes: [$type->id() => $type],
+                disabledTypeIds: [],
+                schemaCompatibility: [],
+            ),
+            database: $this->database,
+            entityTypeManager: $manager,
+            projectRoot: $this->projectRoot,
+        );
+
+        self::assertSame([], $checker->checkColumnDataStorageDrift());
+    }
+
+    #[Test]
+    public function checkRuntimeIncludesColumnDataStorageDriftResults(): void
+    {
+        $type = $this->singleBundleType();
+        $this->createBaseTable('thing', extraColumns: ['status']);
+        $registry = $this->registry(coreFields: ['status' => FieldStorage::Data]);
+
+        $results = $this->checker($type, $registry)->checkRuntime();
+
+        $drift = $this->findByCode($results, DiagnosticCode::COLUMN_DATA_STORAGE_DRIFT);
+        self::assertNotNull($drift, 'checkRuntime() must surface COLUMN_DATA_STORAGE_DRIFT.');
+    }
+
+    // --- Helpers ---
+
+    private function singleBundleType(): EntityType
+    {
+        return new EntityType(
+            id: 'thing',
+            label: 'Thing',
+            class: \stdClass::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+    }
+
+    private function multiBundleType(): EntityType
+    {
+        return new EntityType(
+            id: 'group',
+            label: 'Group',
+            class: \stdClass::class,
+            keys: ['id' => 'gid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            bundleEntityType: 'group_type',
+        );
+    }
+
+    /**
+     * @param list<string> $extraColumns Columns to add beyond the canonical entity-table set.
+     */
+    private function createBaseTable(string $name, array $extraColumns = []): void
+    {
+        $idKey = $name === 'group' ? 'gid' : 'id';
+        $labelKey = $name === 'group' ? 'title' : 'name';
+
+        $fields = [
+            $idKey => ['type' => 'serial', 'not null' => true],
+            'uuid' => ['type' => 'varchar', 'length' => 36, 'not null' => true, 'default' => ''],
+            $labelKey => ['type' => 'varchar', 'length' => 255, 'not null' => true, 'default' => ''],
+            'langcode' => ['type' => 'varchar', 'length' => 12, 'not null' => true, 'default' => 'en'],
+            '_data' => ['type' => 'text', 'not null' => true, 'default' => '{}'],
+        ];
+        if ($name === 'group') {
+            $fields['type'] = ['type' => 'varchar', 'length' => 128, 'not null' => true, 'default' => ''];
+        }
+        foreach ($extraColumns as $col) {
+            $fields[$col] = ['type' => 'varchar', 'length' => 255, 'not null' => false];
+        }
+
+        $this->database->schema()->createTable($name, [
+            'fields' => $fields,
+            'primary key' => [$idKey],
+        ]);
+    }
+
+    /**
+     * @param list<string> $columnNames
+     */
+    private function createSubtable(string $name, array $columnNames): void
+    {
+        $fields = ['gid' => ['type' => 'int', 'not null' => true]];
+        foreach ($columnNames as $col) {
+            $fields[$col] = ['type' => 'varchar', 'length' => 255, 'not null' => false];
+        }
+        $this->database->schema()->createTable($name, [
+            'fields' => $fields,
+            'primary key' => ['gid'],
+        ]);
+    }
+
+    /**
+     * @param array<string, FieldStorage> $coreFields
+     * @param array<string, array<string, FieldStorage>> $bundleFields
+     */
+    private function registry(array $coreFields = [], array $bundleFields = []): FieldDefinitionRegistryInterface
+    {
+        $registry = $this->createMock(FieldDefinitionRegistryInterface::class);
+
+        $coreFieldObjects = [];
+        foreach ($coreFields as $name => $stored) {
+            $coreFieldObjects[$name] = $this->fakeField($name, $stored);
+        }
+
+        $bundleFieldObjects = [];
+        $bundleNames = [];
+        foreach ($bundleFields as $bundle => $fields) {
+            $bundleFieldObjects[$bundle] = [];
+            foreach ($fields as $name => $stored) {
+                $bundleFieldObjects[$bundle][$name] = $this->fakeField($name, $stored);
+            }
+            $bundleNames[] = $bundle;
+        }
+
+        $registry->method('coreFieldsFor')->willReturn($coreFieldObjects);
+        $registry->method('bundleNamesFor')->willReturn($bundleNames);
+        $registry->method('bundleFieldsFor')->willReturnCallback(
+            static fn(string $_entityTypeId, string $bundle): array => $bundleFieldObjects[$bundle] ?? [],
+        );
+
+        return $registry;
+    }
+
+    private function fakeField(string $name, FieldStorage $stored): object
+    {
+        return new class ($name, $stored) {
+            public function __construct(private readonly string $name, private readonly FieldStorage $stored) {}
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getStored(): FieldStorage
+            {
+                return $this->stored;
+            }
+        };
+    }
+
+    private function checker(EntityTypeInterface $type, FieldDefinitionRegistryInterface $registry): HealthChecker
+    {
+        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
+
+        $bootReport = new BootDiagnosticReport(
+            registeredTypes: [$type->id() => $type],
+            disabledTypeIds: [],
+            schemaCompatibility: [],
+        );
+
+        return new HealthChecker(
+            bootReport: $bootReport,
+            database: $this->database,
+            entityTypeManager: $manager,
+            projectRoot: $this->projectRoot,
+            fieldRegistry: $registry,
+        );
+    }
+
+    /** @param list<HealthCheckResult> $results */
+    private function findByCode(array $results, DiagnosticCode $code): ?HealthCheckResult
+    {
+        foreach ($results as $r) {
+            if ($r->code === $code) {
+                return $r;
+            }
+        }
+        return null;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `COLUMN_DATA_STORAGE_DRIFT` diagnostic code (severity `warning`).
- New `HealthChecker::checkColumnDataStorageDrift()` walks every registered entity type, asks the `FieldDefinitionRegistry` for core and per-bundle field definitions, and probes `PRAGMA table_info()` for any column whose name matches a field declared with `FieldStorage::Data`. Emits one warning per `(table, column)` with `entity_type`, `table`, `column`, and `bundle` context.
- Wired into `checkRuntime()` so it surfaces in `waaseyaa health` and `waaseyaa schema:check`.
- Skipped silently when no `FieldDefinitionRegistry` is injected (preserves the prior optional-registry contract).
- SQLite-only at present — portable enumeration follows the same path as orphan detection (tracked under #1301).

Closes #1309.

## Why this matters

After PR #1307 introduced `FieldStorage::Data`, a consumer can wind up with a field registered as `Data` while a column for the field still exists on disk. New writes route to `_data`, but the column holds stale values. Until query routing is symmetric (mission #1257 WP04 / WP05), reads silently take the column. After symmetry, the column is silently stale forever. The new check surfaces this as an operator-visible warning so it gets cleaned up via a migration.

## Spec updates

- `docs/specs/infrastructure.md` — DiagnosticCode table extended.
- `docs/specs/operator-diagnostics.md` — Runtime Health Codes table + Health Check Pipeline §Runtime Checks list extended.

## Test plan

- [x] `./vendor/bin/phpunit packages/foundation/tests/Unit/Diagnostic/HealthCheckerColumnDataDriftTest.php` — 6/6 pass.
- [x] `./vendor/bin/phpunit packages/foundation/tests/Unit/Diagnostic/` — 92/92 pass (no regression in existing diagnostic tests).
- [x] `composer cs-check` clean.
- [x] `composer phpstan` clean (level 5).
- [x] `tools/drift-detector.sh 5` — `infrastructure.md` reviewed in this commit; passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)