### PR TITLE
chore(admin): tighten package envelope as private workspace member (M2A, #1412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Admin SPA package envelope tightened (M2A, audit `admin-spa-modernization-audit-01KRA3RV`, issue #1412)** — `packages/admin/` is now explicitly marked `"private": true` because the audit found zero downstream consumers of `@waaseyaa/admin` / `@waaseyaa/admin/adapters` imports across the workspace. Removed the misleading `exports` map (`./`, `./adapters`, `./nuxt`) and the `files` array. Added `"engines": { "node": ">=22.12.0" }` matching Nuxt 4.4.4's constraint. Description clarified to "monorepo workspace member, not published to npm". `build:contracts` script and the `admin/contracts` CI job retained as a forward-compat type-check gate (still produces `dist/` artifact uploaded by CI). README rewritten from a 21-line i18n-only stub to a ~55-line publishable summary that points at `docs/specs/admin-spa.md` as the canonical reference and covers stack, develop/test/build commands, the bootstrap-contract validation gate, and a pointer at the modernization audit. Future M2 work deferred (separate sub-missions): commit the `dist/` output or remove `build:contracts` entirely; pre-built-tarball model from PR #1350; downstream-consumer integration if/when one appears.
+
 ### Fixed
 
 - **Admin SPA `admin/integration` CI regression — Nuxt 4.4.5 dev-server broken (issue #1419)** — Nuxt 4.4.5 introduced a regression in `@nuxt/vite-builder`'s `resolveServerEntry` that fails `nuxt dev` with `No entry found in rollupOptions.input`. Caret-range `"nuxt": "^4.4.4"` from M1A allowed npm to resolve to 4.4.5, breaking Playwright's `webServer: 'npm run dev'` bootstrap and therefore the `admin/integration` GitHub Actions job. Pinned `"nuxt": "4.4.4"` exact in `packages/admin/package.json`. `nuxt build` was unaffected (production build path uses a different entry resolution code path). Local verification: `nuxt dev` starts cleanly on `http://localhost:3000/admin/`; vitest 187/187 pass; typecheck clean; lint 0 errors. Unpinning becomes safe when Nuxt ships a fixed 4.4.6+ that resolves [Nuxt upstream issue tracking the regression].

--- a/docs/specs/admin-spa.md
+++ b/docs/specs/admin-spa.md
@@ -1,5 +1,6 @@
 # Admin SPA
 
+<!-- Spec reviewed 2026-05-10 - M2A (#1412) envelope tightening: packages/admin/package.json marked `"private": true` (no downstream consumers found in workspace); exports map and files array removed; engines added (`node: ">=22.12.0"`); README rewritten to a ~55-line publishable summary; build:contracts script retained as forward-compat type-check; admin contracts CI gate unchanged -->
 <!-- Spec reviewed 2026-05-10 - #1419 follow-up: Playwright webServer in CI uses `npm run build && npm run preview` (production-mode, ~3s startup) instead of `npm run dev` (>240s in CI, dev-mode-specific stall; local devs keep dev mode for HMR) -->
 <!-- Spec reviewed 2026-05-10 - #1419 follow-up: Playwright webServer timeout 120s → 240s to absorb CI cold-start of nuxt prepare + Vite optimize + Nitro build; local dev unchanged -->
 <!-- Spec reviewed 2026-05-10 - Nuxt 4.4.5 dev-server regression (#1419): pinned `"nuxt": "4.4.4"` exact in packages/admin/package.json; Tech Stack table version unchanged; rationale and unpin condition in CHANGELOG -->

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -1,21 +1,61 @@
 # @waaseyaa/admin
 
-Schema-driven admin SPA for Waaseyaa (Nuxt 3 + Vue 3).
+The schema-driven admin SPA for the Waaseyaa framework. **Internal monorepo workspace member — not published to npm.** Treat as an application, not a library.
+
+The canonical reference for architecture, contracts, and integration is **[`docs/specs/admin-spa.md`](../../docs/specs/admin-spa.md)** in the framework repo. This README only covers what you need to operate the package locally.
+
+## Stack
+
+- **Nuxt 4.4.4** (SSR disabled — pure SPA mode)
+- **Vue 3.5.34** + Composition API
+- **vue-router 5** (required for Volar `sfc-route-blocks` under Nuxt 4)
+- **TypeScript 6.x**, **vitest 4.x**, **Playwright 1.59+**
+
+The Nuxt minor version is pinned exactly (`"nuxt": "4.4.4"`) because Nuxt 4.4.5 ships a `@nuxt/vite-builder` regression in dev mode. See the CHANGELOG entry on issue #1419 for the unpin condition.
+
+## Develop
+
+```bash
+cd packages/admin
+npm install                  # also runs `nuxt prepare`
+npm run dev                  # HMR dev server on http://localhost:3000/admin/
+npm run dev:wsl              # same, but listens on 0.0.0.0 (use from a Windows browser against WSL)
+```
+
+Set `NUXT_BACKEND_URL` if the PHP backend isn't on `http://127.0.0.1:8080`.
+
+## Test & verify
+
+```bash
+npm test                     # Vitest unit suite
+npm run typecheck            # vue-tsc --noEmit
+npm run lint                 # eslint . (0 errors / 61 baseline warnings — see #1411)
+npm run test:e2e             # Playwright; uses production preview in CI, dev in local
+```
+
+## Build
+
+```bash
+npm run build                # Nuxt SPA build → .output/
+npm run preview              # Serve the built output locally
+npm run build:contracts      # Compile contract types to dist/ (verification gate; no consumer)
+```
+
+## Bootstrap contract validation
+
+`contracts/bootstrap.schema.json` is the canonical JSON Schema for the SPA's bootstrap payload. The `admin/contracts` CI job validates the schema against a reference payload using `ajv-cli`. Update the schema in lockstep with backend changes in `packages/admin-surface/`.
 
 ## i18n
 
 Translations live in `app/i18n/` and are consumed by `useLanguage()`.
 
-### Current locales
-- `en` (`app/i18n/en.json`)
-- `fr` (`app/i18n/fr.json`)
+- Current locales: `en` (`app/i18n/en.json`), `fr` (`app/i18n/fr.json`)
+- To add a locale:
+  1. Create `app/i18n/<locale>.json` with the same keys used in `en.json`.
+  2. Import and register it in `app/composables/useLanguage.ts` (extend the `Locale` union and the `messages` map).
+  3. The topbar language selector renders new locales automatically from `useLanguage().locales`.
+  4. Add/update unit tests in `tests/unit/composables/useLanguage.test.ts` and `tests/components/layout/AdminShell.test.ts`.
 
-### Add a new locale
-1. Create `app/i18n/<locale>.json` with the same keys used in `en.json`.
-2. Import and register it in `app/composables/useLanguage.ts`:
-   - `import <locale> from '~/i18n/<locale>.json'`
-   - extend the `Locale` union and `messages` map.
-3. The topbar language selector in `components/layout/AdminShell.vue` will render it automatically from `useLanguage().locales`.
-4. Add/update unit tests in:
-   - `tests/unit/composables/useLanguage.test.ts`
-   - `tests/components/layout/AdminShell.test.ts`
+## Modernization status
+
+This package is the subject of the [Admin SPA Modernization Audit](../../docs/audits/admin-spa-modernization-2026-05-10.md). The audit's Top 5 follow-up missions (M1–M5) are tracked under issues #1411–#1415 in the framework repo.

--- a/packages/admin/package-lock.json
+++ b/packages/admin/package-lock.json
@@ -25,6 +25,9 @@
                 "typescript": "^6.0.3",
                 "vitest": "^4.1.5",
                 "vue-tsc": "~2.2.10"
+            },
+            "engines": {
+                "node": ">=22.12.0"
             }
         },
         "node_modules/@antfu/install-pkg": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,26 +1,12 @@
 {
     "name": "@waaseyaa/admin",
     "version": "1.0.0",
+    "private": true,
     "type": "module",
-    "description": "Schema-driven admin SPA for Waaseyaa with pluggable host contracts",
-    "exports": {
-        ".": {
-            "types": "./dist/contracts/index.d.ts",
-            "import": "./dist/contracts/index.js"
-        },
-        "./adapters": {
-            "types": "./dist/adapters/index.d.ts",
-            "import": "./dist/adapters/index.js"
-        },
-        "./nuxt": "./"
+    "description": "Schema-driven admin SPA for Waaseyaa (monorepo workspace member, not published to npm)",
+    "engines": {
+        "node": ">=22.12.0"
     },
-    "files": [
-        "dist/contracts/",
-        "dist/adapters/",
-        "app/",
-        "nuxt.config.ts",
-        "tsconfig.json"
-    ],
     "scripts": {
         "dev": "nuxt dev",
         "dev:wsl": "nuxt dev --host 0.0.0.0",


### PR DESCRIPTION
## Summary

Audit follow-up **M2A** (subset of M2 #1412) — reconciles the admin SPA's package envelope with reality. The audit found zero downstream consumers of `@waaseyaa/admin` imports anywhere in the workspace, so the `exports` map and `files` array were promising an installable shape that doesn't exist. Mark `"private": true`, drop the misleading metadata, add `engines`, rewrite the README.

## Changes

`packages/admin/package.json`:

- ➕ `"private": true`
- ➕ `"engines": { "node": ">=22.12.0" }` (matches Nuxt 4.4.4 constraint)
- ➖ `exports` map (`.`, `./adapters`, `./nuxt`)
- ➖ `files` array
- Description updated to "monorepo workspace member, not published to npm"

`packages/admin/README.md`:

Rewritten from 21 lines (i18n only) to ~55 lines covering stack, develop/test/build/preview commands, the bootstrap-contract validation gate, i18n, and a pointer at the modernization audit. Points at `docs/specs/admin-spa.md` as the canonical reference.

## Intentionally retained

- `build:contracts` script and the `admin/contracts` CI job — forward-compat type-check gate. Still produces `dist/` artifact uploaded by CI.
- `contracts/bootstrap.schema.json` — referenced by the admin/contracts CI via ajv-cli (separate from the TS compile).

## Deferred to M2B follow-ups

- Commit `dist/contracts/` output OR remove `build:contracts` entirely (decision point)
- Pre-built-tarball model from PR #1350
- Downstream-consumer integration if/when an external Waaseyaa app appears that wants `@waaseyaa/admin/adapters`

## Test plan

- [x] `npm test` — 187/187 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors / 61 baseline warnings
- [x] `npm run build:contracts` — produces `dist/` as before
- [ ] CI green on `admin/build`, `admin/contracts`, `admin/integration`, `admin/adapters`
- [ ] Reviewer reads the new README and confirms it's publishable-quality

## Refs

- Refs: #1412 (M2 umbrella mission)
- Audit source: `docs/audits/admin-spa-modernization-2026-05-10.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Opus 4.7