### PR TITLE
fix(release): exactly-once Packagist publish + forward-only releases (WP01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,14 @@ jobs:
       - name: Validate ingestion schema metadata and compatibility rules
         run: bash bin/check-ingestion-defaults
 
+  release-publish-shape:
+    name: Release publish shape
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert exactly-once Packagist publish + forward-only release shape
+        run: bash bin/check-release-publish-shape
+
   security-defaults:
     name: Security defaults
     runs-on: ubuntu-latest

--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -4,12 +4,15 @@ name: Publish to Packagist
 # dynamically from `packages/*/composer.json` so the matrix can't drift) is
 # published to Packagist after a release tag.
 #
-# Crawling is done by Packagist's GitHub auto-update webhooks installed on the
-# monorepo and each split repo (they fire on the tag push / split push). This
-# workflow used to ALSO POST the update-package API per package, which
-# double-crawled every package per release (webhook + API) — the redundant
-# "publishes twice" behaviour. The update job was removed; this workflow now
-# only VERIFIES the webhook-driven result.
+# Crawling is triggered by the `publish-packagist` job in split.yml: exactly ONE
+# idempotent `POST /api/update-package` per package, gated on split + tag-parity
+# + require-parity success. Packagist's GitHub auto-update PUSH webhooks are
+# DISABLED on the monorepo + every split repo — they fired once per pushed ref
+# (gate-branch + main + tag + gate-delete on the monorepo; main + tag on each
+# split repo), re-crawling and re-publishing the just-cut version 2-3x per
+# release (audit alpha.245 §1). With webhooks off, the single update-package
+# POST is the only crawl trigger, so each package publishes exactly once.
+# This workflow now only VERIFIES that result. See docs/VERSIONING.md §8.
 #
 # Jobs:
 #   - discover: enumerate waaseyaa/* package names

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -156,7 +156,22 @@ jobs:
           SHA=$(splitsh-lite --prefix="${LOCAL_PREFIX}")
           git remote add split "${REMOTE_URL}" 2>/dev/null || true
           git push split "${SHA}:refs/heads/main" --force
-          git push split "${SHA}:refs/tags/${TAG_NAME}" --force
+          # Forward-only: push the release tag NON-FORCE. Packagist treats tag
+          # versions as immutable; force-moving a tag would diverge git from
+          # Packagist (the old dist stays published). If the split repo already
+          # has this tag at a DIFFERENT sha, that is a re-tag attempt — fail
+          # loudly (RETAG_BLOCKED). Re-pushing the SAME sha is an idempotent
+          # no-op (safe on re-runs). Recover a bad release by cutting
+          # alpha.N+1, never by re-tagging. See docs/VERSIONING.md §8.
+          if ! git push split "${SHA}:refs/tags/${TAG_NAME}"; then
+            existing="$(git ls-remote --tags split "refs/tags/${TAG_NAME}" | awk '{print $1}')"
+            if [ -n "${existing}" ] && [ "${existing}" != "${SHA}" ]; then
+              echo "::error::RETAG_BLOCKED: ${REMOTE_REPO} already has tag ${TAG_NAME} at ${existing}; refusing to move it to ${SHA}. Releases are forward-only — cut alpha.N+1 instead of re-tagging."
+            else
+              echo "::error::Tag push of ${TAG_NAME} to ${REMOTE_REPO} failed."
+            fi
+            exit 1
+          fi
 
   verify-monorepo-main-intact:
     name: Verify monorepo main still points at the tagged commit
@@ -234,3 +249,57 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+
+  # Single-crawl publish (WP01, audit §1). Packagist's GitHub auto-update PUSH
+  # webhooks are DISABLED on the monorepo + every split repo (they fired once
+  # per pushed ref -> 2-3 crawls/republishes per release). Instead we trigger
+  # EXACTLY ONE idempotent update-package POST per package, AFTER split + tag
+  # parity + require parity succeed. This is the only crawl trigger, so each
+  # package is published once per release. Requires repo secrets
+  # PACKAGIST_USERNAME + PACKAGIST_TOKEN.
+  publish-packagist:
+    name: Publish to Packagist (one crawl per package)
+    needs: [split, verify-monorepo-main-intact, verify-tag-parity, verify-require-parity]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Discover waaseyaa/* packages
+        id: scan
+        run: |
+          {
+            for f in packages/*/composer.json; do jq -r '.name // empty' "$f"; done
+            jq -r '.name // empty' composer.json
+          } | grep '^waaseyaa/' | sort -u > /tmp/pkgs.txt
+          echo "Discovered $(wc -l < /tmp/pkgs.txt) package(s)."
+
+      - name: Trigger exactly one Packagist crawl per package
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -z "${PACKAGIST_USERNAME}" ] || [ -z "${PACKAGIST_TOKEN}" ]; then
+            echo "::error::PACKAGIST_USERNAME / PACKAGIST_TOKEN secret not set."
+            echo "::error::The Packagist push webhooks are disabled by design (single-crawl model),"
+            echo "::error::so without these secrets nothing publishes. Configure them, then re-run."
+            exit 1
+          fi
+          rc=0
+          while IFS= read -r pkg; do
+            [ -z "${pkg}" ] && continue
+            # waaseyaa/<x> is registered on Packagist at github.com/<owner>/<x>
+            # (each split package's own repo; the monorepo for waaseyaa/framework).
+            repo_url="https://github.com/${REPO_OWNER}/${pkg#waaseyaa/}"
+            code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+              "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -d "{\"repository\":{\"url\":\"${repo_url}\"}}" || echo "000")
+            if [ "${code}" = "200" ] || [ "${code}" = "202" ]; then
+              echo "::notice::${pkg}: update-package accepted (HTTP ${code})."
+            else
+              echo "::error::${pkg}: update-package failed (HTTP ${code}): $(cat /tmp/resp.json 2>/dev/null)"
+              rc=1
+            fi
+          done < /tmp/pkgs.txt
+          exit "${rc}"

