### PR TITLE
feat(bimaaji): M2 WP01 — container audit + mutation-side bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **bimaaji**: `BimaajiServiceProvider` now binds `MutationValidator`, `PatchGenerator`, and `SovereigntyGuardrails` as container-resolvable singletons. M1 left these container-invisible because no consumer needed them; M2 WP01 (`ai-agent-bimaaji-tools-01KS5VKR`) wires them up under the documented C-002 exception so M2 WP03's mutation-tool adapters can resolve them without further bimaaji surgery.
 - **bimaaji**: `bin/waaseyaa graph:dump` CLI command emits the application graph as JSON. Three flags: `--section=<key>` scopes output to a single section (admin/entities/jsonapi/public_surface/routing/sovereignty), `--strict` fails closed on provider errors with the throwable class name in the stderr message, and `--format` is reserved for a future yaml backend (only `json` accepted in beta). Output is byte-for-byte stable across runs for MCP consumers that diff snapshots. Closes M1 WP02 of mission `bimaaji-wakeup-01KS5VEY` (see `docs/plans/2026-05-21-ai-ecosystem-beta-tightening.md`).
 
 ## [0.1.0-alpha.188] - 2026-05-21

--- a/packages/bimaaji/src/BimaajiServiceProvider.php
+++ b/packages/bimaaji/src/BimaajiServiceProvider.php
@@ -14,6 +14,9 @@ use Waaseyaa\Bimaaji\Introspection\JsonApi\JsonApiIntrospectionProvider;
 use Waaseyaa\Bimaaji\Introspection\PublicSurface\PublicSurfaceProvider;
 use Waaseyaa\Bimaaji\Introspection\Routing\RoutingIntrospectionProvider;
 use Waaseyaa\Bimaaji\Introspection\Sovereignty\SovereigntyIntrospectionProvider;
+use Waaseyaa\Bimaaji\Mutation\MutationValidator;
+use Waaseyaa\Bimaaji\Patch\PatchGenerator;
+use Waaseyaa\Bimaaji\Policy\SovereigntyGuardrails;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Foundation\Log\LoggerInterface;
@@ -129,6 +132,37 @@ final class BimaajiServiceProvider extends FoundationServiceProvider implements 
             fn(): GraphDumpHandler => new GraphDumpHandler(
                 providers: $this->defaultSectionProviders(),
                 logger: $this->resolveLogger(),
+            ),
+        );
+
+        // 5. Bind the mutation-side surface (MutationValidator, PatchGenerator,
+        //    SovereigntyGuardrails) so cross-package consumers (M2 ai-agent
+        //    tools, M3 mcp bridge) can resolve them via container::get(...).
+        //    M1 did not enumerate these bindings; M2's plan AD-04 documents
+        //    this as the expected WP01 follow-up under a one-line C-002
+        //    exception. See kitty-specs/ai-agent-bimaaji-tools-01KS5VKR/plan.md.
+        $this->singleton(
+            PatchGenerator::class,
+            fn(): PatchGenerator => new PatchGenerator(),
+        );
+
+        $this->singleton(
+            SovereigntyGuardrails::class,
+            fn(): SovereigntyGuardrails => SovereigntyGuardrails::withDefaultRules(
+                $this->resolveSovereigntyProfile(),
+            ),
+        );
+
+        // MutationValidator captures the application graph at construction.
+        // Bound as a singleton with the graph snapshotted on first resolve —
+        // consumers that need a fresh validator after schema mutations must
+        // call $this->resolve(MutationValidator::class) explicitly after
+        // re-registering the generator (or rebind on a per-request scope in
+        // an application-level provider).
+        $this->singleton(
+            MutationValidator::class,
+            fn(): MutationValidator => new MutationValidator(
+                $this->resolve(ApplicationGraphGenerator::class)->generate(),
             ),
         );
     }

