### PR TITLE
fix(admin): switch Playwright CI webServer to production preview (refs #1419)

### DIFF
--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,5 +1,6 @@
 # Admin SPA
 
+<!-- Spec reviewed 2026-05-10 - #1419 follow-up: Playwright webServer in CI uses `npm run build && npm run preview` (production-mode, ~3s startup) instead of `npm run dev` (>240s in CI, dev-mode-specific stall; local devs keep dev mode for HMR) -->
 <!-- Spec reviewed 2026-05-10 - #1419 follow-up: Playwright webServer timeout 120s → 240s to absorb CI cold-start of nuxt prepare + Vite optimize + Nitro build; local dev unchanged -->
 <!-- Spec reviewed 2026-05-10 - Nuxt 4.4.5 dev-server regression (#1419): pinned `"nuxt": "4.4.4"` exact in packages/admin/package.json; Tech Stack table version unchanged; rationale and unpin condition in CHANGELOG -->
 <!-- Spec reviewed 2026-05-10 - M1B (#1411) @nuxt/eslint adoption: nuxt.config.ts gains modules and eslint config; new packages/admin/eslint.config.mjs imports `.nuxt/eslint.config.mjs`; lint/lint:fix scripts wired; @typescript-eslint/no-explicit-any et al. set to warn (61 deferred baseline warnings); admin contracts unchanged -->

--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -22,11 +22,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
+    // CI uses production-mode `build && preview` because `nuxt dev` exhibits
+    // 100x slowdown on GitHub Actions runners (>240s vs <5s local). Local devs
+    // keep `npm run dev` for HMR. See #1419 for the dev-mode investigation.
+    command: process.env.CI ? 'npm run build && npm run preview' : 'npm run dev',
     url: 'http://localhost:3000/admin',
     reuseExistingServer: !process.env.CI,
-    // 240s gives cold-start CI runners headroom over Nuxt's prepare + Vite
-    // optimize + Nitro build sequence; locally `nuxt dev` is ready in seconds.
     timeout: 240 * 1000,
   },
 })


### PR DESCRIPTION
## Summary

Third attempt at fixing #1419. Locally `nuxt dev` binds in 2s; in CI it exceeds 240s before Playwright's URL probe can detect it. Rather than continue chasing the dev-mode-specific slowdown, switch CI to production-mode `build && preview` — faster startup (~3s after build), more deterministic, and appropriate for E2E smoke tests.

## Change

In `packages/admin/playwright.config.ts`:

```ts
webServer: {
  command: process.env.CI
    ? 'npm run build && npm run preview'
    : 'npm run dev',
  // ...
}
```

Local devs keep `npm run dev` for HMR. CI gets the production-mode static server.

## Why dev-mode misbehaves in CI is still open

After this PR's CI run shows green, dev-mode investigation in #1419 stays open as a separate concern. Candidate hypotheses to explore later:
- Vite optimize hangs in headless CI without TTY
- `@nuxt/eslint` module's hook runs synchronous work that stalls on cold-start
- Some other dev-mode-only hook ordering interaction

This PR does not require that investigation to land; it removes the symptom from CI.

## Local verification

- [x] `npm run build` produces `.output/server/index.mjs`
- [x] `npm run preview` ready in **3s** on `http://localhost:3000/admin` (returns 200, no 301 redirect like dev mode)
- [x] `CI=1 npx playwright test --list` resolves 60 tests across 8 files
- [ ] CI's `admin/integration` job green

## Refs

- Refs: #1419 (third partial fix; investigation continues if dev-mode root-cause matters)
- Builds on: #1420 (nuxt 4.4.4 pin + 240s timeout)
- Audit: docs/audits/admin-spa-modernization-2026-05-10.md

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Opus 4.7