### PR TITLE
feat(agent-output): M4 WP04 part 1 — --output=json for bin/check-package-layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **bin/check-package-layers**: new `--output=json` flag + `WAASEYAA_OUTPUT=json` env var produce an NDJSON envelope on stdout via `Waaseyaa\AgentOutput\Formatter\PackageLayersFormatter` instead of the human-readable pass/fail line. Envelope shape: `{tool: "check-package-layers", result: "pass"|"fail", packages_scanned: int, violations: [{source, target, edge}, ...]}`. Bash detects mode → Python emits structured findings to a tmpfile → PHP shim feeds the formatter. Default (no flag, no env var) behaviour is unchanged: human pass/fail line, exit 0/1. Pattern-proving slice of M4 WP04; the same wrapper template applies to the other three `bin/check-*` scripts in WP04B. M4 WP04 (part 1) of mission `agent-output-package-01KS5VX1`.
+
 ### Changed
 
 - **docs**: M5 WP05 close-out — `docs/specs/bimaaji-install.md` filled in (Supported clients table with the seven launch-client target paths + convention citations, Flag semantics table with exit-code matrix, Interactive UX section documenting the shipped `CliIO::ask()` + `confirm()` prompts as the WP01 scaffold's reduced-scope replacement for the original `[o]verwrite/[s]kip/[d]iff/[a]ll` plan, Trust contract details, Implementation Status with PR provenance). `packages/bimaaji/README.md` adds an "Installing guidelines / skills" section with an invocation matrix and updates the Status section: M3's MCP bridge has shipped, so the README no longer describes bimaaji as PHP-only and the consumer-cleanup notes now point at the new `/mcp` HTTP endpoint. Verification artifact at `kitty-specs/bimaaji-install-command-01KS5W0S/verification.md`. M5 WP05 of mission `bimaaji-install-command-01KS5W0S`.

--- a/bin/check-package-layers
+++ b/bin/check-package-layers
@@ -1,9 +1,34 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hard-gate package-layers check. See CLAUDE.md "Layer Architecture".
+#
+# Output modes (M4 WP04 of mission `agent-output-package-01KS5VX1`):
+#
+#   --output=json    NDJSON envelope on stdout via Waaseyaa\AgentOutput\Formatter\PackageLayersFormatter
+#   WAASEYAA_OUTPUT=json    same effect via env var
+#
+# Default behaviour (no flag, no env var) is unchanged: pass/fail human text,
+# exit 0/1.
+set -uo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export ROOT_DIR
 
+OUTPUT_MODE="human"
+for arg in "$@"; do
+    case "$arg" in
+        --output=json) OUTPUT_MODE="json" ;;
+    esac
+done
+if [[ "${WAASEYAA_OUTPUT:-}" == "json" ]]; then
+    OUTPUT_MODE="json"
+fi
+export OUTPUT_MODE
+
+FINDINGS_FILE="$(mktemp -t waaseyaa-check-package-layers-XXXXXX.json)"
+export FINDINGS_FILE
+trap 'rm -f "$FINDINGS_FILE"' EXIT
+
+set +e
 python3 - <<'PY'
 import json
 import os
@@ -12,6 +37,8 @@ import re
 import sys
 
 root = pathlib.Path(os.environ["ROOT_DIR"])
+output_mode = os.environ.get("OUTPUT_MODE", "human")
+findings_file = os.environ.get("FINDINGS_FILE", "")
 
 # Canonical layer index (0 = foundation). Must match CLAUDE.md "Layer Architecture".
 # waaseyaa/<short> maps to directory packages/<short>/
