### PR TITLE
docs(M-004): downgrade BLOCKED → PARTIALLY UNBLOCKED post-M-006 close-out

### DIFF
--- a/docs/specs/entity-storage-translatable-revisions.md
+++ b/docs/specs/entity-storage-translatable-revisions.md
@@ -1,14 +1,16 @@
 # Entity Storage — Translatable + Revisionable Two-Axis Interaction
 
-> **🛑 BLOCKED — DO NOT PLAN (2026-05-13)**
+> **⚠️ PARTIALLY UNBLOCKED — DO NOT PLAN YET (2026-05-14, updated post-M-006 close-out)**
 >
-> One hard prerequisite remaining: the **ADR 015 listing pipeline** (only the ADR exists today; no implementation mission has been specced). When that mission ships, this banner is removed.
+> One hard prerequisite remaining: the **ADR 015 listing pipeline** (only the ADR exists today; no implementation mission has been specced). Gates WP07 (per-langcode listing filters, langcode cache tags). Per §7.2 of the mission spec, WP01..WP06 are technically plannable without it; WP07 and WP08 (close) are not. When `listing-pipeline-v1` ships, this banner downgrades fully.
 >
-> The single-axis translation substrate prerequisite was satisfied by **M-006 (`entity-storage-translations-v1`, squash `0f7e1809a`)**, which delivered `TranslatableInterface`, per-field `FieldDefinition::translatable()`, translation storage in both `sql-blob` and `sql-column` backends, the configurable fallback chain, translation lifecycle events, the `'translate'` access-policy operation, and the `make:migration --add-translations` CLI. See [`entity-storage-translations-v1.md`](entity-storage-translations-v1.md).
+> The single-axis translation substrate prerequisite was satisfied by **M-006 (`entity-storage-translations-v1`, squash `0f7e1809a` on 2026-05-13, mission closed in PR #1485 / `a7840a36a` on 2026-05-14)**, which delivered `TranslatableInterface`, per-field `FieldDefinition::translatable()`, translation storage in both `sql-blob` and `sql-column` backends, the configurable fallback chain, translation lifecycle events, the `'translate'` access-policy operation, and the `make:migration --add-translations` CLI. See [`entity-storage-translations-v1.md`](entity-storage-translations-v1.md).
+>
+> **Before planning even the unblocked WPs**, revisit §3 FRs and §7 WP decomposition against the M-006 substrate that actually shipped (per the original BLOCKED stamp's "Unblocker" note); the decomposition may shift now that translation deliverables are concrete code instead of a planned shape.
 >
 > See `kitty-specs/entity-storage-translatable-revisions-01KRCDEE/spec.md` for the same banner.
 
-**Status:** Draft mission spec (2026-05-11), **BLOCKED 2026-05-13** (one of two original prerequisites cleared by M-006 on 2026-05-13)
+**Status:** Draft mission spec (2026-05-11), **PARTIALLY UNBLOCKED 2026-05-14** (prereq 1 M-006 satisfied 2026-05-13 squash / 2026-05-14 close-out; prereq 2 `listing-pipeline-v1` still pending; spec still needs revalidation against the M-006 substrate before planning)
 **Audience:** framework maintainers; input for Spec Kitty `specify` → `plan` → `tasks` flow
 **Mission ID:** TBD (to be assigned by `@jonesrussell` on mission creation)
 **Origin:** [ADR 017](../adr/017-per-field-translation.md) §"Revision × translation interaction" (Accepted 2026-05-11).

--- a/kitty-specs/entity-storage-translatable-revisions-01KRCDEE/spec.md
+++ b/kitty-specs/entity-storage-translatable-revisions-01KRCDEE/spec.md
@@ -2,18 +2,21 @@
 <!-- Mission metadata: docs/specs/missions/M-004-entity-storage-translatable-revisions/mission.json -->
 <!-- Mission ID: M-004 | Spec Kitty mission_id below in meta.json -->
 
-> **🛑 BLOCKED — DO NOT PLAN (2026-05-12)**
+> **⚠️ PARTIALLY UNBLOCKED — DO NOT PLAN YET (2026-05-14, updated post-M-006 close-out)**
 >
-> This mission cannot be planned in its current shape. Two hard prerequisites stand between today and a plannable M-004:
+> Original 2026-05-12 BLOCKED stamp identified two hard prerequisites. Status today:
 >
-> 1. **Single-axis translation substrate.** **Spec filed 2026-05-12 as [M-006 `entity-storage-translations-v1`](../entity-storage-translations-v1-01KRF0FQ/spec.md)** (canonical doctrine: `docs/specs/entity-storage-translations-v1.md`). Must SHIP — not just be spec'd — before this composition can plan. M-001 (`entity-storage-v2-01KRCDDC`, squash `509e31fb7`) shipped only the revision axis. Today's translation surface is still a tombstone: `EntityTypeInterface::isTranslatable(): bool` exists as an opt-in flag with no `TranslatableEntityInterface`, no `$entity->getTranslation()`, no translation storage.
-> 2. **ADR 015 listing pipeline.** Required for WP07 (per-langcode listing filters, langcode cache tags). Only the ADR exists; no mission specced or shipped.
+> 1. ~~**Single-axis translation substrate.**~~ ✅ **SATISFIED** by M-006 (`entity-storage-translations-v1-01KRF0FQ`, squash `0f7e1809a` on 2026-05-13, mission closed in PR #1485 / `a7840a36a` on 2026-05-14). The translation tombstone is gone: `TranslatableInterface` (`packages/entity/src/TranslatableInterface.php`) and `TranslatableEntityTrait` are in place; per-field `FieldDefinition::translatable()` works in both `sql-blob` and `sql-column` backends via `TranslationSchemaHandler`; `SaveContext::langcode` + `withLangcode()` carry per-langcode save semantics.
+> 2. **ADR 015 listing pipeline.** ❌ Still pending. Required for WP07 (per-langcode listing filters, langcode cache tags). Only `docs/adr/015-listing-pipeline-views-equivalent.md` exists; no `listing-pipeline-v1` mission specced, no implementation in `packages/`.
 >
-> **Unblocker:** M-006 must complete and squash-merge; the ADR 015 listing pipeline mission must spec and ship. After both land, revisit this spec's §3 FRs and §7 WP decomposition against the new substrate — much of the work decomposition may shift.
+> **Plannable today:** WP01..WP06 (per §7.2 below, after WP01+WP02 the parallel branch WP03/WP04/WP05/WP06 has no listing-pipeline dependency).
+> **Still gated:** WP07 (needs `listing-pipeline-v1` to spec and ship) and WP08 (closes the mission; transitively gated).
+>
+> **Unblocker (full):** Spec and ship `listing-pipeline-v1` as a separate mission. Before *any* planning begins, the original author's caveat still holds — revisit §3 FRs and §7 WP decomposition against the M-006 substrate that actually shipped; the decomposition may shift now that translation deliverables are concrete code instead of a planned shape.
 
 # Entity Storage — Translatable + Revisionable Two-Axis Interaction
 
-**Status:** Draft mission spec (2026-05-11), **BLOCKED 2026-05-12** pending single-axis translation prerequisite
+**Status:** Draft mission spec (2026-05-11), **PARTIALLY UNBLOCKED 2026-05-14** (prereq 1 M-006 satisfied 2026-05-13 squash / 2026-05-14 close-out; prereq 2 `listing-pipeline-v1` still pending; spec still needs revalidation against the M-006 substrate before planning)
 **Audience:** framework maintainers; input for Spec Kitty `specify` → `plan` → `tasks` flow
 **Mission ID:** TBD (to be assigned by `@jonesrussell` on mission creation)
 **Origin:** [ADR 017](../adr/017-per-field-translation.md) §"Revision × translation interaction" (Accepted 2026-05-11).


### PR DESCRIPTION
## Summary

After the M-006 close-out (#1485 / `a7840a36a` on 2026-05-14), I re-checked the BLOCKED stamp on `entity-storage-translatable-revisions` (M-004). The original 2026-05-12 stamp listed **two** hard prerequisites; one is now satisfied, one remains.

### Prereq 1: Single-axis translation substrate — ✅ SATISFIED

M-006 delivered everything the stamp called missing:

- `packages/entity/src/TranslatableInterface.php:63` — `getTranslation()` interface
- `packages/entity/src/TranslatableEntityTrait.php:131` — implementation
- `packages/entity-storage/src/Schema/TranslationSchemaHandler.php` — sibling `<table>__translation` tables (sql-column) + blob shape
- `packages/entity-storage/src/SaveContext.php:39,73` — `langcode` field + `withLangcode()` for per-langcode saves

### Prereq 2: ADR 015 listing pipeline — ❌ STILL PENDING

- `docs/adr/015-listing-pipeline-views-equivalent.md` exists
- No `listing-pipeline-v1` mission specced in `kitty-specs/`
- No `docs/specs/listing-pipeline-*.md`
- No `ListingPipeline` symbol anywhere in `packages/`

Per the mission spec §7.2: *"After WP01 + WP02: WP03, WP04, WP05, WP06 can run in parallel. WP07 needs ADR 015's listing pipeline shipping. WP08 closes the mission."*

So: **WP01..WP06 plannable today; WP07/WP08 still gated.**

### Author caveat preserved

The original stamp's "Unblocker" line warned: *"After both land, revisit this spec's §3 FRs and §7 WP decomposition against the new substrate — much of the work decomposition may shift."* That caveat still applies even for the unblocked WPs — M-006 shipped concrete deliverables that may have shifted the contract this spec assumed. The downgrade text preserves that warning verbatim: **DO NOT PLAN YET**, revalidate first.

## Diff

- `kitty-specs/entity-storage-translatable-revisions-01KRCDEE/spec.md` — replaces the 2026-05-12 BLOCKED stamp + status line
- `docs/specs/entity-storage-translatable-revisions.md` — refreshes the doctrine-spec stamp (already partially refreshed on 2026-05-13; this catches it up to the close-out and adds the WP01-WP06/WP07 split)

`docs/specs/missions/M-004-entity-storage-translatable-revisions/mission.json` is unchanged — its `status: "ready-for-filing"` and `external_dependencies` shape are orthogonal to the stamp downgrade.

## Test plan

- [x] No code changes; docs only
- [x] composer-policy + spec-drift pre-push hooks clean
- [ ] CI green
- [ ] Squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)