### PR TITLE
chore(split): wire ai-tools and listing into split.yml

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -54,6 +54,7 @@ jobs:
           - { local: 'packages/billing', remote: 'billing' }
           - { local: 'packages/bimaaji', remote: 'bimaaji' }
           # Layer 3: Services
+          - { local: 'packages/listing', remote: 'listing' }
           - { local: 'packages/migration', remote: 'migration' }
           - { local: 'packages/search', remote: 'search' }
           - { local: 'packages/seo', remote: 'seo' }
@@ -68,6 +69,7 @@ jobs:
           - { local: 'packages/ai-pipeline', remote: 'ai-pipeline' }
           - { local: 'packages/ai-vector', remote: 'ai-vector' }
           - { local: 'packages/ai-observability', remote: 'ai-observability' }
+          - { local: 'packages/ai-tools', remote: 'ai-tools' }
           # Layer 5.5: GraphQL
           - { local: 'packages/graphql', remote: 'graphql' }
           # Layer 6: Interfaces


### PR DESCRIPTION
## Summary

Both `packages/ai-tools/composer.json` (declaring `waaseyaa/ai-tools`) and `packages/listing/composer.json` (declaring `waaseyaa/listing`) existed but were never added to the `Split Monorepo` matrix.

`bin/check-release-tag-parity` scans `packages/*/composer.json` directly and expects every `waaseyaa/<short>` to have a tag-parity-matched split repo. On `v0.1.0-alpha.181` this failed with `RP003`, gating `publish-github-release`.

This PR adds both entries (alphabetically within their layer sections) so future tagged releases fan out correctly. For the in-flight `v0.1.0-alpha.181`, splits are being backfilled manually using `splitsh-lite` against the existing tag.

Refs the failed split run: https://github.com/waaseyaa/framework/actions/runs/26072085736

## Test plan

- [ ] Merge with no other workflow changes
- [ ] Next tag push triggers the matrix with `ai-tools` and `listing` entries included
- [ ] `bin/check-release-tag-parity` passes on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)