### PR TITLE
feat(wayfinding): Phase 4 — trail persistence + record-to-saved (wayfinding-01KVGH5X)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Wayfinding (flagship) Phase 4 — trail persistence + record-to-saved.** Saved trails are now **versioned + translatable** content entities, with a strict **human-owned / no-silent-overwrite** revision rule. New `wayfinding_trail` entity (`Entity/Trail.php`) is the framework's first shipping **two-axis** type — **revisionable + translatable** (en + fr) — registered via `EntityType::fromClass(Trail::class, revisionable: true, translatable: true)`; its three tables (base, `_revision`, `__translation__revision`) are materialised by `EntitySchemaSync` on `schema:sync` like any other type. New `TrailStore` (`Trail/TrailStore.php`) realises the rule directly on the framework's native two-axis primitives: the **live/current** value is the per-language peer row (`saveTranslation`/`loadTranslation`), while **history + drafts** are per-language revisions (`saveTranslationRevision`/`listTranslationRevisions`, which never touch the peer row). So `record()` saves a human-owned trail (`origin = recorded`); a human's `editAsHuman()` advances the live value and latches it `origin = human`; and `reRecord()` onto a **human-owned** trail appends the re-recording as a **draft revision** and leaves the live value **byte-for-byte intact** (`promoted = false`) — never silently overwriting human edits — while re-recording an agent-recorded (or untranslated) language safely advances it (`promoted = true`). Languages are versioned **independently** (editing fr never disturbs en). New `TrailAccessPolicy` (`#[PolicyAttribute(entityType: 'wayfinding_trail')]`): a trail is owner-only for `update`/`delete`, and `create`/`view` are gated on the `present guided content` capability. This phase ships the **persistence substrate only**; the authenticated HTTP/MCP write tier that exposes it is Phase 5. Acceptance gate: `tests/Unit/Trail/TrailStoreTest.php` drives the real `Trail` type over a real two-axis SQLite store and proves **SC-005** (FR-009/FR-010/FR-011). Mission: `wayfinding-01KVGH5X`.
+
 ## [0.1.0-alpha.231] - 2026-06-19
 
 ### Added

--- a/docs/specs/wayfinding.md
+++ b/docs/specs/wayfinding.md
@@ -1,5 +1,6 @@
 # Wayfinding
 
+<!-- Spec reviewed 2026-06-19 - Phase 4 (trail persistence + record-to-saved). wayfinding L4 gains the wayfinding_trail two-axis (revisionable + translatable, en+fr) entity (Entity/Trail.php), registered via EntityType::fromClass(revisionable:true, translatable:true); three tables (base, _revision, __translation__revision) materialised by EntitySchemaSync on schema:sync — the first shipping two-axis type. TrailStore (Trail/TrailStore.php, depends on concrete EntityRepository = L4→L1 entity-storage) realises the no-silent-overwrite rule on native two-axis primitives: live value = peer row (saveTranslation/loadTranslation); drafts/history = per-language revisions (saveTranslationRevision/listTranslationRevisions). record() makes a human-owned trail (origin=recorded); editAsHuman() advances + latches origin=human; reRecord() onto a human-owned trail appends a DRAFT revision and leaves the live value byte-for-byte intact (promoted=false), else advances it (promoted=true). TrailAccessPolicy: owner-only update/delete, capability-gated create/view. Persistence substrate only; the HTTP/MCP write tier exposing it is Phase 5. Acceptance: tests/Unit/Trail/TrailStoreTest.php proves SC-005 (FR-009/010/011). -->
 <!-- Spec reviewed 2026-06-19 - Phase 3 (overlay/beacon component with full a11y). Admin SPA: new useBeacons composable builds a live trail from wayfinding.beacon SSE events (useRealtime now listens for that event); new WayfindingOverlay.vue mounted globally in app.vue renders the active beacon as an aria-live role=status region, fully keyboard-navigable (arrows move, Esc dismisses), spotlights the data-anchor element (outline ring + scroll + focus, no trap), dismissable, honours prefers-reduced-motion. Ships in the prebuilt bundle (dist rebuilt; served-bundle wf-beacon assertion). Contract detailed in docs/specs/admin-spa.md. -->
 <!-- Spec reviewed 2026-06-19 - Phase 2 (session-scoped beacon delivery). foundation L0 gains SessionChannel (reserved `session:` namespace; token = substr(sha256(session_id),0,32)) and BroadcastRouter now strips client-supplied private channels + auto-subscribes each connection to its own server-derived session channel (resolveSubscriberChannels, pure + unit-tested) — enforcing NFR-001 (a client can only receive its own session's beacons). The SSE connected frame exposes the non-secret sessionToken. wayfinding L4 gains EmitBeaconController: POST /api/wayfinding/beacons, authenticated + 'present guided content' capability (fail-closed, re-checked in controller), validates anchor via AnchorRegistry::isValid, publishes a wayfinding.beacon to the target session's private channel via BroadcastStorage::push; content transported verbatim (escaping is Phase 3). Reconnect/resume inherited from Last-Event-ID. -->
 <!-- Spec reviewed 2026-06-19 - Phase 1 (anchor registry + published catalog). New L4 package packages/wayfinding: AnchorRegistry derives the valid data-anchor catalog from EntityTypeManager + SchemaPresenter (byte-identical to the SPA scheme shipped alpha.227), and AnchorCatalogController publishes it read-only at GET /.well-known/waaseyaa-anchors.json (allowAll, mirrors the /llms.txt discovery family). Mission kitty-specs/wayfinding-01KVGH5X. -->
@@ -121,7 +122,67 @@ aria-live primitive (LD-6 / FR-012). Detailed in [admin-spa.md](admin-spa.md).
   assertion guard it). Beacon content is still transported verbatim from Phase 2;
   the constrained-markup renderer is Phase 4/Phase-5 design under FR-008/NFR-003.
 
