### PR TITLE
refactor(attachment): named arg for #[PolicyAttribute] (#1402)

### DIFF
--- a/packages/attachment/src/Policy/ParentDelegatedAccessPolicy.php
+++ b/packages/attachment/src/Policy/ParentDelegatedAccessPolicy.php
@@ -34,7 +34,7 @@ use Waaseyaa\Entity\EntityTypeManagerInterface;
  *
  * Spec: FR-011.
  */
-#[PolicyAttribute('attachment')]
+#[PolicyAttribute(entityType: 'attachment')]
 final class ParentDelegatedAccessPolicy implements AccessPolicyInterface
 {
     public function __construct(


### PR DESCRIPTION
## Summary
- Convert `#[PolicyAttribute('attachment')]` → `#[PolicyAttribute(entityType: 'attachment')]` in `packages/attachment/src/Policy/ParentDelegatedAccessPolicy.php`. Aligns with the 14+ other call sites and CLAUDE.md's named-constructor convention. No behavior change.

## Test plan
- [x] phpstan green
- [x] phpunit green (full suite, pre-push hook)
- [x] composer-policy green

Closes #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)