### PR TITLE
fix(release): skeleton owned by one workflow + its own Packagist crawl

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -97,8 +97,13 @@ jobs:
           - { local: 'packages/cms', remote: 'cms' }
           - { local: 'packages/core', remote: 'core' }
           - { local: 'packages/full', remote: 'full' }
-          # Project skeleton
-          - { local: 'skeleton', remote: 'waaseyaa' }
+          # NOTE: the project skeleton (waaseyaa/waaseyaa) is intentionally NOT
+          # split here. It is owned solely by sync-skeleton.yml, which rsyncs
+          # the skeleton tree, pins waaseyaa/framework to the release tag, tags
+          # and publishes it. A subtree-split entry here produced a different
+          # SHA and an unpinned manifest, then collided with sync-skeleton's tag
+          # (RETAG_BLOCKED) and skipped the entire publish stage (alpha.246).
+          # The RP106 guard in bin/check-release-publish-shape enforces this.
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/sync-skeleton.yml
+++ b/.github/workflows/sync-skeleton.yml
@@ -67,3 +67,31 @@ jobs:
           # Always tag to match the framework release
           git tag "${TAG_NAME}" -f
           git push origin main --tags --force
+
+      - name: Publish skeleton to Packagist (one crawl)
+        # sync-skeleton.yml is the SOLE owner of waaseyaa/waaseyaa: split.yml's
+        # publish-packagist enumerates only packages/* + the root (never the
+        # skeleton), and the Packagist push webhooks are disabled (single-crawl
+        # model). So this workflow must trigger the skeleton's own single
+        # idempotent update-package POST, or the skeleton silently stops
+        # publishing. Mirrors split.yml's publish-packagist crawl shape.
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          if [ -z "${PACKAGIST_USERNAME}" ] || [ -z "${PACKAGIST_TOKEN}" ]; then
+            echo "::error::PACKAGIST_USERNAME / PACKAGIST_TOKEN secret not set."
+            echo "::error::The Packagist push webhooks are disabled (single-crawl model),"
+            echo "::error::so without these secrets the skeleton does not publish. Configure them, then re-run."
+            exit 1
+          fi
+          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d '{"repository":{"url":"https://github.com/waaseyaa/waaseyaa"}}' || echo "000")
+          if [ "${code}" = "200" ] || [ "${code}" = "202" ]; then
+            echo "::notice::waaseyaa/waaseyaa: update-package accepted (HTTP ${code})."
+          else
+            echo "::error::waaseyaa/waaseyaa: update-package failed (HTTP ${code}): $(cat /tmp/resp.json 2>/dev/null)"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The project skeleton (`waaseyaa/waaseyaa`) is published by exactly one workflow again, fixing a release-pipeline collision that skipped the entire Packagist publish stage.** On the alpha.246 cut, both `split.yml` (a `{ local: 'skeleton', remote: 'waaseyaa' }` subtree-split matrix entry) and `sync-skeleton.yml` targeted the same `waaseyaa/waaseyaa` repo and raced to push the release tag. `sync-skeleton.yml` won; `split.yml`'s push hit the new forward-only `RETAG_BLOCKED` guard (working as designed), failing that `split` job — which `needs:`-gated and **skipped** `verify-tag-parity`, `verify-require-parity`, `publish-packagist`, and the GitHub Release, so **no package reached Packagist**. The skeleton is now owned solely by `sync-skeleton.yml` (it already rsyncs the tree, pins `waaseyaa/framework`, validates, and tags); the redundant `split.yml` entry is removed. Separately, `sync-skeleton.yml` now triggers the skeleton's own single idempotent `update-package` Packagist crawl — `split.yml`'s `publish-packagist` only enumerates `packages/*` + the root (never the skeleton) and the push webhooks are disabled, a gap WP01 left when it deleted the skeleton's webhook without adding it to the single-crawl publisher. Two new invariants in `bin/check-release-publish-shape` (CI-gated) prevent regressions: **RP106** fails if any repo is a publish target of more than one workflow, **RP107** fails if `sync-skeleton.yml` does not trigger the skeleton's Packagist crawl (both verified to fail against the pre-fix config).
+
 ## [0.1.0-alpha.246] - 2026-06-22
 
 ### Fixed

--- a/bin/check-release-publish-shape
+++ b/bin/check-release-publish-shape
@@ -30,13 +30,14 @@ set -uo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SPLIT="${ROOT_DIR}/.github/workflows/split.yml"
 PKG="${ROOT_DIR}/.github/workflows/packagist-update.yml"
+SYNC="${ROOT_DIR}/.github/workflows/sync-skeleton.yml"
 VER="${ROOT_DIR}/docs/VERSIONING.md"
 
 fail=0
 pass() { printf 'OK   %s\n' "$1"; }
 bad()  { printf 'FAIL %s\n' "$1"; fail=1; }
 
-for f in "$SPLIT" "$PKG" "$VER"; do
+for f in "$SPLIT" "$PKG" "$SYNC" "$VER"; do
   [ -f "$f" ] || { echo "FAIL [RP100] missing file: $f"; exit 1; }
 done
 
@@ -77,6 +78,33 @@ if grep -Eqi 'forward-only' "$VER" && grep -Eqi 'update-package|webhook' "$VER";
   pass "[RP105] VERSIONING.md documents forward-only recovery and the single-crawl publish model."
 else
   bad "[RP105] VERSIONING.md does not document forward-only recovery + the single-crawl publish model."
