### PR TITLE
feat(search): title-weighted bm25 ranking and a file/document corpus source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`search`: per-column bm25 title weighting and a non-entity file/document corpus source.** `Fts5SearchProvider` now accepts optional `titleWeight`/`bodyWeight` constructor arguments (both default `1.0`); with the defaults the relevance order is byte-identical to before (it still sorts by the built-in FTS5 `rank`), so every existing consumer is unchanged. When a caller passes non-default weights, the provider sorts by `bm25(search_index, 0.0, titleWeight, bodyWeight)` so a match in the `title` column can outrank a body-only match (the weights are formatted as locale-independent decimal literals because FTS5 auxiliary-function arguments cannot be bound parameters; the UNINDEXED `document_id` column is pinned to `0.0`). Two new value objects let an app index files rather than entities through the same `SearchIndexerInterface`: `Waaseyaa\Search\Document\SearchDocument` (a plain `SearchIndexableInterface` with `entity_type` defaulting to `document`) and `Waaseyaa\Search\Document\MarkdownDirectorySource` (scans a directory of `*.md`, deriving each document's title from the first H1 and falling back to the file name). This unblocks title-weighted relevance ranking for a file-backed docs corpus (waaseyaa.org), where body-frequency ranking previously surfaced the wrong spec.
+
 ## [0.1.0-alpha.209] - 2026-06-14
 
 ### Added

--- a/packages/search/src/Document/MarkdownDirectorySource.php
+++ b/packages/search/src/Document/MarkdownDirectorySource.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Document;
+
+/**
+ * A file/document corpus source for the search indexer: scans a directory of
+ * markdown files and yields one SearchDocument per file, deriving the title
+ * from the first H1 (falling back to the file name) and the body from the raw
+ * file contents. The document id is "{prefix}:{basename}".
+ *
+ * This is the non-entity counterpart to the entity event subscriber: where
+ * entities are indexed automatically on save, a file corpus is indexed by
+ * iterating documents() and handing each to SearchIndexerInterface::index().
+ * Re-run after the corpus on disk changes (removeAll() then re-index) to keep
+ * the index in step with the files.
+ *
+ * @api Public corpus source for consuming apps that index files, not entities.
+ */
+final class MarkdownDirectorySource
+{
+    public function __construct(
+        private readonly string $directory,
+        private readonly string $idPrefix = 'doc',
+    ) {}
+
+    /**
+     * @return iterable<SearchDocument>
+     */
+    public function documents(): iterable
+    {
+        if (!is_dir($this->directory)) {
+            return;
+        }
+
+        $pattern = rtrim($this->directory, '/\\') . DIRECTORY_SEPARATOR . '*.md';
+        $files = glob($pattern);
+        if ($files === false) {
+            return;
+        }
+        sort($files);
+
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
+            if ($contents === false) {
+                continue;
+            }
+
+            $name = basename($file, '.md');
+
+            yield new SearchDocument(
+                id: $this->idPrefix . ':' . $name,
+                title: $this->heading($contents) ?? $name,
+                body: $contents,
+                metadata: ['source_name' => $name],
+            );
+        }
+    }
+
+    private function heading(string $markdown): ?string
+    {
+        $lines = preg_split('/\R/', $markdown);
+        if ($lines === false) {
+            return null;
+        }
+
+        foreach ($lines as $line) {
+            if (preg_match('/^#\s+(.+)$/', trim($line), $m) === 1) {
+                return trim($m[1]);
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/search/src/Document/SearchDocument.php
+++ b/packages/search/src/Document/SearchDocument.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Document;
+
+use Waaseyaa\Search\SearchIndexableInterface;
+
+/**
+ * A plain, entity-free indexable document. The search engine is otherwise
+ * entity-driven (entities implement SearchIndexableInterface and are indexed
+ * on save/delete events); this value object lets a consumer index a file or
+ * any other non-entity document — a spec page, a markdown corpus, a synced
+ * doc set — through the exact same indexer contract.
+ *
+ * The document_id is opaque (e.g. "spec:entity-system"); entity_type defaults
+ * to "document" so the NOT NULL metadata column is always satisfied, and any
+ * metadata key the caller supplies overrides the default.
+ *
+ * @api Public indexable for consuming apps that index files, not entities.
+ */
+final class SearchDocument implements SearchIndexableInterface
+{
+    /**
+     * @param array<string, mixed> $metadata extra search_metadata columns
+     *        (entity_type, content_type, source_name, quality_score, topics,
+     *        url, og_image, created_at); entity_type defaults to "document".
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $title,
+        private readonly string $body,
+        private readonly array $metadata = [],
+    ) {}
+
+    public function getSearchDocumentId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toSearchDocument(): array
+    {
+        return ['title' => $this->title, 'body' => $this->body];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchMetadata(): array
+    {
+        // Caller-supplied keys win; the default only fills entity_type when the
+        // caller omits it (the metadata column is NOT NULL).
+        return $this->metadata + ['entity_type' => 'document'];
+    }
+}

--- a/packages/search/src/Fts5/Fts5SearchProvider.php
+++ b/packages/search/src/Fts5/Fts5SearchProvider.php
@@ -25,6 +25,8 @@ final class Fts5SearchProvider implements SearchProviderInterface
         private readonly DatabaseInterface $database,
         private readonly SearchIndexerInterface $indexer,
         ?LoggerInterface $logger = null,
+        private readonly float $titleWeight = 1.0,
+        private readonly float $bodyWeight = 1.0,
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
@@ -66,15 +68,17 @@ final class Fts5SearchProvider implements SearchProviderInterface
         $totalPages = (int) ceil($totalHits / $request->pageSize);
         $offset = ($request->page - 1) * $request->pageSize;
 
-        // Sort
-        $orderBy = 'si.rank';
+        // Sort. Relevance uses the FTS5 bm25 rank, optionally re-weighted so a
+        // title-column match outranks a body-only match (see rankExpression()).
+        $rankExpr = $this->rankExpression();
+        $orderBy = $rankExpr;
         if ($request->filters->sortField !== 'relevance' && in_array($request->filters->sortField, self::ALLOWED_SORT_COLUMNS, true)) {
             $direction = strtoupper($request->filters->sortOrder) === 'ASC' ? 'ASC' : 'DESC';
             $orderBy = "m.{$request->filters->sortField} $direction";
         }
 
         // Fetch page
-        $sql = "SELECT m.*, si.title, snippet(search_index, 2, '<b>', '</b>', '…', 32) as highlight, si.rank FROM search_index si JOIN search_metadata m ON m.document_id = si.document_id WHERE $whereSQL ORDER BY $orderBy LIMIT :limit OFFSET :offset";
+        $sql = "SELECT m.*, si.title, snippet(search_index, 2, '<b>', '</b>', '…', 32) as highlight, $rankExpr as rank FROM search_index si JOIN search_metadata m ON m.document_id = si.document_id WHERE $whereSQL ORDER BY $orderBy LIMIT :limit OFFSET :offset";
         $params['limit'] = $request->pageSize;
         $params['offset'] = $offset;
 
@@ -140,6 +144,42 @@ final class Fts5SearchProvider implements SearchProviderInterface
         $quoted = array_map(fn(string $term): string => '"' . str_replace('"', '""', $term) . '"', $terms);
 
         return implode(' ', $quoted);
+    }
+
+    /**
+     * The relevance ORDER BY / score expression. With the default per-column
+     * weights (1.0/1.0) this is FTS5's built-in `rank` (bm25 with equal column
+     * weights) — byte-identical to prior behaviour, so existing consumers are
+     * unaffected. When a caller passes non-default weights, the bm25()
+     * auxiliary function applies them per column so a title-column match
+     * outranks a body-only match. The FTS5 search_index table has three
+     * columns in declaration order (document_id UNINDEXED, title, body), and
+     * bm25() takes one weight per column, so the UNINDEXED document_id is
+     * pinned to 0.0 (it never contributes a match anyway).
+     */
+    private function rankExpression(): string
+    {
+        if ($this->titleWeight === 1.0 && $this->bodyWeight === 1.0) {
+            return 'si.rank';
+        }
+
+        return sprintf(
+            'bm25(search_index, 0.0, %s, %s)',
+            $this->weightLiteral($this->titleWeight),
+            $this->weightLiteral($this->bodyWeight),
+        );
+    }
+
+    /**
+     * A locale-independent fixed-point literal for inlining into the bm25()
+     * call. The weights are floats from the constructor (never user input), and
+     * FTS5 auxiliary-function arguments cannot be bound parameters, so they are
+     * formatted as a plain decimal — no exponent form, no locale separators
+     * that SQLite would reject.
+     */
+    private function weightLiteral(float $weight): string
+    {
+        return number_format($weight, 6, '.', '');
     }
 
     private function applyFilters(SearchFilters $filters, array &$whereClauses, array &$params): void

--- a/packages/search/tests/Unit/Document/MarkdownDirectorySourceTest.php
+++ b/packages/search/tests/Unit/Document/MarkdownDirectorySourceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit\Document;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Search\Document\MarkdownDirectorySource;
+use Waaseyaa\Search\Document\SearchDocument;
+
+/**
+ * @covers \Waaseyaa\Search\Document\MarkdownDirectorySource
+ */
+#[CoversClass(MarkdownDirectorySource::class)]
+final class MarkdownDirectorySourceTest extends TestCase
+{
+    private string $fixtures;
+
+    protected function setUp(): void
+    {
+        $this->fixtures = dirname(__DIR__) . '/fixtures/markdown';
+    }
+
+    #[Test]
+    public function it_yields_one_document_per_markdown_file_sorted_by_name(): void
+    {
+        $documents = $this->documents(new MarkdownDirectorySource($this->fixtures, 'spec'));
+
+        $this->assertCount(2, $documents);
+        $this->assertContainsOnlyInstancesOf(SearchDocument::class, $documents);
+        $this->assertSame(['spec:alpha', 'spec:beta'], array_map(static fn(SearchDocument $d): string => $d->getSearchDocumentId(), $documents));
+    }
+
+    #[Test]
+    public function it_derives_the_title_from_the_first_h1(): void
+    {
+        $documents = $this->documents(new MarkdownDirectorySource($this->fixtures, 'spec'));
+
+        $this->assertSame('Alpha Spec', $documents[0]->toSearchDocument()['title']);
+        $this->assertStringContainsString('first fixture document', $documents[0]->toSearchDocument()['body']);
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_file_name_when_there_is_no_h1(): void
+    {
+        $documents = $this->documents(new MarkdownDirectorySource($this->fixtures, 'spec'));
+
+        $this->assertSame('beta', $documents[1]->toSearchDocument()['title']);
+        $this->assertSame('beta', $documents[1]->toSearchMetadata()['source_name']);
+    }
+
+    #[Test]
+    public function a_missing_directory_yields_nothing(): void
+    {
+        $this->assertSame([], $this->documents(new MarkdownDirectorySource($this->fixtures . '/does-not-exist')));
+    }
+
+    /**
+     * @return list<SearchDocument>
+     */
+    private function documents(MarkdownDirectorySource $source): array
+    {
+        return iterator_to_array($source->documents(), false);
+    }
+}

--- a/packages/search/tests/Unit/Fts5SearchProviderWeightingTest.php
+++ b/packages/search/tests/Unit/Fts5SearchProviderWeightingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\Fts5\Fts5SearchIndexer;
+use Waaseyaa\Search\Fts5\Fts5SearchProvider;
+use Waaseyaa\Search\SearchRequest;
+
+/**
+ * Per-column bm25 title weighting: a title-column match must be able to
+ * outrank a body-only match. This is the docs-search relevance fix —
+ * "How do I add an entity type?" should surface the spec titled "Entity
+ * system", not an access-control spec that merely repeats the phrase in body.
+ *
+ * @covers \Waaseyaa\Search\Fts5\Fts5SearchProvider
+ */
+#[CoversClass(Fts5SearchProvider::class)]
+final class Fts5SearchProviderWeightingTest extends TestCase
+{
+    private DBALDatabase $database;
+    private Fts5SearchIndexer $indexer;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+        $this->indexer = new Fts5SearchIndexer($this->database);
+        $this->indexer->ensureSchema();
+
+        // A title-match doc: "entity" lives in the (short) title; the body
+        // mentions "entity type" once, in passing.
+        $this->indexer->index(new SearchDocument(
+            id: 'spec:entity-system',
+            title: 'Entity system',
+            body: 'Register an entity type through the manager. Fields belong to bundles and storage persists data.',
+            metadata: ['entity_type' => 'spec'],
+        ));
+
+        // A body-only doc: the title is unrelated, but the body mentions the
+        // query phrase more often, so raw body frequency favours it.
+        $this->indexer->index(new SearchDocument(
+            id: 'spec:access-control',
+            title: 'Access control',
+            body: 'Access checks run per entity type. The policy decides each entity type grant for a request.',
+            metadata: ['entity_type' => 'spec'],
+        ));
+
+        // Unrelated docs so "entity"/"type" are discriminating terms (real IDF),
+        // mirroring a corpus of many specs rather than two near-duplicates.
+        $this->indexer->index(new SearchDocument('spec:routing', 'Routing', 'The router matches a request path to a controller and middleware stack.', ['entity_type' => 'spec']));
+        $this->indexer->index(new SearchDocument('spec:cache', 'Cache', 'The cache stores computed values in memory with a time to live and tags.', ['entity_type' => 'spec']));
+        $this->indexer->index(new SearchDocument('spec:mail', 'Mail', 'The mailer renders a template and sends a message through a transport.', ['entity_type' => 'spec']));
+        $this->indexer->index(new SearchDocument('spec:queue', 'Queue', 'A job is dispatched onto a queue and a worker processes it asynchronously.', ['entity_type' => 'spec']));
+    }
+
+    #[Test]
+    public function default_weights_rank_the_body_frequency_match_first(): void
+    {
+        $provider = new Fts5SearchProvider($this->database, $this->indexer);
+
+        $result = $provider->search(new SearchRequest('entity type'));
+
+        $this->assertSame(2, $result->totalHits);
+        $this->assertSame('spec:access-control', $result->hits[0]->id, 'Without title weighting, raw body frequency wins.');
+    }
+
+    #[Test]
+    public function title_weighting_floats_the_title_match_above_the_body_only_match(): void
+    {
+        $provider = new Fts5SearchProvider($this->database, $this->indexer, null, 10.0, 1.0);
+
+        $result = $provider->search(new SearchRequest('entity type'));
+
+        $this->assertSame(2, $result->totalHits);
+        $this->assertSame('spec:entity-system', $result->hits[0]->id, 'A title-column match must outrank a body-only match.');
+        $this->assertGreaterThan($result->hits[1]->score, $result->hits[0]->score);
+    }
+}

--- a/packages/search/tests/Unit/SearchDocumentTest.php
+++ b/packages/search/tests/Unit/SearchDocumentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\SearchIndexableInterface;
+
+/**
+ * @covers \Waaseyaa\Search\Document\SearchDocument
+ */
+#[CoversClass(SearchDocument::class)]
+final class SearchDocumentTest extends TestCase
+{
+    #[Test]
+    public function it_is_a_search_indexable(): void
+    {
+        $this->assertInstanceOf(SearchIndexableInterface::class, new SearchDocument('spec:entity-system', 'Entity System', 'body'));
+    }
+
+    #[Test]
+    public function it_exposes_id_title_and_body(): void
+    {
+        $document = new SearchDocument('spec:entity-system', 'Entity System', 'An entity type defines fields.');
+
+        $this->assertSame('spec:entity-system', $document->getSearchDocumentId());
+        $this->assertSame(['title' => 'Entity System', 'body' => 'An entity type defines fields.'], $document->toSearchDocument());
+    }
+
+    #[Test]
+    public function entity_type_defaults_to_document(): void
+    {
+        $document = new SearchDocument('spec:x', 'X', 'y');
+
+        $this->assertSame('document', $document->toSearchMetadata()['entity_type']);
+    }
+
+    #[Test]
+    public function caller_metadata_overrides_the_default_entity_type(): void
+    {
+        $document = new SearchDocument('spec:x', 'X', 'y', ['entity_type' => 'spec', 'source_name' => 'x']);
+
+        $metadata = $document->toSearchMetadata();
+        $this->assertSame('spec', $metadata['entity_type']);
+        $this->assertSame('x', $metadata['source_name']);
+    }
+}

--- a/packages/search/tests/Unit/fixtures/markdown/alpha.md
+++ b/packages/search/tests/Unit/fixtures/markdown/alpha.md
@@ -1,0 +1,3 @@
+# Alpha Spec
+
+The first fixture document, about alpha things.

--- a/packages/search/tests/Unit/fixtures/markdown/beta.md
+++ b/packages/search/tests/Unit/fixtures/markdown/beta.md
@@ -1,0 +1,1 @@
+No heading here, just prose so the title falls back to the file name.


### PR DESCRIPTION
## What

Two additive changes to `waaseyaa/search`, both needed so a file-backed docs corpus (waaseyaa.org) can rank by relevance with the spec **title** weighted above the body:

1. **Per-column bm25 title weighting in `Fts5SearchProvider`.** New optional `titleWeight`/`bodyWeight` constructor args (default `1.0`/`1.0`). With the defaults the relevance order is **byte-identical** to before (still sorts by the built-in FTS5 `rank`), so every existing entity-search consumer is unchanged. Non-default weights sort by `bm25(search_index, 0.0, titleWeight, bodyWeight)` — the FTS5 table's three columns in declaration order are `(document_id UNINDEXED, title, body)`, so the UNINDEXED id is pinned to `0.0`. Weights are inlined as locale-independent decimal literals because FTS5 auxiliary-function arguments cannot be bound parameters.
2. **A non-entity file/document corpus source.** `Waaseyaa\Search\Document\SearchDocument` (a plain `SearchIndexableInterface`; `entity_type` defaults to `document`) and `Waaseyaa\Search\Document\MarkdownDirectorySource` (scans `*.md`, title from the first H1, falls back to file name). Marked `@api` — they are public extension points for consuming apps that index files, not entities.

## Why

The waaseyaa.org docs chat ranked spec passages by body keyword frequency, so "How do I add an entity type?" surfaced `access-control` over the spec titled "Entity system". Per-column title weighting fixes that; the file corpus source lets the file-backed spec set flow through the same indexer the entity pipeline uses.

## Tests

New `Fts5SearchProviderWeightingTest` proves a title match (`Entity system`) outranks a body-frequency match (`access-control`) for the query "entity type" once title weighting is applied, and that the default weights still rank by body frequency. Plus unit tests for both Document classes. `packages/search` suite green (46 tests); `cs-check`, `phpstan`, `check-dead-code`, `check-package-layers` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)