### PR TITLE
fix(admin): pin nuxt 4.4.4 to dodge 4.4.5 dev-server regression (#1419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Admin SPA `admin/integration` CI regression — Nuxt 4.4.5 dev-server broken (issue #1419)** — Nuxt 4.4.5 introduced a regression in `@nuxt/vite-builder`'s `resolveServerEntry` that fails `nuxt dev` with `No entry found in rollupOptions.input`. Caret-range `"nuxt": "^4.4.4"` from M1A allowed npm to resolve to 4.4.5, breaking Playwright's `webServer: 'npm run dev'` bootstrap and therefore the `admin/integration` GitHub Actions job. Pinned `"nuxt": "4.4.4"` exact in `packages/admin/package.json`. `nuxt build` was unaffected (production build path uses a different entry resolution code path). Local verification: `nuxt dev` starts cleanly on `http://localhost:3000/admin/`; vitest 187/187 pass; typecheck clean; lint 0 errors. Unpinning becomes safe when Nuxt ships a fixed 4.4.6+ that resolves [Nuxt upstream issue tracking the regression].
+
 ### Added
 
 - **Admin SPA `@nuxt/eslint` adoption (M1B-eslint, audit `admin-spa-modernization-audit-01KRA3RV`, issue #1411)** — Added `@nuxt/eslint` ^1.15.2 and `eslint` ^9.39.4 as devDependencies, registered as a Nuxt module in `packages/admin/nuxt.config.ts`, scaffolded `packages/admin/eslint.config.mjs` importing the auto-generated `.nuxt/eslint.config.mjs`. New `lint` and `lint:fix` scripts wired. Adoption baseline: 0 errors / 61 warnings (mostly `@typescript-eslint/no-explicit-any` × 40 + unused `vi` imports × 12 + intentional `vue/no-v-html` × 2). Noisy rules tuned to `warn` so the suite passes at zero errors; a follow-up "baseline cleanup" pass can tighten incrementally. `vue/html-self-closing` `--fix` ran across 14 auth/widget files (valid HTML5 void-element form). Verified: `npm run lint` exit 0, `npm test` 187/187 pass, `npm run typecheck` clean. Nuxt modules `@nuxt/image`, `@nuxt/icon`, `@nuxt/fonts` deferred from M1B's original audit scope — each needs its own validation and config and will land as separate follow-ups.

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,5 +1,6 @@
 # Admin SPA
 
+<!-- Spec reviewed 2026-05-10 - Nuxt 4.4.5 dev-server regression (#1419): pinned `"nuxt": "4.4.4"` exact in packages/admin/package.json; Tech Stack table version unchanged; rationale and unpin condition in CHANGELOG -->
 <!-- Spec reviewed 2026-05-10 - M1B (#1411) @nuxt/eslint adoption: nuxt.config.ts gains modules and eslint config; new packages/admin/eslint.config.mjs imports `.nuxt/eslint.config.mjs`; lint/lint:fix scripts wired; @typescript-eslint/no-explicit-any et al. set to warn (61 deferred baseline warnings); admin contracts unchanged -->
 <!-- Spec reviewed 2026-05-10 - M1A (#1411) dep bumps: Tech Stack table refreshed to nuxt ^4.4.4, vue ^3.5.34, vue-router ^5.0.6, typescript ^6.0.3, @types/node ^25.6.2; admin contracts unchanged -->
 <!-- Spec reviewed 2026-04-24 - useCodifiedContext + E2E: `/api/telescope/agent-context/…` (legacy HTTP alias on server); Nuxt routes still `/telescope/codified-context/*`; cross-link telescope-agent-context-telemetry.md -->

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,5 +1,6 @@
 # Admin SPA
 
+<!-- Spec reviewed 2026-05-10 - #1419 follow-up: Playwright webServer timeout 120s → 240s to absorb CI cold-start of nuxt prepare + Vite optimize + Nitro build; local dev unchanged -->
 <!-- Spec reviewed 2026-05-10 - Nuxt 4.4.5 dev-server regression (#1419): pinned `"nuxt": "4.4.4"` exact in packages/admin/package.json; Tech Stack table version unchanged; rationale and unpin condition in CHANGELOG -->
 <!-- Spec reviewed 2026-05-10 - M1B (#1411) @nuxt/eslint adoption: nuxt.config.ts gains modules and eslint config; new packages/admin/eslint.config.mjs imports `.nuxt/eslint.config.mjs`; lint/lint:fix scripts wired; @typescript-eslint/no-explicit-any et al. set to warn (61 deferred baseline warnings); admin contracts unchanged -->
 <!-- Spec reviewed 2026-05-10 - M1A (#1411) dep bumps: Tech Stack table refreshed to nuxt ^4.4.4, vue ^3.5.34, vue-router ^5.0.6, typescript ^6.0.3, @types/node ^25.6.2; admin contracts unchanged -->

--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "hasInstallScript": true,
             "dependencies": {
-                "nuxt": "^4.4.4",
+                "nuxt": "4.4.4",
                 "vue": "^3.5.34",
                 "vue-router": "^5.0.6"
             },
@@ -2043,20 +2043,20 @@
             }
         },
         "node_modules/@nuxt/nitro-server": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.4.5.tgz",
-            "integrity": "sha512-ZxmfxZbQ6Yr/DYkuGmPFtE/A1hDbbcOurlPeh/H4oHfAkv/N6W7OWg/3PGViKwckmF69jUMe/a89HAguaH+r5A==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.4.4.tgz",
+            "integrity": "sha512-jMZPf+vJ2/IF5TZc+c/1c6O6p94pklVLvrexCu9FYZFK3H9oqYUlzBfYRd2kL5tdRTkIOpxTjfcgB1oc62UOhw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/plugin-syntax-typescript": "^7.28.6",
                 "@nuxt/devalue": "^2.0.2",
-                "@nuxt/kit": "4.4.5",
+                "@nuxt/kit": "4.4.4",
                 "@unhead/vue": "^2.1.13",
                 "@vue/shared": "^3.5.33",
                 "consola": "^3.4.2",
                 "defu": "^6.1.7",
                 "destr": "^2.0.5",
-                "devalue": "^5.8.0",
+                "devalue": "^5.7.1",
                 "errx": "^0.1.0",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
@@ -2083,7 +2083,7 @@
             "peerDependencies": {
                 "@babel/plugin-proposal-decorators": "^7.25.0",
                 "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
-                "nuxt": "^4.4.5"
+                "nuxt": "^4.4.4"
             },
             "peerDependenciesMeta": {
                 "@babel/plugin-proposal-decorators": {
@@ -2095,9 +2095,9 @@
             }
         },
         "node_modules/@nuxt/nitro-server/node_modules/@nuxt/kit": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.5.tgz",
-            "integrity": "sha512-J0BpoOomzd3iVZozYlZJ7AwAVliXRgeChZnAkQLfg8d0h/Q+aMK9kkHuhwFULASaRn5idiD4BIhOUz7/uoLbSw==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.4.tgz",
+            "integrity": "sha512-oy4fAeMkyz7gelnalDQLPm8QZRN+c5c/Eh/M6oFgPx86jnA8m6xeOlONpJN2dk0GhcJwJYuN/kmzBffZ93WXPQ==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.3.4",
@@ -2126,9 +2126,9 @@
             }
         },
         "node_modules/@nuxt/schema": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.5.tgz",
-            "integrity": "sha512-kPacVsBInUgM3JiFiHUGd5fr8Ohe+79PGrBwjipfGzA61UMPfj7CmPuKrvmL1i4oLS1I3/flHvU5VFVyQ/wyxQ==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.4.tgz",
+            "integrity": "sha512-X70+lDZ4Wtp38l18/zFlKOZO5fd0uWQ60nrr1gxTNua8sqOxqVeZpLWTBmor7lFfJsXPPclsaFjcstyXYqXgpg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "^3.5.33",
@@ -2254,18 +2254,18 @@
             }
         },
         "node_modules/@nuxt/vite-builder": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.4.5.tgz",
-            "integrity": "sha512-PLb1a3yjSES6CEAKqCuT9qPqT7xLtf5VH3XeE3rZ0iBQ+ReVkglwouE+M/lRR61R7PjlvAszjOyjnKbOG1pOAg==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.4.4.tgz",
+            "integrity": "sha512-SNyxEYVeTo3d26tt5rxS550VOFLyXx1UBqhZJexWhk42HgHa3d115LWZx+4e+FJf75SYZ1B/KTrkVeeOhfNBMw==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "4.4.5",
+                "@nuxt/kit": "4.4.4",
                 "@rollup/plugin-replace": "^6.0.3",
                 "@vitejs/plugin-vue": "^6.0.6",
                 "@vitejs/plugin-vue-jsx": "^5.1.5",
                 "autoprefixer": "^10.5.0",
                 "consola": "^3.4.2",
-                "cssnano": "^7.1.9",
+                "cssnano": "^7.1.7",
                 "defu": "^6.1.7",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
@@ -2278,8 +2278,8 @@
                 "nypm": "^0.6.6",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
-                "postcss": "^8.5.14",
-                "seroval": "^1.5.3",
+                "postcss": "^8.5.12",
+                "seroval": "^1.5.2",
                 "std-env": "^4.1.0",
                 "ufo": "^1.6.4",
                 "unenv": "^2.0.0-rc.24",
@@ -2294,7 +2294,7 @@
             "peerDependencies": {
                 "@babel/plugin-proposal-decorators": "^7.25.0",
                 "@babel/plugin-syntax-jsx": "^7.25.0",
-                "nuxt": "4.4.5",
+                "nuxt": "4.4.4",
                 "rolldown": "^1.0.0-beta.38",
                 "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
                 "vue": "^3.3.4"
@@ -2315,9 +2315,9 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.5.tgz",
-            "integrity": "sha512-J0BpoOomzd3iVZozYlZJ7AwAVliXRgeChZnAkQLfg8d0h/Q+aMK9kkHuhwFULASaRn5idiD4BIhOUz7/uoLbSw==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.4.tgz",
+            "integrity": "sha512-oy4fAeMkyz7gelnalDQLPm8QZRN+c5c/Eh/M6oFgPx86jnA8m6xeOlONpJN2dk0GhcJwJYuN/kmzBffZ93WXPQ==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.3.4",
@@ -10610,19 +10610,19 @@
             }
         },
         "node_modules/nuxt": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.5.tgz",
-            "integrity": "sha512-MwTf3wyaEIm1U9/T1VKpqg7rGhhrn5Cx2ZS40lwo8GxsiY9xE7UOj5Cg0eAI0fSbJzyXlzdxspytgqWsgL+nIA==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.4.tgz",
+            "integrity": "sha512-r9E3PYo+uJazltAmjm0TwFW3MQ++Wd//2uRZgCyqkt7VSAVJ5KnRRwUF7JktK/NZbLYAUDiV3tgqE9ZYbHbymA==",
             "license": "MIT",
             "dependencies": {
                 "@dxup/nuxt": "^0.4.1",
                 "@nuxt/cli": "^3.35.1",
                 "@nuxt/devtools": "^3.2.4",
-                "@nuxt/kit": "4.4.5",
-                "@nuxt/nitro-server": "4.4.5",
-                "@nuxt/schema": "4.4.5",
+                "@nuxt/kit": "4.4.4",
+                "@nuxt/nitro-server": "4.4.4",
+                "@nuxt/schema": "4.4.4",
                 "@nuxt/telemetry": "^2.8.0",
-                "@nuxt/vite-builder": "4.4.5",
+                "@nuxt/vite-builder": "4.4.4",
                 "@unhead/vue": "^2.1.13",
                 "@vue/shared": "^3.5.33",
                 "chokidar": "^5.0.0",
@@ -10630,7 +10630,7 @@
                 "consola": "^3.4.2",
                 "cookie-es": "^2.0.1",
                 "defu": "^6.1.7",
-                "devalue": "^5.8.0",
+                "devalue": "^5.7.1",
                 "errx": "^0.1.0",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
@@ -10692,9 +10692,9 @@
             }
         },
         "node_modules/nuxt/node_modules/@nuxt/kit": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.5.tgz",
