### PR TITLE
fix(ci): bump packaged-form skeleton to alpha.177 + make gate strict (#1315)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,6 @@ jobs:
   packaged-form:
     name: packaged-form
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 

--- a/tests/Architecture/NoKernelSubclassesInTestsTest.php
+++ b/tests/Architecture/NoKernelSubclassesInTestsTest.php
@@ -86,9 +86,17 @@ final class NoKernelSubclassesInTestsTest extends TestCase
         );
 
         foreach ($iterator as $file) {
-            if ($file->isFile() && $file->getExtension() === 'php') {
-                yield $file->getPathname();
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
             }
+            // Skip third-party code installed under tests/ (e.g. the packaged-form
+            // skeleton fixture installs the published framework into its own vendor/).
+            // The architecture rule applies to first-party tests only.
+            $pathname = $file->getPathname();
+            if (str_contains($pathname, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+            yield $pathname;
         }
     }
 }

--- a/tests/PackagedForm/skeleton/composer.json
+++ b/tests/PackagedForm/skeleton/composer.json
@@ -4,9 +4,9 @@
     "type": "project",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.4",
-        "waaseyaa/core": "v0.1.0-alpha.151",
-        "waaseyaa/groups": "v0.1.0-alpha.151"
+        "php": ">=8.5",
+        "waaseyaa/core": "^v0.1.0-alpha.177",
+        "waaseyaa/groups": "^v0.1.0-alpha.177"
     },
     "autoload": {
         "psr-4": {

--- a/tests/PackagedForm/skeleton/composer.lock
+++ b/tests/PackagedForm/skeleton/composer.lock
@@ -4,8 +4,75 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95b0b911b21e1c972295d8b0bd0d33e4",
+    "content-hash": "544e235d2c900d392e0369d023c2a66a",
     "packages": [
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/f53396c2d34225064647a05ca76c1da9d99e5828",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+                "yoast/phpunit-polyfills": "^2.0.0"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
+            },
+            "time": "2023-06-19T06:10:36+00:00"
+        },
         {
             "name": "doctrine/dbal",
             "version": "4.4.3",
@@ -159,6 +226,530 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "lcobucci/clock",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "4cdd88f761e9be9095ccbedf3e08d61ae216c643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/4cdd88f761e9be9095ccbedf3e08d61ae216c643",
+                "reference": "4cdd88f761e9be9095ccbedf3e08d61ae216c643",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.32",
+                "lcobucci/coding-standard": "^12.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-13T21:30:16+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
+        },
+        {
+            "name": "league/event",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "ec38ff7ea10cad7d99a79ac937fbcffb9334c210"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/ec38ff7ea10cad7d99a79ac937fbcffb9334c210",
+                "reference": "ec38ff7ea10cad7d99a79ac937fbcffb9334c210",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0",
+                "psr/event-dispatcher": "^1.0"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.45",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/3.0.3"
+            },
+            "time": "2024-09-04T16:06:53+00:00"
+        },
+        {
+            "name": "league/oauth2-server",
+            "version": "9.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "d8e2f39f645a82b207bbac441694d6e6079357cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/d8e2f39f645a82b207bbac441694d6e6079357cb",
+                "reference": "d8e2f39f645a82b207bbac441694d6e6079357cb",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.4",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "lcobucci/clock": "^2.3 || ^3.0",
+                "lcobucci/jwt": "^5.0",
+                "league/event": "^3.0",
+                "league/uri": "^7.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0  || ~8.5.0",
+                "psr/http-message": "^2.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^3.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^1.12|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4|^2.0",
+                "phpstan/phpstan-phpunit": "^1.3.15|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.5.2|^2.0",
+                "phpunit/phpunit": "^10.5|^11.5|^12.0",
+                "roave/security-advisories": "dev-master",
+                "slevomat/coding-standard": "^8.14.1",
+                "squizlabs/php_codesniffer": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/9.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-25T22:51:15+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "psr/cache",
@@ -361,6 +952,227 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -540,16 +1352,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.8",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d"
+                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7025fd7b687c240426562f86ada06a93b1e771d",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
+                "reference": "4eb0d9dfa9d4f7c59216baf49b3ed6b1fb72293d",
                 "shasum": ""
             },
             "require": {
@@ -600,7 +1412,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -620,20 +1432,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T06:50:29+00:00"
+            "time": "2026-05-06T11:55:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -646,7 +1458,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -671,7 +1483,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -683,24 +1495,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -752,7 +1568,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -772,20 +1588,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -799,7 +1615,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -832,7 +1648,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -844,11 +1660,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -934,16 +1754,16 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v7.4.8",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "ddf5ab29bc0329ece30e16f01c86abb6241e92d8"
+                "reference": "8fd102ae3f4167a552fe8085d09da652ff063163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/ddf5ab29bc0329ece30e16f01c86abb6241e92d8",
-                "reference": "ddf5ab29bc0329ece30e16f01c86abb6241e92d8",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/8fd102ae3f4167a552fe8085d09da652ff063163",
+                "reference": "8fd102ae3f4167a552fe8085d09da652ff063163",
                 "shasum": ""
             },
             "require": {
@@ -1004,7 +1824,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v7.4.8"
+                "source": "https://github.com/symfony/messenger/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -1024,11 +1844,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T12:55:43+00:00"
+            "time": "2026-05-13T08:45:04+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1087,7 +1907,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1111,7 +1931,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -1172,7 +1992,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1196,7 +2016,7 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -1252,7 +2072,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1276,7 +2096,7 @@
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -1335,7 +2155,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1359,16 +2179,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b"
+                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
-                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
+                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
                 "shasum": ""
             },
             "require": {
@@ -1420,7 +2240,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.8"
+                "source": "https://github.com/symfony/routing/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -1440,20 +2260,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-04-22T15:21:55+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -1471,7 +2291,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1507,7 +2327,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1527,20 +2347,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -1553,7 +2373,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1589,7 +2409,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1609,20 +2429,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56"
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/6883ebdf7bf6a12b37519dbc0df62b0222401b56",
-                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -1667,7 +2487,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.8"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -1687,20 +2507,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v7.4.8",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "8f73cbddae916756f319b3e195088da216f0f12f"
+                "reference": "c76458623af9a3fe3b2e5b09b36453f334c2a361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/8f73cbddae916756f319b3e195088da216f0f12f",
-                "reference": "8f73cbddae916756f319b3e195088da216f0f12f",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/c76458623af9a3fe3b2e5b09b36453f334c2a361",
+                "reference": "c76458623af9a3fe3b2e5b09b36453f334c2a361",
                 "shasum": ""
             },
             "require": {
@@ -1771,7 +2591,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v7.4.8"
+                "source": "https://github.com/symfony/validator/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -1791,20 +2611,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T12:55:43+00:00"
+            "time": "2026-05-05T15:30:56+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "15776bb07a91b089037da89f8832fa41d5fa6ec6"
+                "reference": "24cf67be4dd0926e4413635418682f4fff831412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/15776bb07a91b089037da89f8832fa41d5fa6ec6",
-                "reference": "15776bb07a91b089037da89f8832fa41d5fa6ec6",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/24cf67be4dd0926e4413635418682f4fff831412",
+                "reference": "24cf67be4dd0926e4413635418682f4fff831412",
                 "shasum": ""
             },
             "require": {
@@ -1851,7 +2671,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v8.0.8"
+                "source": "https://github.com/symfony/var-exporter/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -1871,20 +2691,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.8",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
+                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
+                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
                 "shasum": ""
             },
             "require": {
@@ -1927,7 +2747,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -1947,7 +2767,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-13T12:04:42+00:00"
         },
         {
             "name": "twig/twig",
@@ -2031,25 +2851,25 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
-                "reference": "1c6ba4f271d10021c8b9532e4963c7cea4a875dc"
+                "reference": "0a13269f653408b205cf9ce42ab3a4b0538657b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/access/zipball/1c6ba4f271d10021c8b9532e4963c7cea4a875dc",
-                "reference": "1c6ba4f271d10021c8b9532e4963c7cea4a875dc",
+                "url": "https://api.github.com/repos/waaseyaa/access/zipball/0a13269f653408b205cf9ce42ab3a4b0538657b2",
+                "reference": "0a13269f653408b205cf9ce42ab3a4b0538657b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/http-foundation": "^7.0",
                 "symfony/routing": "^7.0",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150",
-                "waaseyaa/plugin": "^0.1.0-alpha.150"
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/plugin": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2073,26 +2893,77 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
-            "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.151",
+            "name": "waaseyaa/auth",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
-                "url": "https://github.com/waaseyaa/cache.git",
-                "reference": "c2517edfb8029f5268508e35cc51f85e643b6b41"
+                "url": "https://github.com/waaseyaa/auth.git",
+                "reference": "ac14afe6964a56f715a3a9774d85101403634144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/cache/zipball/c2517edfb8029f5268508e35cc51f85e643b6b41",
-                "reference": "c2517edfb8029f5268508e35cc51f85e643b6b41",
+                "url": "https://api.github.com/repos/waaseyaa/auth/zipball/ac14afe6964a56f715a3a9774d85101403634144",
+                "reference": "ac14afe6964a56f715a3a9774d85101403634144",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/mail": "^0.1.0-alpha.176",
+                "waaseyaa/user": "^0.1.0-alpha.176"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "layer": 6,
+                    "providers": [
+                        "Waaseyaa\\Auth\\AuthServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\Auth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Headless authentication for Waaseyaa — login, registration, 2FA, password reset",
+            "support": {
+                "issues": "https://github.com/waaseyaa/auth/issues",
+                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.177"
+            },
+            "time": "2026-05-11T16:45:02+00:00"
+        },
+        {
+            "name": "waaseyaa/cache",
+            "version": "v0.1.0-alpha.177",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/cache.git",
+                "reference": "0c9e5052f63427afc54c3e011424824ca8cc9122"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/cache/zipball/0c9e5052f63427afc54c3e011424824ca8cc9122",
+                "reference": "0c9e5052f63427afc54c3e011424824ca8cc9122",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.5",
                 "psr/cache": "^3.0",
                 "psr/simple-cache": "^3.0"
             },
@@ -2100,8 +2971,8 @@
                 "phpunit/phpunit": "^10.5"
             },
             "suggest": {
-                "waaseyaa/config": "Required for ConfigCacheInvalidator listener",
-                "waaseyaa/entity": "Required for EntityCacheInvalidator listener"
+                "waaseyaa/config": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176"
             },
             "type": "library",
             "extra": {
@@ -2122,26 +2993,26 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-08T15:25:48+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
-                "reference": "22976a335ea478a18a98d25569c656b7710ca0dc"
+                "reference": "2f9ea8f157cfc9f6d61d9d40ba0e78c15264d0d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/config/zipball/22976a335ea478a18a98d25569c656b7710ca0dc",
-                "reference": "22976a335ea478a18a98d25569c656b7710ca0dc",
+                "url": "https://api.github.com/repos/waaseyaa/config/zipball/2f9ea8f157cfc9f6d61d9d40ba0e78c15264d0d5",
+                "reference": "2f9ea8f157cfc9f6d61d9d40ba0e78c15264d0d5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/event-dispatcher": "^7.0",
                 "symfony/yaml": "^7.0"
             },
