### PR TITLE
fix: Wave 4 batch-1 majors (C-8 session, C-9 userinfo, C-10 cache, C-13 agent-tools, C-25 fpm, C-31 prune)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`user`: session cookies are secure-by-default (audit C-8).** A stock install ran `session_start()` with PHP's bare cookie ini — no `HttpOnly` (XSS-exfiltratable), no `SameSite` (CSRF surface), no `use_strict_mode` (session-fixation). `SessionMiddleware::applySessionCookieIni()` now applies hardened defaults on every request (`httponly=true`, `samesite=Lax`, `use_strict_mode=true`, `secure='auto'` — Secure only under HTTPS via the trusted-proxy guard). Any `config['session']['cookie']` key still overrides the matching default. Regression tests pin the unconfigured-default and the override paths.
+- **`oidc`: `/userinfo` validates the opaque access token by lookup, not as a JWT (audit C-9).** The endpoint fed the bearer to `IdTokenMinter::verifyAndDecode()`, but OIDC access tokens are opaque — so it was broken and the revocation check was dead. It now authenticates via `AccessTokenIssuer::findByOpaqueToken()`, rejecting unknown/revoked/expired tokens with `401`, and derives the subject from the persisted row. (`verifyAndDecode` is retained, now `@api`, for genuine ID-token verification.) New integration test covers valid/revoked/expired/garbage.
+- **`entity-storage`: the query result cache key now includes the access dimension (audit C-10).** The fingerprint omitted the account and the `accessCheck` flag, so an access-filtered list for one account could be served from a cache entry populated by another account or by an unfiltered `accessCheck(false)` run — a cross-account row leak. The key now discriminates on `accessCheckEnabled` + account; same-account caching is unchanged. Regression test pins both leaks closed and the same-account hit.
+- **`ai-tools`: `EntityListTool`/`EntitySearchTool` filter results through a per-entity view check (audit C-13).** Both emitted one item per `findBy()` candidate with no access gate — an information-disclosure oracle for agents. They now drop entities the initiating account may not view (matching the sibling read/revisions tools), capping output to the requested limit. Regression test asserts a forbidden entity is excluded.
+- **`cli`: `audit:prune` requires `--confirm` for real deletion (audit C-31).** It deleted `audit_event` rows guarded only by `--dry-run`. It now refuses to delete without `--confirm` (and refuses non-interactively without it), and echoes the resolved cutoff + row count before deleting. CommandTester tests pin both paths.
+- **`deployer`: the recipe reloads the correct FPM version (audit C-25).** The recipe hard-coded `systemctl reload php8.4-fpm` while the framework requires PHP ≥ 8.5, so deploy finalize failed. It now uses `php{{php_fpm_version}}-fpm` defaulting to `8.5` (overridable per host). Test pins the version.
+
 ## [0.1.0-alpha.213] - 2026-06-15
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -448,6 +448,7 @@
             "Waaseyaa\\OAuthProvider\\Tests\\": "packages/oauth-provider/tests/",
             "Waaseyaa\\Oidc\\Tests\\": "packages/oidc/tests/",
             "Waaseyaa\\Engagement\\Tests\\": "packages/engagement/tests/",
+            "Waaseyaa\\Deployer\\Tests\\": "packages/deployer/tests/",
             "Waaseyaa\\Tests\\": "tests/"
         }
     },

--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -510,6 +510,8 @@ Behavior:
 
 **Trusted proxy guard:** Both `NativeSession::isSecureConnection()` and `SessionMiddleware::isHttpsRequest()` only trust `X-Forwarded-Proto` when `REMOTE_ADDR` matches a configured trusted proxy IP. The header comparison is case-insensitive (`HTTPS`, `Https`, `https` all match). Both methods return `false` early when `REMOTE_ADDR` is empty or missing, preventing accidental matches against empty-string entries in the trusted list. Without trusted proxies configured, the header is ignored. Only exact IP addresses are supported (no CIDR notation). Configure via `'trusted_proxies' => ['127.0.0.1']` in `config/waaseyaa.php`.
 
+**Secure-by-default session cookies (audit C-8):** `SessionMiddleware::applySessionCookieIni()` applies hardened defaults on **every** request — `httponly=true`, `samesite='Lax'`, `use_strict_mode=true` (session-fixation protection), and `secure='auto'` (the Secure flag is set when the request is HTTPS-detected via the trusted-proxy guard above) — even with no `config['session']['cookie']` block configured. Any key supplied under `config['session']['cookie']` overrides the matching default (explicit config always wins). This closes the previous insecure-by-default gap where a stock install ran with PHP's bare cookie ini (no HttpOnly/SameSite/strict-mode).
+
 Does not handle login/logout. Only resolves "who is making this request."
 
 Lives in the `user` package because it depends on `User`, `AnonymousUser`, and entity storage.

--- a/packages/ai-tools/src/AbstractAgentTool.php
+++ b/packages/ai-tools/src/AbstractAgentTool.php
@@ -129,6 +129,25 @@ abstract class AbstractAgentTool implements AgentToolInterface
     }
 
     /**
+     * Predicate form of the per-entity 'view' gate, for filtering result sets.
+     *
+     * Returns true when no access handler has been attached (capability-only
+     * mode — preserves prior behavior), otherwise consults the entity
+     * AccessPolicy for ('view', $account). List/search tools MUST filter each
+     * candidate through this so a forbidden entity never leaks via enumeration
+     * (id/label/existence) or substring match — the same per-entity gate
+     * {@see EntityReadTool} applies to single reads.
+     */
+    protected function canViewEntity(EntityInterface $entity, AccountInterface $account): bool
+    {
+        if ($this->accessHandler === null) {
+            return true;
+        }
+
+        return $this->accessHandler->check($entity, 'view', $account)->isAllowed();
+    }
+
+    /**
      * Enforce the per-entity AccessPolicy for creating an entity of a type.
      * No-op when no access handler has been attached.
      */

--- a/packages/ai-tools/src/Entity/EntityListTool.php
+++ b/packages/ai-tools/src/Entity/EntityListTool.php
@@ -77,6 +77,14 @@ final class EntityListTool extends AbstractAgentTool
             return AgentToolResult::error(sprintf('entity.list: %s', $e->getMessage()));
         }
 