-## Phases 4–5 (planned — see mission spec)
+## Phase 4 — Trail persistence + record-to-saved (shipped)
 
-- **Phase 4** — versioned + translatable saved-trail content entity; record-a-live-trail-to-saved with the human-owned-on-save / no-silent-overwrite rule.
-- **Phase 5** — the authenticated MCP write tier (capability-gated emit + trail management), leaving the read-only trio untouched.
+Saved trails are **versioned + translatable** content entities, and recording a
+live trail to a saved one is governed by the **human-owned-on-save /
+no-silent-overwrite** revision rule (LD-5 / FR-009..FR-011 / SC-005). This phase
+ships the persistence substrate only; the authenticated surface that exposes it
+(HTTP/MCP write tools) is Phase 5.
+
+### `Trail` two-axis entity (`packages/wayfinding/src/Entity/Trail.php`)
+
+`wayfinding_trail` is registered (in `WayfindingServiceProvider::register()`) as
+**revisionable + translatable** via `EntityType::fromClass(Trail::class,
+revisionable: true, translatable: true)`. Keys: `tid` / `uuid` / `title` /
+`revision_id` / `langcode` / `default_langcode`. Fields: `title`, `beacons` (a
+JSON-encoded ordered list of `{anchor_id, content, order}` — `TrailStore` owns
+(de)serialization so the column stays a plain string), `owner_uid`, and `origin`
+(`recorded` | `human`). Its three tables (`wayfinding_trail`,
+`wayfinding_trail_revision`, `wayfinding_trail__translation__revision`) are
+materialised by `EntitySchemaSync` on `schema:sync` like any other type — the
+first shipping two-axis entity in the framework.
+
+### `TrailStore` (`packages/wayfinding/src/Trail/TrailStore.php`)
+
+The persistence model maps one-to-one onto the framework's two-axis primitives,
+which is the whole no-silent-overwrite mechanism:
+
+- **Live / current value** = the per-language peer row — `saveTranslation()` /
+  `loadTranslation()`. This is what plays back.
+- **History + drafts** = the per-language revision log — `saveTranslationRevision()`
+  (which does **not** touch the peer row) / `listTranslationRevisions()`.
+
+Operations:
+
+- **`record(langcode, title, beacons, ownerUid)`** (FR-010) — saves a new trail
+  owned by `ownerUid`, live value `origin = recorded`.
+- **`editAsHuman(id, langcode, …)`** — a human authors/edits a language; advances
+  the live value and latches it `origin = human`. Creating a translation in a new
+  language uses the same path (ownership inherited from the default-language row),
+  so en + fr sequence **independently** (FR-009).
+- **`reRecord(id, langcode, …)`** (FR-011) — if the target language is
+  **human-owned**, the re-recording is appended as a **draft revision** and the
+  live value is left byte-for-byte intact (`promoted = false`); otherwise
+  (agent-recorded, or that language not yet translated) it is safe to advance the
+  live value (`promoted = true`). Either branch creates a new revision.
+
+`TrailStore` requires the concrete `EntityRepository` (the per-language revision
+API is part of the two-axis surface beyond `EntityRepositoryInterface`), a
+legitimate L4→L1 dependency (`waaseyaa/entity-storage`). The acceptance gate is
+`tests/Unit/Trail/TrailStoreTest.php`, which drives the real `Trail` type over a
+real two-axis SQLite store and proves SC-005 directly.
+
+### `TrailAccessPolicy` (`packages/wayfinding/src/Access/TrailAccessPolicy.php`)
+
+`#[PolicyAttribute(entityType: 'wayfinding_trail')]`. A trail becomes human-owned
+on save, so **only its owner** may `update`/`delete`; `view` is the owner or any
+`present guided content` capability holder; `create` is gated on that capability
+(LD-2/FR-003). Field-level: `owner_uid` / `origin` and identity keys are
+store-managed and not directly editable.
+
+## Phase 5 — Authenticated MCP write tier (planned — see mission spec)
+
+The separate authenticated MCP write-tool surface for emitting live trails and
+**managing saved trails** (capability-gated), exposing the Phase-4 `TrailStore`
+over HTTP/MCP, leaving the read-only alpha.221 trio untouched.

--- a/kitty-specs/wayfinding-01KVGH5X/meta.json
+++ b/kitty-specs/wayfinding-01KVGH5X/meta.json
@@ -14,7 +14,7 @@
     "phase_1_anchor_registry_catalog": "shipped (alpha.228)",
     "phase_2_session_delivery": "shipped (alpha.230)",
     "phase_3_overlay_a11y": "shipped (alpha.231)",
-    "phase_4_trail_persistence": "planned",
+    "phase_4_trail_persistence": "shipped (alpha.232)",
     "phase_5_mcp_write_tier": "planned"
   },
   "slug": "wayfinding-01KVGH5X",

--- a/packages/wayfinding/composer.json
+++ b/packages/wayfinding/composer.json
@@ -10,6 +10,10 @@
         },
         {
             "type": "path",
+            "url": "../entity-storage"
+        },
+        {
+            "type": "path",
             "url": "../api"
         },
         {
@@ -25,6 +29,7 @@
         "php": ">=8.5",
         "waaseyaa/api": "^0.1.0-alpha.231",
         "waaseyaa/entity": "^0.1.0-alpha.231",
+        "waaseyaa/entity-storage": "^0.1.0-alpha.231",
         "waaseyaa/foundation": "^0.1.0-alpha.231",
         "waaseyaa/routing": "^0.1.0-alpha.231"
     },