--- a/tests/Integration/PhaseN/AgentRuntime/BimaajiBindingsAuditTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/BimaajiBindingsAuditTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\PhaseN\AgentRuntime;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouteCollection;
+use Waaseyaa\Bimaaji\BimaajiServiceProvider;
+use Waaseyaa\Bimaaji\Graph\ApplicationGraphGenerator;
+use Waaseyaa\Bimaaji\Mutation\MutationValidator;
+use Waaseyaa\Bimaaji\Patch\PatchGenerator;
+use Waaseyaa\Bimaaji\Policy\SovereigntyGuardrails;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Foundation\ServiceProvider\KernelServicesInterface;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyConfigInterface;
+use Waaseyaa\Foundation\Sovereignty\SovereigntyProfile;
+
+/**
+ * Cross-mission gate for M2 (ai-agent ↔ bimaaji in-process tools).
+ *
+ * Asserts that the four bimaaji services M2's tool adapters depend on are
+ * container-resolvable after M1 lands:
+ *
+ *   - ApplicationGraphGenerator (M1 WP01 guarantee — sanity check)
+ *   - MutationValidator         (M2 WP01 addition under documented C-002 exception)
+ *   - PatchGenerator            (M2 WP01 addition under documented C-002 exception)
+ *   - SovereigntyGuardrails     (M2 WP01 addition — kept available so future
+ *                                mutation tools can surface deny reasons)
+ *
+ * If this test passes, M2's WP03 mutation tools can resolve their bimaaji
+ * dependencies from the container without further bimaaji surgery.
+ */
+#[CoversNothing]
+final class BimaajiBindingsAuditTest extends TestCase
+{
+    #[Test]
+    public function resolvesAllRequiredBimaajiServices(): void
+    {
+        $provider = $this->buildBootedProvider();
+
+        $generator = $provider->resolve(ApplicationGraphGenerator::class);
+        self::assertInstanceOf(
+            ApplicationGraphGenerator::class,
+            $generator,
+            'M1 contract: ApplicationGraphGenerator must be container-resolvable after BimaajiServiceProvider::register().',
+        );
+
+        $validator = $provider->resolve(MutationValidator::class);
+        self::assertInstanceOf(
+            MutationValidator::class,
+            $validator,
+            'M2 WP01: MutationValidator must be container-resolvable so M2 WP03 ProposeMutationTool can wrap it.',
+        );
+
+        $patchGenerator = $provider->resolve(PatchGenerator::class);
+        self::assertInstanceOf(
+            PatchGenerator::class,
+            $patchGenerator,
+            'M2 WP01: PatchGenerator must be container-resolvable so M2 WP03 GeneratePatchTool can wrap it.',
+        );
+
+        $guardrails = $provider->resolve(SovereigntyGuardrails::class);
+        self::assertInstanceOf(
+            SovereigntyGuardrails::class,
+            $guardrails,
+            'M2 WP01: SovereigntyGuardrails must be container-resolvable so mutation tools can surface deny reasons.',
+        );
+    }
+
+    #[Test]
+    public function mutationValidatorSeesTheGeneratedGraph(): void
+    {
+        $provider = $this->buildBootedProvider();
+        $validator = $provider->resolve(MutationValidator::class);
+
+        // Smoke-test: the validator's internal graph must be the one the
+        // generator produced. Run a request against a known-unknown entity
+        // type and assert the failure path reports UNKNOWN_ENTITY_TYPE rather
+        // than crashing on a null graph.
+        $request = new \Waaseyaa\Bimaaji\Mutation\MutationRequest(
+            operation: 'add_field',
+            entityType: 'definitely_not_a_real_entity_type',
+            field: 'some_field',
+            parameters: [],
+        );
+        $result = $validator->validate($request);
+        self::assertFalse($result->isSuccess(), 'Validator must reject unknown entity types.');
+    }
+
+    /**
+     * Boot a `BimaajiServiceProvider` with the minimum kernel-services it needs.
+     * Same pattern as M1 WP03's `ApplicationGraphIntegrationTest` — keep the
+     * stub inline so the cross-mission gate is self-contained.
+     */
+    private function buildBootedProvider(): BimaajiServiceProvider
+    {
+        $kernelServices = new class implements KernelServicesInterface {
+            public function get(string $abstract): ?object
+            {
+                return match ($abstract) {
+                    EntityTypeManagerInterface::class, EntityTypeManager::class => self::stubEntityTypeManager(),
+                    RouteCollection::class => new RouteCollection(),
+                    SovereigntyConfigInterface::class => self::stubSovereigntyConfig(),
+                    default => null,
+                };
+            }
+
+            private static function stubEntityTypeManager(): EntityTypeManagerInterface
+            {
+                return new class implements EntityTypeManagerInterface {
+                    public function getDefinition(string $entityTypeId): \Waaseyaa\Entity\EntityTypeInterface
+                    {
+                        throw new \RuntimeException('Not exercised in this audit test.');
+                    }
+
+                    public function registerEntityType(\Waaseyaa\Entity\EntityTypeInterface $type, ?string $registrant = null): void {}
+
+                    public function registerCoreEntityType(\Waaseyaa\Entity\EntityTypeInterface $type, ?string $registrant = null): void {}
+
+                    /** @return array<string, \Waaseyaa\Entity\EntityTypeInterface> */
+                    public function getDefinitions(): array
+                    {
+                        return [];
+                    }
+
+                    public function hasDefinition(string $entityTypeId): bool
+                    {
+                        return false;
+                    }
+
+                    public function getStorage(string $entityTypeId): \Waaseyaa\Entity\Storage\EntityStorageInterface
+                    {
+                        throw new \RuntimeException('Not exercised in this audit test.');
+                    }
+
+                    public function getRepository(string $entityTypeId): \Waaseyaa\Entity\Repository\EntityRepositoryInterface
+                    {
+                        throw new \RuntimeException('Not exercised in this audit test.');
+                    }
+                };
+            }
+
+            private static function stubSovereigntyConfig(): SovereigntyConfigInterface
+            {
+                return new class implements SovereigntyConfigInterface {
+                    public function get(string $key): ?string
+                    {
+                        return null;
+                    }
+
+                    public function getProfile(): SovereigntyProfile
+                    {
+                        return SovereigntyProfile::SelfHosted;
+                    }
+
+                    /** @return array<string, string> */
+                    public function all(): array
+                    {
+                        return [];
+                    }
+                };
+            }
+        };
+
+        $provider = new BimaajiServiceProvider();
+        $provider->setKernelContext('/tmp', [], []);
+        $provider->setKernelServices($kernelServices);
+        $provider->register();
+
+        return $provider;
+    }
+}