+        // Per-entity access gate: drop entities the initiating account may not
+        // view before they are serialized. No-op in capability-only mode (no
+        // access handler attached). Result stays bounded by $limit.
+        $entities = array_values(array_filter(
+            $entities,
+            fn(EntityInterface $e): bool => $this->canViewEntity($e, $account),
+        ));
+
         $items = array_map(static function (EntityInterface $e): array {
             $item = [
                 'entity_type' => $e->getEntityTypeId(),

--- a/packages/ai-tools/src/Entity/EntitySearchTool.php
+++ b/packages/ai-tools/src/Entity/EntitySearchTool.php
@@ -87,6 +87,12 @@ final class EntitySearchTool extends AbstractAgentTool
             if (count($matches) >= $limit) {
                 break;
             }
+            // Per-entity access gate: never surface an entity the initiating
+            // account may not view (no enumeration / substring-match oracle).
+            // No-op in capability-only mode (no access handler attached).
+            if (!$this->canViewEntity($entity, $account)) {
+                continue;
+            }
             if ($this->matches($entity, $needle)) {
                 $matches[] = ['entity_type' => $entity->getEntityTypeId(), 'id' => $entity->id()];
             }

--- a/packages/ai-tools/tests/Unit/Entity/EntityListSearchAccessFilterTest.php
+++ b/packages/ai-tools/tests/Unit/Entity/EntityListSearchAccessFilterTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\AI\Tools\Tests\Unit\Entity;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\AI\Tools\Entity\EntityListTool;
+use Waaseyaa\AI\Tools\Entity\EntitySearchTool;
+use Waaseyaa\AI\Tools\Tests\Fixtures\InMemoryToolRepository;
+use Waaseyaa\AI\Tools\Tests\Fixtures\SingleTypeEntityTypeManager;
+use Waaseyaa\AI\Tools\Tests\Fixtures\ToolTestEntity;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+
+/**
+ * C-13 (security): EntityListTool / EntitySearchTool must apply the same
+ * per-entity 'view' AccessPolicy gate that EntityReadTool already applies, so
+ * an agent cannot enumerate (list) or substring-match (search) entities it is
+ * forbidden to view. The filter must run against the REAL initiating account
+ * threaded into execute() — not a bypass/system account.
+ */
+#[CoversClass(EntityListTool::class)]
+#[CoversClass(EntitySearchTool::class)]
+final class EntityListSearchAccessFilterTest extends TestCase
+{
+    private InMemoryToolRepository $repo;
+    private SingleTypeEntityTypeManager $etm;
+    private EntityAccessHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryToolRepository();
+        // Two entities sharing a substring ('secret') in their title so search
+        // would match both absent any access filtering.
+        $this->repo->seed(new ToolTestEntity(['id' => '1', 'title' => 'public secret']));
+        $this->repo->seed(new ToolTestEntity(['id' => '2', 'title' => 'classified secret']));
+
+        $type = new EntityType(
+            id: 'tool_test',
+            label: 'Tool Test',
+            class: ToolTestEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'revision' => 'revision_id'],
+            revisionable: true,
+            revisionDefault: true,
+        );
+        $this->etm = new SingleTypeEntityTypeManager($type, $this->repo);
+
+        // Policy: id '2' is view-forbidden; everything else is viewable.
+        $policy = new class implements AccessPolicyInterface {
+            public function appliesTo(string $entityTypeId): bool
+            {
+                return $entityTypeId === 'tool_test';
+            }
+
+            public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+            {
+                if ($operation === 'view') {
+                    return (string) $entity->id() === '2'
+                        ? AccessResult::forbidden('classified')
+                        : AccessResult::allowed();
+                }
+
+                return AccessResult::neutral();
+            }
+
+            public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+            {
+                return AccessResult::neutral();
+            }
+        };
+        $this->handler = new EntityAccessHandler([$policy]);
+    }
+
+    /** @param list<string> $permissions */
+    private function account(array $permissions): AccountInterface
+    {
+        return new class($permissions) implements AccountInterface {
+            /** @param list<string> $permissions */
+            public function __construct(private readonly array $permissions) {}
+
+            public function id(): int|string
+            {
+                return 7;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return in_array($permission, $this->permissions, true);
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     * @return list<string>
+     */
+    private function ids(array $items): array
+    {
+        return array_values(array_map(static fn(array $i): string => (string) $i['id'], $items));
+    }
+
+    #[Test]
+    public function list_excludes_a_view_forbidden_entity(): void
+    {
+        $tool = new EntityListTool($this->etm);
+        $tool->setAccessHandler($this->handler);
+
+        $result = $tool->execute(
+            ['entity_type' => 'tool_test'],
+            $this->account(['tool.entity.list']),
+        );
+
+        $this->assertFalse($result->isError);
+        $data = $result->content[0]['data'] ?? [];
+        $ids = $this->ids($data['items'] ?? []);
+        $this->assertContains('1', $ids, 'the viewable entity is listed');
+        $this->assertNotContains('2', $ids, 'the view-forbidden entity must not be listed');
+        $this->assertSame(1, $data['count'], 'count reflects the post-filter set');
+    }
+
+    #[Test]
+    public function search_excludes_a_view_forbidden_entity(): void
+    {
+        $tool = new EntitySearchTool($this->etm);
+        $tool->setAccessHandler($this->handler);
+
+        // Both titles contain 'secret'; only the viewable one may surface.
+        $result = $tool->execute(
+            ['entity_type' => 'tool_test', 'query' => 'secret'],
+            $this->account(['tool.entity.search']),
+        );
+
+        $this->assertFalse($result->isError);
+        $data = $result->content[0]['data'] ?? [];
+        $ids = $this->ids($data['items'] ?? []);
+        $this->assertContains('1', $ids, 'the viewable match is returned');
+        $this->assertNotContains('2', $ids, 'the view-forbidden match must not be returned');
+        $this->assertSame(1, $data['count'], 'count reflects the post-filter set');
+    }
+
+    #[Test]
+    public function without_a_handler_both_tools_are_capability_only(): void
+    {
+        // No access handler attached: behavior is unchanged (capability-only),
+        // so both entities surface. This pins that the fix is a no-op for
+        // handler-less consumers.
+        $list = new EntityListTool($this->etm);
+        $listResult = $list->execute(['entity_type' => 'tool_test'], $this->account(['tool.entity.list']));
+        $this->assertFalse($listResult->isError);
+        $this->assertSame(2, ($listResult->content[0]['data']['count'] ?? null));
+
+        $search = new EntitySearchTool($this->etm);
+        $searchResult = $search->execute(
+            ['entity_type' => 'tool_test', 'query' => 'secret'],
+            $this->account(['tool.entity.search']),
+        );
+        $this->assertFalse($searchResult->isError);
+        $this->assertSame(2, ($searchResult->content[0]['data']['count'] ?? null));
+    }
+}

--- a/packages/cli/src/Command/Audit/PruneCommand.php
+++ b/packages/cli/src/Command/Audit/PruneCommand.php
@@ -15,11 +15,17 @@ use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
- * `bin/waaseyaa audit:prune --older-than=<duration> [--kind=<glob>] [--dry-run]`
+ * `bin/waaseyaa audit:prune --older-than=<duration> [--kind=<glob>] [--dry-run] [--confirm]`
  *
  * Deletes audit_event rows older than the given ISO-8601 duration
  * (e.g. `PT1H`, `P30D`, `P1Y`). Emits one self-audit event of kind
  * `audit.retention_pruned` after each real execution (FR-012).
+ *
+ * Destructive operation: real deletion requires `--confirm`. Without it (and
+ * without `--dry-run`) the command echoes the resolved cutoff timestamp and the
+ * exact row count it would delete, then refuses and exits 0 — nothing is
+ * deleted and no self-audit event is recorded. This guards against typo-prone
+ * `--older-than` durations silently destroying the append-only audit log.
  *
  * Options:
  *   --older-than  ISO-8601 duration string (required). Events created before
@@ -29,6 +35,8 @@ use Waaseyaa\Foundation\Log\NullLogger;
  *                   `entity.*`  → all entity.* cases
  *                   literal     → single exact kind
  *   --dry-run     Print the count that would be pruned; do not delete.
+ *   --confirm     Required for real deletion. Without it, the command refuses
+ *                 to delete and prints the cutoff + row count it would remove.
  *
  * @api
  */
@@ -99,6 +107,26 @@ final class PruneCommand
                 $olderThanRaw,
                 $cutoff->format(\DateTimeInterface::ATOM),
             ));
+
+            return 0;
+        }
+
+        // Destructive-op guard (C-31): real deletion requires an explicit
+        // --confirm. Without it, echo the resolved cutoff + the exact row count
+        // that WOULD be deleted, then refuse — record no self-audit event and
+        // delete no rows. This refusal is unconditional (interactive or not),
+        // matching the import:reset / import:rollback idiom.
+        $isConfirmed = (bool) $io->option('confirm');
+
+        if (!$isConfirmed) {
+            $io->writeln(sprintf(
+                'Refusing to prune %d audit events without --confirm (kind: %s, older than: %s, cutoff: %s).',
+                $count,
+                $kindPattern,
+                $olderThanRaw,
+                $cutoff->format(\DateTimeInterface::ATOM),
+            ));
+            $io->writeln('Re-run with --confirm to delete, or --dry-run to preview.');
 
             return 0;
         }

--- a/packages/cli/src/Provider/AuditServiceProvider.php
+++ b/packages/cli/src/Provider/AuditServiceProvider.php
@@ -64,6 +64,11 @@ final class AuditServiceProvider extends ServiceProvider implements HasNativeCom
                     mode: OptionMode::None,
                     description: 'Print the count that would be pruned without deleting.',
                 ),