--- a/packages/wayfinding/src/Access/TrailAccessPolicy.php
+++ b/packages/wayfinding/src/Access/TrailAccessPolicy.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Wayfinding\Http\EmitBeaconController;
+
+/**
+ * Access policy for saved Wayfinding trails (Phase 4, LD-5).
+ *
+ * Entity-level (deny-by-default):
+ *   - view   : the owner, or any holder of the "present guided content"
+ *              capability, may view a saved trail.
+ *   - update : **owner only** — a trail becomes human-owned on save, and only
+ *              its owner edits it (the no-silent-overwrite guarantee is enforced
+ *              in {@see \Waaseyaa\Wayfinding\Trail\TrailStore}; this policy keeps
+ *              non-owners off the human-edit path entirely).
+ *   - delete : owner only.
+ *   - create : holders of the "present guided content" capability (the write
+ *              tier, LD-2/FR-003).
+ *
+ * Field-level (open-by-default, Forbidden restricts): `owner_uid` and `origin`
+ * are store-managed provenance fields and are never directly editable; identity
+ * fields are read-only too.
+ *
+ * @api
+ */
+#[PolicyAttribute(entityType: 'wayfinding_trail')]
+final class TrailAccessPolicy implements AccessPolicyInterface, FieldAccessPolicyInterface
+{
+    private const string CAPABILITY = EmitBeaconController::CAPABILITY;
+
+    /** Store-managed or identity fields that are never directly editable. */
+    private const array READONLY_FIELDS = ['tid', 'uuid', 'revision_id', 'langcode', 'default_langcode', 'owner_uid', 'origin'];
+
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'wayfinding_trail';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        return match ($operation) {
+            'view' => $this->viewAccess($entity, $account),
+            'update' => $this->ownerOnly($entity, $account, 'update'),
+            'delete' => $this->ownerOnly($entity, $account, 'delete'),
+            default => AccessResult::neutral("No opinion on '$operation' operation."),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission(self::CAPABILITY)) {
+            return AccessResult::allowed('Holder of the "present guided content" capability may create trails.');
+        }
+
+        return AccessResult::neutral('Account lacks the "present guided content" capability.');
+    }
+
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation,
+        AccountInterface $account,
+    ): AccessResult {
+        if ($operation === 'edit' && in_array($fieldName, self::READONLY_FIELDS, true)) {
+            return AccessResult::forbidden("Field '$fieldName' is store-managed and not directly editable.");
+        }
+
+        return AccessResult::neutral();
+    }
+
+    private function viewAccess(EntityInterface $entity, AccountInterface $account): AccessResult
+    {
+        if ($this->isOwner($entity, $account) || $account->hasPermission(self::CAPABILITY)) {
+            return AccessResult::allowed('Owner or capability holder may view this trail.');
+        }
+
+        return AccessResult::neutral('Account is neither the owner nor a capability holder.');
+    }
+
+    private function ownerOnly(EntityInterface $entity, AccountInterface $account, string $operation): AccessResult
+    {
+        return $this->isOwner($entity, $account)
+            ? AccessResult::allowed("Trail owner may {$operation} this trail.")
+            : AccessResult::forbidden("Only the trail owner may {$operation} this trail.");
+    }
+
+    private function isOwner(EntityInterface $entity, AccountInterface $account): bool
+    {
+        $ownerUid = $entity->get('owner_uid');
+        if ($ownerUid === null) {
+            return false;
+        }
+
+        return (string) $ownerUid === (string) $account->id() && (int) $account->id() > 0;
+    }
+}

--- a/packages/wayfinding/src/Entity/Trail.php
+++ b/packages/wayfinding/src/Entity/Trail.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Entity;
+
+use Waaseyaa\Entity\Attribute\ContentEntityKeys;
+use Waaseyaa\Entity\Attribute\ContentEntityType;
+use Waaseyaa\Entity\Attribute\Field;
+use Waaseyaa\Entity\ContentEntityBase;
+
+/**
+ * A saved Wayfinding trail (Phase 4): an ordered, element-anchored beacon list
+ * persisted as a versioned, translatable content entity (LD-5 / FR-009).
+ *
+ * Two-axis storage (revisionable + translatable, en + fr): each language is a
+ * peer with its own current value and its own independent revision history. The
+ * peer row holds the *live* trail (what a human authors and what plays back);
+ * the per-language revision history holds prior versions and re-recorded
+ * **drafts**. That split is the substrate for the no-silent-overwrite rule
+ * (FR-011): re-recording a human-owned trail appends a draft revision and never
+ * touches the live peer row — see {@see \Waaseyaa\Wayfinding\Trail\TrailStore}.
+ *
+ * `beacons` is a JSON-encoded ordered list of `{anchor_id, content, order}`;
+ * {@see TrailStore} owns (de)serialization so the column stays a plain string.
+ * `origin` records whether the live value came from an agent recording
+ * (`recorded`) or a human edit (`human`) — the latch the re-record rule reads.
+ *
+ * @api
+ */
+#[ContentEntityType(id: 'wayfinding_trail', label: 'Wayfinding Trail', description: 'A saved, versioned, translatable guided trail of beacons.')]
+#[ContentEntityKeys(
+    id: 'tid',
+    uuid: 'uuid',
+    label: 'title',
+    revision: 'revision_id',
+    langcode: 'langcode',
+    default_langcode: 'default_langcode',
+)]
+final class Trail extends ContentEntityBase
+{
+    /** The live value originated from a human edit and must not be overwritten by a re-record. */
+    public const string ORIGIN_HUMAN = 'human';
+
+    /** The live value originated from an agent recording (safe to advance on re-record). */
+    public const string ORIGIN_RECORDED = 'recorded';
+
+    #[Field(label: 'Title', description: 'Human-readable trail title.', required: true, settings: ['weight' => 0])]
+    public string $title = '';
+
+    #[Field(type: 'text', label: 'Beacons', description: 'JSON-encoded ordered list of {anchor_id, content, order}.', required: true, settings: ['weight' => 1])]
+    public string $beacons = '[]';
+
+    #[Field(type: 'integer', label: 'Owner UID', description: 'Account that owns this saved trail.', required: true, settings: ['weight' => 2, 'not_null' => true])]
+    public int $owner_uid = 0;
+
+    #[Field(label: 'Origin', description: 'Provenance of the live value: "recorded" or "human".', required: true, settings: ['weight' => 3])]
+    public string $origin = self::ORIGIN_RECORDED;
+
+    public function __construct(
+        array $values = [],
+        string $entityTypeId = '',
+        array $entityKeys = [],
+        array $fieldDefinitions = [],
+    ) {
+        parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
+    }
+}

