### PR TITLE
fix(path,groups): close two regressions from #1495 in v0.1.0-alpha.181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SSR rendering broken under fail-closed access checking.** `PathAliasResolver` was missed by the #1495 sweep and called `getQuery()->execute()` without binding an account or opting out — every SSR request (and every other URL → entity lookup) hit `MissingQueryAccountException` and returned HTTP 500. Eight Phase13 `SsrHttpKernelIntegrationTest` cases regressed in v0.1.0-alpha.181. Marked as a documented system-context bypass (URL aliases must resolve globally; entity-level access is enforced when the caller subsequently loads the resolved entity). Added to `docs/security/sql-entity-query-access-check-bypass-audit.md`.
+- **`Groups\Tests\Integration\TwoBundleCoexistenceTest` regressed in v0.1.0-alpha.181.** Tests that construct `SqlEntityQuery` directly to exercise bundle-routing semantics now opt out of access checking — they verify field-resolution behaviour, not access semantics.
+
 ## [0.1.0-alpha.181] - 2026-05-19
 
 ### Added

--- a/docs/security/sql-entity-query-access-check-bypass-audit.md
+++ b/docs/security/sql-entity-query-access-check-bypass-audit.md
@@ -38,6 +38,7 @@ These sites never have an end-user `AccountInterface` available and run with ful
 | `packages/genealogy/src/Ssr/GenealogySsrController.php` | 155 | SSR controller hydrates pedigree data for the demo surface; mirrors the service-layer policy above. Revisit when genealogy has a proper account-aware access policy. | 2026-05-18 |
 | `packages/genealogy/src/Ssr/GenealogySsrController.php` | 164 | Same SSR controller, sibling query. | 2026-05-18 |
 | `packages/mcp/src/Tools/McpTool.php` | 68 | MCP relationship-id lookup feeds tool-execution context; the MCP surface authenticates via its own credential layer (not the user account model), so the entity-query account is intentionally unset. | 2026-05-18 |
+| `packages/path/src/PathAliasResolver.php` | 25 | System-context URL → entity-id lookup. Path aliases must resolve globally for any visitor; entity-level access is enforced when the caller subsequently loads the resolved entity. Missed during the original audit and caught when Phase13 SSR integration tests started returning HTTP 500 instead of 200/403/404 after v0.1.0-alpha.181 shipped. | 2026-05-19 |
 
 ### Conditional fallback — set account when available, bypass otherwise
 

--- a/packages/groups/tests/Integration/TwoBundleCoexistenceTest.php
+++ b/packages/groups/tests/Integration/TwoBundleCoexistenceTest.php
@@ -163,6 +163,7 @@ final class TwoBundleCoexistenceTest extends TestCase
         ]));
 
         $ids = (new SqlEntityQuery($this->groupType, $this->database, null, $this->registry))
+            ->accessCheck(false)
             ->condition('type', 'alpha')
             ->condition('alpha_code', 'A-42')
             ->execute();
@@ -183,6 +184,7 @@ final class TwoBundleCoexistenceTest extends TestCase
         $this->expectException(BundleAmbiguousFieldException::class);
 
         (new SqlEntityQuery($this->groupType, $this->database, null, $this->registry))
+            ->accessCheck(false)
             ->condition('shared_tag', 'anything')
             ->execute();
     }

--- a/packages/path/src/PathAliasResolver.php
+++ b/packages/path/src/PathAliasResolver.php
@@ -18,7 +18,12 @@ final readonly class PathAliasResolver
             return null;
         }
 
+        // System-context URL → entity-id lookup. Path aliases must resolve
+        // globally; entity-level access is enforced when the resolved entity
+        // is subsequently loaded by the caller.
+        // See docs/security/sql-entity-query-access-check-bypass-audit.md.
         $query = $this->pathAliasStorage->getQuery()
+            ->accessCheck(false)
             ->condition('alias', $alias)
             ->condition('langcode', $langcode)
             ->range(0, 20);

--- a/packages/path/tests/Unit/PathAliasResolverTest.php
+++ b/packages/path/tests/Unit/PathAliasResolverTest.php
@@ -28,6 +28,7 @@ final class PathAliasResolverTest extends TestCase
         ]);
 
         $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([10]);
@@ -48,6 +49,7 @@ final class PathAliasResolverTest extends TestCase
     public function returns_null_when_alias_not_found(): void
     {
         $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([]);


### PR DESCRIPTION
## Summary

Two regressions shipped in v0.1.0-alpha.181 because mission #1495's audit of `SqlEntityQuery::accessCheck()` call sites missed:

1. **`PathAliasResolver`** — every URL → entity-id lookup hit `MissingQueryAccountException` because the query never bound an account nor opted out. Eight Phase13 `SsrHttpKernelIntegrationTest` cases regressed (HTTP 500 instead of 200/403/404). Path aliases are system-context: they must resolve globally so any visitor can route a URL; entity-level access is enforced by the caller when it loads the resolved entity. Marked with `accessCheck(false)` and documented in `docs/security/sql-entity-query-access-check-bypass-audit.md`.

2. **`Groups\Tests\Integration\TwoBundleCoexistenceTest`** — two test cases that construct `SqlEntityQuery` directly to exercise bundle-routing semantics now opt out of access checking. They verify field-resolution behaviour (`BundleAmbiguousFieldException` ordering, inner-join narrowing), not access semantics.

Also updates the `PathAliasResolverTest` unit mock to stub the new `accessCheck()` call on `EntityQueryInterface`.

## Out of scope (follow-up)

`Waaseyaa\Attachment\Policy\ParentDelegatedAccessPolicy` cannot be auto-instantiated by `AccessPolicyRegistry` (constructor needs `EntityTypeManager` + `EntityAccessHandler`). It currently logs an error at boot and the policy is silently dropped — attachments fall back to no access policy. This is a real bug but doesn't break tests, so it's filed as a follow-up. See linked issue.

Refs #1495.

## Test plan

- [x] `./vendor/bin/phpunit --testsuite Unit` — 7907/7907 green locally
- [x] `./vendor/bin/phpunit --testsuite Integration` — 1197/1197 green locally
- [x] `composer cs-check` — clean
- [ ] CI green
- [ ] Cut v0.1.0-alpha.182 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)