### PR DESCRIPTION
## Summary

M2 WP01 of the AI ecosystem beta tightening cluster. Bridges from M1 (shipped) to M2's tool adapters by exposing the mutation-side bimaaji surface to the container.

Adds three bindings to \`BimaajiServiceProvider\` — taking the one-line C-002 exception explicitly documented in M2's plan AD-04 (\`kitty-specs/ai-agent-bimaaji-tools-01KS5VKR/plan.md\`):

- \`PatchGenerator\` — parameterless singleton.
- \`SovereigntyGuardrails\` — factory-built from the sovereignty profile.
- \`MutationValidator\` — captures \`ApplicationGraph\` at first resolve (snapshot semantics documented in the binding's comment).

Also adds the M2 cross-mission gate test \`tests/Integration/PhaseN/AgentRuntime/BimaajiBindingsAuditTest.php\` (2 tests / 5 assertions) — boots the same minimal kernel pattern M1 WP03 established and asserts all four bimaaji services resolve. Smoke-validates the new \`MutationValidator\` binding by exercising its unknown-entity-type rejection path.

After this lands, M2 WP02 (read tools) and WP03 (mutation tools) can resolve their bimaaji dependencies from the container without further bimaaji surgery.

Refs: kitty-specs/ai-agent-bimaaji-tools-01KS5VKR/tasks/WP01-cross-mission-gate-and-container-audit.md.

## Test plan

- [x] \`./vendor/bin/phpunit tests/Integration/PhaseN/AgentRuntime/BimaajiBindingsAuditTest.php\` — 2 tests / 5 assertions pass
- [x] \`./vendor/bin/phpunit packages/bimaaji/tests/Unit/BimaajiServiceProviderTest.php\` — 7 tests / 41 assertions still pass (no regression after the new bindings)
- [x] \`composer cs-check\` clean after one cs-fix pass
- [x] \`phpstan analyse\` clean on touched files
- [x] \`bin/check-package-layers\`, \`bin/check-composer-policy\`, \`bin/check-dead-code\`, \`bin/check-getquery-bindings\` — all OK
- [ ] CI: full pipeline on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)