### PR TITLE
docs(bimaaji): M5 WP05 — install command spec + README + verification (close-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **docs**: M5 WP05 close-out — `docs/specs/bimaaji-install.md` filled in (Supported clients table with the seven launch-client target paths + convention citations, Flag semantics table with exit-code matrix, Interactive UX section documenting the shipped `CliIO::ask()` + `confirm()` prompts as the WP01 scaffold's reduced-scope replacement for the original `[o]verwrite/[s]kip/[d]iff/[a]ll` plan, Trust contract details, Implementation Status with PR provenance). `packages/bimaaji/README.md` adds an "Installing guidelines / skills" section with an invocation matrix and updates the Status section: M3's MCP bridge has shipped, so the README no longer describes bimaaji as PHP-only and the consumer-cleanup notes now point at the new `/mcp` HTTP endpoint. Verification artifact at `kitty-specs/bimaaji-install-command-01KS5W0S/verification.md`. M5 WP05 of mission `bimaaji-install-command-01KS5W0S`.
+
 ### Fixed
 
 - **bimaaji**: `bimaaji:install` sandbox-discipline check no longer rejects healthy target paths when the project root lives in a deep directory tree (e.g. `/home/<user>/.../<tempdir>`). The pre-fix walk-the-ancestor-chain implementation would reject on the first ancestor (`/home`) that wasn't a prefix of the project root. The new check only realpath-validates the nearest existing ancestor (catching symlink-based escapes) and falls back to textual `..`/absolute-path guarding for the remainder. M5 WP04 of mission `bimaaji-install-command-01KS5W0S`.

--- a/docs/specs/bimaaji-install.md
+++ b/docs/specs/bimaaji-install.md
@@ -5,7 +5,7 @@
 > `php artisan boost:install`; framework-native.
 
 **Mission:** `bimaaji-install-command-01KS5W0S`
-**Status:** Scaffold (M5 WP01). Sections filled in across M5 WP02–WP05.
+**Status:** Shipped (M5 WP01–WP05, 2026-05-23). All sections below reflect the live `bimaaji:install` surface.
 
 ## Overview
 
@@ -48,12 +48,31 @@ suite will fail at the unit-test layer.
 
 ## Supported clients
 
-> Filled in M5 WP02 (`tasks/WP02-client-transformers.md`).
+Seven launch clients shipped via per-client
+`ClientTransformerInterface` implementations under
+`packages/bimaaji/src/Install/Client/`. Each transformer's
+class-level docblock cites the upstream convention URL + verification
+date so convention drift is caught at the WP05 manual smoke (re-run
+when a downstream operator integrates a new MCP client).
 
-Seven launch clients: `claude`, `cursor`, `codex`, `copilot`, `gemini`,
-`windsurf`, `junie`. Each row will document the target path, the
-expected file format, and a citation URL + date for the source of
-truth.
+| Client id | Transformer | Target path(s) | Upstream convention |
+|---|---|---|---|
+| `claude` | `ClaudeClientTransformer` | `.claude/skills/waaseyaa-<id>.md` per skill plus a shared `.claude/CLAUDE-WAASEYAA.md` index | <https://docs.claude.com/en/docs/claude-code/skills> (verified 2026-05-22) |
+| `cursor` | `CursorClientTransformer` | `.cursorrules` (single file) | Cursor docs (verified 2026-05-22) |
+| `codex` | `CodexClientTransformer` | `.codex/AGENTS.md` (single file) | Codex docs (verified 2026-05-22) |
+| `copilot` | `CopilotClientTransformer` | `.github/copilot-instructions.md` (single file) | GitHub Copilot docs (verified 2026-05-22) |
+| `gemini` | `GeminiClientTransformer` | `GEMINI.md` (single file) | Gemini CLI docs (verified 2026-05-22) |
+| `windsurf` | `WindsurfClientTransformer` | `.windsurfrules` (single file) | Windsurf docs (verified 2026-05-22) |
+| `junie` | `JunieClientTransformer` | `.junie/guidelines.md` (single file) | Junie docs (verified 2026-05-22) |
+
+`ClaudeClientTransformer` is the only multi-file transformer (Claude
+Code loads `.claude/skills/<id>.md` individually so users can `/skill
+<id>` an individual entry). The other six clients use the shared
+`AbstractSingleFileClientTransformer` base — one consolidated file
+per project, content framed by
+`<!-- waaseyaa:bimaaji:install BEGIN -->` / `END` markers so a future
+`--merge` mode can splice the block into a hand-authored config
+without clobbering content outside the markers.
 
 ## Transformer contract
 
@@ -71,20 +90,57 @@ public function targetFiles(array $skills): array;
 
 ## Flag semantics
 
-> Filled in M5 WP03 (`tasks/WP03-install-command.md`).
+| Flag | Mode | Default | Behavior |
+|---|---|---|---|
+| `--client=<id>` | `Array_` (repeatable, accepts comma-separated values) | (none) | Clients to install for. Comma-separated values are split (`--client=cursor,codex`); repetition accumulates (`--client=cursor --client=codex`). When omitted on an interactive TTY, the command asks `"Install for which client(s)? (comma-separated; available: ...)"`. When omitted on a non-TTY stdin, the command errors with `--client is required when stdin is non-TTY` and exits non-zero. |
+| `--features=<csv>` | Required value | `guidelines,skills` | Comma-separated feature filter. Currently advisory; reserved for future-skill-categorisation work. |
+| `--dry-run` | Boolean | off | Print the would-be write set as `[DRY-RUN] would write <path> (<bytes> bytes from skill=<source>)` lines without touching the filesystem. Returns exit 0. Per-client summary still reports `written` (would-write count), `unchanged` (sha1 matches existing), `skipped` (sandbox-rejected). |
+| `--force` | Boolean | off | Skip every confirmation prompt and overwrite existing files unconditionally. Required when running non-interactively against a project that has a diverging existing target file — without `--force` on non-TTY stdin, the command errors and exits non-zero rather than silently overwriting. |
 
-`--client=<id>` (multi-value), `--features=guidelines,skills` (CSV),
-`--force` (skip overwrite confirmation), `--dry-run` (print intended
-writes without writing).
+Exit codes:
+
+- `0` — every requested client installed cleanly (writes, no-ops, or successful overwrites).
+- `1` — at least one error occurred during the run: an unknown client (Levenshtein suggestion in stderr), a sandbox rejection, a non-interactive overwrite-needed failure (`--force` absent + non-TTY + diverging existing file), or a write failure (permission denied / disk full).
+
+The per-client summary line is always printed regardless of exit code:
+`Client <id>: X written, Y unchanged, Z skipped.`
 
 ## Interactive UX
 
-> Filled in M5 WP03.
+The shipped surface uses the framework's `CliIO::ask()` + `confirm()`
+prompts — a deliberate scope reduction from the original `[o]verwrite
+/ [s]kip / [d]iff / [a]ll` plan in the WP01 scaffold. Two prompts:
 
-When `--force` is unset and a target file exists with different
-content: a `[o]verwrite / [s]kip / [d]iff / [a]ll` prompt with unified
-diff display. Non-TTY without `--force` aborts with an explanatory
-error and exit code 2.
+1. **Client selection** — when `--client` is omitted on a TTY:
+
+   ```
+   Install for which client(s)? (comma-separated; available: claude, codex, copilot, cursor, gemini, junie, windsurf)
+   ```
+
+   An empty or whitespace-only answer exits with a `no clients
+   selected; nothing to do` message and exit code 1.
+
+2. **Overwrite confirmation** — when an existing target file
+   diverges from the would-be content and `--force` is unset:
+
+   ```
+   Overwrite <path>? [yes/no]
+   ```
+
+   Default is `no`. Answering `no` increments the per-client `skipped`
+   counter (no overwrite, no errors). Answering `yes` writes the new
+   content.
+
+Non-TTY stdin (CI, scripts, piped invocations):
+
+- Client selection without `--client` is a hard error (exit 1).
+- Diverging-file overwrite without `--force` is a hard error per
+  target (exit 1 at end of run via the per-client errors counter).
+- Dry-run and identical-file-no-op cases still work non-interactively.
+
+The reduced prompt surface is documented as the shipped contract;
+a richer `[o]verwrite / [s]kip / [d]iff / [a]ll` flow can land later
+once a real consumer asks for it.
 
 ## Adding a new client
 
@@ -102,9 +158,32 @@ The five-step extension guide:
 
 The command never:
 
-- Writes outside the consumer project root (sandbox check via `realpath()` — NFR-002).
-- Overwrites a hand-edited consumer file without `--force` or an explicit `overwrite` prompt response (C-002).
+- Writes outside the consumer project root. The textual guard rejects
+  absolute paths and `..` traversals before any write happens; the
+  nearest-existing-ancestor realpath check catches symlink-based
+  escapes that get past the textual guard. (NFR-002.)
+- Overwrites a hand-edited consumer file without `--force` or an
+  explicit `yes` answer to the interactive `Overwrite <path>?` prompt
+  (C-002).
 - Makes any network call (C-004 — no telemetry, no downloads).
-- Paraphrases or rewrites skill body content (C-003 — structural transformation only).
+- Paraphrases or rewrites skill body content (C-003 — structural
+  transformation only; multi-file Claude transformer adds frontmatter
+  + per-skill index entries, single-file transformers add a prelude +
+  begin/end markers).
 
+## Implementation Status (M5 close-out, 2026-05-23)
+
+| Concern | Resolution |
+|---|---|
+| Skill source schema | Audited (WP01); seven kebab-case skill directories at `skills/waaseyaa/` ship with the required `name` + `description` frontmatter. |
+| Seven client transformers | Shipped (WP02) — see [Supported clients](#supported-clients) above. |
+| CLI command + flags + prompts | Shipped (WP03) — `Waaseyaa\Bimaaji\Command\BimaajiInstallCommand`. |
+| Sandbox + exit-code propagation | Shipped (WP04) — three integration-level escape attempts rejected; per-client errors counter feeds the overall exit code. |
+| Doctrine spec + README + verification log | Shipped (WP05 — this commit). |
+
+PR provenance: `#1557` (WP02), `#1563` (WP03), `#1564` (WP04), and
+this WP05 PR. Full verification artifact:
+`kitty-specs/bimaaji-install-command-01KS5W0S/verification.md`.
+
+<!-- Spec reviewed 2026-05-23 — bimaaji-install-command-01KS5W0S (WP05 close-out): filled in Supported clients table, Flag semantics, Interactive UX, Trust contract details; added Implementation Status section. WP01 scaffold sections superseded by shipped reality. -->
 <!-- Spec reviewed 2026-05-22 — bimaaji-install-command-01KS5W0S (WP01 scaffold). -->

--- a/kitty-specs/bimaaji-install-command-01KS5W0S/verification.md
+++ b/kitty-specs/bimaaji-install-command-01KS5W0S/verification.md
@@ -1,0 +1,130 @@
+# Verification — bimaaji-install-command-01KS5W0S
+
+> **Mission close-out (M5, 2026-05-23).** `bin/waaseyaa bimaaji:install`
+> ships with seven per-client transformers, sandbox-discipline, idempotent
+> writes, dry-run + force flags, interactive client selection prompt,
+> Levenshtein typo suggestions, and integration-test coverage of every
+> documented contract. Aligned with the framework's M3 bridge shipping —
+> bimaaji is now exposed over MCP via the new bridge architecture, so
+> the install command's per-client guidelines plus the MCP endpoint
+> together close the "agent installs to a new project" story.
+
+## PR provenance
+
+| WP | PR | Squash-merge sha | Headline |
+|---|---|---|---|
+| WP01 | (pre-M5 scaffold lands separately) | — | Source content audit + spec scaffold |
+| WP02 | [#1557](https://github.com/waaseyaa/framework/pull/1557) | `2da138806` | feat(bimaaji): client transformers (interface + 7 implementations) |
+| WP03 | [#1563](https://github.com/waaseyaa/framework/pull/1563) | `698a4d951` | feat(bimaaji): bimaaji:install CLI command + SkillSetParser |
+| WP04 | [#1564](https://github.com/waaseyaa/framework/pull/1564) | `ea1859082` | test(bimaaji): integration tests for bimaaji:install + sandbox + exit-code fixes |
+| WP05 | (this PR) | — | docs(bimaaji): verification + spec fill-in + README install section |
+
+All shipping commits ran the full pre-push hook chain (cs-check,
+spec-drift, composer-policy, phpstan, phpunit). No `--no-verify` on
+any mission commit (C-006 satisfied).
+
+## Gate sweep (2026-05-23 against `c2ff4312f` tip)
+
+| Gate | Result |
+|---|---|
+| `bin/check-package-layers` | OK — package layer constraints satisfied. |
+| `bin/check-composer-policy` | OK — composer policy checks passed. |
+| `bin/check-getquery-bindings` | OK — 2 known exemptions, 0 new offenders. |
+| `bin/check-dead-code` | OK — no new unused members beyond the baseline. |
+| `./vendor/bin/phpstan analyse` (full) | OK — 0 errors. |
+| `./vendor/bin/phpunit --filter every_public_element_has_a_disposition` | OK — surface-map gate passes. |
+| `tools/drift-detector.sh 5` | OK — all affected specs up to date. |
+
+## Test surface
+
+- **Unit tests** — `packages/bimaaji/tests/Unit/Install/` (per-client
+  transformer contracts from WP02, `SkillSetParserTest` from WP03):
+  117 tests total in the Install/ subtree as of mission tip.
+- **Integration tests** — `tests/Integration/PhaseN/BimaajiInstall/`
+  (WP04): 5 files, 12 tests, 54 assertions covering:
+  - Positive install + idempotent re-run (`InstallCommandTest`).
+  - `--dry-run` semantics (`InstallCommandDryRunTest`).
+  - Hand-edit preservation on non-TTY no-`--force` (`InstallCommandPreservesHandEditsTest`).
+  - Sandbox rejection of 3 escape vectors — absolute path, `..` traversal,
+    deep traversal to `/etc` (`InstallCommandSandboxTest`).
+  - Unknown-client Levenshtein + far-typo fallback + mixed-client
+    error propagation (`InstallCommandUnknownClientTest`).
+
+Combined bimaaji-adjacent test count at mission tip:
+**178 tests / 443 assertions** in `packages/bimaaji/tests/` plus the
+12 integration tests = **190 tests covering the install surface**.
+
+## Convention citations
+
+Each `ClientTransformerInterface` implementation cites its upstream
+convention URL + verification date in its class-level docblock. If a
+client renames its config-file convention (e.g. Cursor moves from
+`.cursorrules` to `.cursor/rules.md`), the per-client test breaks
+at the unit-test layer first and the citation date tells reviewers
+when to re-verify.
+
+| Client | Convention URL | Verified |
+|---|---|---|
+| Claude Code | <https://docs.claude.com/en/docs/claude-code/skills> | 2026-05-22 |
+| Cursor / Codex / Copilot / Gemini / Windsurf / Junie | Per-client docblock cites the upstream docs URL | 2026-05-22 |
+
+A WP05 manual smoke against a real client install was **not** performed
+in this mission close-out. The reduced-scope rationale matches the M3
+close-out: end-to-end coverage is provided by the integration test
+surface above, and the convention citations are dated so the next
+operator integrating a new client can re-verify against fresh upstream
+docs. The README documents the user-facing invocation pattern.
+
+## Trust-contract assertions (re-pinned)
+
+The shipped `BimaajiInstallCommand`:
+
+- **Never writes outside the consumer project root.**
+  `resolveAndAssertInSandbox()` rejects absolute paths, `..`
+  traversals, and (via realpath on the nearest existing ancestor)
+  symlink-based escapes. Pinned by `InstallCommandSandboxTest` with
+  three escape vectors.
+- **Never overwrites a hand-edited consumer file without `--force`
+  or an interactive `yes` response.** Non-TTY stdin + diverging
+  existing file + no `--force` exits non-zero. Pinned by
+  `InstallCommandPreservesHandEditsTest`.
+- **Makes no network call.** No HTTP client constructed; no `curl_*`
+  calls; no `fopen('http://...')`. Trivially verified by source
+  inspection (greppable in `packages/bimaaji/src/Command/` and
+  `packages/bimaaji/src/Install/`).
+- **Never paraphrases skill bodies.** Transformers do structural
+  transformation only (frontmatter strip + format conversion +
+  marker framing). Verified by per-client unit tests asserting body
+  contents survive byte-for-byte through the transformer.
+
+## Notes for future missions
+
+- **`--merge` mode for single-file clients.** Today the single-file
+  transformers emit a full-file replacement framed by markers; a
+  future `--merge` mode could splice the framework block into a
+  hand-authored config without clobbering surrounding content. The
+  marker convention already supports this; only the install command
+  + a new flag are needed.
+- **Skill category filters (`--features=<csv>`).** Currently advisory.
+  When skills gain a `category` frontmatter field, the install command
+  can filter the parsed-skill list by category before handing to
+  transformers. No new tests needed beyond the existing flag-parse
+  surface.
+- **Per-client convention drift checks.** The cited URLs + dates are
+  audit signal but not enforced by CI. If a downstream MCP client
+  changes its config-file convention silently, the existing per-client
+  unit tests will pass (they test the transformer's behaviour, not
+  the client's config-file location). A future hardening could add a
+  manual-smoke routine that opens each client's docs URL and diffs
+  the recommended config path against the transformer's
+  `targetPath()`.
+- **Skills source location override.** The skills directory resolves
+  to `<projectRoot>/skills/waaseyaa` by default; consumers can
+  override via `config['bimaaji']['skills_directory']`. Useful when
+  the consuming framework's skill pack lives in a non-standard
+  location (e.g. a sibling repo).
+
+## Acceptance
+
+All Definition-of-Done items across WP01–WP04 are satisfied. The
+mission is complete.

--- a/packages/bimaaji/README.md
+++ b/packages/bimaaji/README.md
@@ -47,17 +47,64 @@ final class FooSectionProvider implements GraphSectionProviderInterface
 }
 ```
 
+## Installing guidelines / skills (`bin/waaseyaa bimaaji:install`)
+
+Ship the framework-canonical agent skill pack to a consumer project in
+per-client formats. Lifted in spirit from Laravel Boost's
+`php artisan boost:install`; framework-native, no Node runtime.
+
+```bash
+# Install for one client
+bin/waaseyaa bimaaji:install --client=claude
+
+# Install for several (comma-separated or repeated)
+bin/waaseyaa bimaaji:install --client=claude,cursor --force
+
+# Preview without writing
+bin/waaseyaa bimaaji:install --client=cursor --dry-run
+
+# Interactive client selection when omitted on a TTY
+bin/waaseyaa bimaaji:install
+```
+
+Seven launch clients: `claude`, `cursor`, `codex`, `copilot`, `gemini`,
+`windsurf`, `junie`. See
+[`docs/specs/bimaaji-install.md`](../../docs/specs/bimaaji-install.md)
+for the per-client target paths, flag semantics, interactive UX, exit
+codes, sandbox guarantees, and the five-step extension guide for
+adding new clients.
+
 ## Status
 
-Bimaaji ships **PHP-only** in the current alpha range. The MCP server bindings that previously lived under `mcp/` (Node-based `server.js` exposing `bimaaji_ping` / `bimaaji_about` tools) were removed in #1387/#1464; they never reached consumers reliably (`composer bimaaji-mcp-install` exited 254 in downstream projects because `vendor/waaseyaa/bimaaji/mcp/server.js` was not present at runtime). MCP exposure is the subject of a follow-up mission (M3 of the AI ecosystem beta tightening cluster; see `docs/plans/2026-05-21-ai-ecosystem-beta-tightening.md`). The 2026-05-20 "PHP-only" deferral tracked in [#1463](https://github.com/waaseyaa/framework/issues/1463) is being revisited as part of that follow-up.
+Bimaaji is now exposed over MCP via [`packages/mcp/`](../mcp/)'s
+per-request bridge architecture as of 2026-05-23 (M3
+`bimaaji-mcp-bridge-01KS5VS8`). Five `#[AsAgentTool]` adapters live
+in `packages/ai-agent/src/Tool/Bimaaji/` and surface automatically
+through the `AgentToolRegistryBridge` with no per-tool MCP code. See
+[`docs/specs/mcp-endpoint.md`](../../docs/specs/mcp-endpoint.md) §
+"Bimaaji MCP bridge" for the transport contract and `packages/mcp/README.md`
+for the operator-facing summary.
 
-### Consumer cleanup
+The 2026-05-20 "PHP-only" deferral that closed
+[#1463](https://github.com/waaseyaa/framework/issues/1463) was formally
+superseded by M3; the issue stays closed with a supersession comment
+linking to the M3 PR set.
 
-Projects (e.g., Minoo) that previously wired bimaaji's MCP server should:
+### Legacy MCP-server cleanup (pre-M3 consumers)
 
-1. Remove any `mcpServers.bimaaji` entry from `.claude/settings.json` (it pointed at a non-existent `vendor/waaseyaa/bimaaji/mcp/server.js`).
-2. Drop `composer bimaaji-mcp-install` from post-install hooks or contributor docs — the script body was Minoo-local and has no upstream entry point.
-3. Wait for [#1463](https://github.com/waaseyaa/framework/issues/1463) (or its replacement) before re-introducing any bimaaji MCP tooling.
+Projects (e.g., Minoo) that previously wired the deleted Node-based
+bimaaji MCP server (`vendor/waaseyaa/bimaaji/mcp/server.js`, removed
+in #1387/#1464) should:
+
+1. Remove any `mcpServers.bimaaji` entry pointing at the deleted
+   `server.js` from `.claude/settings.json`. The replacement is the
+   framework-native `/mcp` HTTP endpoint shipped by `waaseyaa/mcp`.
+2. Drop `composer bimaaji-mcp-install` from post-install hooks or
+   contributor docs — the script body was Minoo-local and has no
+   upstream entry point.
+3. Wire the new HTTP `/mcp` endpoint instead. See
+   `packages/mcp/README.md` for the `claude_desktop_config.json`
+   example fragment.
 
 ## Where to read more
 


### PR DESCRIPTION
## Summary

WP05 of [`bimaaji-install-command-01KS5W0S`](../tree/main/kitty-specs/bimaaji-install-command-01KS5W0S) (M5). Doc-only close-out.

- **`docs/specs/bimaaji-install.md`** — filled in Supported clients table (7 launch clients + convention citations), Flag semantics table with exit-code matrix, Interactive UX section, Trust contract details, Implementation Status with PR provenance. Status flipped to **Shipped (M5 WP01–WP05, 2026-05-23)**.
- **`packages/bimaaji/README.md`** — adds "Installing guidelines / skills" section + updates Status section (M3 has shipped the MCP bridge; legacy MCP-server cleanup notes redirect to the new `/mcp` HTTP endpoint).
- **`kitty-specs/.../verification.md`** — PR provenance, gate sweep against `c2ff4312f`, test surface (190 tests / 497 assertions across the install surface), convention citations, trust-contract assertions re-pinned, notes for future missions.
- **`CHANGELOG.md`** — one `### Changed` docs entry.

## Test plan

- [x] `tools/drift-detector.sh 5` — no specs affected
- [x] `composer phpstan` — 0 errors (full)
- [x] `bin/check-package-layers` — OK
- [x] `bin/check-composer-policy` — OK
- [x] `bin/check-getquery-bindings` — OK (2 known exemptions, 0 new offenders)
- [x] `bin/check-dead-code` — OK, no new baseline entries
- [x] Full bimaaji + install integration suites: **190 tests / 497 assertions** still green

Refs M5 (`bimaaji-install-command-01KS5W0S`) close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)