### PR TITLE
chore(m002): six follow-up fixes from post-merge mission review

### DIFF
--- a/docs/public-surface-map.md
+++ b/docs/public-surface-map.md
@@ -262,6 +262,45 @@ Machine-readable source: `docs/public-surface-map.php`.
 | `NotifiableTrait` | trait | Default `NotifiableInterface` implementation routing by channel for entity classes |
 | `ChannelInterface` | interface | Delivers a notification to a notifiable recipient via one transport |
 
+### migration
+
+Mission `migration-platform-v1-01KRCDE9` (M-002). All entries below are intentional public surface — the plugin SPI, value objects, the framework destination, reference processors, exceptions, schema, log channels, and the conformance harness third-party plugin authors extend.
+
+| Element | Type | Purpose |
+|---------|------|---------|
+| `SourcePluginInterface` | interface | Source plugin SPI: streams `SourceRecord` instances and assigns `SourceId`s (FR-049, WP01) |
+| `ProcessPluginInterface` | interface | Per-field record transformer SPI (FR-005, WP01) |
+| `DestinationPluginInterface` | interface | Destination plugin SPI: `write`, `rollback`, `lookup` per source id (FR-006, WP01) |
+| `HasMigrationPluginsInterface` | interface | Marker for service providers exposing migration plugins via reflection discovery (WP01) |
+| `HasMigrationsInterface` | interface | Marker for service providers contributing migration manifests (FR-003, WP02) |
+| `MigrationDefinition` | final class | Immutable migration definition: id, source, processors, destination, dependencies, stability (WP02) |
+| `SourceId` | final class | Stable composite key identifying a source record across re-runs (WP01) |
+| `SourceRecord` | final class | DTO carrying a raw row from a source plugin: `sourceType`, `fields` (WP01) |
+| `DestinationRecord` | final class | DTO carrying processed fields to a destination plugin: `entityType`, `bundle`, `fields`, `sourceId`, `sourceRecordHash` (WP01) |
+| `WriteResult` | final class | Destination write outcome: `destinationEntityType`, `destinationUuid`, `sourceRecordHash`, `runId`, `writtenAt` (FR-006, WP01) |
+| `ProcessContext` | final class | Per-field processor context carrying current record + run metadata (WP01) |
+| `Destination\EntityDestination` | final class | Built-in destination writing to Waaseyaa entities via `EntityRepository` (FR-018..FR-029, WP05/WP08) |
+| `Destination\EntityDestinationFactory` | final class | Constructs `EntityDestination` instances bound to a migration id (WP05) |
+| `Process\PassThroughProcessor` | final class | Reference processor: emits the input value unchanged (WP03) |
+| `Process\HtmlSanitizeProcessor` | final class | Reference processor: sanitises HTML field values (WP03) |
+| `Process\LookupProcessor` | final class | Reference processor: resolves cross-migration lookups via `MigrationIdMap` (FR-028, WP03) |
+| `Process\ConcatProcessor` | final class | Reference processor: concatenates multiple source fields (WP03) |
+| `Process\TypeCoerceProcessor` | final class | Reference processor: coerces strings to int/float/bool (WP03) |
+| `Process\DefaultValueProcessor` | final class | Reference processor: substitutes a default when the input is null/empty (WP03) |
+| `ReservedPluginIds` | final class | Constants for framework-reserved plugin ids; collision raises `MigrationPluginCollisionException` (WP01) |
+| `Exception\SourceReadException` | final class | Source plugin failed to read a record / opened-file errors (WP01) |
+| `Exception\ProcessException` | final class | Process plugin raised during per-field transformation (WP03) |
+| `Exception\DestinationWriteException` | final class | Destination plugin failed to write; carries `$reason` code (WP05) |
+| `Exception\MigrationAbortedException` | final class | Operator-triggered abort surfaced from runner / signal handler (WP06) |
+| `Exception\MigrationConcurrencyException` | final class | Per-migration lock contention; carries `holdingPid` + `lockPath` (FR-061, WP09) |
+| `Exception\MigrationCycleException` | final class | Dependency-graph cycle detected during discovery (WP02) |
+| `Exception\MigrationDependencyMissingException` | final class | Migration depends on an unknown id (WP02) |
+| `Exception\MigrationPluginCollisionException` | final class | Two plugins claim the same id; reserved-id collisions set `$isReserved=true` (WP01) |
+| `Schema\MigrationIdMapSchema` | final class | DDL builder for the `migration_id_map` table (FR-029, WP04) |
+| `Log\Channels` | final class | Logger channel constants: `MIGRATION_DEPRECATION`, `MIGRATION_DISCOVERY` (WP01) |
+| `Testing\SourceConformanceTestCase` | abstract class | Conformance harness third-party source plugins extend (FR-052, WP10; autoload-dev) |
+| `Testing\DestinationConformanceTestCase` | abstract class | Conformance harness third-party destination plugins extend (FR-050/FR-051, WP10; autoload-dev) |
+
 ---
 
 ## Layer 4: API