-            "integrity": "sha512-J0BpoOomzd3iVZozYlZJ7AwAVliXRgeChZnAkQLfg8d0h/Q+aMK9kkHuhwFULASaRn5idiD4BIhOUz7/uoLbSw==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.4.tgz",
+            "integrity": "sha512-oy4fAeMkyz7gelnalDQLPm8QZRN+c5c/Eh/M6oFgPx86jnA8m6xeOlONpJN2dk0GhcJwJYuN/kmzBffZ93WXPQ==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.3.4",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -39,7 +39,7 @@
         "lint:fix": "eslint . --fix"
     },
     "dependencies": {
-        "nuxt": "^4.4.4",
+        "nuxt": "4.4.4",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6"
     },

--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000/admin',
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // 240s gives cold-start CI runners headroom over Nuxt's prepare + Vite
+    // optimize + Nitro build sequence; locally `nuxt dev` is ready in seconds.
+    timeout: 240 * 1000,
   },
 })


### PR DESCRIPTION
## Summary

**Partial fix** for #1419. Two changes:

1. **Pins `"nuxt": "4.4.4"` exact** (was caret-`^4.4.4`) — Nuxt 4.4.5 ships a regression in `@nuxt/vite-builder`'s `resolveServerEntry` that breaks `nuxt dev` with `No entry found in rollupOptions.input`. The pin keeps the resolver on 4.4.4.
2. **Bumps Playwright webServer timeout 120 → 240s** — CI cold-start of `nuxt prepare` + Vite dep optimize + Nitro build needs headroom over GitHub Actions runners after M1A's dep graph grew.

## What this does NOT fix

After both changes, `admin/integration` still fails — even 240s isn't enough for Playwright to detect `http://localhost:3000/admin` responding. The failure mode shifted but the job is still red. Needs deeper triage of why `nuxt dev` doesn't reach the URL probe in CI (could be the proxy rule, the baseURL redirect, or a Vite optimization deadlock). Tracking that follow-up in #1419 — this PR is real progress (rollup regression fixed, timeout headroom in place) but #1419 stays open.

## What's verified

- [x] `npx nuxt dev` locally starts on `http://localhost:3000/admin/`
- [x] `npm test` — 187/187 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `nuxt build` (production) passes in CI
- [x] `admin/build`, `admin/contracts`, `admin/adapters` all green

## Refs

- Refs: #1419 (partial)
- Introduced regression by: #1417 (M1A)
- Discovered while shipping: #1418 (M1B-eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Opus 4.7