### PR TITLE
chore(.gitignore): newsletter-test-* and img scratch leak patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,11 @@ phpstan-tests/
 /waaseyaa_test_lock_*/
 /waaseyaa_idmap_*
 /playwright-transform-cache-*/
+/newsletter-test-*
+# Media test scratch (`img` + 22-char hex/alnum suffix). 15-char floor avoids
+# matching real `img*.{js,css,svg,...}` source files, all of which contain `.`
+# or `-` before the suffix.
+/img[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]*
 
 # Spec Kitty session scratch (implement/review prompts, handoff/research notes)
 /spec-kitty-implement-*.md


### PR DESCRIPTION
Both shapes were repeatedly showing up in repo root and polluting `git status` (and `scripts/release.sh`'s clean-tree gate):

- `newsletter-test-<22-alnum>` — empty files from a newsletter dispatcher test that's calling `tempnam()` with the repo root instead of `/tmp`.
- `img<22-alnum>` containing `test-image` — same pattern from a media upload/storage test.

Both join the existing "Runtime/test artifacts that leak into repo root" section. The `img*` pattern uses 15+ `[A-Za-z0-9]` chars so real source files (`img-loader.js`, `img-stub.svg`, etc., which have `-` or `.` before the suffix) are not matched — verified locally with a real `img-loader.js` touch test.

The underlying `tempnam()`-into-repo-root calls remain (per the existing `#TODO: trace and fix at source` comment in the section). Surface-only hygiene fix.

Discovered while running `scripts/release.sh` for alpha.186 — these untracked files blocked the clean-tree check and forced a workflow-dispatch path. Future releases (and any `git status` glance) won't trip over them.