--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -275,6 +275,40 @@ return [
     'Waaseyaa\Migration\Discovery\HasMigrationPluginsInterface' => 'public',
     // Migration platform discovery / dependency graph (mission migration-platform-v1-01KRCDE9 WP02).
     'Waaseyaa\Migration\Discovery\HasMigrationsInterface' => 'public',
+    // Migration platform DTOs / value objects (mission migration-platform-v1-01KRCDE9 WP01..WP04).
+    'Waaseyaa\Migration\MigrationDefinition' => 'public',
+    'Waaseyaa\Migration\SourceId' => 'public',
+    'Waaseyaa\Migration\Plugin\SourceRecord' => 'public',
+    'Waaseyaa\Migration\Plugin\DestinationRecord' => 'public',
+    'Waaseyaa\Migration\Plugin\WriteResult' => 'public',
+    'Waaseyaa\Migration\Plugin\ProcessContext' => 'public',
+    // Migration platform destination (WP05).
+    'Waaseyaa\Migration\Plugin\Destination\EntityDestination' => 'public',
+    'Waaseyaa\Migration\Plugin\Destination\EntityDestinationFactory' => 'public',
+    // Migration platform reference processors (WP03).
+    'Waaseyaa\Migration\Plugin\Process\PassThroughProcessor' => 'public',
+    'Waaseyaa\Migration\Plugin\Process\HtmlSanitizeProcessor' => 'public',
+    'Waaseyaa\Migration\Plugin\Process\LookupProcessor' => 'public',
+    'Waaseyaa\Migration\Plugin\Process\ConcatProcessor' => 'public',
+    'Waaseyaa\Migration\Plugin\Process\TypeCoerceProcessor' => 'public',
+    'Waaseyaa\Migration\Plugin\Process\DefaultValueProcessor' => 'public',
+    // Migration platform plugin meta (WP01).
+    'Waaseyaa\Migration\Plugin\ReservedPluginIds' => 'public',
+    // Migration platform exceptions (WP01..WP09).
+    'Waaseyaa\Migration\Exception\SourceReadException' => 'public',
+    'Waaseyaa\Migration\Exception\ProcessException' => 'public',
+    'Waaseyaa\Migration\Exception\DestinationWriteException' => 'public',
+    'Waaseyaa\Migration\Exception\MigrationAbortedException' => 'public',
+    'Waaseyaa\Migration\Exception\MigrationConcurrencyException' => 'public',
+    'Waaseyaa\Migration\Exception\MigrationCycleException' => 'public',
+    'Waaseyaa\Migration\Exception\MigrationDependencyMissingException' => 'public',
+    'Waaseyaa\Migration\Exception\MigrationPluginCollisionException' => 'public',
+    // Migration platform schema + logging (WP04, WP10).
+    'Waaseyaa\Migration\Schema\MigrationIdMapSchema' => 'public',
+    'Waaseyaa\Migration\Log\Channels' => 'public',
+    // Migration platform conformance bases (WP10, autoload-dev — stable surface for extenders).
+    'Waaseyaa\Migration\Testing\SourceConformanceTestCase' => 'public',
+    'Waaseyaa\Migration\Testing\DestinationConformanceTestCase' => 'public',
 
     // Layer 3: Services — internal
     'Waaseyaa\Billing\StripeClientInterface' => 'internal',

--- a/docs/specs/migration-platform.md
+++ b/docs/specs/migration-platform.md
@@ -377,6 +377,16 @@ entity via the storage coordinator. The id-map row is removed by the runner
 destination is empty). If rollback fails, the id-map row is preserved so the
 operator can retry.
 
