### PR TITLE
fix(entity-storage): wire DefinitionValidator into kernel boot (closes #1443)

### DIFF
--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -1777,10 +1777,12 @@ types (FR-014, FR-015).
 
 ### Definition validation
 
-`DefinitionValidator` (in `Waaseyaa\EntityStorage\Query`) validates
-`FieldDefinition` objects at registration time. It throws
-`UnsupportedQueryException` when the active backend reports `supportsQuery()` =
-`false`. `UnsupportedListingException` is thrown when listing is unsupported.
+`DefinitionValidator` (in `Waaseyaa\EntityStorage\Query`) enforces FR-021's
+fail-fast contract at kernel boot time. `AbstractKernel::validateQueryDefinitions()`
+calls `validateAll()` after all service providers have registered their entity
+types and before the booted flag is set. It throws `UnsupportedQueryException`
+when any indexed field's resolved backend reports `supportsQuery()` = `false`.
+Boot fails immediately — there is no silent fallback and no runtime retry.
 
 ### Revisionable entities (WP07–WP09)
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1,5 +1,6 @@
 # Infrastructure
 
+<!-- Spec reviewed 2026-05-12 - #1443 AbstractKernel::validateQueryDefinitions() added after discoverAccessPolicies() in boot(); wires DefinitionValidator (entity-storage L1) via BackendRegistrarFactory+BackendResolver for FR-021 fail-fast enforcement. Kernel bootstrapper exemption applies (CLAUDE.md). No infrastructure contract surface changed. -->
 <!-- Spec reviewed 2026-05-11 - M4A-1 (#1428 / umbrella #1414) new kernel-adjacent route registrar `WorkflowDefinitionsApiRouter` in foundation/src/Http/Router/ wired alongside CodifiedContextApiRouter et al. in HttpKernel::$foundationRouters; route entry added to BuiltinRouteRegistrar for `GET /api/workflow-definitions` (admin-role-gated). Pure wiring change; no infrastructure contract surface affected. -->
 <!-- Spec reviewed 2026-05-11 - M4A-4 (#1434 / umbrella #1414) BuiltinRouteRegistrar and WorkflowDefinitionsApiRouter extended to dispatch `POST /api/workflow-definitions/dry-run` to the new WorkflowDryRunController in waaseyaa/api (admin-role-gated). Pure wiring change; no infrastructure contract surface affected. -->
 <!-- Spec reviewed 2026-05-10 - M3A (#1413) SchemaRouter ctor takes optional FieldDefinitionRegistryInterface and forwards to SchemaPresenter; HttpKernel passes $this->fieldRegistry. Pure wiring change; no infrastructure contract surface affected. -->

--- a/kitty-specs/entity-storage-v2-01KRCDDC/mission-review.md
+++ b/kitty-specs/entity-storage-v2-01KRCDDC/mission-review.md
@@ -31,7 +31,7 @@ Everything else (cross-WP edits, byte-identity gate, deferral discipline, autolo
 | FR-008 – FR-010 (sql-blob refactor + behavior identity) | OK | Byte-identity gate is structurally correct: `assertSame` on raw bytes, baseline pinned to literals (`'[]'`, escaped Unicode). Cannot drift to match a buggy refactor. |
 | FR-011 – FR-016 (sql-column) | OK | Backend, schema builder, query translator, type mapping all shipped; conformance suite green. |
 | FR-017 – FR-020 (lifecycle events, coordinator) | OK | `BeforeSaveEvent`, `AfterSaveEvent`, abort/partial-save semantics tested. `SaveContext::withoutNewRevision` correctly gated on `entityType->isRevisionable()` at coordinator line 127. |
-| **FR-021** (DefinitionValidator UnsupportedQueryException at boot) | **WEAK — see H-01** | Class exists, unit tests pass, but no production caller invokes `validateAll()`. The fail-fast contract is unenforced. |
+| **FR-021** (DefinitionValidator UnsupportedQueryException at boot) | **PASS — H-01 RESOLVED** | `AbstractKernel::validateQueryDefinitions()` calls `validateAll()` at boot. Integration tests in `DefinitionValidatorBootTest` confirm boot fails on a rejecting backend. Closes #1443. |
 | FR-022 – FR-045 (revisions: interface, trait, metadata, table builder, sql-blob/sql-column revision storage, pruner) | OK | All shipped; pruner is disabled by default per ADR 016 (a non-goal). |
 | FR-046 (UnsupportedListingException) | OK | |
 | FR-047 – FR-048 (migration CLI + backfill) | OK | `MakeStorageMigrationHandler`, `BackfillHelper` present and unit-tested. |
@@ -48,7 +48,7 @@ Everything else (cross-WP edits, byte-identity gate, deferral discipline, autolo
 | # | Criterion | Status | Notes |
 |---|---|---|---|
 | 1 | All 12 WPs merged | **PASS** | Confirmed in `wps.yaml` and `git log`; mission squash-merged at `509e31fb7`. |
-| 2 | All §3 FRs covered by tests | **PASS** (with H-01 caveat) | 56 FRs covered per acceptance checklist; FR-021 coverage is unit-level only, not end-to-end through boot — see H-01. |
+| 2 | All §3 FRs covered by tests | **PASS** | 56 FRs covered per acceptance checklist; FR-021 now covered end-to-end through kernel boot (H-01 resolved, #1443). |
 | 3 | Conformance suite green for sql-blob and sql-column | **PASS** | 5 inherited tests × 2 backends, full suite 7693 green. |
 | 4 | WP11 Minoo migration 7 days in prod no incident | **DEFERRED** (acknowledged) | `validation/pending-minoo-cycle.md` documents the operator-side T057–T060 exit criteria. The deferral is explicit, not silent. Mission spec §14 criterion 4 is NOT re-defined — it remains an open obligation owed by the Minoo cycle. |
 | 5 | Charter §3.2 criterion 8 ("revisions in production") satisfiable | **PASS** (satisfiable, not satisfied) | The framework now supports revisionable entity types; satisfaction requires the same Minoo cycle as criterion 4. |
@@ -85,21 +85,11 @@ No moderation workflows, no per-field translation, no admin revision-compare UI,
 
 ## 5. Risk Findings
 
-### H-01 — DefinitionValidator has no production caller [HIGH, dead-on-the-vine]
+### H-01 — DefinitionValidator has no production caller [HIGH, dead-on-the-vine] — RESOLVED
 
-Grep of `packages/**/src/` (excluding tests, testing/) for `DefinitionValidator` and `validateAll`:
+~~Grep of `packages/**/src/` (excluding tests, testing/) for `DefinitionValidator` and `validateAll` found only the class itself and a docblock `@see`. No kernel boot, service provider, or `BackendRegistrar` site called `validateAll()`. FR-021 fail-fast guarantee was unenforced.~~
 
-```
-packages/entity-storage/src/Query/DefinitionValidator.php   (class itself)
-packages/entity-storage/src/Exception/UnsupportedQueryException.php  (docblock @see only)
-```
-
-There is no kernel boot, service provider, or `BackendRegistrar` site that calls `$validator->validateAll()`. The class is unreachable from any HTTP/CLI boot. FR-021 specifies that boot MUST fail when a registered entity type declares a query the resolved backend cannot support — this is currently impossible to trigger outside of unit tests.
-
-The WP06 cycle-1 review accepted the WP with this gap explicitly noted as "deferred to a follow-up WP." That deferral was never converted into a follow-up artifact.
-
-**Severity:** High (a documented fail-fast contract that does not fail-fast in production is worse than no contract — it gives false confidence).
-**Disposition:** Open a follow-up WP/issue to wire `DefinitionValidator::validateAll()` into `AbstractKernel::boot()` (after `BackendRegistrar::build()` runs, before `discoverAndRegisterProviders()` returns).
+**RESOLVED** by PR fixing GitHub issue #1443. `AbstractKernel::validateQueryDefinitions()` is now called in `boot()` after `discoverAccessPolicies()` and before `$this->booted = true`. It builds `BackendRegistrar` from `$this->manifest->providers`, wraps it in `BackendResolver`, and calls `DefinitionValidator::validateAll()`. Three integration tests in `packages/foundation/tests/Integration/Kernel/DefinitionValidatorBootTest.php` cover the happy path, the boot-failure path, and the non-indexed-field bypass.
 
 ### R-01 — Cross-WP edits — all verified clean
 
@@ -126,7 +116,7 @@ WP09 added an optional `operations` array (default `[]`) to `PolicyAttribute`. U
 | Candidate | Where | Risk | Mitigation in place? |
 |---|---|---|---|
 | Empty `IN`/`NOT IN` queries return zero results | DBAL pattern, framework-wide (CLAUDE.md) | Not introduced by this mission | N/A |
-| `DefinitionValidator` not invoked at boot | `packages/entity-storage/src/Query/DefinitionValidator.php` | **Yes** — FR-021 fail-fast guarantee silently absent | **No** — see H-01 |
+| `DefinitionValidator` not invoked at boot | `packages/entity-storage/src/Query/DefinitionValidator.php` | ~~**Yes** — FR-021 fail-fast guarantee silently absent~~ **RESOLVED** — wired into `AbstractKernel::validateQueryDefinitions()` (#1443) | **Yes** — see H-01 resolution |
 | Consumer reads `$e->code` per spec/contract | spec.md:317, contracts/partial-save-error.md:33 | Returns inherited `\Exception::$code` int (0) silently | **No** — see H-02 |
 | `SqlColumnBackend::delete()` double-delete | Coordinator deletes the row too | Idempotent: `DELETE` against an already-deleted row is a no-op | Yes — documented in WP12 docblock |
 | Non-revisionable entity touched by `withoutNewRevision=true` | EntityStorageCoordinator:127 | None — gated on `isRevisionable()` | Yes |
@@ -151,10 +141,10 @@ No new public attack surface introduced. No secrets in defaults.
 
 | ID | Item | Type | Suggested follow-up |
 |---|---|---|---|
-| H-01 | Wire `DefinitionValidator::validateAll()` into `AbstractKernel::boot()` | Code | New WP or GitHub issue. ~20-line delta. Required to make FR-021 honest. |
+| H-01 | ~~Wire `DefinitionValidator::validateAll()` into `AbstractKernel::boot()`~~ | Code | **RESOLVED** — `AbstractKernel::validateQueryDefinitions()` added; closes GitHub #1443. |
 | H-02 | Update `spec.md` §6.5 (line 317) and `contracts/partial-save-error.md` (line 33) to declare `$errorCode` not `$code`; add the PHP-constraint footnote that already lives in the class docblock | Docs | Single doc-fix PR. No code change. |
 | O-01 | Convert `validation/pending-minoo-cycle.md` exit criteria into a tracked Minoo-repo issue with a 7-day clock | Operational | Tracks §14 criterion 4 / criterion 5. |
-| O-02 | After H-01 lands, add an integration test that constructs a kernel with a deliberately-misconfigured entity type and asserts boot raises `UnsupportedQueryException` | Test | Locks the fail-fast guarantee. |
+| O-02 | ~~After H-01 lands, add an integration test~~ | Test | **RESOLVED** — three tests in `packages/foundation/tests/Integration/Kernel/DefinitionValidatorBootTest.php` cover happy path, boot-failure path, and non-indexed bypass. |
 | O-03 | After T060 closes, capture any lessons in `docs/upgrades/waaseyaa-alpha-X-to-Y.md` §9 per the deferred-cycle note | Docs | |
 
 ---
@@ -165,6 +155,8 @@ No new public attack surface introduced. No secrets in defaults.
 
 The framework deliverable is sound: the multi-backend architecture is in place, the byte-identity gate is structurally honest, cross-WP edits are narrow and documented, layer rules hold, and the conformance suite genuinely caught a contract violation in WP05 (the `SqlColumnBackend::delete()` no-op). Deferral discipline on §14 criterion 4 is explicit — the obligation is not silently redefined, just shifted to the Minoo cycle with documented exit criteria.
 
-Two follow-ups are owed: (a) wire `DefinitionValidator` into production boot so FR-021's fail-fast guarantee is real, and (b) reconcile spec.md §6.5 and contracts/partial-save-error.md with the `$errorCode` naming that already lives in the class, upgrade guide, and public-surface-map.
+~~Two follow-ups are owed: (a) wire `DefinitionValidator` into production boot so FR-021's fail-fast guarantee is real, and (b) reconcile spec.md §6.5 and contracts/partial-save-error.md with the `$errorCode` naming that already lives in the class, upgrade guide, and public-surface-map.~~
+
+**Update:** (a) resolved by #1443 — `AbstractKernel::validateQueryDefinitions()` now enforces FR-021 at boot. (b) H-02 remains open (doc-only fix, no code change needed).
 
 Neither blocks the mission's release; both should be tracked before the next storage-touching mission begins.

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -15,10 +15,13 @@ use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeLifecycleManager;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\EntityStorage\Backend\BackendRegistrarFactory;
+use Waaseyaa\EntityStorage\BackendResolver;
 use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
 use Waaseyaa\EntityStorage\Driver\RevisionableStorageDriver;
 use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
 use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\EntityStorage\Query\DefinitionValidator;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\EntityStorage\Tenancy\CommunityScope;
@@ -150,6 +153,7 @@ abstract class AbstractKernel
         $this->validateContentTypes();
         $this->bootProviders();
         $this->discoverAccessPolicies();
+        $this->validateQueryDefinitions();
         $this->bootKnowledgeExtensionRunner();
 
         $this->finalizeBoot();
@@ -367,6 +371,24 @@ abstract class AbstractKernel
     protected function discoverAccessPolicies(): void
     {
         $this->accessHandler = new AccessPolicyRegistry($this->logger)->discover($this->manifest);
+    }
+
+    /**
+     * Enforce FR-021 fail-fast contract: every indexed field must be backed by
+     * a backend that returns true from supportsQuery(). Called once at boot,
+     * after all service providers have registered their entity types, and before
+     * the booted flag is set. Boot fails immediately on the first violation —
+     * there is no silent fallback and no runtime retry.
+     *
+     * @throws \Waaseyaa\EntityStorage\Exception\UnsupportedQueryException
+     */
+    protected function validateQueryDefinitions(): void
+    {
+        $registrar = new BackendRegistrarFactory($this->manifest->providers)->create();
+        $registrar->build();
+
+        $resolver = new BackendResolver($registrar);
+        new DefinitionValidator($this->entityTypeManager, $resolver, $this->logger)->validateAll();
     }
 
     protected function bootKnowledgeExtensionRunner(): void

--- a/packages/foundation/tests/Integration/Kernel/DefinitionValidatorBootTest.php
+++ b/packages/foundation/tests/Integration/Kernel/DefinitionValidatorBootTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Tests\Integration\Kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Backend\FieldStorageBackendInterface;
+use Waaseyaa\EntityStorage\Backend\HasFieldStorageBackendsInterface;
+use Waaseyaa\EntityStorage\Backend\IsFrameworkBackendProviderInterface;
+use Waaseyaa\EntityStorage\Exception\UnsupportedQueryException;
+use Waaseyaa\EntityStorage\Query\DefinitionValidator;
+use Waaseyaa\EntityStorage\Query\EntityQuery;
+use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+
+/**
+ * Integration tests verifying that FR-021's fail-fast contract is enforced
+ * at kernel boot time, not at first query execution.
+ *
+ * These tests exercise the FULL kernel boot path: compileManifest() →
+ * discoverAndRegisterProviders() → … → validateQueryDefinitions() must run
+ * before $this->booted = true, so a broken entity-type declaration prevents
+ * the kernel from ever reaching a serving state.
+ *
+ * @see AbstractKernel::validateQueryDefinitions()
+ * @see DefinitionValidator::validateAll()
+ */
+#[CoversNothing]
+final class DefinitionValidatorBootTest extends TestCase
+{
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = $this->createMinimalProjectRoot();
+
+        // Reset the static backend slot between tests.
+        BootTestBackendRegistry::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path: kernel boots when all indexed fields have supporting backends
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function kernel_boots_when_indexed_field_backend_supports_queries(): void
+    {
+        BootTestBackendRegistry::register(new BootTestBackend(backendId: 'test-column', querySupported: true));
+
+        $kernel = $this->buildKernel(
+            entityTypeConfig: $this->indexedFieldEntityTypeConfig(backendId: 'test-column'),
+        );
+
+        // Should not throw — backend supports querying.
+        $kernel->publicBoot();
+
+        $this->assertNotNull($kernel->getEntityTypeManager());
+    }
+
+    // -------------------------------------------------------------------------
+    // Boot-failure path: kernel boot throws when a backend rejects declared query
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function kernel_boot_throws_when_indexed_field_backend_rejects_queries(): void
+    {
+        BootTestBackendRegistry::register(new BootTestBackend(backendId: 'test-blob', querySupported: false));
+
+        $kernel = $this->buildKernel(
+            entityTypeConfig: $this->indexedFieldEntityTypeConfig(backendId: 'test-blob'),
+        );
+
+        $this->expectException(UnsupportedQueryException::class);
+        $kernel->publicBoot();
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-indexed fields do not trigger boot failure even on rejecting backends
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function kernel_boots_when_non_indexed_field_backend_rejects_queries(): void
+    {
+        BootTestBackendRegistry::register(new BootTestBackend(backendId: 'test-blob', querySupported: false));
+
+        $kernel = $this->buildKernel(
+            entityTypeConfig: $this->nonIndexedFieldEntityTypeConfig(backendId: 'test-blob'),
+        );
+
+        // Non-indexed field → no query-need probe → boot succeeds.
+        $kernel->publicBoot();
+
+        $this->assertNotNull($kernel->getEntityTypeManager());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function buildKernel(string $entityTypeConfig): object
+    {
+        $projectRoot = $this->projectRoot;
+
+        file_put_contents(
+            $projectRoot . '/config/entity-types.php',
+            $entityTypeConfig,
+        );
+
+        return new class($projectRoot) extends AbstractKernel {
+            public function publicBoot(): void
+            {
+                $this->boot();
+            }
+
+            /**
+             * Override manifest compilation to inject the test backend provider
+             * while still running the real boot path for everything else.
+             */
+            protected function compileManifest(): void
+            {
+                parent::compileManifest();
+
+                // Append the test backend provider to the manifest's provider list
+                // so BackendRegistrarFactory discovers it during validateQueryDefinitions().
+                $this->manifest = new PackageManifest(
+                    providers: array_merge(
+                        $this->manifest->providers,
+                        [BootTestBackendProvider::class],
+                    ),
+                    migrations: $this->manifest->migrations,
+                    fieldTypes: $this->manifest->fieldTypes,
+                    formatters: $this->manifest->formatters,
+                    middleware: $this->manifest->middleware,
+                    permissions: $this->manifest->permissions,
+                    policies: $this->manifest->policies,
+                    packageDeclarations: $this->manifest->packageDeclarations,
+                    attributeEntityTypes: $this->manifest->attributeEntityTypes,
+                    nativeCommandProviders: $this->manifest->nativeCommandProviders,
+                );
+            }
+        };
+    }
+
+    private function createMinimalProjectRoot(): string
+    {
+        $projectRoot = sys_get_temp_dir() . '/waaseyaa_dvboot_test_' . uniqid();
+        mkdir($projectRoot . '/config', 0755, true);
+        mkdir($projectRoot . '/storage', 0755, true);
+
+        file_put_contents(
+            $projectRoot . '/config/waaseyaa.php',
+            "<?php return ['database' => ':memory:'];",
+        );
+
+        // entity-types.php is written per test via buildKernel().
+        file_put_contents(
+            $projectRoot . '/config/entity-types.php',
+            "<?php return [];",
+        );
+
+        return $projectRoot;
+    }
+
+    private function indexedFieldEntityTypeConfig(string $backendId): string
+    {
+        return <<<PHP
+<?php
+return [
+    new \Waaseyaa\Entity\EntityType(
+        id: 'article',
+        label: 'Article',
+        class: \stdClass::class,
+        _fieldDefinitions: [
+            'status' => (new \Waaseyaa\Field\FieldDefinition(
+                name: 'status',
+                type: 'string',
+                targetEntityTypeId: 'article',
+            ))->storedIn('{$backendId}')->indexed(),
+        ],
+    ),
+];
+PHP;
+    }
+
+    private function nonIndexedFieldEntityTypeConfig(string $backendId): string
+    {
+        return <<<PHP
+<?php
+return [
+    new \Waaseyaa\Entity\EntityType(
+        id: 'article',
+        label: 'Article',
+        class: \stdClass::class,
+        _fieldDefinitions: [
+            'body' => (new \Waaseyaa\Field\FieldDefinition(
+                name: 'body',
+                type: 'text',
+                targetEntityTypeId: 'article',
+            ))->storedIn('{$backendId}'),
+        ],
+    ),
+];
+PHP;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test-only fixture classes — defined here (not under src/) for autoload-dev.
+// ---------------------------------------------------------------------------
+
+/**
+ * Static slot so BackendRegistrar can instantiate BootTestBackendProvider
+ * with no args, while the test controls which backend is returned.
+ */
+final class BootTestBackendRegistry
+{
+    private static ?FieldStorageBackendInterface $backend = null;
+
+    public static function register(FieldStorageBackendInterface $backend): void
+    {
+        self::$backend = $backend;
+    }
+
+    public static function get(): FieldStorageBackendInterface
+    {
+        if (self::$backend === null) {
+            throw new \LogicException('BootTestBackendRegistry: no backend registered.');
+        }
+
+        return self::$backend;
+    }
+
+    public static function reset(): void
+    {
+        self::$backend = null;
+    }
+}
+
+/**
+ * Framework-owned provider that fetches its backend from the static registry.
+ * Must be no-arg-constructable (BackendRegistrar::build() requirement).
+ */
+final class BootTestBackendProvider implements IsFrameworkBackendProviderInterface
+{
+    public function fieldStorageBackends(): array
+    {
+        return [BootTestBackendRegistry::get()];
+    }
+}
+
+/**
+ * Minimal backend implementation for kernel boot validation tests.
+ */
+final class BootTestBackend implements FieldStorageBackendInterface
+{
+    public function __construct(
+        private readonly string $backendId,
+        private readonly bool $querySupported,
+    ) {}
+
+    public function id(): string
+    {
+        return $this->backendId;
+    }
+
+    public function read(EntityInterface $entity, FieldDefinition $field): mixed
+    {
+        return null;
+    }
+
+    public function write(EntityInterface $entity, FieldDefinition $field, mixed $value): void {}
+
+    public function delete(EntityInterface $entity): void {}
+
+    public function supportsQuery(FieldDefinition $field, EntityQuery $query): bool
+    {
+        return $this->querySupported;
+    }
+}


### PR DESCRIPTION
## Summary

- FR-021's fail-fast contract was aspirational: `DefinitionValidator::validateAll()` existed but had zero production callers — boot never failed when a registered entity type declared a query the resolved backend couldn't support
- Adds `AbstractKernel::validateQueryDefinitions()` called in `boot()` after `discoverAccessPolicies()` and before `$this->booted = true`; uses `BackendRegistrarFactory` + `BackendResolver` to build the validator from manifest providers
- Adds 3 integration tests in `packages/foundation/tests/Integration/Kernel/DefinitionValidatorBootTest.php` exercising the full kernel boot path

## Before / After

**Before** (grep of `packages/**/src/` for `validateAll`):
```
packages/entity-storage/src/Query/DefinitionValidator.php   (class itself only)
packages/entity-storage/src/Exception/UnsupportedQueryException.php  (@see docblock only)
```
Zero production callers.

**After**:
```
packages/foundation/src/Kernel/AbstractKernel.php:391  new DefinitionValidator(...)->validateAll();
```
One production caller — in the boot path, before `$this->booted = true`.

## New integration tests

| Test | Asserts |
|---|---|
| `kernel_boots_when_indexed_field_backend_supports_queries` | Happy path — boot succeeds |
| `kernel_boot_throws_when_indexed_field_backend_rejects_queries` | Boot-failure path — `UnsupportedQueryException` propagates out of `boot()` |
| `kernel_boots_when_non_indexed_field_backend_rejects_queries` | Non-indexed field is not probed — boot succeeds |

## Finding closed

H-01 in `kitty-specs/entity-storage-v2-01KRCDDC/mission-review.md` marked RESOLVED. FR-021 row updated from WEAK to PASS. `docs/specs/entity-system.md` definition validation section updated to reflect active enforcement.

## Gates

- `composer cs-check` — clean
- `composer phpstan` — no errors
- `bin/check-package-layers` — OK
- `bin/check-composer-policy` — OK
- All pre-push hooks — ✔ (composer-policy, spec-drift, phpstan, phpunit)
- Full suite: 7696 tests (6655 in pre-push subset), 1 pre-existing failure unrelated to this PR (`PublicSurfaceVerificationTest` stale surface map entry, exists on `main`)

Closes #1443