### PR TITLE
fix(ssr): resolve public content by uuid so /{type}/{uuid} no longer 404s (#1686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Public content is reachable at `GET /{type}/{uuid}`, not only `/{type}/{id}` (#1686).** The canonical SSR path fed the raw path segment to `SqlEntityStorage::load()`, which queries the numeric `id` column only — so a UUID never matched and a valid published entity 404'd purely on identifier shape. `SsrPageHandler` now resolves a UUID-shaped segment to the numeric id first (new `loadByIdOrUuid()`, mirroring `JsonApiController`); `load()` itself stays numeric-keyed (the column is never dual-keyed). The canonical public path is unchanged (still numeric); UUID resolution is additive. Identity resolution uses `accessCheck(false)` so authorization stays with the existing SSR visibility gates (`EditorialVisibilityResolver` + `shouldDenyContentGroupRender`) — the UUID and numeric paths are symmetric and the UUID path cannot leak a draft. (The default "published content is anonymously viewable, drafts gated" policy and the fail-closed gate were already in place via the kernel-registered `PublishedContentAccessPolicy` — verified, not changed.) Acceptance: `SsrPageHandlerUuidResolutionTest`.
+
 ## [0.1.0-alpha.242] - 2026-06-21
 
 ### Fixed

--- a/packages/ssr/src/SsrPageHandler.php
+++ b/packages/ssr/src/SsrPageHandler.php
@@ -166,8 +166,7 @@ final class SsrPageHandler
                 return $this->htmlResult($response->getStatusCode(), (string) $response->getContent(), $headers);
             }
 
-            $targetStorage = $this->entityTypeManager->getStorage($entityTypeId);
-            $entity = $targetStorage->load($entityId);
+            $entity = $this->loadByIdOrUuid($entityTypeId, $entityId);
             if ($entity === null) {
                 $response = new RenderController($twig)->renderNotFound($aliasLookupPath, $account);
                 $headers = $this->extractHeaders($response);
@@ -735,6 +734,45 @@ final class SsrPageHandler
         }
 
         return [$type, $id];