--- a/bin/check-release-publish-shape
+++ b/bin/check-release-publish-shape
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# check-release-publish-shape
+# ---------------------------
+# WP01 (framework-cleanup-alpha245): assert the release pipeline produces
+# EXACTLY ONE Packagist crawl per package per release, and that releases are
+# forward-only.
+#
+# Background (audit alpha.245, §1): Packagist was driven by GitHub auto-update
+# PUSH webhooks on the monorepo + every split repo. A release pushes multiple
+# refs per repo (gate-branch create + main + tag + gate-branch delete on the
+# monorepo; main + tag on each split repo), and GitHub fires one webhook per
+# ref, so the just-cut version was crawled/published 2-3x. split.yml also
+# force-pushed the tag, so a re-run could silently MOVE a tag while Packagist
+# kept the immutable original (git/Packagist divergence).
+#
+# The fix this gate enforces:
+#   1. The split TAG push is NOT --force (a re-tag attempt fails loudly).
+#   2. A re-tag / SHA-mismatch guard exists on the split tag push.
+#   3. Publishing is a single idempotent POST to Packagist's update-package API
+#      (one crawl per package), NOT the per-ref push webhook.
+#   4. That publish step is GATED on split + tag-parity + require-parity success.
+#   5. VERSIONING.md documents forward-only recovery (bump to alpha.N+1, never
+#      a re-tag) and that the push webhooks are disabled in favour of the POST.
+#
+# Exit non-zero if any invariant is violated. This is the WP01 failing-first
+# test: it FAILS against pre-fix workflows and PASSES after the fix.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SPLIT="${ROOT_DIR}/.github/workflows/split.yml"
+PKG="${ROOT_DIR}/.github/workflows/packagist-update.yml"
+VER="${ROOT_DIR}/docs/VERSIONING.md"
+
+fail=0
+pass() { printf 'OK   %s\n' "$1"; }
+bad()  { printf 'FAIL %s\n' "$1"; fail=1; }
+
+for f in "$SPLIT" "$PKG" "$VER"; do
+  [ -f "$f" ] || { echo "FAIL [RP100] missing file: $f"; exit 1; }
+done
+
+# 1. The split TAG push must NOT be --force.
+if grep -Eq 'push[^#]*refs/tags/[^#]*--force' "$SPLIT"; then
+  bad "[RP101] split.yml force-pushes the release tag (refs/tags/... --force) — a re-tag would silently move it; Packagist keeps the immutable original."
+else
+  pass "[RP101] split.yml tag push is non-force."
+fi
+
+# 2. A re-tag / SHA-mismatch guard must exist on the split tag push.
+if grep -q 'RETAG_BLOCKED' "$SPLIT"; then
+  pass "[RP102] split.yml has a re-tag / SHA-mismatch guard (RETAG_BLOCKED)."
+else
+  bad "[RP102] split.yml has no re-tag / SHA-mismatch guard on the tag push."
+fi
+
+# 3. Publishing must use a single idempotent update-package POST (not webhooks).
+if grep -Eq 'api/update-package' "$SPLIT" "$PKG"; then
+  pass "[RP103] release pipeline POSTs to Packagist update-package (explicit single crawl)."
+else
+  bad "[RP103] no Packagist update-package POST — publishing still relies on per-ref push webhooks (multi-crawl)."
+fi
+
+# 4. The publish step must be gated on split + parity success.
+pp_block="$(sed -n '/^  publish-packagist:/,/^  [A-Za-z0-9_-]*:/p' "$SPLIT")"
+if [ -n "${pp_block}" ] \
+  && printf '%s\n' "${pp_block}" | grep -q 'verify-tag-parity' \
+  && printf '%s\n' "${pp_block}" | grep -q 'verify-require-parity' \
+  && printf '%s\n' "${pp_block}" | grep -q 'split'; then
+  pass "[RP104] publish-packagist is gated on split + tag-parity + require-parity."
+else
+  bad "[RP104] the Packagist publish step is not gated on split + tag-parity + require-parity."
+fi
+
+# 5. VERSIONING.md documents forward-only recovery + webhook-off publish model.
+if grep -Eqi 'forward-only' "$VER" && grep -Eqi 'update-package|webhook' "$VER"; then
+  pass "[RP105] VERSIONING.md documents forward-only recovery and the single-crawl publish model."
+else
+  bad "[RP105] VERSIONING.md does not document forward-only recovery + the single-crawl publish model."
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "release-publish-shape: VIOLATIONS FOUND (see FAIL lines above)."
+  exit 1
+fi
+echo ""
+echo "release-publish-shape: OK — exactly-once publish + forward-only invariants hold."

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -100,6 +100,39 @@ CI validates that every file under `defaults/` contains this block.
 
 ---
 