+                new OptionDefinition(
+                    name: 'confirm',
+                    mode: OptionMode::None,
+                    description: 'Required for real deletion. Without it the command refuses and prints the cutoff + row count it would delete.',
+                ),
             ],
             handler: [PruneCommand::class, 'execute'],
         );

--- a/packages/cli/tests/Unit/Command/Audit/PruneCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Audit/PruneCommandTest.php
@@ -240,7 +240,7 @@ final class PruneCommandTest extends TestCase
     public function realRunRecordsSelfAuditAndPrints(): void
     {
         $writer = $this->makeNullWriter();
-        $io = $this->makeIo(['older-than' => 'PT1H']);
+        $io = $this->makeIo(['older-than' => 'PT1H', 'confirm' => true]);
         $command = new PruneCommand($this->makeNullQuery(6), $writer, $this->makeNullDb());
 
         $exitCode = $command->execute($io);
@@ -250,6 +250,160 @@ final class PruneCommandTest extends TestCase
         self::assertSame(AuditEventKind::AuditRetentionPruned, $writer->recorded[0]->kind);
         self::assertSame(6, $writer->recorded[0]->attributes['deleted_count']);
         self::assertStringContainsString('6', $io->outputLines()[0]);
+    }
+
+    #[Test]
+    public function realRunWithoutConfirmDeletesNothingAndWarns(): void
+    {
+        // C-31 regression: a non-dry-run invocation WITHOUT --confirm must not
+        // delete or record a self-audit event, and must echo the cutoff + count.
+        $writer = $this->makeNullWriter();
+        $delete = new class implements DeleteInterface {
+            public int $executeCalls = 0;
+
+            public function condition(string $field, mixed $value, string $operator = '='): static
+            {
+                return $this;
+            }
+
+            public function execute(): int
+            {
+                $this->executeCalls++;
+
+                return 0;
+            }
+        };
+        $db = new class ($delete) implements DatabaseInterface {
+            public function __construct(private readonly DeleteInterface $del) {}
+
+            public function delete(string $table): DeleteInterface
+            {
+                return $this->del;
+            }
+
+            public function select(string $table, string $alias = ''): SelectInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function insert(string $table): InsertInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function update(string $table): UpdateInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function schema(): SchemaInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function transaction(string $name = ''): TransactionInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function query(string $sql, array $args = []): \Traversable
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function quoteIdentifier(string $identifier): string
+            {
+                return '"' . $identifier . '"';
+            }
+        };
+
+        // older-than P30D, no dry-run, no confirm.
+        $io = $this->makeIo(['older-than' => 'P30D', 'kind' => '*']);
+        $command = new PruneCommand($this->makeNullQuery(9), $writer, $db);
+
+        $exitCode = $command->execute($io);
+
+        self::assertSame(0, $exitCode, 'refusal path exits 0 (operator-driven op)');
+        self::assertSame(0, $delete->executeCalls, 'no DELETE may run without --confirm');
+        self::assertEmpty($writer->recorded, 'no self-audit event without --confirm');
+        $output = implode("\n", $io->outputLines());
+        self::assertStringContainsString('--confirm', $output, 'must instruct operator to re-run with --confirm');
+        self::assertStringContainsString('9', $output, 'must echo the row count it would delete');
+    }
+
+    #[Test]
+    public function realRunWithConfirmDeletesAndRecordsSelfAudit(): void
+    {
+        // C-31 regression (positive case): --confirm proceeds with deletion.
+        $writer = $this->makeNullWriter();
+        $delete = new class implements DeleteInterface {
+            public int $executeCalls = 0;
+
+            public function condition(string $field, mixed $value, string $operator = '='): static
+            {
+                return $this;
+            }
+
+            public function execute(): int
+            {
+                $this->executeCalls++;
+
+                return 0;
+            }
+        };
+        $db = new class ($delete) implements DatabaseInterface {
+            public function __construct(private readonly DeleteInterface $del) {}
+
+            public function delete(string $table): DeleteInterface
+            {
+                return $this->del;
+            }
+
+            public function select(string $table, string $alias = ''): SelectInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function insert(string $table): InsertInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function update(string $table): UpdateInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function schema(): SchemaInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function transaction(string $name = ''): TransactionInterface
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function query(string $sql, array $args = []): \Traversable
+            {
+                throw new \LogicException('Not needed in this test.');
+            }
+
+            public function quoteIdentifier(string $identifier): string
+            {
+                return '"' . $identifier . '"';
+            }
+        };
+
+        $io = $this->makeIo(['older-than' => 'P30D', 'kind' => '*', 'confirm' => true]);
+        $command = new PruneCommand($this->makeNullQuery(9), $writer, $db);
+
+        $exitCode = $command->execute($io);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(1, $delete->executeCalls, '--confirm must trigger exactly one DELETE');
+        self::assertCount(1, $writer->recorded, '--confirm must record the self-audit event');
+        self::assertSame(AuditEventKind::AuditRetentionPruned, $writer->recorded[0]->kind);
     }
 
     #[Test]

