### PR TITLE
refactor(csrf): remove dead attachXsrfCookie() instance method (#1395)

### DIFF
--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,5 +1,6 @@
 # Access Control
 
+<!-- Spec reviewed 2026-05-10 - #1395 dead-code removal: CsrfMiddleware::attachXsrfCookie() instance method deleted; attachCookieIfHtml() static helper (called by HttpKernel) remains the sole live cookie-attachment path. No change to session resolution, gate logic, or access pipeline semantics. -->
 <!-- Spec reviewed 2026-05-10 - WP05 php-8.5 upgrade: @PHP8x5Migration cs-fixer pass — AuthorizationMiddleware and EntityAccessHandler touched by octal_notation + new_expression_parentheses rules only; no semantic change to access pipeline or gate logic. -->
 <!-- Spec reviewed 2026-05-10 - WP03 php-8.5 upgrade: AccessResult::allowed/forbidden/neutral/unauthenticated gained #[\NoDiscard] — no semantic change to access pipeline, gate logic, or AccessChecker. -->
 <!-- Spec reviewed 2026-05-01 - Auth README added under packages/auth/ (skeleton only — purpose, layer, key classes); no AuthManager/RateLimiter/TwoFactorManager contract change. Reaffirms WP05 paired-nullable invariants and AccessChecker placement (mission #824 WP09 surface F, closes #849) -->

--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -29,10 +29,7 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
         $this->ensureToken();
 
         if (!$this->requiresValidation($request)) {
-            $response = $next->handle($request);
-            $this->attachXsrfCookie($request, $response);
-
-            return $response;
+            return $next->handle($request);
         }
 
         if (!$this->hasValidToken($request)) {
@@ -57,10 +54,7 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
             ], 403, ['Content-Type' => 'application/vnd.api+json']);
         }
 