+**Rollback vs FR-042 idempotent re-run (issue #1452).** FR-042 governs
+re-running an unchanged record — a separate code path from `rollback()`.
+Whether `rollback()` clears the id-map row alongside the entity is an
+implementation-defined retention policy: the framework default clears it,
+audit/replay-oriented destinations may retain it. Both modes are
+conformant; the conformance harness gates on
+`DestinationConformanceTestCase::rollbackClearsLookup()`. See
+`kitty-specs/migration-platform-v1-01KRCDE9/contracts/destination-plugin.md`
+§"Conformance requirements (WP10)" for the normative statement.
+
 ### 7.4 Lookup path
 
 `EntityDestination::lookup(SourceId $sourceId)` returns the `WriteResult`

--- a/kitty-specs/migration-platform-v1-01KRCDE9/contracts/destination-plugin.md
+++ b/kitty-specs/migration-platform-v1-01KRCDE9/contracts/destination-plugin.md
@@ -217,7 +217,14 @@ Subscribers that want to skip work during imports (e.g. expensive cache invalida
 | C1 | `write()` returns a `WriteResult` whose `$destinationUuid` is non-empty. | FR-006, §10.2 |
 | C2 | Writing the same `DestinationRecord` twice creates exactly one destination entity (idempotency). | FR-030, §10.2 |
 | C3 | After `write()`, `lookup($sourceId)` returns the same `WriteResult`. | FR-028 |
-| C4 | After `rollback($result)`, `lookup($sourceId)` returns `null`. | FR-041, §10.2 |
+| C4 | After `rollback($result)`, `lookup($sourceId)` returns `null` **for destinations whose `rollback()` clears the id-map row** (framework default). Destinations that intentionally retain id-map rows for audit/replay MAY opt out by overriding `DestinationConformanceTestCase::rollbackClearsLookup()` to `false`; in that mode the harness asserts only that `rollback()` executes without raising. | FR-041, FR-042, §10.2 |
+
+**Reconciliation with FR-042 (issue #1452).** FR-042 ("Re-running an unchanged record MUST NOT create a duplicate destination entity. The id-map row's `last_imported_at` SHOULD update.") governs the **idempotent re-run** code path — a separate scenario from `rollback()`. C4 governs the **rollback** code path. The two paths are operationally distinct: rollback is an entity delete; an unchanged re-run is a skip-or-touch on a still-extant entity. Whether `rollback()` deletes the id-map row alongside the entity is an implementation-defined retention policy:
+
+- **Framework default** (`EntityDestination` and any plugin where `rollbackClearsLookup() === true`): `rollback()` removes the id-map row via `MigrationIdMap::deleteByDestination()`, so subsequent `lookup($sourceId)` returns `null`.
+- **Retain-for-audit destinations** (`rollbackClearsLookup() === false`): `rollback()` deletes the destination entity but leaves the id-map row in place so the audit log can replay the prior import. `lookup($sourceId)` MAY return the prior `WriteResult` even after `rollback()`.
+
+Both modes are conformant. Third-party authors choose by overriding `rollbackClearsLookup()`; the harness gates accordingly. FR-042's id-map retention requirement on unchanged re-run is independent of this choice — both modes still satisfy FR-042.
 | C5 | A simulated access-denial raises `DestinationWriteException` with code `entity_create_denied`. | FR-020 |
 | C6 | The id-map row written by `write()` survives `EntityRepository::save()` success; an injected save failure leaves zero id-map rows (R1). | FR-029 |
 | C7 | `SaveContext::isImport()` returns `true` inside the `BeforeSaveEvent` and `AfterSaveEvent` dispatched during `write()`. | FR-022 |

--- a/packages/cli/src/Command/Import/ImportStatusCommand.php
+++ b/packages/cli/src/Command/Import/ImportStatusCommand.php
@@ -13,22 +13,19 @@ use Waaseyaa\Migration\MigrationRunState;
 /**
  * `bin/waaseyaa import:status [<migration-id>]` — surface per-migration state.
  *
- * WP06 shipped the placeholder rendering described in spec §9.2 with
- * zero-valued FAILED / SKIPPED columns; WP07 wires `migration_run_state`
- * so those columns reflect real per-record outcomes.
+ * Columns rendered per spec §9.2:
  *
- *   - `STATE` is computed from `migration_id_map` row count vs source count.
- *     A future WP may extend this with a "running" state once the lock
- *     (WP09) is in place.
+ *   - `STATE` is computed from `migration_id_map` row count vs source count
+ *     (`pending` / `partial` / `complete`).
  *
  *   - `TOTAL` is the source plugin's reported `count()` (or `?` if unknown).
  *
  *   - `IMPORTED` is {@see MigrationIdMap::countForMigration()} — the cheapest
  *     row-level signal available without touching the destination storage.
  *
- *   - `FAILED` / `SKIPPED` come from {@see MigrationRunState::countByStatus()}
- *     (WP07). Records that have never been touched do not show up here —
- *     the columns reflect the LATEST per-record outcome (FR-038).
+ *   - `FAILED` / `SKIPPED` come from {@see MigrationRunState::countByStatus()}.
+ *     Records that have never been touched do not show up here — the columns
+ *     reflect the LATEST per-record outcome (FR-038).
  *
  *   - `LAST RUN` is {@see MigrationIdMap::maxLastImportedAt()}.
  *
@@ -65,8 +62,8 @@ final class ImportStatusCommand
         // Header row matches spec §9.2 column ordering. Widths picked so the
         // common identifiers (e.g. `wp_comments_to_engagement`) fit without
         // wrapping; identifiers longer than 30 chars overflow gracefully (the
-        // table is meant for operators, not for downstream parsers — `--format=json`
-        // for that lands with WP07's `migration_run_state` integration).
+        // table is meant for operators, not downstream parsers — a `--format=json`
+        // mode is tracked as a separate enhancement).
         $io->writeln(\sprintf(
             '%-30s  %-10s  %6s  %8s  %6s  %7s  %s',
             'ID',
@@ -122,9 +119,6 @@ final class ImportStatusCommand
 
         $state = match (true) {
             $importedCount === 0 && $bucket['error'] === 0 => 'pending',
-            // A future WP may extend this with a "running" state once the
-            // lock (WP09) is in place; today we stick to the
-            // pending/partial/complete trichotomy.
             $sourceCount !== null && $importedCount >= $sourceCount => 'complete',
             default => 'partial',
         };

--- a/packages/migration/src/Runner/MigrationLock.php
+++ b/packages/migration/src/Runner/MigrationLock.php
@@ -211,10 +211,15 @@ final class MigrationLock
     /**
      * Release the lock if held; safe to call multiple times.
      *
-     * On Windows, deletion of an open file silently fails; we still
-     * release the OS-level lock via `flock($handle, LOCK_UN)` and close
-     * the handle, leaving the file body. The next `acquire()` will reuse
-     * the path.
+     * Releases the OS-level lock via `flock($handle, LOCK_UN)` and closes
+     * the handle. The lock file itself is intentionally left on disk:
+     *
+     *  - Operators inspect it for the holder PID (see {@see pid()}).
+     *  - The next `acquire()` truncates and overwrites the body on success.
+     *  - Removing the file here would introduce a TOCTOU window — another
+     *    process could `fopen()` a now-stale path between our `unlink()`
+     *    and its own `flock()`, then both holders would believe they own
+     *    distinct locks against the same migration id.
      *
      * @api
      */
@@ -229,7 +234,6 @@ final class MigrationLock
 
         \flock($handle, \LOCK_UN);
         \fclose($handle);
-        @\unlink($this->lockPath);
 
         $this->logger?->debug('MigrationLock: released', [
             'migration_id' => $this->migrationId,

--- a/packages/migration/src/Runner/RollbackWalker.php
+++ b/packages/migration/src/Runner/RollbackWalker.php
@@ -86,6 +86,12 @@ final class RollbackWalker
         $definition = $this->registry->get($migrationId);
         $destination = $definition->destination;
 
+        // Pin the start timestamp from the injected clock. The end timestamp
+        // is captured below; we clamp it `>= $startedAt` (see footer) so the
+        // monotonic invariant in {@see RollbackReport::__construct()} holds
+        // even when the system clock jumps backwards mid-walk (NTP skew,
+        // VM suspend/resume, leap-second smear). FR-044's best-effort
+        // semantics make that scenario operationally possible.
         $startedAt = ($this->clock)();
         $visited = 0;
         $rolledBack = 0;
@@ -128,6 +134,14 @@ final class RollbackWalker
         }
 
         $finishedAt = ($this->clock)();
+
+        // Clamp $finishedAt monotonically. On clock regression we advance
+        // the finish stamp by 1µs over the start so the invariant
+        // `finishedAt >= startedAt` in RollbackReport holds without
+        // requiring callers to inspect / repair the clock themselves.
+        if ($finishedAt < $startedAt) {
+            $finishedAt = $startedAt->modify('+1 microsecond');
+        }
 
         $this->logger->info(
             'Migration rollback complete',

--- a/packages/migration/testing/DestinationConformanceTestCase.php
+++ b/packages/migration/testing/DestinationConformanceTestCase.php
@@ -118,10 +118,22 @@ abstract class DestinationConformanceTestCase extends TestCase
 
     /**
      * Whether the plugin's `rollback()` MUST remove the id-map row so
-     * subsequent `lookup()` calls return null. Most destinations enforce
-     * this (D3), but some intentionally retain the id-map row for audit /
-     * replay; subclasses with that behaviour MAY override this to `false`
-     * and document the deviation.
+     * subsequent `lookup()` calls return null.
+     *
+     * The framework default (`EntityDestination` and any plugin returning
+     * `true`) deletes the id-map row alongside the destination entity.
+     * Destinations that intentionally retain the row for audit / replay
+     * override this to `false`; the conformance harness then asserts only
+     * that `rollback()` executes without raising.
+     *
+     * This knob is the contract reconciliation between the D3 conformance
+     * gate ("lookup() === null after rollback") and FR-042 (id-map
+     * retention on idempotent re-run). The two requirements govern
+     * different code paths — rollback vs unchanged re-run — and both
+     * `true` and `false` returns here are conformant. See
+     * `kitty-specs/migration-platform-v1-01KRCDE9/contracts/destination-plugin.md`
+     * §"Conformance requirements (WP10)" for the full reconciliation
+     * (issue #1452).
      */
     protected function rollbackClearsLookup(): bool
     {

--- a/packages/migration/tests/Fixtures/CsvSource.php
+++ b/packages/migration/tests/Fixtures/CsvSource.php
@@ -99,7 +99,18 @@ final class CsvSource implements SourcePluginInterface
      */
     public function records(): iterable
     {
-        $handle = @\fopen($this->filePath, 'rb');
+        // Pre-check readability so we can raise the typed exception without
+        // relying on `@` to silence PHP's fopen() warning on missing files
+        // (issue #1454).
+        if (!\is_file($this->filePath) || !\is_readable($this->filePath)) {
+            throw new SourceReadException(
+                sourceId: $this->pluginId,
+                migrationId: 'unknown',
+                reason: \sprintf('Cannot open CSV file %s for reading.', $this->filePath),
+            );
+        }
+
+        $handle = \fopen($this->filePath, 'rb');
         if ($handle === false) {
             throw new SourceReadException(
                 sourceId: $this->pluginId,

--- a/packages/migration/tests/Integration/MigrationLockIntegrationTest.php
+++ b/packages/migration/tests/Integration/MigrationLockIntegrationTest.php
@@ -118,11 +118,14 @@ final class MigrationLockIntegrationTest extends TestCase
         $exitCode = $this->runChildAcquireRelease('demo', $this->lockDir);
         self::assertSame(0, $exitCode, 'Child must exit 0 after acquiring + releasing the lock.');
 
-        // After child exit, the lock file should be removed.
+        // After child exit, the lock file persists on disk (issue #1450 —
+        // release() leaves the body so operators can inspect the prior
+        // holder's PID; the OS-level flock has been released).
         $lockPath = $this->lockDir . \DIRECTORY_SEPARATOR . 'demo.lock';
-        self::assertFileDoesNotExist($lockPath);
+        self::assertFileExists($lockPath);
 
-        // Parent acquires cleanly — no leftover handle, no exception.
+        // Parent acquires cleanly — flock is free, body gets overwritten
+        // with our PID on acquire().
         $lock = new MigrationLock(migrationId: 'demo', lockDir: $this->lockDir);
         $lock->acquire();
         try {
@@ -145,9 +148,20 @@ final class MigrationLockIntegrationTest extends TestCase
         $exitCode = $this->runChildAcquireThenExit('demo', $this->lockDir);
         self::assertSame(1, $exitCode, 'Child must exit 1 to signal it acquired the lock without explicit release.');
 
-        // shutdown_function ran inside the child — file should be gone.
+        // shutdown_function ran inside the child and released the OS-level
+        // flock. The lock file itself persists (issue #1450); the proof
+        // that the lock came down is that we can acquire it here without
+        // raising MigrationConcurrencyException.
         $lockPath = $this->lockDir . \DIRECTORY_SEPARATOR . 'demo.lock';
-        self::assertFileDoesNotExist($lockPath, 'register_shutdown_function should have released the lock.');
+        self::assertFileExists($lockPath, 'Lock file body persists across release for PID inspection.');
+
+        $lock = new MigrationLock(migrationId: 'demo', lockDir: $this->lockDir);
+        $lock->acquire();
+        try {
+            self::assertSame(\getmypid(), $lock->pid(), 'Acquire must succeed after the child shutdown handler released the OS flock.');
+        } finally {
+            $lock->release();
+        }
     }
 
     #[Test]
@@ -163,12 +177,11 @@ final class MigrationLockIntegrationTest extends TestCase
         self::assertFileExists($lock->lockPath());
 
         $lock->release();
-        // On non-Windows the file is removed; on Windows the body may
-        // persist if the OS refused to unlink an open handle — but we
-        // already closed it, so the assertion is the same.
-        if (\PHP_OS_FAMILY !== 'Windows') {
-            self::assertFileDoesNotExist($lock->lockPath());
-        }
+        // Issue #1450 — the lock file persists after release on every
+        // platform. release() unlocks the OS-level flock and closes the
+        // handle but leaves the body in place for operator PID
+        // inspection. The next acquire() truncates and overwrites it.
+        self::assertFileExists($lock->lockPath());
     }
 
     /**

--- a/packages/migration/tests/Unit/Runner/MigrationLockTest.php
+++ b/packages/migration/tests/Unit/Runner/MigrationLockTest.php
@@ -83,14 +83,22 @@ final class MigrationLockTest extends TestCase
     }
 
     #[Test]
-    public function release_removes_the_lock_file(): void
+    public function release_leaves_the_lock_file_in_place_for_pid_inspection(): void
     {
+        // Issue #1450 — release() intentionally does NOT unlink the lock
+        // file. Removing it would introduce a TOCTOU window between unlink
+        // and the next acquirer's fopen()+flock(). The PID body is the
+        // operator-facing inspection surface; it is overwritten on the
+        // next successful acquire().
         $lock = new MigrationLock(migrationId: 'demo', lockDir: $this->lockDir);
         $lock->acquire();
         self::assertFileExists($lock->lockPath());
 
         $lock->release();
-        self::assertFileDoesNotExist($lock->lockPath());
+        self::assertFileExists(
+            $lock->lockPath(),
+            'release() must leave the lock file on disk so operators can inspect the previous holder PID.',
+        );
     }
 
     #[Test]
@@ -101,7 +109,9 @@ final class MigrationLockTest extends TestCase
         $lock->release();
         $lock->release(); // No throw.
 
-        self::assertFileDoesNotExist($lock->lockPath());
+        // Lock file persists; release() is idempotent on the OS lock and
+        // does not delete the file (issue #1450).
+        self::assertFileExists($lock->lockPath());
     }
 
     #[Test]

--- a/packages/migration/tests/Unit/Runner/RollbackWalkerTest.php
+++ b/packages/migration/tests/Unit/Runner/RollbackWalkerTest.php
@@ -183,7 +183,54 @@ final class RollbackWalkerTest extends TestCase
         return $written;
     }
 
-    private function makeWalker(DestinationPluginInterface $destination): RollbackWalker
+    /**
+     * Regression for issue #1448 — system clock skew during a rollback walk
+     * MUST NOT raise out of `RollbackReport::__construct()`. The walker
+     * clamps `$finishedAt` to `>= $startedAt`, so even if the injected
+     * clock returns a finish stamp earlier than the start the report
+     * still satisfies its monotonic invariant.
+     */
+    #[Test]
+    public function clock_regression_during_walk_does_not_break_report_construction(): void
+    {
+        $this->seedIdMap(2);
+
+        $destination = new RecordingDestination();
+
+        // Clock returns "now" for the first call (startedAt) and "now - 5s"
+        // for the second call (finishedAt). Without the clamp in
+        // RollbackWalker::rollback(), this would trip
+        // RollbackReport's `finishedAt >= startedAt` invariant.
+        $start = new \DateTimeImmutable('2026-05-13T12:00:00+00:00');
+        $skewed = new \DateTimeImmutable('2026-05-13T11:59:55+00:00');
+        $sequence = [$start, $skewed];
+        $clock = static function () use (&$sequence): \DateTimeImmutable {
+            $next = \array_shift($sequence);
+            \assert($next instanceof \DateTimeImmutable);
+            return $next;
+        };
+
+        $walker = $this->makeWalker($destination, $clock);
+
+        $report = $walker->rollback(self::MIGRATION_ID);
+
+        self::assertSame(2, $report->visited);
+        self::assertSame(2, $report->rolledBack);
+        self::assertSame(0, $report->failed);
+        self::assertTrue(
+            $report->finishedAt >= $report->startedAt,
+            'RollbackReport must satisfy the monotonic timestamp invariant even under clock skew.',
+        );
+        self::assertSame($start, $report->startedAt);
+        // The walker advances finishedAt by exactly 1µs over the start stamp
+        // when the clock regresses.
+        self::assertSame(
+            $start->modify('+1 microsecond')->format('Y-m-d\TH:i:s.uP'),
+            $report->finishedAt->format('Y-m-d\TH:i:s.uP'),
+        );
+    }
+
+    private function makeWalker(DestinationPluginInterface $destination, ?\Closure $clock = null): RollbackWalker
     {
         $definition = new MigrationDefinition(
             id: self::MIGRATION_ID,
@@ -205,6 +252,7 @@ final class RollbackWalkerTest extends TestCase
         return new RollbackWalker(
             registry: $registry,
             idMap: $this->idMap,
+            clock: $clock,
         );
     }
 }


### PR DESCRIPTION
no-changelog: M-002 post-merge follow-up cleanup; the migration platform substrate is already covered by the existing [Unreleased] entry from WP12. These six fixes refine existing surface (public-surface-map registration, contract reconciliation, three bug fixes, two cleanups) — no new behavior to announce.

## Summary
- Closes 6 of 7 M-002 follow-ups filed from the mission review (issues #1448, #1450, #1451, #1452, #1453, #1454).
- Excludes #1449 (cross-WP `EntityRepository::save()` widening) — see PR #1456.

## What's in here
- **#1451** Register ~25 M-002 stable surface symbols in `docs/public-surface-map.{md,php}` — DTOs, exceptions, framework destination, six reference processors, schema, log channels, and the two conformance bases.
- **#1452** Reconcile D3 conformance gate (`lookup() === null` after rollback) with FR-042 (id-map retention on idempotent re-run). Both modes are conformant; updated `contracts/destination-plugin.md`, `docs/specs/migration-platform.md`, and `DestinationConformanceTestCase` PHPDoc.
- **#1448** Clamp \`RollbackReport::\$finishedAt >= \$startedAt\` inside \`RollbackWalker::rollback()\` so wall-clock skew during a walk no longer trips the report's monotonic invariant. Regression test exercises a regressing injected clock.
- **#1450** Drop \`unlink()\` from \`MigrationLock::release()\` — the file persists on disk so operators can inspect the prior PID; next \`acquire()\` truncates and overwrites. Eliminates the TOCTOU window. Updated unit + integration tests.
- **#1453** Remove stale WP07 placeholder language from \`ImportStatusCommand\`'s PHPDoc and inline comments.
- **#1454** Replace \`@\\fopen()\` in \`CsvSource\` fixture with a pre-flight \`is_file()\` + \`is_readable()\` check so \`SourceReadException\` raises without warning leak.

## Test plan
- [x] Full PHPUnit passes — 8255 tests, 0 failures
- [x] check-composer-policy, check-package-layers, cs-check (two passes), phpstan all green
- [x] PublicSurfaceVerificationTest accepts the ~25 newly registered M-002 symbols
- [x] MigrationLockTest + MigrationLockIntegrationTest updated to assert file-persistence
- [x] RollbackWalkerTest::clock_regression_during_walk_does_not_break_report_construction added

## Known CI gates (NOT blockers — pre-existing on main)
- \`ci/unit-tests\` — 17 errors about \`TranslatableArticleFixture\` not implementing \`TranslatableInterface\`. Fails on main (\`09686c43b\`) too. M-006 territory, separate issue.
- \`Public-surface-map parity check\` — CI uses PHP 8.4.21 but repo requires PHP 8.5+. CI infrastructure issue, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)