--- a/packages/deployer/recipe/waaseyaa.php
+++ b/packages/deployer/recipe/waaseyaa.php
@@ -52,7 +52,10 @@ task('waaseyaa:clear-manifest', function (): void {
 
 desc('Reload PHP-FPM to pick up new release');
 task('waaseyaa:php-fpm-reload', function (): void {
-    run('sudo systemctl reload php8.4-fpm');
+    // Defaults to the framework's minimum supported runtime (PHP >=8.5).
+    // Override per host with set('php_fpm_version', '8.6') in your deploy.php.
+    $phpFpmVersion = get('php_fpm_version', '8.5');
+    run("sudo systemctl reload php{$phpFpmVersion}-fpm");
 });
 
 desc('Ensure shared runtime directories exist');

--- a/packages/deployer/tests/Unit/PhpFpmReloadVersionTest.php
+++ b/packages/deployer/tests/Unit/PhpFpmReloadVersionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Deployer\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins C-25: the shared Deployer recipe must reload the FPM service for the
+ * framework's supported PHP runtime (>=8.5), not the unsupported php8.4-fpm unit.
+ *
+ * The recipe is a Deployer DSL script with global, non-idempotent side effects
+ * (set()/task()/after()), so it cannot be executed inside the test suite. We
+ * assert against the recipe source text instead, which is sufficient to lock the
+ * version invariant in place.
+ */
+#[CoversNothing]
+final class PhpFpmReloadVersionTest extends TestCase
+{
+    private function recipeSource(): string
+    {
+        $path = \dirname(__DIR__, 2) . '/recipe/waaseyaa.php';
+        self::assertFileExists($path, 'Shared Deployer recipe is missing.');
+        $source = file_get_contents($path);
+        self::assertIsString($source, 'Could not read the shared Deployer recipe.');
+
+        return $source;
+    }
+
+    #[Test]
+    public function recipeDoesNotReloadTheUnsupportedPhp84FpmUnit(): void
+    {
+        self::assertStringNotContainsString(
+            'php8.4-fpm',
+            $this->recipeSource(),
+            'The recipe reloads php8.4-fpm, but the framework requires PHP >=8.5; '
+            . 'on a correctly provisioned host that systemd unit does not exist and '
+            . 'the deploy finalize step fails.',
+        );
+    }
+
+    #[Test]
+    public function recipeParameterisesTheFpmVersionWithAnEightFiveDefault(): void
+    {
+        $source = $this->recipeSource();
+
+        self::assertStringContainsString(
+            "get('php_fpm_version', '8.5')",
+            $source,
+            'The FPM service version must be parameterised via the php_fpm_version '
+            . "parameter defaulting to '8.5' so consumers can override it per host.",
+        );
+        self::assertStringContainsString(
+            'php{$phpFpmVersion}-fpm',
+            $source,
+            'The reload command must interpolate the resolved php_fpm_version into '
+            . 'the FPM systemd unit name.',
+        );
+    }
+}

--- a/packages/entity-storage/src/SqlEntityQuery.php
+++ b/packages/entity-storage/src/SqlEntityQuery.php
@@ -644,6 +644,19 @@ final class SqlEntityQuery implements EntityQueryInterface
 
     /**
      * Deterministic fingerprint for {@see SqlEntityQueryResultCache}.
+     *
+     * Security (C-010): the cached result of a query is a function of the
+     * access dimension as well as the SQL shape. An access-filtered list is
+     * account-specific, so the account MUST discriminate the key when access
+     * checking is on — otherwise account B can be served account A's filtered
+     * survivors, or a system-context accessCheck(false) unfiltered list can be
+     * served to an access-checked caller (cross-account / filter-bypass leak).
+     * We always fold in accessCheckEnabled; we fold in a per-account
+     * discriminator only when access checking is on. When it is off the result
+     * is account-independent, so every accessCheck(false) caller emits the same
+     * `account => null` and legitimately shares one cache key. The throw at the
+     * top of execute() guarantees accessCheckEnabled is never true with a null
+     * account, so the discriminator is always present when it matters.
      */
     private function buildCacheFingerprint(): string
     {
@@ -653,6 +666,10 @@ final class SqlEntityQuery implements EntityQueryInterface
             'rangeOffset' => $this->rangeOffset,
             'rangeLimit' => $this->rangeLimit,
             'isCount' => $this->isCount,
+            'accessCheck' => $this->accessCheckEnabled,
+            'account' => $this->accessCheckEnabled && $this->account !== null
+                ? [$this->account->id(), $this->account::class]
+                : null,
         ];
 
         return hash('xxh128', json_encode($payload, JSON_THROW_ON_ERROR));

--- a/packages/entity-storage/tests/Unit/SqlEntityQueryAccessCacheKeyTest.php
+++ b/packages/entity-storage/tests/Unit/SqlEntityQueryAccessCacheKeyTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\SqlEntityQuery;
+use Waaseyaa\EntityStorage\SqlEntityQueryResultCache;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\EntityStorage\Tests\Fixtures\TestStorageEntity;
+
+/**
+ * Regression test for C-010: the query result cache key must include the
+ * access dimension (accessCheckEnabled + a per-account discriminator) so an
+ * access-filtered list for one account cannot be served from a cache entry
+ * populated by a different account or by an unfiltered accessCheck(false) run.
+ *
+ * The storage owns a single SqlEntityQueryResultCache that every getQuery()
+ * shares, so identical conditions across queries collide on the fingerprint
+ * unless the fingerprint discriminates on access + account.
+ */
+#[CoversClass(SqlEntityQuery::class)]
+#[CoversClass(SqlEntityQueryResultCache::class)]
+final class SqlEntityQueryAccessCacheKeyTest extends TestCase
+{
+    private DBALDatabase $database;
+
+    private SqlEntityStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+        $entityType = new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: TestStorageEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+        );
+
+        $schemaHandler = new SqlSchemaHandler($entityType, $this->database);
+        $schemaHandler->ensureTable();
+
+        // Single shared result cache across every getQuery() call — the leak
+        // surface. (SqlEntityStorage defaults to one anyway; pass it explicitly
+        // to make the shared-key contract unambiguous.)
+        $this->storage = new SqlEntityStorage(
+            $entityType,
+            $this->database,
+            new EventDispatcher(),
+            queryResultCache: new SqlEntityQueryResultCache(),
+        );
+    }
+
+    #[Test]
+    public function differentAccountsDoNotShareAnAccessFilteredCacheEntry(): void
+    {
+        $this->seedRows([
+            ['title' => 'a1', 'owner_id' => 1],
+            ['title' => 'a2', 'owner_id' => 1],
+            ['title' => 'b1', 'owner_id' => 2],
+            ['title' => 'b2', 'owner_id' => 2],
+        ]);
+
+        $handler = new EntityAccessHandler();
+        $handler->addPolicy($this->ownerOnlyPolicy());
+
+        // Account 1 runs first and populates the shared cache with ITS
+        // access-filtered survivors (a1, a2).
+        $idsA = $this->newQuery()
+            ->withAccessHandler($handler)
+            ->withEntityLoader($this->storage->loadMultiple(...))
+            ->setAccount($this->makeAccount(1))
+            ->sort('id', 'ASC')
+            ->execute();
+        $this->assertSame(['a1', 'a2'], $this->titlesFor($idsA));
+
+        // Account 2 runs the identical query. Pre-fix it gets a cache hit on
+        // account 1's fingerprint and is served a1/a2 — a cross-account leak.
+        // Post-fix it computes its own survivors (b1, b2).
+        $idsB = $this->newQuery()
+            ->withAccessHandler($handler)
+            ->withEntityLoader($this->storage->loadMultiple(...))
+            ->setAccount($this->makeAccount(2))
+            ->sort('id', 'ASC')
+            ->execute();
+
+        $this->assertSame(
+            ['b1', 'b2'],
+            $this->titlesFor($idsB),
+            'account 2 must see only its own rows, not account 1\'s cached survivors',
+        );
+    }
+
+    #[Test]
+    public function accessCheckFalseResultIsNotServedToAnAccessCheckedQuery(): void
+    {
+        $this->seedRows([
+            ['title' => 'a1', 'owner_id' => 1],
+            ['title' => 'a2', 'owner_id' => 1],
+            ['title' => 'b1', 'owner_id' => 2],
+            ['title' => 'b2', 'owner_id' => 2],
+        ]);
+
+        // System context: unfiltered bypass populates the shared cache with all
+        // four candidate ids under the (conditions-only, pre-fix) fingerprint.
+        $unfiltered = $this->newQuery()
+            ->accessCheck(false)
+            ->sort('id', 'ASC')
+            ->execute();
+        $this->assertCount(4, $unfiltered);
+
+        // Same conditions, now WITH access checking for account 1. Pre-fix it
+        // gets a cache hit on the bypass entry and is handed all four ids — a
+        // filter bypass. Post-fix it is filtered to account 1's two rows.
+        $handler = new EntityAccessHandler();
+        $handler->addPolicy($this->ownerOnlyPolicy());
+
+        $checked = $this->newQuery()
+            ->withAccessHandler($handler)
+            ->withEntityLoader($this->storage->loadMultiple(...))
+            ->setAccount($this->makeAccount(1))
+            ->sort('id', 'ASC')
+            ->execute();
+
+        $this->assertSame(
+            ['a1', 'a2'],
+            $this->titlesFor($checked),
+            'an access-checked query must not be served the accessCheck(false) unfiltered list',
+        );
+    }
+
+    #[Test]
+    public function sameAccountStillSharesItsCacheEntry(): void
+    {
+        $this->seedRows([
+            ['title' => 'a1', 'owner_id' => 1],
+            ['title' => 'b1', 'owner_id' => 2],
+        ]);
+
+        $handler = new EntityAccessHandler();
+        $handler->addPolicy($this->ownerOnlyPolicy());
+
+        $account = $this->makeAccount(1);
+
+        $first = $this->newQuery()
+            ->withAccessHandler($handler)
+            ->withEntityLoader($this->storage->loadMultiple(...))
+            ->setAccount($account)
+            ->sort('id', 'ASC')
+            ->execute();
+        $this->assertSame(['a1'], $this->titlesFor($first));
+
+        // Insert a now-visible row WITHOUT going through storage->save() (which
+        // would invalidate the cache). owner_id lives in the _data blob (it is
+        // not a base column), so the hydrated entity's owner matches account 1.
+        // A cache hit means the second run for the same account returns the
+        // memoized survivor set (no a2), proving per-account caching still works.
+        $this->database->insert('article')
+            ->fields(['uuid', 'title', 'langcode', '_data'])
+            ->values(['uuid-a2', 'a2', 'en', json_encode(['owner_id' => 1], JSON_THROW_ON_ERROR)])
+            ->execute();
+
+        $second = $this->newQuery()
+            ->withAccessHandler($handler)
+            ->withEntityLoader($this->storage->loadMultiple(...))
+            ->setAccount($this->makeAccount(1))
+            ->sort('id', 'ASC')
+            ->execute();
+
+        $this->assertSame(
+            ['a1'],
+            $this->titlesFor($second),
+            'a second identical query for the same account hits the cache (no a2)',
+        );
+    }
+
+    private function newQuery(): SqlEntityQuery
+    {
+        $query = $this->storage->getQuery();
+        \assert($query instanceof SqlEntityQuery);
+        return $query;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function seedRows(array $rows): void
+    {
+        foreach ($rows as $row) {
+            $this->storage->save($this->storage->create($row));
+        }
+    }
+
+    /**
+     * @param array<int, int|string> $ids
+     * @return list<string>
+     */
+    private function titlesFor(array $ids): array
+    {
+        $entities = $this->storage->loadMultiple($ids);
+        $titles = [];
+        foreach ($ids as $id) {
+            $entity = $entities[$id] ?? null;
+            if ($entity instanceof EntityInterface) {
+                $title = $entity->get('title');
+                $titles[] = is_string($title) ? $title : '';
+            }
+        }
+        return $titles;
+    }
+
+    private function makeAccount(int $id): AccountInterface
+    {
+        return new class($id) implements AccountInterface {
+            public function __construct(private readonly int $accountId) {}
+
+            public function id(): int|string
+            {
+                return $this->accountId;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return false;
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return $this->accountId !== 0;
+            }
+        };
+    }
+
+    private function ownerOnlyPolicy(): AccessPolicyInterface
+    {
+        return new class implements AccessPolicyInterface {
+            public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+            {
+                $ownerId = $entity->get('owner_id');
+                if (\is_int($ownerId) && $ownerId === $account->id()) {
+                    return AccessResult::allowed('owner match');
+                }
+                return AccessResult::forbidden('owner mismatch');
+            }
+
+            public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+            {
+                return AccessResult::neutral();
+            }
+
+            public function appliesTo(string $entityTypeId): bool
+            {
+                return $entityTypeId === 'article';
+            }
+        };
+    }
+}

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -252,12 +252,10 @@ final class OidcServiceProvider extends ServiceProvider
         $this->singleton(
             UserinfoController::class,
             fn(): UserinfoController => new UserinfoController(
-                idTokenMinter: $this->resolve(IdTokenMinter::class),
                 accessTokenIssuer: $this->resolve(AccessTokenIssuer::class),
                 entityTypeManager: $this->resolve(EntityTypeManager::class),
                 entityAccessHandler: $this->resolve(EntityAccessHandler::class),
                 claimResolver: $this->resolve(UserinfoClaimResolver::class),
-                issuer: $this->resolveIssuer(),
             ),
         );
     }

