### PR TITLE
fix: make Skeleton Smoke green — Packagist-wait reorder + repair the migrate command

### DIFF
--- a/.github/workflows/skeleton-smoke.yml
+++ b/.github/workflows/skeleton-smoke.yml
@@ -33,7 +33,11 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Wider than the work itself takes: the Packagist-propagation gate below can
+    # legitimately wait several minutes for the slowest sibling crawl during a
+    # release window (its per-package budget is 30x60s, but realistically bounded
+    # by the single slowest crawl since siblings index concurrently).
+    timeout-minutes: 40
     steps:
       - name: Resolve target framework version
         id: target
@@ -69,39 +73,44 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - name: composer create-project waaseyaa/waaseyaa
-        run: |
-          composer create-project waaseyaa/waaseyaa smoke-app \
-            --stability=alpha --no-interaction --prefer-dist
-
-      - name: Wait for Packagist to index framework + siblings
+      # MUST run BEFORE composer create-project. create-project resolves the
+      # skeleton's FULL dependency graph in one shot: waaseyaa/waaseyaa ->
+      # waaseyaa/framework -> every waaseyaa/* sibling pinned to the EXACT tag
+      # (self.version). If ANY of those isn't crawled onto Packagist yet,
+      # composer fails opaquely ("found [many versions] but it does not match
+      # the constraint", without naming the culprit) and the whole smoke run
+      # dies before it ever reaches a wait/retry. The previous layout polled
+      # only framework + admin-surface AFTER create-project, so a lagging
+      # sibling (e.g. waaseyaa/access at a fresh release) sailed straight into a
+      # create-project resolution failure on every release — the persistent red
+      # this step fixes. Poll the SAME set packagist-update.yml verifies (the
+      # skeleton + the framework meta + every packages/*/composer.json sibling),
+      # breaking per package as soon as the tag is visible.
+      - name: Wait for Packagist to index skeleton + framework + all siblings
         env:
           CONSTRAINT: ${{ steps.target.outputs.constraint }}
         run: |
-          # composer require fails opaquely when ANY sibling waaseyaa/*
-          # package hasn't been indexed yet — the resolver lists tens of
-          # found versions but says "does not match the constraint", masking
-          # WHICH dep is the culprit. Poll the Packagist p2 endpoint for
-          # each first-party sibling (admin-surface has been the canary)
-          # so the smoke run has a clean go/no-go signal before invoking
-          # composer. Budget: 30 attempts × 60s = 30 minutes — wider than
-          # the previous 12-minute composer-retry loop because split
-          # packages can lag the framework's own crawl during release
-          # windows. p2 is a CDN GET; polling 7 packages is cheap.
           set -euo pipefail
           tag="v${CONSTRAINT}"
           # Discover all waaseyaa/* packages from the checked-out monorepo
