### PR TITLE
refactor(tests): named args for FieldDefinition test calls (#1403)

### DIFF
--- a/packages/admin-surface/tests/Unit/Catalog/FieldDefinitionTest.php
+++ b/packages/admin-surface/tests/Unit/Catalog/FieldDefinitionTest.php
@@ -15,7 +15,7 @@ final class FieldDefinitionTest extends TestCase
     #[Test]
     public function minimalFieldToArray(): void
     {
-        $field = new FieldDefinition('title', 'Title', 'string');
+        $field = new FieldDefinition(name: 'title', label: 'Title', type: 'string');
 
         $array = $field->toArray();
 
@@ -30,7 +30,7 @@ final class FieldDefinitionTest extends TestCase
     #[Test]
     public function fullyConfiguredField(): void
     {
-        $field = new FieldDefinition('body', 'Body', 'string');
+        $field = new FieldDefinition(name: 'body', label: 'Body', type: 'string');
         $field->widget('richtext')
             ->weight(10)
             ->required()
@@ -49,7 +49,7 @@ final class FieldDefinitionTest extends TestCase
     #[Test]
     public function readOnlyField(): void
     {
-        $field = new FieldDefinition('uuid', 'UUID', 'string');
+        $field = new FieldDefinition(name: 'uuid', label: 'UUID', type: 'string');
         $field->readOnly();
 
         $array = $field->toArray();

--- a/packages/entity-storage/tests/Unit/SqlSchemaHandlerTest.php
+++ b/packages/entity-storage/tests/Unit/SqlSchemaHandlerTest.php
@@ -209,18 +209,18 @@ final class SqlSchemaHandlerTest extends TestCase
         $handler = new SqlSchemaHandler($this->entityType, $this->database);
         $m = new ReflectionMethod(SqlSchemaHandler::class, 'deriveColumnSpec');
 
-        $textLong = new FieldDefinition('description', 'text_long');
+        $textLong = new FieldDefinition(name: 'description', type: 'text_long');
         self::assertSame('text', $this->invokeDeriveColumnSpec($m, $handler, $textLong)['type']);
 
-        $uri = new FieldDefinition('url', 'uri');
+        $uri = new FieldDefinition(name: 'url', type: 'uri');
         $uriSpec = $this->invokeDeriveColumnSpec($m, $handler, $uri);
         self::assertSame('varchar', $uriSpec['type']);
         self::assertSame(2048, $uriSpec['length']);
 
-        $uriCustom = new FieldDefinition('booking_url', 'uri', settings: ['length' => 512]);
+        $uriCustom = new FieldDefinition(name: 'booking_url', type: 'uri', settings: ['length' => 512]);
         self::assertSame(512, $this->invokeDeriveColumnSpec($m, $handler, $uriCustom)['length']);
 
-        $ref = new FieldDefinition('community_id', 'entity_reference', targetEntityTypeId: 'node');
+        $ref = new FieldDefinition(name: 'community_id', type: 'entity_reference', targetEntityTypeId: 'node');
         self::assertSame('int', $this->invokeDeriveColumnSpec($m, $handler, $ref)['type']);
     }
 
@@ -237,7 +237,7 @@ final class SqlSchemaHandlerTest extends TestCase
 
         $handler = new SqlSchemaHandler($this->entityType, $this->database, null, null, $logger);
         $m = new ReflectionMethod(SqlSchemaHandler::class, 'deriveColumnSpec');
-        $field = new FieldDefinition('weird', 'not_a_real_field_type');
+        $field = new FieldDefinition(name: 'weird', type: 'not_a_real_field_type');
         $spec = $this->invokeDeriveColumnSpec($m, $handler, $field);
         self::assertSame('text', $spec['type']);
     }


### PR DESCRIPTION
## Summary
- Convert 8 positional `new FieldDefinition(...)` test call sites to named-arg form per CLAUDE.md's named-constructor convention.
- 3 sites in `packages/admin-surface/tests/Unit/Catalog/FieldDefinitionTest.php` (admin-surface `FieldDefinition`).
- 5 sites in `packages/entity-storage/tests/Unit/SqlSchemaHandlerTest.php` (`Waaseyaa\Field\FieldDefinition`).
- Mechanical, no behavior change. 8 insertions / 8 deletions.

## Test plan
- [x] phpunit green (full suite, pre-push hook)

Closes #1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)