+    }
+
+    /**
+     * Resolve a content entity by its canonical numeric id OR — when the path
+     * segment is UUID-shaped and the type has a `uuid` key — by uuid (#1686).
+     *
+     * The canonical public path stays numeric `/{type}/{id}`, but a valid entity
+     * must never 404 purely on identifier shape: `GET /story/{uuid}` previously
+     * fed the UUID to `load()`, which queries the numeric `id` column only, so it
+     * never matched. We resolve the uuid to the numeric id via a query first;
+     * `load()` itself stays numeric-keyed (the column is never dual-keyed).
+     *
+     * `accessCheck(false)` — identity resolution only. Authorization stays with
+     * the SSR visibility gates in the caller (`EditorialVisibilityResolver` +
+     * {@see shouldDenyContentGroupRender()}), exactly as on the numeric path
+     * (`load()` does not access-check either), so the uuid and numeric paths are
+     * symmetric and the uuid path cannot leak a draft.
+     */
+    private function loadByIdOrUuid(string $entityTypeId, int|string $id): ?EntityInterface
+    {
+        $storage = $this->entityTypeManager->getStorage($entityTypeId);
+        $keys = $this->entityTypeManager->getDefinition($entityTypeId)->getKeys();
+
+        if (
+            isset($keys['uuid'])
+            && preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', (string) $id) === 1
+        ) {
+            $ids = $storage->getQuery()
+                ->accessCheck(false)
+                ->condition($keys['uuid'], (string) $id)
+                ->execute();
+            if ($ids === []) {
+                return null;
+            }
+
+            return $storage->load(reset($ids));
+        }
+
+        return $storage->load($id);
     }
 
     /**

--- a/packages/ssr/tests/Unit/SsrPageHandlerUuidResolutionTest.php
+++ b/packages/ssr/tests/Unit/SsrPageHandlerUuidResolutionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\SSR\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Api\Http\DiscoveryApiHandler;
+use Waaseyaa\Cache\CacheConfigResolver;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Node\Node;
+use Waaseyaa\SSR\SsrPageHandler;
+
+/**
+ * #1686 — the canonical public content path must resolve `GET /{type}/{uuid}`,
+ * not only `/{type}/{id}`. `SsrPageHandler` fed the raw path segment to
+ * `SqlEntityStorage::load()`, which queries the numeric `id` column only, so a
+ * UUID never matched and a valid entity 404'd purely on identifier shape.
+ *
+ * `loadByIdOrUuid()` now resolves a UUID-shaped segment to the numeric id first;
+ * `load()` stays numeric-keyed.
+ */
+#[CoversClass(SsrPageHandler::class)]
+final class SsrPageHandlerUuidResolutionTest extends TestCase
+{
+    private DBALDatabase $db;
+    private SqlEntityStorage $storage;
+    private EntityTypeManager $etm;
+
+    protected function setUp(): void
+    {
+        $this->db = DBALDatabase::createSqlite();
+        $entityType = new EntityType(
+            id: 'story',
+            label: 'Story',
+            class: Node::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+            group: 'content',
+        );
+
+        new SqlSchemaHandler($entityType, $this->db)->ensureTable();
+
+        $this->storage = new SqlEntityStorage($entityType, $this->db, new EventDispatcher());
+
+        $storage = $this->storage;
+        $this->etm = new EntityTypeManager(new EventDispatcher(), static fn(EntityTypeInterface $_t): SqlEntityStorage => $storage);
+        $this->etm->registerEntityType($entityType);
+    }
+
+    #[Test]
+    public function resolves_a_content_entity_by_uuid_and_by_numeric_id(): void
+    {
+        $entity = $this->storage->create(['title' => 'Water Is Life', 'status' => true]);
+        $this->storage->save($entity);
+
+        $id = $entity->id();
+        $uuid = (string) $entity->get('uuid');
+        self::assertNotSame('', $uuid, 'precondition: the saved entity has a uuid');
+
+        // By UUID — previously a 404 (numeric load() never matched).
+        $byUuid = $this->loadByIdOrUuid('story', $uuid);
+        self::assertInstanceOf(EntityInterface::class, $byUuid);
+        self::assertSame((string) $id, (string) $byUuid->id(), 'uuid resolves to the same entity');
+
+        // By numeric id — the canonical path, unchanged.
+        $byId = $this->loadByIdOrUuid('story', (string) $id);
+        self::assertInstanceOf(EntityInterface::class, $byId);
+        self::assertSame((string) $id, (string) $byId->id());
+    }
+
+    #[Test]
+    public function returns_null_for_an_unknown_uuid(): void
+    {
+        $this->storage->save($this->storage->create(['title' => 'Seeded', 'status' => true]));
+
+        // Well-formed but unused UUID → no match → null (the caller renders 404,
+        // which is correct: the entity genuinely does not exist).
+        self::assertNull($this->loadByIdOrUuid('story', '99999999-9999-4999-8999-999999999999'));
+    }
+
+    private function loadByIdOrUuid(string $entityTypeId, string $id): ?EntityInterface
+    {
+        $handler = new SsrPageHandler(
+            entityTypeManager: $this->etm,
+            database: $this->db,
+            renderCache: null,
+            cacheConfigResolver: new CacheConfigResolver([]),
+            discoveryHandler: new DiscoveryApiHandler($this->etm, $this->db),
+            projectRoot: '/tmp/test-project',
+            config: [],
+            accessHandler: null,
+        );
+
+        $method = new \ReflectionMethod(SsrPageHandler::class, 'loadByIdOrUuid');
+
+        /** @var EntityInterface|null $result */
+        $result = $method->invoke($handler, $entityTypeId, $id);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Closes #1686.

## The bug
`GET /story/{uuid}` 404s. `SsrPageHandler` resolves `/{type}/{id}` then calls
`SqlEntityStorage::load()`, which queries the numeric `id` column only — a UUID
never matches, so a valid **published** entity 404s purely on identifier shape.

## Fix
`SsrPageHandler::loadByIdOrUuid()` resolves a UUID-shaped segment to the numeric
id first (a `uuid`-key query), then `load()`s it — mirroring
`JsonApiController::loadByIdOrUuid`. `load()` stays numeric-keyed; **the column is
never dual-keyed** (per the issue's locked decision), and the canonical public
path is unchanged (still numeric — UUID resolution is additive).

Identity resolution uses `accessCheck(false)`, so authorization stays with the
**existing** SSR visibility gates (`EditorialVisibilityResolver` +
`shouldDenyContentGroupRender`) — exactly as the numeric path behaves (`load()`
doesn't access-check either). The UUID and numeric paths are therefore symmetric
and the UUID path **cannot leak a draft**.

## The other two coupled concerns were already handled (verified, not changed)
The issue also flags a default published-viewable policy and a fail-closed
content gate. Both are already live: `PublishedContentAccessPolicy` is registered
as a kernel default (`AbstractKernel::discoverAccessPolicies`) and `SsrPageHandler`
receives the kernel's access handler (`SsrServiceProvider`), so published
content-group entities resolve `Allowed` (render) and drafts stay Neutral (denied);
`shouldDenyContentGroupRender` fails closed only on a `null` handler. Pinned by the
existing `SsrContentPublishedGateTest`. Per the data-freshness rule I verified this
against the code rather than re-implementing it.

## Tests
- `SsrPageHandlerUuidResolutionTest`: resolves a content entity by uuid **and** by
  numeric id; returns null for an unknown uuid.
- Existing `SsrContentPublishedGateTest` + `SsrPageHandlerTest` stay green.
- dead-code/phpstan clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