+## 8. Forward-Only Releases & Single-Crawl Publish
+
+Releases are **forward-only**. A tagged release version is **immutable** once
+published to Packagist — Packagist keeps the dist for an existing tag and will
+not adopt a moved tag (anti-tamper). Therefore:
+
+- **Never re-tag.** If a cut release is bad, recover by cutting the **next**
+  version (`alpha.N+1`), never by deleting/moving an existing tag. `release-cut.yml`
+  already refuses to re-cut an existing version; `split.yml` pushes the release
+  tag to each split repo **non-force** and fails with `RETAG_BLOCKED` if the tag
+  already exists there at a different commit.
+
+- **One crawl per package per release.** Packagist's GitHub auto-update **push
+  webhooks are disabled** on the monorepo and every split repo. They fired once
+  per pushed ref (gate-branch create + main fast-forward + tag + gate-branch
+  delete on the monorepo; main + tag on each split repo), so GitHub delivered
+  multiple webhooks and Packagist re-crawled/re-published the just-cut version
+  2-3x (audit alpha.245 §1). Publishing is instead a single idempotent
+  `POST /api/update-package` per package, run by the `publish-packagist` job in
+  `split.yml` **after** split + tag-parity + require-parity succeed. That POST is
+  the only crawl trigger, so each package is published exactly once.
+
+  Requires repo secrets `PACKAGIST_USERNAME` + `PACKAGIST_TOKEN`. The
+  invariant is enforced in CI by `bin/check-release-publish-shape`.
+
+**Cutover order (one-time, when this lands):** (1) merge this change; (2) set the
+`PACKAGIST_USERNAME`/`PACKAGIST_TOKEN` secrets; (3) **then** delete the Packagist
+auto-update webhook from the monorepo and every split repo. Do not delete the
+webhooks before the POST mechanism + secrets are live, or a release would not
+publish at all.
+
+---
+
 ## Audit Log
 
 _No entries yet. Records of tag deletions and v1.0 authorizations will appear here._


### PR DESCRIPTION
**Batch 0 gate — WP01 of the alpha.245 cleanup mission (`framework-cleanup-alpha245`). Until this lands, cut no release.**

## Problem (audit alpha.245 §1)
Packagist was driven by GitHub **auto-update push webhooks** on the monorepo + every split repo. A single release pushes **multiple refs** per registered repo — monorepo: gate-branch create + `main` fast-forward + tag + gate-branch delete; each split repo: `main` + tag. GitHub fires **one webhook per ref**, so Packagist re-crawled and **re-published the just-cut version 2–3×** ("double-publishing"). `split.yml` also **force-pushed the tag**, so a re-run could silently *move* a tag while Packagist kept the immutable original (git ↔ Packagist divergence; the "blocked re-tag" symptom).

## Fix — one crawl per package per release, forward-only
- **`split.yml`** — push the release tag **non-`--force`**; if a split repo already has the tag at a different sha, fail loudly with `RETAG_BLOCKED` (re-pushing the same sha is an idempotent no-op, safe on re-runs).
- **`split.yml`** — new **`publish-packagist`** job: exactly **one idempotent `POST /api/update-package` per package**, gated on `split` + `verify-tag-parity` + `verify-require-parity`. This is the only crawl trigger once the push webhooks are off.
- **`packagist-update.yml`** — header updated to the webhook-off / single-crawl model (still verifies p2 visibility post-publish).
- **`docs/VERSIONING.md` §8** — forward-only recovery (recover a bad cut with `alpha.N+1`, never a re-tag) + the single-crawl publish model + cutover order.
- **`bin/check-release-publish-shape`** — CI gate (new job in `ci.yml`) asserting the exactly-once invariants.

## Failing-first test
`bin/check-release-publish-shape` encodes the invariants (non-force tag, `RETAG_BLOCKED` guard, single `update-package` POST, gated on parity, forward-only doc). Verified:
- **Pre-fix** (workflow/doc changes reverted): `EXIT=1`, 5 FAIL.
- **Post-fix**: `EXIT=0`, all OK.

No BC shims.

## Cutover (one-time, at merge — do NOT do before merge or publishing breaks)
1. Merge this PR.
2. Set repo secrets `PACKAGIST_USERNAME` + `PACKAGIST_TOKEN`.
3. **Then** delete the Packagist auto-update webhook on the monorepo + every split repo (they are the multi-crawl source).

Until step 3, the old webhooks still fire; the new POST is additive and idempotent, so there is no publish gap during cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)