--- a/packages/wayfinding/src/Trail/ReRecordResult.php
+++ b/packages/wayfinding/src/Trail/ReRecordResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Trail;
+
+/**
+ * Outcome of re-recording a live trail onto an existing saved trail (FR-011).
+ *
+ * `promoted` is true when the re-recording advanced the live trail (the target
+ * was not human-owned, so there was nothing to overwrite); false when it landed
+ * as a **draft revision** behind a human-owned live value, which is left
+ * untouched. Either way a new revision was created — `revisionId` is its
+ * per-language revision id.
+ *
+ * @api
+ */
+final readonly class ReRecordResult
+{
+    public function __construct(
+        public bool $promoted,
+        public int $revisionId,
+    ) {}
+}

--- a/packages/wayfinding/src/Trail/SavedTrail.php
+++ b/packages/wayfinding/src/Trail/SavedTrail.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Trail;
+
+/**
+ * Read model for one language of a saved trail: its live (current) value.
+ *
+ * Returned by {@see TrailStore} reads. `beacons` is the decoded ordered list of
+ * `{anchor_id, content, order}`; `origin` is the live-value provenance latch
+ * (`recorded` | `human`) the no-silent-overwrite rule reads (FR-011).
+ *
+ * @api
+ *
+ * @phpstan-type BeaconShape array{anchor_id: string, content: string, order: int}
+ */
+final readonly class SavedTrail
+{
+    /**
+     * @param list<BeaconShape> $beacons
+     */
+    public function __construct(
+        public string $id,
+        public string $langcode,
+        public string $title,
+        public array $beacons,
+        public string $origin,
+        public int $ownerUid,
+    ) {}
+}