-        $response = $next->handle($request);
-        $this->attachXsrfCookie($request, $response);
-
-        return $response;
+        return $next->handle($request);
     }
 
     /**
@@ -158,32 +152,6 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
         }
 
         return false;
-    }
-
-    private function attachXsrfCookie(Request $request, Response $response): void
-    {
-        // Only set cookie on text/html responses.
-        $contentType = $response->headers->get('Content-Type', '');
-        $primaryType = strtolower(trim(explode(';', $contentType)[0]));
-        if ($primaryType !== 'text/html') {
-            return;
-        }
-
-        // Idempotency: don't double-set if already present.
-        foreach ($response->headers->getCookies() as $cookie) {
-            if ($cookie->getName() === self::XSRF_COOKIE_NAME) {
-                return;
-            }
-        }
-
-        $cookie = Cookie::create(self::XSRF_COOKIE_NAME)
-            ->withValue(rawurlencode($this->getToken()))
-            ->withPath('/')
-            ->withSecure($request->isSecure())
-            ->withHttpOnly(false)
-            ->withSameSite(Cookie::SAMESITE_LAX);
-
-        $response->headers->setCookie($cookie);
     }
 
     private function ensureToken(): void

--- a/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php
@@ -22,9 +22,10 @@ final class CsrfMiddlewareTest extends TestCase
     protected function setUp(): void
     {
         if (session_status() !== \PHP_SESSION_ACTIVE) {
-            // Use a mock session for tests.
-            $_SESSION = [];
+            session_start();
         }
+
+        $_SESSION = [];
 
         $this->middleware = new CsrfMiddleware();
 
@@ -38,6 +39,9 @@ final class CsrfMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        if (session_status() === \PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
         $_SESSION = [];
     }
 
@@ -408,37 +412,8 @@ final class CsrfMiddlewareTest extends TestCase
 
     // -------------------------------------------------------------------------
     // T006 — Cookie writer: every contract §1 attribute pinned
+    // Tests call the static helper directly — the live path used by HttpKernel.
     // -------------------------------------------------------------------------
-
-    private function makePassthroughWithHtmlResponse(): HttpHandlerInterface
-    {
-        return new class implements HttpHandlerInterface {
-            public function handle(Request $request): Response
-            {
-                return new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
-            }
-        };
-    }
-
-    private function makePassthroughWithJsonResponse(): HttpHandlerInterface
-    {
-        return new class implements HttpHandlerInterface {
-            public function handle(Request $request): Response
-            {
-                return new Response('{}', 200, ['Content-Type' => 'application/json']);
-            }
-        };
-    }
-
-    private function makePassthroughWithOctetStreamResponse(): HttpHandlerInterface
-    {
-        return new class implements HttpHandlerInterface {
-            public function handle(Request $request): Response
-            {
-                return new Response('binary', 200, ['Content-Type' => 'application/octet-stream']);
-            }
-        };
-    }
 
     #[Test]
     public function cookieName(): void
@@ -446,7 +421,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -460,7 +436,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = $token;
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -473,7 +450,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -486,7 +464,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('https://example.com/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -499,7 +478,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('http://example.com/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -512,7 +492,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -525,7 +506,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -538,7 +520,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -552,7 +535,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
@@ -566,7 +550,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/api', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithJsonResponse());
+        $response = new Response('{}', 200, ['Content-Type' => 'application/json']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $this->assertCount(0, $response->headers->getCookies());
     }
@@ -577,7 +562,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/download', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithOctetStreamResponse());
+        $response = new Response('binary', 200, ['Content-Type' => 'application/octet-stream']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $this->assertCount(0, $response->headers->getCookies());
     }
@@ -588,7 +574,8 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $xsrfCookies = array_filter(
             $response->headers->getCookies(),
@@ -603,25 +590,14 @@ final class CsrfMiddlewareTest extends TestCase
         $_SESSION['_csrf_token'] = bin2hex(random_bytes(32));
 
         $request = Request::create('/page', 'GET');
+        $response = new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
 
-        // First pass
-        $response = $this->middleware->process($request, $this->makePassthroughWithHtmlResponse());
-
-        // Second pass: simulate re-running the middleware on the already-cookie-set response
-        $responseWithCookie = $response;
-        $nextWithPresetCookie = new class ($responseWithCookie) implements HttpHandlerInterface {
-            public function __construct(private readonly Response $inner) {}
-
-            public function handle(Request $request): Response
-            {
-                return $this->inner;
-            }
-        };
-
-        $finalResponse = $this->middleware->process($request, $nextWithPresetCookie);
+        // Call the static helper twice on the same response — should remain idempotent.
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
+        CsrfMiddleware::attachCookieIfHtml($request, $response);
 
         $xsrfCookies = array_filter(
-            $finalResponse->headers->getCookies(),
+            $response->headers->getCookies(),
             fn($c) => $c->getName() === 'XSRF-TOKEN',
         );
         $this->assertCount(1, $xsrfCookies);


### PR DESCRIPTION
## Summary
- Removes `CsrfMiddleware::attachXsrfCookie()` (private instance method) and its two call sites in `process()` — it operated on a discarded auth-pipeline pass-through response that never reached the browser.
- Redirects 13 unit tests (T006 cookie-attribute suite) from `process()`-and-inspect-cookies to direct calls to the static `attachCookieIfHtml()` helper that `HttpKernel` actually uses.
- Removes three now-unused passthrough fixture methods (`makePassthroughWith{Html,Json,OctetStream}Response`).
- Updates `setUp()`/`tearDown()` to call `session_start()`/`session_destroy()` so the static helper's session-active guard is satisfied in the test environment.
- Adds a spec-review comment to `docs/specs/access-control.md` to clear the spec-drift pre-push gate.

## Test plan
- [x] `vendor/bin/phpunit packages/user/tests/Unit/Middleware/CsrfMiddlewareTest.php` — 41/41 pass
- [x] `vendor/bin/phpunit tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php` — 4/4 pass (live path still works end-to-end)
- [x] `vendor/bin/phpstan` — 0 errors (57 pre-existing baseline errors in test file unchanged)
- [x] `composer cs-check` — clean (pre-existing `CpNewCheckTest.php` lint error unrelated to this change)
- [x] Pre-push hooks (spec-drift, composer-policy, phpstan, phpunit) — all green

Closes #1395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)