### PR TITLE
fix(check-package-layers): exempt TranslationRouter (kernel-adjacent route registrar)

### DIFF
--- a/bin/check-package-layers
+++ b/bin/check-package-layers
@@ -144,6 +144,8 @@ KERNEL_EXEMPT_FILES = {
         "kernel-adjacent route registrar wired from HttpKernel",
     "foundation/src/Http/Router/SearchRouter.php":
         "kernel-adjacent route registrar wired from HttpKernel",
+    "foundation/src/Http/Router/TranslationRouter.php":
+        "kernel-adjacent route registrar wired from HttpKernel",
     "foundation/src/Http/Router/WorkflowDefinitionsApiRouter.php":
         "kernel-adjacent route registrar wired from HttpKernel",
     "foundation/src/Http/Router/WaaseyaaContext.php":


### PR DESCRIPTION
## Summary

Unblock CI on main. `TranslationRouter` (added in `9f27281d6`) is wired only from `HttpKernel.php:404` alongside the other 9 `Http/Router/*` registrars that are already entries in `KERNEL_EXEMPT_FILES`. The exemption was missed at introduction, which causes `bin/check-package-layers` to fail in CI on every subsequent PR — main is currently red.

Two-line diff: adds the missing entry with the identical rationale string used for the other route registrars in the same family.

no-changelog: CI gate fix only, no public-surface change.

## Test plan

- [x] `bin/check-package-layers` passes locally
- [ ] CI: gate flips to green; check-package-layers no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)