### PR TITLE
docs(bimaaji): WP04 README + spec status + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,14 @@ When the mapping is not obvious, search under `docs/specs/` (e.g. `rg -n "TopicO
 6. Verify with `bin/waaseyaa schedule:list` — your tasks should appear grouped under the class FQCN
 7. To disable a built-in entry: add its FQCN to `schedule.disabled_entries` in configuration
 
+**Adding a Bimaaji graph section provider:**
+1. Implement `Waaseyaa\Bimaaji\Graph\GraphSectionProviderInterface` — `getKey(): string` returns the section identifier; `provide(): GraphSection` returns the versioned payload.
+2. Mark with `@api` in PHPDoc if the class is part of a public extension surface (dead-code detector gates on this).
+3. Bind it in your package's `ServiceProvider::register()`. The canonical tag is `BimaajiServiceProvider::SECTION_PROVIDER_TAG` (`bimaaji.section_provider`) — use it for forward-compatibility with future tagged-collection container support.
+4. Constructor dependencies must be container-resolvable; lean on the kernel-services bus when crossing package boundaries.
+5. Verify by resolving `Waaseyaa\Bimaaji\Graph\ApplicationGraphGenerator` from the container — the framework's default `BimaajiServiceProvider` only composes the six built-in providers, so a downstream provider currently needs to either (a) rebind `ApplicationGraphGenerator` with its own iterable that includes the new provider, or (b) wait for the tagged-collection resolution feature scheduled for M3's container work.
+6. Read `docs/specs/bimaaji.md` "Implementation Status" before adding mutation-side behavior — the validated mutation pipeline (`MutationValidator` → `PatchSet`) belongs to bimaaji's mutation surface, not graph providers.
+
 ## Workflow (Spec Kitty–first)
 
 Substantive work is driven by **[Spec Kitty](https://github.com/Priivacy-ai/spec-kitty)** missions and work packages (`.kittify/`, `spec-kitty next`, dashboard); **GitHub** is the PR/CI/releases surface and optional issue visibility. Full rules: `docs/specs/workflow.md` (versioning, PR traceability).

--- a/docs/specs/bimaaji.md
+++ b/docs/specs/bimaaji.md
@@ -1,5 +1,29 @@
 # Bimaaji — Application Graph & Agent Mutation Layer
 
+<!-- Spec reviewed 2026-05-21 - M1 (bimaaji-wakeup-01KS5VEY) flipped Implementation Status from "scaffolding only" to "shipped". -->
+
+## Implementation Status
+
+**Shipped (as of M1 `bimaaji-wakeup-01KS5VEY`):**
+
+- `BimaajiServiceProvider` is auto-discovered via `extra.waaseyaa.providers` in `packages/bimaaji/composer.json`.
+- `ApplicationGraphGenerator` is bound as a container singleton, wired with the six default `GraphSectionProvider` implementations (admin, entities, jsonapi, public_surface, routing, sovereignty).
+- Each default provider's constructor dependencies (`EntityTypeManagerInterface`, `RouteCollection`, `SovereigntyProfile`) resolve from the kernel-services bus. `RouteCollection` falls back to `WaaseyaaRouter::getRouteCollection()`; `SovereigntyProfile` falls back to `SovereigntyProfile::Local`.
+- `BimaajiServiceProvider` implements `HasNativeCommandsInterface` (empty stub; the `graph:dump` command lands in WP02 of M1).
+- Unit test coverage at `packages/bimaaji/tests/Unit/BimaajiServiceProviderTest.php` (7 tests, 38 assertions: binding identity, tagged collection, six-section output, lazy resolution, capability interface, RouteCollection fallback).
+
+**In progress (M1 follow-up WPs):**
+
+- WP02 — `bin/waaseyaa graph:dump [--section=…] [--format=json|yaml] [--strict]` CLI command (FR-005, FR-006, FR-011..FR-013).
+- WP03 — booted-kernel integration test under `tests/Integration/PhaseN/Bimaaji/` (FR-010, NFR-001, SC-005).
+- WP05 — cross-mission gate proving M2 needs no further bimaaji wiring (verification artifact at `kitty-specs/bimaaji-wakeup-01KS5VEY/verification.md`).
+
+**Deferred (post-M1):**
+
+- MCP transport (M3 `bimaaji-mcp-bridge-01KS5VS8`) — supersedes the 2026-05-20 PHP-only deferral tracked in [#1463](https://github.com/waaseyaa/framework/issues/1463).
+- In-process `ai-agent` tool sources (M2 `ai-agent-bimaaji-tools-01KS5VKR`).
+- Per-client guidelines/skills install command (M5 `bimaaji-install-command-01KS5W0S`).
+
 ## Purpose
 
 Bimaaji provides machine-readable introspection of a booted Waaseyaa application and a safe mutation protocol for AI agents. It answers: "What does this application contain, and how can an agent safely change it?"

--- a/packages/bimaaji/README.md
+++ b/packages/bimaaji/README.md
@@ -1,14 +1,55 @@
 # waaseyaa/bimaaji
 
-**Bimaaji** is a Waaseyaa package for graph-oriented knowledge work. This repository currently contains scaffolding only; behavior will land in follow-up issues.
+**Bimaaji** is a Waaseyaa package providing **application graph introspection** and an **agent-safe mutation protocol**. The name (Anishinaabemowin: "to give life to") reflects its role: making a booted Waaseyaa application's structure visible and actionable to AI agents.
 
-Roadmap context: [GitHub Milestone #67](https://github.com/waaseyaa/framework/milestone/67).
+## What it does
 
-Full documentation will be added in [Issue #1209](https://github.com/waaseyaa/framework/issues/1209).
+Bimaaji exposes two surfaces:
+
+1. **Read-only introspection.** Six `GraphSectionProvider` implementations (admin, entities, jsonapi, public_surface, routing, sovereignty) emit versioned `GraphSection` payloads that, taken together, describe what an application contains: registered entity types and their fields, every registered route plus access classification, the JSON:API surface, admin entity groupings, the current sovereignty profile, and the public-surface map.
+2. **Validated mutation.** A `MutationRequest` → `MutationValidator` → `PatchSet` pipeline lets an agent propose changes (e.g., "add field X to entity Y"). The validator gates every request through `SovereigntyGuardrails`; the patch generator emits content-hashed, reviewable file patches. **Bimaaji itself never writes to disk** — patches are returned for human (or upstream agent) review.
+
+## Quick start
+
+After installing `waaseyaa/framework` (which depends on this package), the framework's `PackageManifestCompiler` auto-discovers `BimaajiServiceProvider`. The application graph generator is then reachable from the container:
+
+```php
+use Waaseyaa\Bimaaji\Graph\ApplicationGraphGenerator;
+
+$graph = $container->get(ApplicationGraphGenerator::class)->generate();
+foreach ($graph->sections as $key => $section) {
+    echo "{$key}: " . count($section->data) . " entries\n";
+}
+```
+
+The six default section providers are pre-wired:
+
+| Provider | Section key | Constructor deps |
+|---|---|---|
+| `AdminIntrospectionProvider` | `admin` | `EntityTypeManagerInterface` |
+| `EntityIntrospectionProvider` | `entities` | `EntityTypeManagerInterface` |
+| `JsonApiIntrospectionProvider` | `jsonapi` | `RouteCollection` |
+| `PublicSurfaceProvider` | `public_surface` | `RouteCollection` |
+| `RoutingIntrospectionProvider` | `routing` | `RouteCollection` |
+| `SovereigntyIntrospectionProvider` | `sovereignty` | `SovereigntyProfile` |
+
+`SovereigntyProfile` is derived from `SovereigntyConfigInterface::getProfile()` and falls back to `SovereigntyProfile::Local` when no config is bound. `RouteCollection` is looked up directly and falls back to `WaaseyaaRouter::getRouteCollection()`.
+
+## Extending: third-party graph sections
+
+A consuming package can contribute its own section by implementing `GraphSectionProviderInterface` and binding it in its own `ServiceProvider::register()`. The canonical tag is `BimaajiServiceProvider::SECTION_PROVIDER_TAG` (`bimaaji.section_provider`); tag your binding under it for forward-compatibility with future tagged-collection container support.
+
+```php
+final class FooSectionProvider implements GraphSectionProviderInterface
+{
+    public function getKey(): string { return 'foo'; }
+    public function provide(): GraphSection { /* ... */ }
+}
+```
 
 ## Status
 
-**Bimaaji ships PHP-only in the current alpha range.** The MCP server bindings that previously lived under `mcp/` (Node-based `server.js` exposing `bimaaji_ping` / `bimaaji_about` tools) have been removed — they never reached consumers reliably (`composer bimaaji-mcp-install` exited 254 in downstream projects because `vendor/waaseyaa/bimaaji/mcp/server.js` was not present at runtime). Restoration is a roadmap item, tracked in [#1463](https://github.com/waaseyaa/framework/issues/1463) (deferred from [#1387](https://github.com/waaseyaa/framework/issues/1387)).
+Bimaaji ships **PHP-only** in the current alpha range. The MCP server bindings that previously lived under `mcp/` (Node-based `server.js` exposing `bimaaji_ping` / `bimaaji_about` tools) were removed in #1387/#1464; they never reached consumers reliably (`composer bimaaji-mcp-install` exited 254 in downstream projects because `vendor/waaseyaa/bimaaji/mcp/server.js` was not present at runtime). MCP exposure is the subject of a follow-up mission (M3 of the AI ecosystem beta tightening cluster; see `docs/plans/2026-05-21-ai-ecosystem-beta-tightening.md`). The 2026-05-20 "PHP-only" deferral tracked in [#1463](https://github.com/waaseyaa/framework/issues/1463) is being revisited as part of that follow-up.
 
 ### Consumer cleanup
 
@@ -16,4 +57,10 @@ Projects (e.g., Minoo) that previously wired bimaaji's MCP server should:
 
 1. Remove any `mcpServers.bimaaji` entry from `.claude/settings.json` (it pointed at a non-existent `vendor/waaseyaa/bimaaji/mcp/server.js`).
 2. Drop `composer bimaaji-mcp-install` from post-install hooks or contributor docs — the script body was Minoo-local and has no upstream entry point.
-3. Wait for [#1463](https://github.com/waaseyaa/framework/issues/1463) before re-introducing any bimaaji MCP tooling.
+3. Wait for [#1463](https://github.com/waaseyaa/framework/issues/1463) (or its replacement) before re-introducing any bimaaji MCP tooling.
+
+## Where to read more
+
+- **Doctrine spec:** [docs/specs/bimaaji.md](../../docs/specs/bimaaji.md) — design rationale, FRs/NFRs, invariants, file map.
+- **Design history:** [docs/plans/2026-05-21-ai-ecosystem-beta-tightening.md](../../docs/plans/2026-05-21-ai-ecosystem-beta-tightening.md) — the 5-mission cluster that promoted bimaaji from "scaffolding" to "shipped."
+- **Roadmap context:** [GitHub Milestone #67](https://github.com/waaseyaa/framework/milestone/67) (Track 2: Bimaaji & agentic).


### PR DESCRIPTION
## Summary

M1 WP04 of the AI ecosystem beta tightening cluster — documentation follow-up to WP01 (#1542).

- `packages/bimaaji/README.md`: rewritten to remove the "scaffolding only" framing now that `BimaajiServiceProvider` is wired.
- `docs/specs/bimaaji.md`: Implementation Status section added.
- `CLAUDE.md`: operation checklist gains "Adding a Bimaaji graph section provider".

no-changelog: docs-only. The bimaaji bullets describing the surface this documents already shipped in `[0.1.0-alpha.188]`.

Refs: spec-kitty mission `bimaaji-wakeup-01KS5VEY`, FR-007 / FR-008 / SC-003 / SC-004. Depends on #1544.

## Test plan

- [x] Composer policy passes
- [x] Drift detector clean
- [ ] CI: docs-only change, expecting green after #1544 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)