--- a/packages/wayfinding/src/Trail/TrailStore.php
+++ b/packages/wayfinding/src/Trail/TrailStore.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Trail;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\Wayfinding\Entity\Trail;
+
+/**
+ * Persistence for saved Wayfinding trails (Phase 4): record-to-saved, human
+ * authoring, and re-recording — on the `wayfinding_trail` two-axis
+ * (revisionable + translatable) entity (LD-5 / FR-009..FR-011).
+ *
+ * The model maps one-to-one onto the framework's two-axis primitives:
+ *
+ *  - **Live / current value** = the per-language peer row, written by
+ *    {@see EntityRepository::saveTranslation()} and read by
+ *    {@see EntityRepository::loadTranslation()}. This is what plays back.
+ *  - **History + drafts** = the per-language revision log, appended by
+ *    {@see EntityRepository::saveTranslationRevision()} (which does NOT touch the
+ *    peer row) and read by {@see EntityRepository::listTranslationRevisions()}.
+ *
+ * That split is the whole no-silent-overwrite rule (FR-011): re-recording onto a
+ * **human-owned** trail appends a draft revision and leaves the live peer row —
+ * the human's edits — exactly as it was. Languages (en + fr) sequence
+ * independently, so editing one never disturbs another (FR-009).
+ *
+ * Requires the concrete {@see EntityRepository} (not the interface) because the
+ * draft path uses the per-language revision API, which is part of the two-axis
+ * surface beyond `EntityRepositoryInterface`.
+ *
+ * @api
+ *
+ * @phpstan-type BeaconShape array{anchor_id: string, content: string, order: int}
+ */
+final class TrailStore
+{
+    public function __construct(
+        private readonly EntityRepository $trails,
+    ) {}
+
+    /**
+     * FR-010: record a live trail to a new saved trail, owned by $ownerUid. The
+     * recorded value is the live value of a fresh, agent-originated trail.
+     *
+     * @param list<BeaconShape|array<string, mixed>> $beacons
+     */
+    public function record(string $langcode, string $title, array $beacons, int $ownerUid): SavedTrail
+    {
+        $trail = new Trail(
+            ['default_langcode' => 1] + $this->valuesFor($title, $beacons, Trail::ORIGIN_RECORDED, $ownerUid, $langcode),
+        );
+        $trail->enforceIsNew();
+        $this->trails->save($trail);
+
+        $id = (string) $trail->id();
+
+        return $this->current($id, $langcode)
+            ?? throw new \RuntimeException("Saved trail {$id} could not be read back after recording.");
+    }
+
+    /**
+     * A human authors or edits a trail in one language. This advances the live
+     * value and latches it `human` — so a later re-record will not overwrite it.
+     * Creating a translation in a new language uses the same path; ownership is
+     * inherited from the trail's default-language row.
+     *
+     * @param list<BeaconShape|array<string, mixed>> $beacons
+     */
+    public function editAsHuman(string $trailId, string $langcode, string $title, array $beacons): SavedTrail
+    {
+        $owner = $this->resolveOwner($trailId, $langcode);
+        $this->trails->saveTranslation(
+            $trailId,
+            $langcode,
+            $this->valuesFor($title, $beacons, Trail::ORIGIN_HUMAN, $owner, $langcode),
+        );
+
+        return $this->current($trailId, $langcode)
+            ?? throw new \RuntimeException("Saved trail {$trailId} ({$langcode}) could not be read back after editing.");
+    }
+
+    /**
+     * FR-011: re-record a live trail onto an existing saved trail.
+     *
+     * If the target language is human-owned, the re-recording is appended as a
+     * **draft revision** and the live value is left untouched — never silently
+     * overwritten. Otherwise (agent-recorded, or this language not yet
+     * translated) it is safe to advance the live value, which is then promoted.
+     * Either branch creates a new per-language revision.
+     *
+     * @param list<BeaconShape|array<string, mixed>> $beacons
+     */
+    public function reRecord(string $trailId, string $langcode, string $title, array $beacons): ReRecordResult
+    {
+        $current = $this->trails->loadTranslation($trailId, $langcode);
+        $humanOwned = $current !== null && (string) $current->get('origin') === Trail::ORIGIN_HUMAN;
+
+        $owner = $current !== null
+            ? (int) $current->get('owner_uid')
+            : $this->resolveOwner($trailId, null);
+        $values = $this->valuesFor($title, $beacons, Trail::ORIGIN_RECORDED, $owner, $langcode);
+
+        if ($humanOwned) {
+            // Draft only: append a revision; the live peer row (human edits) is
+            // not touched. The draft is recoverable from the revision history.
+            $revisionId = $this->trails->saveTranslationRevision($trailId, $langcode, $values);
+
+            return new ReRecordResult(promoted: false, revisionId: $revisionId);
+        }
+
+        // Nothing human to protect — advance the live value to the re-recording.
+        $revisionId = $this->trails->saveTranslation($trailId, $langcode, $values);
+
+        return new ReRecordResult(promoted: true, revisionId: $revisionId);
+    }
+
+    /**
+     * The live (current) value of one language, or null when that language has
+     * no saved trail.
+     */
+    public function current(string $trailId, string $langcode): ?SavedTrail
+    {
+        $entity = $this->trails->loadTranslation($trailId, $langcode);
+
+        return $entity === null ? null : $this->toSavedTrail($trailId, $langcode, $entity);
+    }
+
+    /**
+     * Number of revisions recorded for one language (history + drafts). A fresh
+     * recording starts at zero per-language revisions; each edit/re-record adds
+     * one.
+     */
+    public function revisionCount(string $trailId, string $langcode): int
+    {
+        return \count($this->trails->listTranslationRevisions($trailId, $langcode));
+    }
+
+    /**
+     * The most recent revision snapshot for one language, or null when none —
+     * used to surface a pending re-recorded draft for review.
+     */
+    public function latestRevision(string $trailId, string $langcode): ?SavedTrail
+    {
+        $revisions = $this->trails->listTranslationRevisions($trailId, $langcode);
+        $latest = $revisions[0] ?? null; // listTranslationRevisions yields newest first
+
+        return $latest === null ? null : $this->toSavedTrail($trailId, $langcode, $latest);
+    }
+
+    private function toSavedTrail(string $trailId, string $langcode, EntityInterface $entity): SavedTrail
+    {
+        return new SavedTrail(
+            id: $trailId,
+            langcode: $langcode,
+            title: (string) ($entity->get('title') ?? ''),
+            beacons: $this->decodeBeacons((string) ($entity->get('beacons') ?? '[]')),
+            origin: (string) ($entity->get('origin') ?? Trail::ORIGIN_RECORDED),
+            ownerUid: (int) ($entity->get('owner_uid') ?? 0),
+        );
+    }
+
+    private function resolveOwner(string $trailId, ?string $langcode): int
+    {
+        if ($langcode !== null) {
+            $peer = $this->trails->loadTranslation($trailId, $langcode);
+            if ($peer !== null) {
+                return (int) $peer->get('owner_uid');
+            }
+        }
+
+        $default = $this->trails->find($trailId);
+
+        return $default !== null ? (int) $default->get('owner_uid') : 0;
+    }
+
+    /**
+     * @param list<BeaconShape|array<string, mixed>> $beacons
+     * @return array{title: string, beacons: string, owner_uid: int, origin: string, langcode: string}
+     */
+    private function valuesFor(string $title, array $beacons, string $origin, int $ownerUid, string $langcode): array
+    {
+        return [
+            'title' => $title,
+            'beacons' => $this->encodeBeacons($beacons),
+            'owner_uid' => $ownerUid,
+            'origin' => $origin,
+            'langcode' => $langcode,
+        ];
+    }
+
+    /**
+     * @param list<BeaconShape|array<string, mixed>> $beacons
+     */
+    private function encodeBeacons(array $beacons): string
+    {
+        $normalized = array_map(
+            static fn(array $beacon): array => [
+                'anchor_id' => (string) ($beacon['anchor_id'] ?? ''),
+                'content' => (string) ($beacon['content'] ?? ''),
+                'order' => (int) ($beacon['order'] ?? 0),
+            ],
+            $beacons,
+        );
+
+        return json_encode($normalized, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @return list<BeaconShape>
+     */
+    private function decodeBeacons(string $json): array
+    {
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($decoded as $beacon) {
+            if (!\is_array($beacon)) {
+                continue;
+            }
+            $out[] = [
+                'anchor_id' => (string) ($beacon['anchor_id'] ?? ''),
+                'content' => (string) ($beacon['content'] ?? ''),
+                'order' => (int) ($beacon['order'] ?? 0),
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/packages/wayfinding/src/WayfindingServiceProvider.php
+++ b/packages/wayfinding/src/WayfindingServiceProvider.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Wayfinding;
 
+use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
+use Waaseyaa\Wayfinding\Entity\Trail;
 use Waaseyaa\Wayfinding\Http\AnchorCatalogController;
 use Waaseyaa\Wayfinding\Http\EmitBeaconController;
 
@@ -19,8 +21,11 @@ use Waaseyaa\Wayfinding\Http\EmitBeaconController;
  * and registers the public, read-only anchor-catalog endpoint.
  * Phase 2 (session-scoped delivery): registers the authenticated emit endpoint
  * ({@see EmitBeaconController}) that publishes beacons to a target session's
- * reserved private channel over the bounded SSE loop. Later phases add the overlay,
- * trail persistence, and the authenticated MCP write tier
+ * reserved private channel over the bounded SSE loop.
+ * Phase 4 (trail persistence): registers the {@see Trail} two-axis (revisionable +
+ * translatable) entity type that backs saved trails (LD-5 / FR-009..FR-011); the
+ * persistence model lives in {@see \Waaseyaa\Wayfinding\Trail\TrailStore} and the
+ * authenticated write tier that exposes it is Phase 5
  * (kitty-specs/wayfinding-01KVGH5X/spec.md).
  */
 final class WayfindingServiceProvider extends ServiceProvider
@@ -32,6 +37,17 @@ final class WayfindingServiceProvider extends ServiceProvider
         // its own from the kernel-bound EntityTypeManager.
         $this->singleton(AnchorRegistry::class, fn(): AnchorRegistry => new AnchorRegistry(
             $this->resolve(EntityTypeManager::class),
+        ));
+
+        // Phase 4: the saved-trail entity is versioned + translatable (en + fr)
+        // — the two storage axes the no-silent-overwrite revision rule rides on
+        // (LD-5). Schema is materialised by EntitySchemaSync at db:init like any
+        // other registered type.
+        $this->entityType(EntityType::fromClass(
+            Trail::class,
+            revisionable: true,
+            translatable: true,
+            group: 'content',
         ));
     }
 

--- a/packages/wayfinding/tests/Unit/Access/TrailAccessPolicyTest.php
+++ b/packages/wayfinding/tests/Unit/Access/TrailAccessPolicyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Tests\Unit\Access;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Wayfinding\Access\TrailAccessPolicy;
+use Waaseyaa\Wayfinding\Entity\Trail;
+use Waaseyaa\Wayfinding\Http\EmitBeaconController;
+
+/**
+ * The saved-trail access policy: a trail becomes human-owned on save, so only
+ * its owner edits/deletes it, while the "present guided content" capability
+ * gates creation and (with ownership) viewing (LD-2/LD-5).
+ */
+#[CoversClass(TrailAccessPolicy::class)]
+final class TrailAccessPolicyTest extends TestCase
+{
+    private TrailAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new TrailAccessPolicy();
+    }
+
+    private function trailOwnedBy(int $ownerUid): Trail
+    {
+        return new Trail(['owner_uid' => $ownerUid]);
+    }
+
+    private function account(int|string $id, bool $hasCapability = false): AccountInterface
+    {
+        $account = $this->createStub(AccountInterface::class);
+        $account->method('id')->willReturn($id);
+        $account->method('isAuthenticated')->willReturn((int) $id > 0);
+        $account->method('getRoles')->willReturn([]);
+        $account->method('hasPermission')->willReturnCallback(
+            static fn(string $permission): bool => $hasCapability && $permission === EmitBeaconController::CAPABILITY,
+        );
+
+        return $account;
+    }
+
+    #[Test]
+    public function applies_only_to_the_trail_entity_type(): void
+    {
+        $this->assertTrue($this->policy->appliesTo('wayfinding_trail'));
+        $this->assertFalse($this->policy->appliesTo('node'));
+    }
+
+    #[Test]
+    public function owner_may_view_update_and_delete(): void
+    {
+        $trail = $this->trailOwnedBy(7);
+        $owner = $this->account(7);
+
+        $this->assertTrue($this->policy->access($trail, 'view', $owner)->isAllowed());
+        $this->assertTrue($this->policy->access($trail, 'update', $owner)->isAllowed());
+        $this->assertTrue($this->policy->access($trail, 'delete', $owner)->isAllowed());
+    }
+
+    #[Test]
+    public function non_owner_is_forbidden_from_editing_or_deleting(): void
+    {
+        $trail = $this->trailOwnedBy(7);
+        $other = $this->account(8, hasCapability: true);
+
+        $this->assertTrue($this->policy->access($trail, 'update', $other)->isForbidden());
+        $this->assertTrue($this->policy->access($trail, 'delete', $other)->isForbidden());
+        // …but a capability holder may still view.
+        $this->assertTrue($this->policy->access($trail, 'view', $other)->isAllowed());
+    }
+
+    #[Test]
+    public function anonymous_account_is_neither_owner_nor_capable(): void
+    {
+        $trail = $this->trailOwnedBy(7);
+        $anon = $this->account(0);
+
+        $this->assertTrue($this->policy->access($trail, 'view', $anon)->isNeutral());
+        $this->assertTrue($this->policy->access($trail, 'update', $anon)->isForbidden());
+        $this->assertTrue($this->policy->createAccess('wayfinding_trail', '', $anon)->isNeutral());
+    }
+
+    #[Test]
+    public function capability_holder_may_create(): void
+    {
+        $capable = $this->account(9, hasCapability: true);
+        $plain = $this->account(9);
+
+        $this->assertTrue($this->policy->createAccess('wayfinding_trail', '', $capable)->isAllowed());
+        $this->assertTrue($this->policy->createAccess('wayfinding_trail', '', $plain)->isNeutral());
+    }
+
+    #[Test]
+    public function store_managed_fields_are_not_directly_editable(): void
+    {
+        $trail = $this->trailOwnedBy(7);
+        $owner = $this->account(7);
+
+        $this->assertTrue($this->policy->fieldAccess($trail, 'owner_uid', 'edit', $owner)->isForbidden());
+        $this->assertTrue($this->policy->fieldAccess($trail, 'origin', 'edit', $owner)->isForbidden());
+        // Content fields stay open (neutral) for the owner.
+        $this->assertTrue($this->policy->fieldAccess($trail, 'title', 'edit', $owner)->isNeutral());
+        $this->assertTrue($this->policy->fieldAccess($trail, 'beacons', 'edit', $owner)->isNeutral());
+    }
+}

--- a/packages/wayfinding/tests/Unit/Trail/TrailStoreTest.php
+++ b/packages/wayfinding/tests/Unit/Trail/TrailStoreTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Tests\Unit\Trail;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\RevisionableStorageDriver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Wayfinding\Entity\Trail;
+use Waaseyaa\Wayfinding\Trail\TrailStore;
+
+/**
+ * Acceptance gate for Wayfinding Phase 4 — trail persistence (SC-005).
+ *
+ * Drives {@see TrailStore} against the REAL {@see Trail} entity type (resolved
+ * from its attributes via {@see EntityType::fromClass()}) over a real two-axis
+ * (revisionable + translatable) SQLite store, proving:
+ *   - a live trail records to a versioned, human-owned saved entity (FR-009/FR-010);
+ *   - re-recording over a human-owned trail creates a new revision and the prior
+ *     human edits SURVIVE untouched (FR-011 — the no-silent-overwrite rule);
+ *   - re-recording an agent-recorded trail safely advances the live value;
+ *   - en and fr are versioned independently (FR-009 translatable axis).
+ */
+#[CoversClass(TrailStore::class)]
+final class TrailStoreTest extends TestCase
+{
+    private TrailStore $store;
+
+    protected function setUp(): void
+    {
+        $db = DBALDatabase::createSqlite();
+
+        $entityType = EntityType::fromClass(
+            Trail::class,
+            revisionable: true,
+            translatable: true,
+            group: 'content',
+        );
+
+        $handler = new SqlSchemaHandler($entityType, $db);
+        $handler->ensureTable();
+        $handler->ensureRevisionTable();
+        $handler->ensureTranslationRevisionTable();
+
+        $resolver = new SingleConnectionResolver($db);
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')->willReturnArgument(0);
+
+        // Mirror the kernel: the SQL driver needs the entity's id key ('tid'),
+        // not the 'id' default (AbstractKernel::bootEntityTypeManager).
+        $repository = new EntityRepository(
+            $entityType,
+            new SqlStorageDriver($resolver, $entityType->getKeys()['id']),
+            $dispatcher,
+            new RevisionableStorageDriver($resolver, $entityType),
+            $db,
+        );
+
+        $this->store = new TrailStore($repository);
+    }
+
+    /**
+     * @param list<array{anchor_id: string, content: string, order: int}> ...
+     * @return array{anchor_id: string, content: string, order: int}
+     */
+    private static function beacon(string $anchorId, string $content, int $order): array
+    {
+        return ['anchor_id' => $anchorId, 'content' => $content, 'order' => $order];
+    }
+
+    #[Test]
+    public function record_creates_a_versioned_human_owned_trail(): void
+    {
+        $saved = $this->store->record('en', 'Onboarding', [
+            self::beacon('field:node:title', 'Edit the title', 0),
+            self::beacon('action:node:submit', 'Now save', 1),
+        ], ownerUid: 7);
+
+        $this->assertNotSame('', $saved->id);
+        $this->assertSame('en', $saved->langcode);
+        $this->assertSame('Onboarding', $saved->title);
+        $this->assertSame(7, $saved->ownerUid);
+        $this->assertSame(Trail::ORIGIN_RECORDED, $saved->origin);
+        $this->assertCount(2, $saved->beacons);
+        $this->assertSame('field:node:title', $saved->beacons[0]['anchor_id']);
+        $this->assertSame('Now save', $saved->beacons[1]['content']);
+        $this->assertSame(1, $saved->beacons[1]['order']);
+
+        // It reads back as the live value of its language.
+        $current = $this->store->current($saved->id, 'en');
+        $this->assertNotNull($current);
+        $this->assertSame('Onboarding', $current->title);
+        $this->assertSame(7, $current->ownerUid);
+    }
+
+    #[Test]
+    public function re_recording_a_human_owned_trail_never_overwrites_edits(): void
+    {
+        $id = $this->store->record('en', 'Recorded', [self::beacon('a', 'recorded one', 0)], ownerUid: 5)->id;
+
+        // The owner edits the trail — it becomes human-owned.
+        $this->store->editAsHuman($id, 'en', 'Human title', [
+            self::beacon('a', 'human one', 0),
+            self::beacon('b', 'human two', 1),
+        ]);
+        $afterEdit = $this->store->current($id, 'en');
+        $this->assertNotNull($afterEdit);
+        $this->assertSame('Human title', $afterEdit->title);
+        $this->assertSame(Trail::ORIGIN_HUMAN, $afterEdit->origin);
+
+        $revsBeforeReRecord = $this->store->revisionCount($id, 'en');
+
+        // An agent re-records the live trail over the human-owned one.
+        $result = $this->store->reRecord($id, 'en', 'Agent re-record', [self::beacon('a', 'agent one', 0)]);
+
+        // It landed as a DRAFT, not promoted — the live value was human-owned.
+        $this->assertFalse($result->promoted);
+
+        // The human's live trail SURVIVES, byte-for-byte (FR-011 / SC-005).
+        $afterReRecord = $this->store->current($id, 'en');
+        $this->assertNotNull($afterReRecord);
+        $this->assertSame('Human title', $afterReRecord->title);
+        $this->assertSame(Trail::ORIGIN_HUMAN, $afterReRecord->origin);
+        $this->assertCount(2, $afterReRecord->beacons);
+        $this->assertSame('human one', $afterReRecord->beacons[0]['content']);
+
+        // A NEW revision was created, and the re-recorded draft is recoverable.
+        $this->assertSame($revsBeforeReRecord + 1, $this->store->revisionCount($id, 'en'));
+        $draft = $this->store->latestRevision($id, 'en');
+        $this->assertNotNull($draft);
+        $this->assertSame('Agent re-record', $draft->title);
+        $this->assertSame('agent one', $draft->beacons[0]['content']);
+    }
+
+    #[Test]
+    public function re_recording_an_agent_recorded_trail_advances_the_live_value(): void
+    {
+        $id = $this->store->record('en', 'v1', [self::beacon('a', 'one', 0)], ownerUid: 5)->id;
+
+        // No human edits yet — re-recording is safe to promote.
+        $result = $this->store->reRecord($id, 'en', 'v2', [self::beacon('a', 'two', 0)]);
+        $this->assertTrue($result->promoted);
+
+        $current = $this->store->current($id, 'en');
+        $this->assertNotNull($current);
+        $this->assertSame('v2', $current->title);
+        $this->assertSame('two', $current->beacons[0]['content']);
+        $this->assertSame(Trail::ORIGIN_RECORDED, $current->origin);
+    }
+
+    #[Test]
+    public function languages_are_versioned_independently(): void
+    {
+        $id = $this->store->record('en', 'English', [self::beacon('a', 'en beacon', 0)], ownerUid: 9)->id;
+
+        // The owner edits English, then authors and edits a French translation.
+        $this->store->editAsHuman($id, 'en', 'English edited', [self::beacon('a', 'en beacon v2', 0)]);
+        $this->store->editAsHuman($id, 'fr', 'Français', [self::beacon('a', 'balise fr', 0)]);
+        $this->store->editAsHuman($id, 'fr', 'Français v2', [self::beacon('a', 'balise fr v2', 0)]);
+
+        $en = $this->store->current($id, 'en');
+        $fr = $this->store->current($id, 'fr');
+        $this->assertNotNull($en);
+        $this->assertNotNull($fr);
+
+        // Each language has its own live value — editing fr never touched en.
+        $this->assertSame('English edited', $en->title);
+        $this->assertSame('en beacon v2', $en->beacons[0]['content']);
+        $this->assertSame('Français v2', $fr->title);
+        $this->assertSame('balise fr v2', $fr->beacons[0]['content']);
+
+        // …and its own independent revision sequence (en: 1 edit, fr: 2 edits).
+        $this->assertSame(1, $this->store->revisionCount($id, 'en'));
+        $this->assertSame(2, $this->store->revisionCount($id, 'fr'));
+
+        // An untranslated language is simply absent.
+        $this->assertNull($this->store->current($id, 'oj'));
+        $this->assertSame(0, $this->store->revisionCount($id, 'oj'));
+    }
+}


### PR DESCRIPTION
## Wayfinding (flagship) Phase 4 — Trail persistence + record-to-saved

Mission: `wayfinding-01KVGH5X` · phase 4 of 5 · acceptance-gated, finish-and-ship.

Saved trails become **versioned + translatable** content entities governed by the
**human-owned / no-silent-overwrite** revision rule (LD-5 / FR-009..FR-011 / **SC-005**).

### What ships

- **`wayfinding_trail` two-axis entity** (`Entity/Trail.php`) — the framework's
  **first shipping revisionable + translatable** type (en + fr), registered via
  `EntityType::fromClass(revisionable: true, translatable: true)`. Its three tables
  (base, `_revision`, `__translation__revision`) materialise via `EntitySchemaSync`
  on `schema:sync`, like any other type.
- **`TrailStore`** (`Trail/TrailStore.php`) — realises the rule on the framework's
  native two-axis primitives:
  - **live/current value** = per-language peer row (`saveTranslation` / `loadTranslation`)
  - **history + drafts** = per-language revisions (`saveTranslationRevision` /
    `listTranslationRevisions`, which never touch the peer row)

  `record()` saves a human-owned trail (`origin=recorded`); `editAsHuman()` advances
  and latches `origin=human`; `reRecord()` onto a **human-owned** trail appends a
  **draft revision** and leaves the live value **byte-for-byte intact**
  (`promoted=false`) — never silently overwriting human edits — else safely advances
  it (`promoted=true`). Languages version **independently**.
- **`TrailAccessPolicy`** — owner-only `update`/`delete`; `create`/`view` gated on the
  `present guided content` capability.

### Scope boundary

Persistence **substrate only**. The authenticated HTTP/MCP write tier that exposes
`TrailStore` is **Phase 5** ("managing saved trails"). `TrailStore` depends on the
concrete `EntityRepository` (the per-language revision API is beyond
`EntityRepositoryInterface`) — a legitimate L4→L1 edge on `waaseyaa/entity-storage`.

### Acceptance gate

`tests/Unit/Trail/TrailStoreTest.php` drives the **real** `Trail` type over a **real**
two-axis SQLite store and proves SC-005 directly (record → versioned/human-owned;
re-record over human-owned → new revision, prior edits survive; agent-recorded →
advances; en/fr independent). Plus `TrailAccessPolicyTest` (owner-gating). 21/21
wayfinding tests green; `schema:sync` verified to create all three trail tables.

### Verified locally
phpstan (L5), cs-check, check-package-layers, check-composer-policy, check-dead-code,
check-getquery-bindings, check-symfony-imports, check-release-require-parity, drift
(spec updated), MetapackageSmokeTest, and a full `db:init → optimize:manifest →
schema:sync` boot smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
