### PR TITLE
fix(ci): mark surface-parity check warn-only until AST scanner lands (#1465)

### DIFF
--- a/.github/workflows/surface-parity.yml
+++ b/.github/workflows/surface-parity.yml
@@ -23,7 +23,11 @@ on:
 jobs:
   surface-parity:
     runs-on: ubuntu-latest
-    name: Public-surface-map parity check
+    # WARN-ONLY: tools/check-surface-parity.php is a SKELETON stub that emits
+    # false positives (real symbols reported as "removed from source"). Marked
+    # warn-only until the real AST scanner lands. Tracked in #1465.
+    name: Public-surface-map parity check (warn-only)
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Refs #1465 — \`tools/check-surface-parity.php\` is an explicit SKELETON stub that emits false positives (real symbols reported as missing). Marked warn-only matching the existing pattern (\`composer-deps-audit (warn-only)\`, \`dead-code-audit (warn-only)\`).
- Removes the gate as a hard blocker on every PR. The check still runs and surfaces its (currently bogus) output as a non-blocking warning.
- Restore strict mode in a follow-up that lands the real AST-based scanner using \`nikic/php-parser\` per the inline TODO at \`tools/check-surface-parity.php:76\`.

## Why now
After PR #1460 (PHP 8.4 → 8.5 in surface-parity.yml), the parity check actually started running. The skeleton's false positives surfaced immediately, blocking PR #1464 with a bogus \"AssetManagerInterface removed\" error. The interface exists at \`packages/foundation/src/Asset/AssetManagerInterface.php\`.

## Test plan
- [ ] Self-validating — the check runs as warn-only on this PR
- [ ] No other gates regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)