@@ -2167,47 +3038,47 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-08T15:25:48+00:00"
+            "time": "2026-05-10T14:49:58+00:00"
         },
         {
             "name": "waaseyaa/core",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/core.git",
-                "reference": "80e08bc1bd756e0c5c93b665562e1609070197e6"
+                "reference": "6a2bb7edb033c44744ceede6232fe1466ec0525d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/core/zipball/80e08bc1bd756e0c5c93b665562e1609070197e6",
-                "reference": "80e08bc1bd756e0c5c93b665562e1609070197e6",
+                "url": "https://api.github.com/repos/waaseyaa/core/zipball/6a2bb7edb033c44744ceede6232fe1466ec0525d",
+                "reference": "6a2bb7edb033c44744ceede6232fe1466ec0525d",
                 "shasum": ""
             },
             "require": {
-                "waaseyaa/access": "^0.1.0-alpha.150",
-                "waaseyaa/cache": "^0.1.0-alpha.150",
-                "waaseyaa/config": "^0.1.0-alpha.150",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.150",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/entity-storage": "^0.1.0-alpha.150",
-                "waaseyaa/error-handler": "^0.1.0-alpha.150",
-                "waaseyaa/field": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150",
-                "waaseyaa/i18n": "^0.1.0-alpha.150",
-                "waaseyaa/plugin": "^0.1.0-alpha.150",
-                "waaseyaa/queue": "^0.1.0-alpha.150",
-                "waaseyaa/routing": "^0.1.0-alpha.150",
-                "waaseyaa/state": "^0.1.0-alpha.150",
-                "waaseyaa/typed-data": "^0.1.0-alpha.150",
-                "waaseyaa/user": "^0.1.0-alpha.150",
-                "waaseyaa/validation": "^0.1.0-alpha.150"
+                "waaseyaa/access": "^0.1.0-alpha.176",
+                "waaseyaa/cache": "^0.1.0-alpha.176",
+                "waaseyaa/config": "^0.1.0-alpha.176",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.176",
+                "waaseyaa/error-handler": "^0.1.0-alpha.176",
+                "waaseyaa/field": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/i18n": "^0.1.0-alpha.176",
+                "waaseyaa/plugin": "^0.1.0-alpha.176",
+                "waaseyaa/queue": "^0.1.0-alpha.176",
+                "waaseyaa/routing": "^0.1.0-alpha.176",
+                "waaseyaa/state": "^0.1.0-alpha.176",
+                "waaseyaa/typed-data": "^0.1.0-alpha.176",
+                "waaseyaa/user": "^0.1.0-alpha.176",
+                "waaseyaa/validation": "^0.1.0-alpha.176"
             },
             "suggest": {
-                "waaseyaa/debug": "Enable dev-only debug helpers and toolbar integration.",
-                "waaseyaa/telescope": "Enable runtime observability dashboards and inspection tooling.",
-                "waaseyaa/testing": "Install in-memory testing fixtures and framework test helpers."
+                "waaseyaa/debug": "^0.1.0-alpha.176",
+                "waaseyaa/telescope": "^0.1.0-alpha.176",
+                "waaseyaa/testing": "^0.1.0-alpha.176"
             },
             "type": "metapackage",
             "extra": {
@@ -2223,27 +3094,27 @@
             "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
             "support": {
                 "issues": "https://github.com/waaseyaa/core/issues",
-                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
-                "reference": "1fd80b1a189c8ecfdcc136517123fc647546057d"
+                "reference": "f0ce767c739b9a67fdc05b5b2a1e52efe98d2629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/database-legacy/zipball/1fd80b1a189c8ecfdcc136517123fc647546057d",
-                "reference": "1fd80b1a189c8ecfdcc136517123fc647546057d",
+                "url": "https://api.github.com/repos/waaseyaa/database-legacy/zipball/f0ce767c739b9a67fdc05b5b2a1e52efe98d2629",
+                "reference": "f0ce767c739b9a67fdc05b5b2a1e52efe98d2629",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "^4.0",
-                "php": ">=8.4"
+                "php": ">=8.5"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2267,37 +3138,38 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-19T17:32:28+00:00"
+            "time": "2026-05-10T14:49:58+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
-                "reference": "47849a0525f6a1954f7dcc51284601bdd451bd8d"
+                "reference": "527d5ca927b582972686dbf86e7399c2bafc5119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/entity/zipball/47849a0525f6a1954f7dcc51284601bdd451bd8d",
-                "reference": "47849a0525f6a1954f7dcc51284601bdd451bd8d",
+                "url": "https://api.github.com/repos/waaseyaa/entity/zipball/527d5ca927b582972686dbf86e7399c2bafc5119",
+                "reference": "527d5ca927b582972686dbf86e7399c2bafc5119",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/event-dispatcher": "^7.0",
                 "symfony/uid": "^7.0",
                 "symfony/validator": "^7.0",
-                "waaseyaa/cache": "^0.1.0-alpha.150",
-                "waaseyaa/config": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150",
-                "waaseyaa/plugin": "^0.1.0-alpha.150",
-                "waaseyaa/typed-data": "^0.1.0-alpha.150",
-                "waaseyaa/validation": "^0.1.0-alpha.150"
+                "waaseyaa/cache": "^0.1.0-alpha.176",
+                "waaseyaa/config": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/plugin": "^0.1.0-alpha.176",
+                "waaseyaa/typed-data": "^0.1.0-alpha.176",
+                "waaseyaa/validation": "^0.1.0-alpha.176"
             },
             "require-dev": {
+                "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^10.5"
             },
             "suggest": {
@@ -2322,31 +3194,32 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
-                "reference": "53aea3c3d376f287804a46ecac20338223c4f5d8"
+                "reference": "c07b77a4f1fd5a167f391e5e4dcbc55a45f3c76a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/entity-storage/zipball/53aea3c3d376f287804a46ecac20338223c4f5d8",
-                "reference": "53aea3c3d376f287804a46ecac20338223c4f5d8",
+                "url": "https://api.github.com/repos/waaseyaa/entity-storage/zipball/c07b77a4f1fd5a167f391e5e4dcbc55a45f3c76a",
+                "reference": "c07b77a4f1fd5a167f391e5e4dcbc55a45f3c76a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/event-dispatcher": "^7.0",
-                "waaseyaa/cache": "^0.1.0-alpha.150",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.150",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/field": "^0.1.0-alpha.150"
+                "waaseyaa/cache": "^0.1.0-alpha.176",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/field": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2370,38 +3243,33 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/error-handler",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/error-handler.git",
-                "reference": "698ebbd0b279d044055d153348a0c814445d4f40"
+                "reference": "9c80a48b4842b44b97608ccf7507d6f70f734ec9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/error-handler/zipball/698ebbd0b279d044055d153348a0c814445d4f40",
-                "reference": "698ebbd0b279d044055d153348a0c814445d4f40",
+                "url": "https://api.github.com/repos/waaseyaa/error-handler/zipball/9c80a48b4842b44b97608ccf7507d6f70f734ec9",
+                "reference": "9c80a48b4842b44b97608ccf7507d6f70f734ec9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/foundation": "^0.1.0-alpha.150"
+                "php": ">=8.5",
+                "waaseyaa/foundation": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
-                "waaseyaa": {
-                    "providers": [
-                        "Waaseyaa\\ErrorHandler\\ErrorHandlerServiceProvider"
-                    ]
-                },
                 "branch-alias": {
                     "dev-main": "0.1.x-dev",
                     "dev-develop/v1.1": "0.1.x-dev"
@@ -2419,35 +3287,41 @@
             "description": "Rich exception pages, solution hints, and editor links for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/error-handler/issues",
-                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
-                "reference": "8fefd73ac7faedef1dd2ad71c99a3f3cd5a33afa"
+                "reference": "59aa4cadc8472430e51c126a0b86cab5a962899f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/field/zipball/8fefd73ac7faedef1dd2ad71c99a3f3cd5a33afa",
-                "reference": "8fefd73ac7faedef1dd2ad71c99a3f3cd5a33afa",
+                "url": "https://api.github.com/repos/waaseyaa/field/zipball/59aa4cadc8472430e51c126a0b86cab5a962899f",
+                "reference": "59aa4cadc8472430e51c126a0b86cab5a962899f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/plugin": "^0.1.0-alpha.150",
-                "waaseyaa/typed-data": "^0.1.0-alpha.150"
+                "php": ">=8.5",
+                "waaseyaa/access": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/plugin": "^0.1.0-alpha.176",
+                "waaseyaa/typed-data": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\Field\\FieldServiceProvider"
+                    ]
+                },
                 "branch-alias": {
                     "dev-main": "0.1.x-dev",
                     "dev-develop/v1.1": "0.1.x-dev"
@@ -2465,37 +3339,40 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "bf7da90a4966c319e40173fead1ab65171719dc0"
+                "reference": "05d9e982dcb1ec6234085f251f5f1e2841390531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/bf7da90a4966c319e40173fead1ab65171719dc0",
-                "reference": "bf7da90a4966c319e40173fead1ab65171719dc0",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/05d9e982dcb1ec6234085f251f5f1e2841390531",
+                "reference": "05d9e982dcb1ec6234085f251f5f1e2841390531",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "^4.0",
-                "php": ">=8.4",
+                "php": ">=8.5",
+                "psr/event-dispatcher": "^1.0",
                 "symfony/dependency-injection": "^7.0",
                 "symfony/event-dispatcher": "^7.0",
                 "symfony/http-foundation": "^7.0",
                 "symfony/messenger": "^7.0",
                 "symfony/uid": "^7.0",
-                "waaseyaa/queue": "^0.1.0-alpha.150"
+                "waaseyaa/queue": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5",
-                "waaseyaa/error-handler": "^0.1.0-alpha.150"
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/error-handler": "^0.1.0-alpha.176",
+                "waaseyaa/routing": "^0.1.0-alpha.176"
             },
             "type": "library",
             "extra": {
@@ -2510,6 +3387,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Http/Request.php"
+                ],
                 "psr-4": {
                     "Waaseyaa\\Foundation\\": "src/"
                 }
@@ -2521,30 +3401,30 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/groups",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/groups.git",
-                "reference": "554524e53d56070d2ddb6fa5c5e16935fb1c76b8"
+                "reference": "8a5ef070537052c6852ed4b0df4ed559477c5d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/groups/zipball/554524e53d56070d2ddb6fa5c5e16935fb1c76b8",
-                "reference": "554524e53d56070d2ddb6fa5c5e16935fb1c76b8",
+                "url": "https://api.github.com/repos/waaseyaa/groups/zipball/8a5ef070537052c6852ed4b0df4ed559477c5d4d",
+                "reference": "8a5ef070537052c6852ed4b0df4ed559477c5d4d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/entity-storage": "^0.1.0-alpha.150",
-                "waaseyaa/field": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150"
+                "php": ">=8.5",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.176",
+                "waaseyaa/field": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2570,29 +3450,29 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Multi-bundle Group content entity type for Waaseyaa (extracted from Minoo)",
+            "description": "Multi-bundle Group content entity type for Waaseyaa (group + group_type; app-defined bundles)",
             "support": {
                 "issues": "https://github.com/waaseyaa/groups/issues",
-                "source": "https://github.com/waaseyaa/groups/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/groups/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
-                "reference": "ed47e9eb95922394fda9bef51e945875a4a9ce5d"
+                "reference": "97caf5d6ac25ea64daa140159923efe6b1d854f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/i18n/zipball/ed47e9eb95922394fda9bef51e945875a4a9ce5d",
-                "reference": "ed47e9eb95922394fda9bef51e945875a4a9ce5d",
+                "url": "https://api.github.com/repos/waaseyaa/i18n/zipball/97caf5d6ac25ea64daa140159923efe6b1d854f5",
+                "reference": "97caf5d6ac25ea64daa140159923efe6b1d854f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "twig/twig": "^3.0"
             },
             "require-dev": {
@@ -2617,27 +3497,27 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-08T15:25:48+00:00"
+            "time": "2026-05-10T14:49:58+00:00"
         },
         {
             "name": "waaseyaa/mail",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mail.git",
-                "reference": "dc3851a58d9cac04b348c5336959dd0eac78c924"
+                "reference": "1440b19c017443a760b174cbee28a0f522ddc432"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/dc3851a58d9cac04b348c5336959dd0eac78c924",
-                "reference": "dc3851a58d9cac04b348c5336959dd0eac78c924",
+                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/1440b19c017443a760b174cbee28a0f522ddc432",
+                "reference": "1440b19c017443a760b174cbee28a0f522ddc432",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/foundation": "^0.1.0-alpha.150"
+                "php": ">=8.5",
+                "waaseyaa/foundation": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5",
@@ -2671,27 +3551,81 @@
             "description": "Transport-agnostic mail API for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mail/issues",
-                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
-            "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.151",
+            "name": "waaseyaa/oidc",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
-                "url": "https://github.com/waaseyaa/plugin.git",
-                "reference": "1356445770a3bdb357e36a43eb1c524622392565"
+                "url": "https://github.com/waaseyaa/oidc.git",
+                "reference": "d775b47cce36c5ffefe31382d82aa24e22b42d12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/1356445770a3bdb357e36a43eb1c524622392565",
-                "reference": "1356445770a3bdb357e36a43eb1c524622392565",
+                "url": "https://api.github.com/repos/waaseyaa/oidc/zipball/d775b47cce36c5ffefe31382d82aa24e22b42d12",
+                "reference": "d775b47cce36c5ffefe31382d82aa24e22b42d12",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/cache": "^0.1.0-alpha.150"
+                "lcobucci/jwt": "^5.3",
+                "league/oauth2-server": "^9.0",
+                "php": ">=8.5",
+                "waaseyaa/access": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/user": "^0.1.0-alpha.176"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "layer": 6,
+                    "providers": [
+                        "Waaseyaa\\Oidc\\OidcServiceProvider"
+                    ],
+                    "migrations": "migrations"
+                },
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\Oidc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "OpenID Connect issuer for Waaseyaa — ecosystem-wide single sign-on",
+            "support": {
+                "issues": "https://github.com/waaseyaa/oidc/issues",
+                "source": "https://github.com/waaseyaa/oidc/tree/v0.1.0-alpha.177"
+            },
+            "time": "2026-05-11T16:45:02+00:00"
+        },
+        {
+            "name": "waaseyaa/plugin",
+            "version": "v0.1.0-alpha.177",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/plugin.git",
+                "reference": "a19a36de3161b14c19ff21874e9293ca52c87992"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/a19a36de3161b14c19ff21874e9293ca52c87992",
+                "reference": "a19a36de3161b14c19ff21874e9293ca52c87992",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.5",
+                "waaseyaa/cache": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2715,29 +3649,29 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
-                "reference": "0db47e82e55bd5a5e61d204833f6892db9c16fde"
+                "reference": "a5536761c2a928fd98f419b406cdeadb01081307"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/0db47e82e55bd5a5e61d204833f6892db9c16fde",
-                "reference": "0db47e82e55bd5a5e61d204833f6892db9c16fde",
+                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/a5536761c2a928fd98f419b406cdeadb01081307",
+                "reference": "a5536761c2a928fd98f419b406cdeadb01081307",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/messenger": "^7.0",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150"
+                "waaseyaa/database-legacy": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2747,7 +3681,8 @@
                 "waaseyaa": {
                     "providers": [
                         "Waaseyaa\\Queue\\QueueServiceProvider"
-                    ]
+                    ],
+                    "migrations": "migrations"
                 },
                 "branch-alias": {
                     "dev-main": "0.1.x-dev",
@@ -2766,36 +3701,43 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
-                "reference": "9f27adeb67de53c458f8b9c70bd9ae1649dce5ee"
+                "reference": "5bdc598d51fbbf7a7455350f7d3642b9a8ffdf24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/routing/zipball/9f27adeb67de53c458f8b9c70bd9ae1649dce5ee",
-                "reference": "9f27adeb67de53c458f8b9c70bd9ae1649dce5ee",
+                "url": "https://api.github.com/repos/waaseyaa/routing/zipball/5bdc598d51fbbf7a7455350f7d3642b9a8ffdf24",
+                "reference": "5bdc598d51fbbf7a7455350f7d3642b9a8ffdf24",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/routing": "^7.0",
-                "waaseyaa/access": "^0.1.0-alpha.150",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/i18n": "^0.1.0-alpha.150"
+                "waaseyaa/access": "^0.1.0-alpha.176",
+                "waaseyaa/auth": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/i18n": "^0.1.0-alpha.176",
+                "waaseyaa/oidc": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\Routing\\AuthOidcRouteServiceProvider"
+                    ]
+                },
                 "branch-alias": {
                     "dev-main": "0.1.x-dev",
                     "dev-develop/v1.1": "0.1.x-dev"
@@ -2813,27 +3755,27 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
-                "reference": "d5d360ecbf9df03ea82f3d197288d5c244684ff2"
+                "reference": "83d419df44e31901b2b8860e0bc88320dad44003"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/state/zipball/d5d360ecbf9df03ea82f3d197288d5c244684ff2",
-                "reference": "d5d360ecbf9df03ea82f3d197288d5c244684ff2",
+                "url": "https://api.github.com/repos/waaseyaa/state/zipball/83d419df44e31901b2b8860e0bc88320dad44003",
+                "reference": "83d419df44e31901b2b8860e0bc88320dad44003",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.150"
+                "php": ">=8.5",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2857,26 +3799,26 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
-                "reference": "56dda48a10fe7f26e2f0c13be427126b50fa34c1"
+                "reference": "4fcdbf3d6fa79e868223254d3a18abd55572f73c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/typed-data/zipball/56dda48a10fe7f26e2f0c13be427126b50fa34c1",
-                "reference": "56dda48a10fe7f26e2f0c13be427126b50fa34c1",
+                "url": "https://api.github.com/repos/waaseyaa/typed-data/zipball/4fcdbf3d6fa79e868223254d3a18abd55572f73c",
+                "reference": "4fcdbf3d6fa79e868223254d3a18abd55572f73c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/validator": "^7.0"
             },
             "require-dev": {
@@ -2901,32 +3843,32 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-10T00:55:54+00:00"
+            "time": "2026-05-10T14:49:58+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
-                "reference": "669ea7c937d395ad1323b11d8ea8849c43c512ae"
+                "reference": "a0986889464220ad089bb7c172e9b25d80c72e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/user/zipball/669ea7c937d395ad1323b11d8ea8849c43c512ae",
-                "reference": "669ea7c937d395ad1323b11d8ea8849c43c512ae",
+                "url": "https://api.github.com/repos/waaseyaa/user/zipball/a0986889464220ad089bb7c172e9b25d80c72e13",
+                "reference": "a0986889464220ad089bb7c172e9b25d80c72e13",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/http-foundation": "^7.0",
                 "twig/twig": "^3.0",
-                "waaseyaa/access": "^0.1.0-alpha.150",
-                "waaseyaa/entity": "^0.1.0-alpha.150",
-                "waaseyaa/foundation": "^0.1.0-alpha.150",
-                "waaseyaa/mail": "^0.1.0-alpha.150"
+                "waaseyaa/access": "^0.1.0-alpha.176",
+                "waaseyaa/entity": "^0.1.0-alpha.176",
+                "waaseyaa/foundation": "^0.1.0-alpha.176",
+                "waaseyaa/mail": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -2955,28 +3897,28 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.151",
+            "version": "v0.1.0-alpha.177",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
-                "reference": "456d6e6a9a3af365ec5c28e162a049981ef01814"
+                "reference": "22589caf4d220d9e345e8e81a269b4306db4612d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/validation/zipball/456d6e6a9a3af365ec5c28e162a049981ef01814",
-                "reference": "456d6e6a9a3af365ec5c28e162a049981ef01814",
+                "url": "https://api.github.com/repos/waaseyaa/validation/zipball/22589caf4d220d9e345e8e81a269b4306db4612d",
+                "reference": "22589caf4d220d9e345e8e81a269b4306db4612d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "symfony/validator": "^7.0",
-                "waaseyaa/typed-data": "^0.1.0-alpha.150"
+                "waaseyaa/typed-data": "^0.1.0-alpha.176"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -3000,9 +3942,9 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.151"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.177"
             },
