### PR TITLE
fix(ci): bump surface-parity workflow to PHP 8.5 (#1458)

### DIFF
--- a/.github/workflows/surface-parity.yml
+++ b/.github/workflows/surface-parity.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
## Summary
- Closes #1458 — `.github/workflows/surface-parity.yml` was pinned to PHP 8.4 while the repo requires PHP 8.5+ (since #1406, 2026-05-10).
- Result: `composer install` failed with 60+ `requires php >=8.5` errors on every PR, breaking the `Public-surface-map parity check` gate.
- All other workflows (ci.yml, release.yml, skeleton-smoke.yml) already use PHP 8.5.

## Test plan
- [ ] `Public-surface-map parity check` gate passes on this PR (self-validating)
- [ ] No regressions on other gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)