-          # (matches packagist-update.yml's discover step so the two stay in lockstep).
+          # (matches packagist-update.yml's discover step so the two stay in
+          # lockstep), and prepend the skeleton + framework meta that
+          # create-project pulls first. The skeleton (waaseyaa/waaseyaa) lives in
+          # its own repo, synced + tagged in lockstep by the upstream "Sync
+          # Application Skeleton" run that triggered this smoke.
           pkgs=$(
+            echo "waaseyaa/waaseyaa"
+            echo "waaseyaa/framework"
             for f in framework/packages/*/composer.json; do
               jq -r '.name // empty' "$f"
             done
-            jq -r '.name // empty' framework/composer.json
           )
-          # Smoke-canary subset: framework + the packages most likely to lag
-          # (admin-surface historically; others can be added if they trip the gate).
-          canaries="waaseyaa/framework waaseyaa/admin-surface"
-          for pkg in $canaries; do
+          # p2 is a cheap CDN GET; break per package as soon as the tag is
+          # visible. Budget: 30 attempts x 60s per package, but realistically
+          # bounded by the single slowest crawl since siblings index
+          # concurrently — by the time an early package is visible the rest
+          # usually are too.
+          for pkg in $pkgs; do
             attempt=1
             max_attempts=30
             while true; do
@@ -122,6 +131,11 @@ jobs:
               sleep 60
             done
           done
+
+      - name: composer create-project waaseyaa/waaseyaa
+        run: |
+          composer create-project waaseyaa/waaseyaa smoke-app \
+            --stability=alpha --no-interaction --prefer-dist
 
       - name: Pin framework to ${{ steps.target.outputs.constraint }}
         working-directory: smoke-app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`waaseyaa migrate` (and `migrate:rollback` / `migrate:status`) work again in consumer apps.** The `migrate*` commands resolved their handlers (`MigrateHandler` / `MigrateRollbackHandler` / `MigrateStatusHandler`) from the console handler container by class name, but those handlers are not container auto-wirable: `Migrator`'s first constructor parameter is a raw `Doctrine\DBAL\Connection` (auto-wiring fails with *"unresolvable parameter $params"*) and each handler additionally requires a `\Closure` migrations provider (a closure can never be reflection-constructed). So every `waaseyaa migrate` invocation in a fresh skeleton / consumer app died at command time — surfaced once the Skeleton Smoke's `composer create-project` step stopped failing first (see below). `MigrateServiceProvider` now binds the three handlers explicitly with a lazily-built migration runtime (DBAL connection + `MigrationRepository` + `MigrationLoader`), mirroring how `db:init` and `AbstractKernel::bootMigrations()` construct it; the database is opened only when a migrate* command actually runs. `migrate`, `migrate --dry-run`, `migrate --verify`, and `migrate:status` are verified working in a real consumer app. Regression guard: `MigrateServiceProviderTest` asserts the handlers are bound (never left to auto-wiring).
+- **Skeleton Smoke (Packaged-form CI) no longer fails on every release from a Packagist propagation race.** `composer create-project waaseyaa/waaseyaa` resolves the skeleton's full dependency graph (`waaseyaa/framework` → every `waaseyaa/*` sibling pinned to the exact tag via `self.version`) in one shot and fails opaquely if any sibling hasn't been crawled onto Packagist yet, but the index-wait gate ran *after* `create-project` and polled only `framework` + `admin-surface` — so a lagging sibling (e.g. `waaseyaa/access`) sailed straight into a resolution failure. The wait gate now runs **before** `create-project` and polls the full sibling set (the skeleton + the framework meta + every `packages/*/composer.json` sibling), matching `packagist-update.yml`. CI-only; alert-only workflow, does not gate releases.
+
 ## [0.1.0-alpha.235] - 2026-06-20
 
 ### Fixed

--- a/packages/cli/src/Provider/MigrateServiceProvider.php
+++ b/packages/cli/src/Provider/MigrateServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\CLI\Provider;
 
+use Doctrine\DBAL\Connection;
 use Waaseyaa\CLI\Command\HandlerCommand;
 use Waaseyaa\CLI\Command\HandlerOption;
 use Waaseyaa\CLI\Command\HandlerOptionMode;
@@ -11,12 +12,127 @@ use Waaseyaa\CLI\Handler\MigrateDefaultsHandler;
 use Waaseyaa\CLI\Handler\MigrateHandler;
 use Waaseyaa\CLI\Handler\MigrateRollbackHandler;
 use Waaseyaa\CLI\Handler\MigrateStatusHandler;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Kernel\Bootstrap\DatabaseBootstrapper;
+use Waaseyaa\Foundation\Kernel\EnvLoader;
+use Waaseyaa\Foundation\Migration\MigrationLoader;
+use Waaseyaa\Foundation\Migration\MigrationRepository;
+use Waaseyaa\Foundation\Migration\Migrator;
+use Waaseyaa\Foundation\Schema\Compiler\Sqlite\SqliteCapabilities;
+use Waaseyaa\Foundation\Schema\Compiler\Sqlite\SqliteCompiler;
 use Waaseyaa\Foundation\ServiceProvider\Capability\ProvidesConsoleCommandsInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
 final class MigrateServiceProvider extends ServiceProvider implements ProvidesConsoleCommandsInterface
 {
-    public function register(): void {}
+    /**
+     * Memoised migration runtime: [Migrator, MigrationRepository, MigrationLoader, Connection].
+     *
+     * @var array{0: Migrator, 1: MigrationRepository, 2: MigrationLoader, 3: Connection}|null
+     */
+    private ?array $runtime = null;
+
+    /**
+     * Bind the migrate* command handlers explicitly.
+     *
+     * `migrate`, `migrate:rollback` and `migrate:status` resolve `MigrateHandler`
+     * / `MigrateRollbackHandler` / `MigrateStatusHandler` from the console
+     * handler container. Those handlers take a `Migrator` (whose first ctor
+     * param is a raw `Doctrine\DBAL\Connection` — unresolvable by auto-wiring,
+     * "unresolvable parameter $params") AND a required `\Closure` migrations
+     * provider (a closure can never be auto-wired). So leaving them to the
+     * container's reflection fallback throws at command time and `migrate` is
+     * dead in every consumer app. Bind them here with the migration runtime
+     * built the same way `db:init` builds it (DBALDatabase connection +
+     * MigrationRepository + MigrationLoader). The factories are lazy singletons,
+     * so the database is only opened when a migrate* command actually runs.
+     */
+    public function register(): void
+    {
+        $this->singleton(MigrateHandler::class, function (): MigrateHandler {
+            [$migrator, $repository, $loader, $connection] = $this->migrationRuntime();
+
+            return new MigrateHandler(
+                $migrator,
+                static fn(): array => $loader->loadAll(),
+                static fn(): array => $loader->loadAllV2(),
+                $repository,
+                $this->sqliteCompiler($connection),
+                $this->isProduction(),
+            );
+        });
+
+        $this->singleton(MigrateRollbackHandler::class, function (): MigrateRollbackHandler {
+            [$migrator, , $loader] = $this->migrationRuntime();
+
+            return new MigrateRollbackHandler($migrator, static fn(): array => $loader->loadAll());
+        });
+
+        $this->singleton(MigrateStatusHandler::class, function (): MigrateStatusHandler {
+            [$migrator, , $loader] = $this->migrationRuntime();
+
+            return new MigrateStatusHandler($migrator, static fn(): array => $loader->loadAll());
+        });
+    }
+
+    /**
+     * Build (once) the migration runtime against the app's SQLite database,
+     * mirroring DbInitHandler / AbstractKernel::bootMigrations().
+     *
+     * @return array{0: Migrator, 1: MigrationRepository, 2: MigrationLoader, 3: Connection}
+     */
+    private function migrationRuntime(): array
+    {
+        if ($this->runtime !== null) {
+            return $this->runtime;
+        }
+
+        $projectRoot = $this->projectRoot !== '' ? $this->projectRoot : (string) getcwd();
+        // The kernel loads .env at boot, but load it defensively (idempotent) so
+        // WAASEYAA_DB resolution matches db:init exactly.
+        EnvLoader::load($projectRoot . '/.env');
+        $dbPath = DatabaseBootstrapper::resolveDatabasePath($projectRoot, $this->config);
+
+        $database = DBALDatabase::createSqlite($dbPath);
+        $connection = $database->getConnection();
+
+        $repository = new MigrationRepository($connection);
+        $repository->createTable();
+
+        $manifest = new PackageManifestCompiler(
+            basePath: $projectRoot,
+            storagePath: $projectRoot . '/storage',
+        )->load();
+        $loader = new MigrationLoader($projectRoot, $manifest);
+
+        $migrator = new Migrator($connection, $repository);
+
+        return $this->runtime = [$migrator, $repository, $loader, $connection];
+    }
+
+    /**
+     * The SQLite schema compiler used by `migrate --dry-run`, built for the
+     * live database's SQLite version so capability gating (rename/drop column)
+     * matches the real engine.
+     */
+    private function sqliteCompiler(Connection $connection): SqliteCompiler
+    {
+        $version = (string) $connection->fetchOne('SELECT sqlite_version()');
+
+        return new SqliteCompiler(SqliteCapabilities::forVersion($version));
+    }
+
+    private function isProduction(): bool
+    {
+        $appEnv = getenv('APP_ENV');
+        if (!is_string($appEnv) || $appEnv === '') {
+            $fromServer = $_SERVER['APP_ENV'] ?? null;
+            $appEnv = is_string($fromServer) && $fromServer !== '' ? $fromServer : 'production';
+        }
+
+        return $appEnv === 'production';
+    }
 
     public function consoleCommands(): iterable
     {

--- a/packages/cli/tests/Unit/Provider/MigrateServiceProviderTest.php
+++ b/packages/cli/tests/Unit/Provider/MigrateServiceProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\CLI\Handler\MigrateHandler;
+use Waaseyaa\CLI\Handler\MigrateRollbackHandler;
+use Waaseyaa\CLI\Handler\MigrateStatusHandler;
+use Waaseyaa\CLI\Provider\MigrateServiceProvider;
+
+/**
+ * Regression guard for the migrate* command wiring.
+ *
+ * `MigrateHandler` / `MigrateRollbackHandler` / `MigrateStatusHandler` can NOT
+ * be container auto-wired: their `Migrator` dependency's first ctor parameter is
+ * a raw `Doctrine\DBAL\Connection` (auto-wire fails with "unresolvable parameter
+ * $params"), and each handler additionally requires a `\Closure` migrations
+ * provider (a closure can never be reflection-constructed). So the provider MUST
+ * bind them explicitly; if it regresses to leaving them to the console handler
+ * container's reflection fallback, every `waaseyaa migrate*` invocation dies at
+ * command time in every consumer app.
+ */
+#[CoversClass(MigrateServiceProvider::class)]
+final class MigrateServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function it_binds_the_migrate_command_handlers_so_they_are_never_auto_wired(): void
+    {
+        $provider = new MigrateServiceProvider();
+        $provider->setKernelContext('', [], []);
+        $provider->register();
+
+        $bindings = $provider->getBindings();
+
+        // Each handler is bound (so the handler container resolves it from the
+        // provider instead of falling through to the failing reflection path)...
+        self::assertArrayHasKey(MigrateHandler::class, $bindings);
+        self::assertArrayHasKey(MigrateRollbackHandler::class, $bindings);
+        self::assertArrayHasKey(MigrateStatusHandler::class, $bindings);
+
+        // ...as a lazy factory closure, so registering the provider never opens
+        // the database (the runtime is built only when a migrate* command runs).
+        self::assertIsCallable($bindings[MigrateHandler::class]['concrete']);
+        self::assertIsCallable($bindings[MigrateRollbackHandler::class]['concrete']);
+        self::assertIsCallable($bindings[MigrateStatusHandler::class]['concrete']);
+    }
+}


### PR DESCRIPTION
Makes the persistently-red **Skeleton Smoke (Packaged-form CI)** green. Two layered failures: the visible one (Packagist race) was masking a second one (`waaseyaa migrate` broken in every consumer app).

## 1. Packagist propagation race (skeleton-smoke.yml)

`composer create-project waaseyaa/waaseyaa` resolves the skeleton's **full** dependency graph in one shot: `waaseyaa/framework` → every `waaseyaa/*` sibling pinned to the **exact** tag (`self.version`). If any sibling isn't crawled onto Packagist yet, composer fails opaquely (*"found [many] but it does not match the constraint"*). The index-wait gate ran **after** `create-project` and polled only `framework` + `admin-surface`, so a lagging sibling (observed: `waaseyaa/access@v0.1.0-alpha.235`) sailed straight into a resolution failure on every release.

- Move the wait gate **before** `create-project`.
- Poll the full set `packagist-update.yml` verifies (skeleton + framework meta + every `packages/*/composer.json` sibling), breaking per package as the tag appears.
- Bump job timeout 20→40m for the propagation budget.

## 2. `waaseyaa migrate` broken in consumer apps (MigrateServiceProvider)

With #1 fixed, the smoke reached **Run migrations** and died: `Cannot auto-wire "Doctrine\DBAL\Connection": unresolvable parameter "$params"`. The `migrate` / `migrate:rollback` / `migrate:status` handlers resolve by class name from the console handler container, but they can't be auto-wired — `Migrator`'s first param is a raw `Doctrine\DBAL\Connection` and each handler requires a `\Closure` migrations provider. This was a latent regression in **every** consumer app (reproduced in a real app), masked until create-project stopped failing first.

- `MigrateServiceProvider` now binds the three handlers explicitly with a lazily-built migration runtime (DBAL connection + `MigrationRepository` + `MigrationLoader`), mirroring `db:init` / `AbstractKernel::bootMigrations()`. DB opens only when a migrate* command runs.
- Verified in a real consumer app: `migrate` ("Nothing to migrate"), `migrate --dry-run` (full plan), `migrate --verify` (report), `migrate:status` (table) — all exit 0.
- Regression guard: `MigrateServiceProviderTest` asserts the handlers are bound (never left to auto-wiring).

> Note (out of scope): `migrate:defaults` has the same latent shape (non-auto-wirable `string $projectRoot`); not exercised by the smoke, flagged for a follow-up.

## Validation

- `MigrateServiceProviderTest` + existing `MigrateHandlerTest` green; phpstan + cs-check clean on changed files.
- Real-consumer-app validation of all migrate sub-commands.
- `workflow_dispatch` of the reordered smoke confirmed the new gate polls the full sibling set (all "visible attempt 1") before create-project.
- The smoke goes fully green once a release containing the migrate fix is published (next alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)