--- a/packages/oidc/src/Token/IdTokenMinter.php
+++ b/packages/oidc/src/Token/IdTokenMinter.php
@@ -72,7 +72,13 @@ final class IdTokenMinter
     /**
      * Verify a JWT signature and decode its claims using the active key set.
      *
+     * This is JWT (ID-token) verification. Do NOT use it on opaque OIDC access
+     * tokens — those are validated by lookup (see AccessTokenIssuer / the
+     * /userinfo flow), not by signature (audit C-9).
+     *
      * @return array<string, mixed>|null Claims array, or null if invalid/expired.
+     *
+     * @api
      */
     public function verifyAndDecode(string $jwt, string $expectedIssuer, string $expectedAudience): ?array
     {

--- a/packages/oidc/src/Userinfo/UserinfoController.php
+++ b/packages/oidc/src/Userinfo/UserinfoController.php
@@ -12,14 +12,14 @@ use Waaseyaa\Access\FieldAccessPolicyInterface;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\Oidc\Token\AccessTokenIssuer;
-use Waaseyaa\Oidc\Token\IdTokenMinter;
 use Waaseyaa\User\User;
 
 /**
  * GET/POST /oidc/userinfo — OIDC Core §5.3.
  *
- * Authenticates the bearer access token (JWT), loads the subject User entity,
- * and builds the claim set. Each claim is gated through FieldAccessPolicyInterface
+ * Authenticates the bearer access token (opaque — looked up in the persisted
+ * oidc_access_token row, with revocation and expiry enforced), loads the subject
+ * User entity, and builds the claim set. Each claim is gated through FieldAccessPolicyInterface
  * (DIR-004): claims backed by a Forbidden field are omitted entirely — never
  * serialised as null or "".
  *
@@ -30,12 +30,10 @@ use Waaseyaa\User\User;
 final readonly class UserinfoController
 {
     public function __construct(
-        private IdTokenMinter $idTokenMinter,
         private AccessTokenIssuer $accessTokenIssuer,
         private EntityTypeManager $entityTypeManager,
         private EntityAccessHandler $entityAccessHandler,
         private UserinfoClaimResolver $claimResolver,
-        private string $issuer,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -50,29 +48,31 @@ final readonly class UserinfoController
             return $this->error(401, 'Bearer realm="oidc"', 'invalid_token', 'Missing or malformed Authorization header.');
         }
 
-        $jwt = substr($authHeader, 7);
-        if ($jwt === '') {
+        $bearer = substr($authHeader, 7);
+        if ($bearer === '') {
             return $this->error(401, 'Bearer realm="oidc"', 'invalid_token', 'Empty bearer token.');
         }
 
-        // Verify JWT signature + standard claims
-        $claims = $this->idTokenMinter->verifyAndDecode($jwt, $this->issuer, $this->issuer);
-        if ($claims === null) {
-            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Token validation failed.');
+        // Access tokens are opaque (not JWTs): authenticate by looking up the
+        // persisted oidc_access_token row, then enforce revocation and expiry.
+        $token = $this->accessTokenIssuer->findByOpaqueToken($bearer);
+        if ($token === null) {
+            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Unknown access token.');
         }
 
-        // Check oidc_access_token revocation
-        $jti = isset($claims['jti']) && is_string($claims['jti']) ? $claims['jti'] : null;
-        if ($jti !== null) {
-            $storedToken = $this->accessTokenIssuer->findByJti($jti);
-            if ($storedToken === null || ($storedToken['revoked_at'] ?? null) !== null) {
-                return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Token has been revoked.');
-            }
+        if (($token['revoked_at'] ?? null) !== null) {
+            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Token has been revoked.');
         }
 
-        $accountId = isset($claims['sub']) && is_string($claims['sub']) ? $claims['sub'] : null;
-        if ($accountId === null) {
-            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Missing sub claim.');
+        if (!isset($token['expires_at']) || (int) $token['expires_at'] < time()) {
+            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Token has expired.');
+        }
+
+        $accountId = isset($token['account_id']) && is_scalar($token['account_id'])
+            ? (string) $token['account_id']
+            : null;
+        if ($accountId === null || $accountId === '') {
+            return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Token has no subject.');
         }
 
         // Load the User entity
@@ -86,8 +86,8 @@ final readonly class UserinfoController
             return $this->error(401, 'Bearer realm="oidc", error="invalid_token"', 'invalid_token', 'Subject not found.');
         }
 
-        // Resolve scopes from JWT
-        $scope = isset($claims['scope']) && is_string($claims['scope']) ? $claims['scope'] : 'openid';
+        // Resolve scopes from the persisted token row
+        $scope = isset($token['scope']) && is_string($token['scope']) && $token['scope'] !== '' ? $token['scope'] : 'openid';
         $scopes = array_filter(explode(' ', $scope), static fn(string $s): bool => $s !== '');
         $candidateClaims = $this->claimResolver->claimsFor(array_values($scopes));
 

--- a/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
+++ b/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Userinfo;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Oidc\Keys\SigningKey;
+use Waaseyaa\Oidc\Token\AccessTokenIssuer;
+use Waaseyaa\Oidc\Token\AccessTokenPair;
+use Waaseyaa\Oidc\Token\KeyMaterialProviderInterface;
+use Waaseyaa\Oidc\Userinfo\UserinfoClaimResolver;
+use Waaseyaa\Oidc\Userinfo\UserinfoController;
+use Waaseyaa\User\User;
+
+/**
+ * Regression test for C-9: /oidc/userinfo must authenticate the OPAQUE access
+ * token (the value clients actually receive from the token endpoint), not a JWT.
+ *
+ * Before the fix the controller fed the bearer to IdTokenMinter::verifyAndDecode,
+ * which rejects any non-three-part string -> every real (opaque) access token 401s,
+ * and the jti-keyed revocation check was unreachable dead code.
+ */
+#[CoversClass(UserinfoController::class)]
+final class UserinfoControllerTest extends TestCase
+{
+    private const ACCOUNT_ID = 42;
+
+    private DBALDatabase $tokenDb;
+    private AccessTokenIssuer $accessTokenIssuer;
+    private SqlEntityStorage $userStorage;
+
+    protected function setUp(): void
+    {
+        // Shared in-memory connection for the oidc_access_token table so the
+        // issuer and the controller see the same rows.
+        $this->tokenDb = DBALDatabase::createSqlite();
+        $this->accessTokenIssuer = new AccessTokenIssuer($this->tokenDb);
+
+        // User entity storage (separate in-memory DB is fine; the controller
+        // resolves it via the EntityTypeManager).
+        $userDb = DBALDatabase::createSqlite();
+        $userEntityType = new EntityType(
+            id: 'user',
+            label: 'User',
+            class: User::class,
+            keys: ['id' => 'uid', 'uuid' => 'uuid', 'label' => 'name'],
+        );
+        $schemaHandler = new SqlSchemaHandler($userEntityType, $userDb);
+        $schemaHandler->ensureTable();
+        $schemaHandler->addFieldColumns([
+            'name' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+            'mail' => ['type' => 'varchar', 'length' => 255, 'not null' => false],
+            'email_verified' => ['type' => 'int', 'not null' => true, 'default' => 0],
+            'status' => ['type' => 'int', 'not null' => true, 'default' => 1],
+            'created' => ['type' => 'int', 'not null' => false],
+        ]);
+        $this->userStorage = new SqlEntityStorage($userEntityType, $userDb, new EventDispatcher());
+
+        $user = new User([
+            'uid' => self::ACCOUNT_ID,
+            'name' => 'Subject Forty-Two',
+            'mail' => 'subject42@example.test',
+            'email_verified' => true,
+        ]);
+        $user->enforceIsNew();
+        $this->userStorage->save($user);
+    }
+
+    #[Test]
+    public function validOpaqueTokenReturns200WithClaims(): void
+    {
+        $pair = $this->issueToken();
+
+        $response = ($this->controller())($this->bearerRequest($pair->token));
+
+        self::assertSame(200, $response->getStatusCode(), 'A valid opaque access token must authenticate.');
+        self::assertSame('application/json', $response->headers->get('Content-Type'));
+
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($payload);
+        self::assertSame((string) self::ACCOUNT_ID, $payload['sub']);
+        self::assertSame('subject42@example.test', $payload['email']);
+        // Scope was 'openid email profile' -> email/name claims resolvable.
+        self::assertSame('Subject Forty-Two', $payload['name']);
+    }
+
+    #[Test]
+    public function revokedTokenReturns401(): void
+    {
+        $pair = $this->issueToken();
+        $this->accessTokenIssuer->revoke($pair->jti, new DateTimeImmutable('@2000000100'));
+
+        $response = ($this->controller())($this->bearerRequest($pair->token));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_token', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function expiredTokenReturns401(): void
+    {
+        // Issue with a 'now' one hour + a day in the past so expires_at < time().
+        $past = new DateTimeImmutable('-2 days');
+        $pair = $this->accessTokenIssuer->issue(
+            'spa-1',
+            (string) self::ACCOUNT_ID,
+            ['openid', 'email', 'profile'],
+            $past,
+        );
+
+        $response = ($this->controller())($this->bearerRequest($pair->token));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_token', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function garbageBearerReturns401(): void
+    {
+        $response = ($this->controller())($this->bearerRequest('not-a-real-token-value'));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_token', $this->jsonError($response));
+    }
+
+    #[Test]
+    public function missingAuthorizationHeaderReturns401(): void
+    {
+        $response = ($this->controller())(Request::create('/oidc/userinfo', 'GET'));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('invalid_token', $this->jsonError($response));
+    }
+
+    private function issueToken(): AccessTokenPair
+    {
+        return $this->accessTokenIssuer->issue(
+            'spa-1',
+            (string) self::ACCOUNT_ID,
+            ['openid', 'email', 'profile'],
+            new DateTimeImmutable(),
+        );
+    }
+
+    private function controller(): UserinfoController
+    {
+        $entityTypeManager = $this->createMock(EntityTypeManager::class);
+        $entityTypeManager->method('getStorage')->with('user')->willReturn($this->userStorage);
+
+        return new UserinfoController(
+            accessTokenIssuer: $this->accessTokenIssuer,
+            entityTypeManager: $entityTypeManager,
+            entityAccessHandler: new EntityAccessHandler(),
+            claimResolver: new UserinfoClaimResolver(),
+        );
+    }
+
+    private function bearerRequest(string $token): Request
+    {
+        $request = Request::create('/oidc/userinfo', 'GET');
+        $request->headers->set('Authorization', 'Bearer ' . $token);
+
+        return $request;
+    }
+
+    private function jsonError(Response $response): string
+    {
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($payload);
+
+        return (string) ($payload['error'] ?? '');
+    }
+}

--- a/packages/user/src/Middleware/SessionMiddleware.php
+++ b/packages/user/src/Middleware/SessionMiddleware.php
@@ -25,7 +25,10 @@ final class SessionMiddleware implements HttpMiddlewareInterface
     /**
      * @param EntityStorageInterface $userStorage Storage for loading user entities.
      * @param AccountInterface|null $devFallback Account returned when no session UID exists. Intended for dev environments only.
-     * @param array<string, mixed>|null $sessionCookieOptions Optional session ini overrides before session_start().
+     * @param array<string, mixed>|null $sessionCookieOptions Optional session ini overrides applied before session_start().
+     *        Secure-by-default: when null (or when a key is omitted) the hardened defaults
+     *        httponly=true, samesite='Lax', use_strict_mode=true, secure='auto' are applied.
+     *        Any key supplied here overrides the matching default.
      *        Keys: httponly (bool), secure (bool|'auto' — auto uses HTTPS detection), samesite (string), use_strict_mode (bool).
      * @param list<string> $trustedProxies IP addresses allowed to set X-Forwarded-Proto.
      * @param AccountContextInterface|null $accountContext Request-scoped acting-account holder,
@@ -74,35 +77,45 @@ final class SessionMiddleware implements HttpMiddlewareInterface
         return $next->handle($request);
     }
 
+    /**
+     * Secure-by-default session cookie ini.
+     *
+     * Hardened defaults are always applied (closing the insecure-by-default
+     * session cookie gap); any key in $sessionCookieOptions overrides the
+     * matching default. `secure => 'auto'` only sets the Secure flag when the
+     * request is detected as HTTPS, so plain-HTTP dev sessions keep working.
+     *
+     * @var array<string, bool|string>
+     */
+    private const array SECURE_COOKIE_DEFAULTS = [
+        'httponly' => true,
+        'secure' => 'auto',
+        'samesite' => 'Lax',
+        'use_strict_mode' => true,
+    ];
+
     private function applySessionCookieIni(): void
     {
-        if ($this->sessionCookieOptions === null) {
-            return;
+        // Explicit config (left operand) wins; hardened defaults fill the rest,
+        // so every key below is guaranteed present (no array_key_exists guard).
+        $opts = ($this->sessionCookieOptions ?? []) + self::SECURE_COOKIE_DEFAULTS;
+
+        ini_set('session.cookie_httponly', filter_var($opts['httponly'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0');
+
+        $secure = $opts['secure'];
+        if ($secure === 'auto') {
+            $secure = $this->isHttpsRequest();
+        } else {
+            $secure = filter_var($secure, FILTER_VALIDATE_BOOLEAN);
         }
+        ini_set('session.cookie_secure', $secure ? '1' : '0');
 
-        $opts = $this->sessionCookieOptions;
-
-        if (array_key_exists('httponly', $opts)) {
-            ini_set('session.cookie_httponly', filter_var($opts['httponly'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0');
-        }
-
-        if (array_key_exists('secure', $opts)) {
-            $secure = $opts['secure'];
-            if ($secure === 'auto') {
-                $secure = $this->isHttpsRequest();
-            } else {
-                $secure = filter_var($secure, FILTER_VALIDATE_BOOLEAN);
-            }
-            ini_set('session.cookie_secure', $secure ? '1' : '0');
-        }
-
-        if (array_key_exists('samesite', $opts) && is_string($opts['samesite']) && $opts['samesite'] !== '') {
+        // An explicit override may set samesite to '' to opt out; the default never does.
+        if (is_string($opts['samesite']) && $opts['samesite'] !== '') {
             ini_set('session.cookie_samesite', $opts['samesite']);
         }
 
-        if (array_key_exists('use_strict_mode', $opts)) {
-            ini_set('session.use_strict_mode', filter_var($opts['use_strict_mode'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0');
-        }
+        ini_set('session.use_strict_mode', filter_var($opts['use_strict_mode'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0');
     }
 
     private function isHttpsRequest(): bool

--- a/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
@@ -563,4 +563,88 @@ final class SessionMiddlewareTest extends TestCase
             unset($_SERVER['HTTP_X_FORWARDED_PROTO'], $_SERVER['REMOTE_ADDR']);
         }
     }
+
+    #[Test]
+    #[RunInSeparateProcess]
+    public function applies_secure_session_cookie_defaults_when_unconfigured(): void
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $keys = [
+            'session.cookie_httponly',
+            'session.cookie_samesite',
+            'session.use_strict_mode',
+        ];
+        $saved = [];
+        foreach ($keys as $key) {
+            $saved[$key] = ini_get($key);
+        }
+
+        try {
+            // Prove the starting state is insecure so the assertions are meaningful.
+            ini_set('session.cookie_httponly', '0');
+            ini_set('session.cookie_samesite', '');
+            ini_set('session.use_strict_mode', '0');
+
+            // No fourth arg => $sessionCookieOptions is null (default config).
+            $middleware = new SessionMiddleware($storage);
+            $method = new \ReflectionMethod(SessionMiddleware::class, 'applySessionCookieIni');
+            $method->invoke($middleware);
+
+            $this->assertSame('1', ini_get('session.cookie_httponly'), 'HttpOnly must be on by default');
+            $this->assertSame('Lax', ini_get('session.cookie_samesite'), 'SameSite must default to Lax');
+            $this->assertSame('1', ini_get('session.use_strict_mode'), 'Strict session-id mode must be on by default');
+        } finally {
+            foreach ($saved as $key => $value) {
+                if ($value !== false && $value !== '') {
+                    ini_set($key, $value);
+                } else {
+                    ini_restore($key);
+                }
+            }
+        }
+    }
+
+    /**
+     * Overridability: explicit config wins over the hardened defaults, while
+     * un-overridden keys still receive their secure default.
+     */
+    #[Test]
+    #[RunInSeparateProcess]
+    public function explicit_session_cookie_options_override_secure_defaults(): void
+    {
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $keys = [
+            'session.cookie_httponly',
+            'session.cookie_samesite',
+            'session.use_strict_mode',
+        ];
+        $saved = [];
+        foreach ($keys as $key) {
+            $saved[$key] = ini_get($key);
+        }
+
+        try {
+            ini_set('session.use_strict_mode', '0');
+
+            $middleware = new SessionMiddleware($storage, null, null, [
+                'httponly' => false,
+                'samesite' => 'Strict',
+                // use_strict_mode intentionally omitted -> default (true) applies.
+            ]);
+            $method = new \ReflectionMethod(SessionMiddleware::class, 'applySessionCookieIni');
+            $method->invoke($middleware);
+
+            $this->assertSame('0', ini_get('session.cookie_httponly'), 'explicit httponly=false must override the default');
+            $this->assertSame('Strict', ini_get('session.cookie_samesite'), 'explicit samesite must override the Lax default');
+            $this->assertSame('1', ini_get('session.use_strict_mode'), 'omitted key must still receive its secure default');
+        } finally {
+            foreach ($saved as $key => $value) {
+                if ($value !== false && $value !== '') {
+                    ini_set($key, $value);
+                } else {
+                    ini_restore($key);
+                }
+            }
+        }
+    }
 }

--- a/tests/Integration/PhaseOcapAudit/AuditRetentionPruneTest.php
+++ b/tests/Integration/PhaseOcapAudit/AuditRetentionPruneTest.php
@@ -87,7 +87,7 @@ final class AuditRetentionPruneTest extends TestCase
 
         // Build and run the prune command.
         $command = new PruneCommand($this->query, $this->writer, $this->database);
-        $io = $this->makeIo(['older-than' => 'PT1H']);
+        $io = $this->makeIo(['older-than' => 'PT1H', 'confirm' => true]);
 
         $exitCode = $command->execute($io);
 


### PR DESCRIPTION
Six adversarially-verified major fixes: **C-8** secure-by-default session cookies, **C-9** OIDC /userinfo opaque-token validation (endpoint was broken), **C-10** query-cache cross-account leak, **C-13** agent-tool per-entity view gate, **C-25** deployer FPM version, **C-31** audit:prune --confirm guard. Each with a regression test; local gates green (cs/phpstan-src/dead-code/symfony-imports). The 34 pre-existing Windows-only oidc crypto failures are unrelated (fail on a clean tree; pass on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)