@@ -138,8 +165,6 @@ KERNEL_EXEMPT_FILES = {
     "foundation/src/Http/Router/EntityTypeLifecycleRouter.php":
         "kernel-adjacent route registrar wired from HttpKernel",
     "foundation/src/Http/Router/JsonApiRouter.php":
-        "kernel-adjacent route registrar wired from HttpKernel",
-    "foundation/src/Http/Router/McpRouter.php":
         "kernel-adjacent route registrar wired from HttpKernel",
     "foundation/src/Http/Router/SchemaRouter.php":
         "kernel-adjacent route registrar wired from HttpKernel",
@@ -321,11 +346,26 @@ def scan_php_imports(pkg_dir: pathlib.Path, self_layer: int) -> list[tuple[str, 
 # Run checks.
 # ---------------------------------------------------------------------------
 
+def emit(line: str) -> None:
+    """Emit human-readable text; suppressed in JSON mode."""
+    if output_mode == "human":
+        print(line)
+
+
+def emit_err(line: str) -> None:
+    if output_mode == "human":
+        print(line, file=sys.stderr)
+
+
 errors = 0
+packages_scanned = 0
+violations: list[dict[str, str]] = []
 packages_dir = root / "packages"
 
 if not packages_dir.is_dir():
-    print("FAIL [PL000] packages/ not found", file=sys.stderr)
+    emit_err("FAIL [PL000] packages/ not found")
+    if output_mode == "json" and findings_file:
+        pathlib.Path(findings_file).write_text(json.dumps({"packages_scanned": 0, "violations": []}))
     sys.exit(1)
 
 for pkg_dir in sorted(packages_dir.iterdir()):
@@ -338,6 +378,7 @@ for pkg_dir in sorted(packages_dir.iterdir()):
     pkg_type = data.get("type", "library")
     if pkg_type == "metapackage" or pkg_dir.name in METAPACKAGES:
         continue
+    packages_scanned += 1
 
     name = data.get("name", "")
     short = short_from_package_name(name) if name else None
@@ -345,14 +386,16 @@ for pkg_dir in sorted(packages_dir.iterdir()):
         continue
     if short != pkg_dir.name:
         errors += 1
-        print(f"FAIL [PL001] {manifest.relative_to(root)}: name {name!r} does not match directory {pkg_dir.name!r}")
+        emit(f"FAIL [PL001] {manifest.relative_to(root)}: name {name!r} does not match directory {pkg_dir.name!r}")
+        violations.append({"source": pkg_dir.name, "target": name, "edge": "manifest-name"})
         continue
 
     if short not in LAYER_BY_SHORT:
         errors += 1
-        print(
+        emit(
             f"FAIL [PL002] {manifest.relative_to(root)}: package {short!r} missing from bin/check-package-layers LAYER_BY_SHORT — add layer and update CLAUDE.md"
         )
+        violations.append({"source": short, "target": "LAYER_BY_SHORT", "edge": "missing-layer-entry"})
         continue
 
     layer_self = LAYER_BY_SHORT[short]
@@ -370,32 +413,63 @@ for pkg_dir in sorted(packages_dir.iterdir()):
                 continue
             if dep_short not in LAYER_BY_SHORT:
                 errors += 1
-                print(
+                emit(
                     f"FAIL [PL003] {manifest.relative_to(root)} {sec}: dependency {dep_name!r} (short={dep_short!r}) not in LAYER_BY_SHORT"
                 )
+                violations.append({"source": short, "target": dep_short, "edge": sec})
                 continue
             layer_dep = LAYER_BY_SHORT[dep_short]
             if layer_dep > layer_self:
                 errors += 1
-                print(
+                emit(
                     f"FAIL [PL004] {manifest.relative_to(root)} {sec}: layer violation — "
                     f"{short} (layer {layer_self}) must not depend on {dep_short} (layer {layer_dep}). "
                     f"See CLAUDE.md Layer Architecture and GitHub #315/#316."
                 )
+                violations.append({"source": short, "target": dep_short, "edge": sec})
 
     # ----- PHP file-level `use` imports -----
     for rel, dep_short, dep_layer in scan_php_imports(pkg_dir, layer_self):
         errors += 1
-        print(
+        emit(
             f"FAIL [PL005] packages/{rel}: file-level layer violation — "
             f"{short} (layer {layer_self}) imports waaseyaa/{dep_short} (layer {dep_layer}). "
             f"If this file is kernel-adjacent, move it under {short}/src/Kernel/ or add an "
             f"entry to KERNEL_EXEMPT_FILES in bin/check-package-layers with a one-line rationale."
         )
+        violations.append({"source": short, "target": dep_short, "edge": "use"})
 
-if errors:
-    print(f"\nPackage layer check failed with {errors} error(s).", file=sys.stderr)
-    sys.exit(1)
+# Write the structured findings to FINDINGS_FILE for the bash wrapper's PHP shim,
+# regardless of mode (the wrapper only reads it in JSON mode).
+if findings_file:
+    try:
+        pathlib.Path(findings_file).write_text(json.dumps({
+            "packages_scanned": packages_scanned,
+            "violations": violations,
+        }))
+    except OSError:
+        pass
 
-print("OK — package layer constraints (composer.json + PHP file-level) satisfied.")
+if output_mode == "human":
+    if errors:
+        print(f"\nPackage layer check failed with {errors} error(s).", file=sys.stderr)
+        sys.exit(1)
+    print("OK — package layer constraints (composer.json + PHP file-level) satisfied.")
+    sys.exit(0)
+
+# JSON mode: stay silent on stdout/stderr — the bash wrapper emits the envelope.
+sys.exit(1 if errors else 0)
 PY
+PYTHON_EXIT=$?
+set -e
+
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+    php -d display_errors=stderr -r '
+require getenv("ROOT_DIR") . "/vendor/autoload.php";
+$raw = @file_get_contents(getenv("FINDINGS_FILE"));
+$findings = is_string($raw) && $raw !== "" ? json_decode($raw, true, 512, JSON_THROW_ON_ERROR) : ["packages_scanned" => 0, "violations" => []];
+echo (new Waaseyaa\AgentOutput\Formatter\PackageLayersFormatter())->format($findings);
+'
+fi
+
+exit "$PYTHON_EXIT"

--- a/kitty-specs/agent-output-package-01KS5VX1/tasks/WP04-cli-integration.md
+++ b/kitty-specs/agent-output-package-01KS5VX1/tasks/WP04-cli-integration.md
@@ -41,19 +41,55 @@ tags: []
 
 Wire each affected CLI command to detect agent env / `--output=json` and route output through the right formatter. This is the highest-touch WP — it edits several scripts and config files. Integration tests verify the round-trip.
 
+## Scope realization (2026-05-23)
+
+WP04 is the highest-touch WP in the mission. This commit ships a
+**pattern-proving slice** that:
+
+1. Wires `--output=json` end-to-end through one `bin/check-*` script
+   (`bin/check-package-layers`) using the canonical pattern: bash
+   detects mode → Python emits structured findings to a tmpfile →
+   PHP shim feeds the existing `PackageLayersFormatter` and prints
+   the NDJSON envelope.
+2. Verifies the contract with both integration tests
+   (`PackageLayersJsonOutputTest`, `HumanOutputUnchangedTest`).
+
+The remaining subtasks land in **WP04B** (deferred to a follow-up
+mission so the highest-touch WP doesn't balloon a single PR):
+
+- **T015** — PHPUnit event subscriber + `phpunit.xml.dist` extension
+  registration. Net-new code against PHPUnit 10's event API.
+- **T016** — PHPStan custom error formatter + `phpstan.neon`
+  `errorFormatters` registration. Net-new code against PHPStan's
+  ErrorFormatter interface.
+- **T017 (remainder)** — Apply the bash + Python + PHP shim pattern
+  proven here to `bin/check-dead-code`, `bin/check-getquery-bindings`,
+  `bin/check-composer-policy`. Mechanical replication; each script
+  follows the WP04 part-1 template + uses its own already-shipped
+  formatter (DeadCodeFormatter, GetQueryBindingsFormatter,
+  ComposerPolicyFormatter — all in `packages/agent-output/`).
+- **T017 (drift-detector)** — `tools/drift-detector.sh` shell wrapper
+  pipe to `php bin/agent-output-format drift-detector`. The shim
+  reads stdin and calls `DriftDetectorFormatter::parseRawOutput()`.
+- **T018 (PhpUnitJsonOutputTest)** — depends on T015.
+
+The two shipped integration tests already cover T018's
+`PackageLayersJsonOutputTest` and `HumanOutputUnchangedTest`
+scenarios.
+
 ## Subtasks
 
-### T015 — PHPUnit Printer / Subscriber
+### T015 — PHPUnit Printer / Subscriber (deferred to WP04B)
 
 PHPUnit 10's event subscriber API is the right hook. Add a Subscriber class under `packages/agent-output/src/Listener/PhpUnitEventSubscriber.php` (or similar) that listens for `TestPassed`, `TestFailed`, `TestSuiteFinished`. Register via `phpunit.xml.dist`'s `<extensions>` block.
 
 The subscriber activates only when `AgentDetector::detect() !== null` OR `WAASEYAA_OUTPUT=json` OR `--output=json` passed. Otherwise it's a no-op (default PHPUnit output preserved — C-002).
 
-### T016 — PHPStan custom error format
+### T016 — PHPStan custom error format (deferred to WP04B)
 
 `phpstan.neon`: register a custom error formatter class via the `errorFormatters` key. The formatter activates the same way as T015. PHPStan calls into the formatter at the end of the run with the full error set.
 
-### T017 — `bin/check-*` PHP CLI scripts
+### T017 — `bin/check-*` PHP CLI scripts (1 of 4 shipped; 3 deferred to WP04B)
 
 For each of `check-package-layers`, `check-dead-code`, `check-getquery-bindings`, `check-composer-policy`:
 

--- a/tests/Integration/PhaseN/AgentOutput/HumanOutputUnchangedTest.php
+++ b/tests/Integration/PhaseN/AgentOutput/HumanOutputUnchangedTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\PhaseN\AgentOutput;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Asserts that `bin/check-package-layers`'s default (human) output is
+ * unchanged by the M4 WP04 `--output=json` wiring. The agent-output
+ * mode is opt-in (flag or env var); the default mode must emit the
+ * same pass/fail human line the rest of the framework's CI expects.
+ *
+ * Per FR-C-002 (agent-output is additive, not replace), human consumers
+ * should not have to learn a new output format to use the framework's
+ * gates locally.
+ *
+ * @api
+ */
+#[CoversNothing]
+final class HumanOutputUnchangedTest extends TestCase
+{
+    #[Test]
+    public function defaultModeEmitsTheCanonicalHumanPassLineAndExitsZero(): void
+    {
+        $result = $this->runCheckScript([], []);
+
+        self::assertSame(0, $result['exit_code'], 'check-package-layers should be green on main; stderr: ' . $result['stderr']);
+        self::assertSame(
+            'OK — package layer constraints (composer.json + PHP file-level) satisfied.',
+            trim($result['stdout']),
+            'Default human output line must be unchanged.',
+        );
+    }
+
+    #[Test]
+    public function noEnvelopeJsonAppearsInHumanModeOutput(): void
+    {
+        $result = $this->runCheckScript([], []);
+
+        self::assertStringNotContainsString('"tool":', $result['stdout']);
+        self::assertStringNotContainsString('"result":', $result['stdout']);
+        self::assertStringNotContainsString('"violations":', $result['stdout']);
+    }
+
+    /**
+     * @param list<string> $args
+     * @param array<string, string> $env
+     * @return array{exit_code: int, stdout: string, stderr: string}
+     */
+    private function runCheckScript(array $args, array $env): array
+    {
+        $projectRoot = dirname(__DIR__, 4);
+        $bin = $projectRoot . '/bin/check-package-layers';
+        self::assertFileExists($bin);
+
+        $command = array_merge([$bin], $args);
+        $process = proc_open(
+            command: $command,
+            descriptor_spec: [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            pipes: $pipes,
+            cwd: $projectRoot,
+            env_vars: array_merge(getenv(), $env),
+        );
+
+        self::assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return ['exit_code' => $exitCode, 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+}

--- a/tests/Integration/PhaseN/AgentOutput/PackageLayersJsonOutputTest.php
+++ b/tests/Integration/PhaseN/AgentOutput/PackageLayersJsonOutputTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\PhaseN\AgentOutput;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end round-trip test for `bin/check-package-layers --output=json`.
+ *
+ * Shells out to the production script in both JSON-flag and JSON-env modes
+ * and asserts the script emits a single NDJSON envelope on stdout that
+ * matches the contract documented in
+ * `packages/agent-output/src/Formatter/PackageLayersFormatter.php`. The
+ * gate must remain green on `main` for this test to assert `result: pass`.
+ *
+ * @api
+ */
+#[CoversNothing]
+final class PackageLayersJsonOutputTest extends TestCase
+{
+    #[Test]
+    public function flagJsonModeEmitsAValidEnvelopeAndExitsZeroOnCleanRepo(): void
+    {
+        $result = $this->runCheckScript(['--output=json'], []);
+
+        self::assertSame(0, $result['exit_code'], 'check-package-layers should be green on main; stderr: ' . $result['stderr']);
+        self::assertSame('', trim($result['stderr']), 'JSON mode should not leak human-readable lines to stderr.');
+
+        $envelope = $this->assertSingleEnvelopeOnStdout($result['stdout']);
+        self::assertSame('check-package-layers', $envelope['tool']);
+        self::assertSame('pass', $envelope['result']);
+        self::assertIsInt($envelope['packages_scanned']);
+        self::assertGreaterThan(0, $envelope['packages_scanned']);
+        self::assertSame([], $envelope['violations']);
+    }
+
+    #[Test]
+    public function envVarTriggersJsonModeWithoutTheFlag(): void
+    {
+        $result = $this->runCheckScript([], ['WAASEYAA_OUTPUT' => 'json']);
+
+        self::assertSame(0, $result['exit_code']);
+        $envelope = $this->assertSingleEnvelopeOnStdout($result['stdout']);
+        self::assertSame('check-package-layers', $envelope['tool']);
+        self::assertSame('pass', $envelope['result']);
+    }
+
+    /**
+     * @return array{tool: string, result: string, packages_scanned: int, violations: array<int, mixed>}
+     */
+    private function assertSingleEnvelopeOnStdout(string $stdout): array
+    {
+        $trimmed = rtrim($stdout, "\n");
+        self::assertNotSame('', $trimmed, 'JSON mode must emit one envelope on stdout.');
+        self::assertStringNotContainsString("\n", $trimmed, 'Multi-line NDJSON not expected for a single tool invocation; got: ' . $trimmed);
+
+        $envelope = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($envelope);
+        self::assertArrayHasKey('tool', $envelope);
+        self::assertArrayHasKey('result', $envelope);
+        self::assertArrayHasKey('packages_scanned', $envelope);
+        self::assertArrayHasKey('violations', $envelope);
+
+        return $envelope;
+    }
+
+    /**
+     * @param list<string> $args
+     * @param array<string, string> $env
+     * @return array{exit_code: int, stdout: string, stderr: string}
+     */
+    private function runCheckScript(array $args, array $env): array
+    {
+        $projectRoot = dirname(__DIR__, 4);
+        $bin = $projectRoot . '/bin/check-package-layers';
+        self::assertFileExists($bin);
+
+        $command = array_merge([$bin], $args);
+        $process = proc_open(
+            command: $command,
+            descriptor_spec: [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            pipes: $pipes,
+            cwd: $projectRoot,
+            env_vars: array_merge(getenv(), $env),
+        );
+
+        self::assertIsResource($process);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return ['exit_code' => $exitCode, 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+}


### PR DESCRIPTION
## Summary

WP04 part 1 of [`agent-output-package-01KS5VX1`](../tree/main/kitty-specs/agent-output-package-01KS5VX1) (M4). WP04 is the largest WP in the cluster (PHPUnit subscriber + PHPStan formatter + 4 bin/check-* + drift-detector wrapper + 3 integration tests); this PR ships a **pattern-proving slice** with one bin/check-* wired end-to-end + 2 integration tests. Remaining subtasks land in WP04B (see scope-realization note in `tasks/WP04-cli-integration.md`).

- **`bin/check-package-layers`** — `--output=json` flag + `WAASEYAA_OUTPUT=json` env var emit an NDJSON envelope via the existing `PackageLayersFormatter` (bash detects mode → Python emits structured findings to a tmpfile → PHP shim feeds the formatter). Default mode (no flag, no env) is unchanged.
- **`PackageLayersJsonOutputTest`** — both flag mode and env-var mode produce a single well-formed envelope on stdout, exit 0, no stderr leakage.
- **`HumanOutputUnchangedTest`** — default mode emits the canonical pass line and exits 0; no JSON fields leak into default output.

## What's deferred to WP04B

- T015 — PHPUnit event subscriber + `phpunit.xml.dist` extension (net-new code against PHPUnit 10's event API).
- T016 — PHPStan custom error formatter + `phpstan.neon` `errorFormatters` registration.
- T017 (remainder) — Apply the wrapper pattern to `bin/check-dead-code`, `bin/check-getquery-bindings`, `bin/check-composer-policy` (mechanical replication of the WP04 part-1 template + use of each script's already-shipped formatter).
- T017 (drift-detector) — `tools/drift-detector.sh` pipe-to-PHP wrapper using `DriftDetectorFormatter::parseRawOutput()`.
- T018 (PhpUnitJsonOutputTest) — depends on T015.

## Test plan

- [x] `composer phpstan` — 0 errors (full)
- [x] `bin/check-package-layers` — OK in default mode (human pass line)
- [x] `bin/check-package-layers --output=json` — OK, emits `{"tool":"check-package-layers","result":"pass","packages_scanned":68,"violations":[]}`
- [x] `bin/check-composer-policy` — OK
- [x] `bin/check-getquery-bindings` — OK (2 known exemptions, 0 new offenders)
- [x] `bin/check-dead-code` — OK, no new baseline entries
- [x] AgentOutput integration suite: **4 tests / 37 assertions**
- [x] Pre-push hooks: ✓ spec-drift, ✓ phpstan, ✓ composer-policy, ✓ phpunit

Refs M4 (`agent-output-package-01KS5VX1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)