+fi
+
+# 6. No repo may be a publish target of more than one workflow. split.yml's
+#    subtree-split matrix (`remote:` targets) and sync-skeleton.yml's target
+#    repo must be DISJOINT. A repo owned by two workflows races to push the
+#    same tag at release time — the second loses to RETAG_BLOCKED and the whole
+#    publish stage (parity + Packagist) is skipped. This caught the alpha.246
+#    skeleton collision: split.yml fanned `skeleton -> waaseyaa` while
+#    sync-skeleton.yml already owns waaseyaa/waaseyaa.
+split_targets="$(grep -oE "remote: *'[a-z0-9_-]+'" "$SPLIT" | sed -E "s/remote: *'([a-z0-9_-]+)'/\1/" | sort -u)"
+sync_targets="$(grep -oE 'repository: *waaseyaa/[a-z0-9_-]+' "$SYNC" | sed -E 's#repository: *waaseyaa/##' | sort -u)"
+dual_owned="$(comm -12 <(printf '%s\n' "$split_targets") <(printf '%s\n' "$sync_targets") | grep -v '^$' || true)"
+if [ -z "$dual_owned" ]; then
+  pass "[RP106] no repo is a publish target of more than one workflow (split.yml ∩ sync-skeleton.yml = ∅)."
+else
+  bad "[RP106] repo(s) targeted by BOTH split.yml and sync-skeleton.yml (dual-owner → RETAG_BLOCKED at release): $(printf '%s' "$dual_owned" | tr '\n' ' ')"
+fi
+
+# 7. The skeleton repo (waaseyaa/waaseyaa) is published ONLY by sync-skeleton.yml
+#    once split.yml no longer fans it out. split.yml's publish-packagist crawls
+#    only packages/* + the root (never the skeleton), and the push webhooks are
+#    off — so sync-skeleton.yml MUST trigger the skeleton's single Packagist
+#    crawl itself, or the skeleton silently stops publishing (the gap WP01 left).
+if grep -Eq 'api/update-package' "$SYNC"; then
+  pass "[RP107] sync-skeleton.yml triggers the skeleton's Packagist crawl (single owner publishes it)."
+else
+  bad "[RP107] sync-skeleton.yml does not POST a Packagist crawl for waaseyaa/waaseyaa — its publish is dropped."
 fi
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary

The **alpha.246 cut skipped the entire publish stage** — no package reached Packagist. Root cause: two workflows owned the skeleton repo `waaseyaa/waaseyaa` and raced to push the release tag.

- `split.yml` had a `{ local: 'skeleton', remote: 'waaseyaa' }` subtree-split matrix entry.
- `sync-skeleton.yml` also targets `waaseyaa/waaseyaa` (rsync + version-pin + tag).

On the tag push, `sync-skeleton.yml` tagged first; `split.yml`'s tag push then hit the new forward-only **`RETAG_BLOCKED`** guard (**working as designed** — it refused to move an existing tag). That failed the `split (skeleton, waaseyaa)` job, which `needs:`-gated and **skipped** `verify-tag-parity`, `verify-require-parity`, `publish-packagist`, and the GitHub Release. Verified: `waaseyaa/seo`/`entity` split repos got the alpha.246 tag, but Packagist still tops out at alpha.245.

## Fix (single owner + close the publish gap + regression guard)

1. **Remove the skeleton entry from `split.yml`.** `sync-skeleton.yml` is the correct sole owner: it rsyncs `skeleton/`, **pins `waaseyaa/framework` to the tag** (`sync-skeleton-requirements.php`), validates the manifest, and tags. The subtree-split entry produced a *different* SHA and an *unpinned* manifest, then collided.
2. **`sync-skeleton.yml` now triggers the skeleton's own single idempotent `update-package` Packagist crawl.** `split.yml`'s `publish-packagist` enumerates only `packages/*` + the root (`waaseyaa/framework`) — **never** the skeleton (`waaseyaa/waaseyaa` lives at `skeleton/composer.json`). With the push webhooks disabled (single-crawl model), nothing was crawling the skeleton: **WP01 deleted its webhook without adding it to the single-crawl publisher**, so the skeleton silently stopped publishing after WP01 (alpha.245 — cut *before* WP01 — was its last webhook-driven publish). This closes that gap.
3. **`bin/check-release-publish-shape` (CI-gated) gains two invariants**, both **verified to fail against the pre-fix config**:
   - **RP106** — fails if any repo is a publish target of more than one workflow (`split.yml` ∩ `sync-skeleton.yml` must be ∅).
   - **RP107** — fails if `sync-skeleton.yml` does not trigger the skeleton's Packagist crawl.

## Verification

- `bin/check-release-publish-shape` — RP101–RP107 all OK (RP106/RP107 failed before the fix).
- `bin/check-release-require-parity` (offline matrix half) + `bin/check-monorepo-release-shape HEAD` — OK; `waaseyaa/waaseyaa` is not in the root `require`, so dropping the matrix entry breaks no parity.
- Both workflow YAMLs parse.

## Recovery

Forward-only: **alpha.246 is burned** (monorepo + per-package split repos are tagged, but it never published). After this merges green, I'll re-cut **alpha.247** via the canonical path and verify exactly-once publish directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)