-            "time": "2026-04-20T00:08:16+00:00"
+            "time": "2026-05-11T16:45:02+00:00"
         }
     ],
     "packages-dev": [
@@ -4794,7 +5736,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4"
+        "php": ">=8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary
- Closes #1315 — the packaged-form CI fixture + kernel-path integration test exist (`tests/PackagedForm/skeleton/`); this PR bumps the skeleton off its stale `alpha.151` pin (26 versions behind) and flips the gate from warn-only to strict.

## Changes
- `tests/PackagedForm/skeleton/composer.json` — bumps `waaseyaa/core` and `waaseyaa/groups` to `^v0.1.0-alpha.177` (resolves against `v0.1.0-alpha.177` on Packagist), bumps PHP constraint to `>=8.5`.
- `tests/PackagedForm/skeleton/composer.lock` — regenerated; all `waaseyaa/*` siblings resolve to `v0.1.0-alpha.177`.
- `.github/workflows/ci.yml` — drops `continue-on-error: true` from the `packaged-form` job. The gate is now strict.
- `tests/Architecture/NoKernelSubclassesInTestsTest.php` — skip `vendor/` subdirectories when scanning `tests/` for forbidden named kernel subclasses. The skeleton's own `vendor/` legitimately contains the framework's `HttpKernel` + `ConsoleKernel`; the architecture rule is meant for first-party test drift only.

## Local validation
- `bin/check-composer-policy` — OK
- `bin/check-package-layers` — OK
- `composer cs-check` × 2 — clean
- `composer phpstan` — `No errors` (1310 files)
- `./vendor/bin/phpunit` (framework, full suite) — 8264 tests, 221192 assertions, 0 failures
- Skeleton's `./vendor/bin/phpunit` — 1 test, 7 assertions, OK against alpha.177

## Test plan
- [ ] `packaged-form` job passes strict on this PR (no `continue-on-error`)
- [ ] `ci/unit-tests` + `composer-policy` + all other CI gates green
- [ ] Cache key for `packaged-form-composer-v1-*` rebuilds (lock hash changed; first run will be slower — expected)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)