### PR TITLE
WP14 messaging: enforce participant-only read/post with an access policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Messaging now actually enforces participant-only access — the README/spec guarantee was unbacked by code (audit #31, WP14).** The README and `docs/specs/messaging.md` promise "only participants can read or post," but **no `AccessPolicy`/`#[PolicyAttribute]` existed** for the thread entities, so nothing enforced it. New `MessagingAccessPolicy` (implements `AccessPolicyInterface` + `FieldAccessPolicyInterface`, `#[PolicyAttribute(['message_thread','thread_message','thread_participant'])]`) enforces it: **reads** are gated by `access('view')` (a `message_thread`/`thread_message`/`thread_participant` is viewable only by a participant of its thread — `JsonApiController::index()/show()` already filter on `view`), and **posts/edits** by `fieldAccess('edit')` returning **Forbidden** unless the account is a participant of the message's `thread_id` (`store()` runs the field-edit check on the constructed message, which carries `thread_id` — the only create-time hook that sees the target thread). Creating a new thread is open to any authenticated account; `administer content` bypasses. Participation is resolved with an `accessCheck(false)` system query against `thread_participant`; the `EntityTypeManager` is injected by the kernel's policy dependency resolver (nullable → fail-closed standalone). `messaging` now declares its `waaseyaa/access` dependency. Acceptance: `MessagingAccessPolicyTest::{a_participant_can_read_a_thread_message_but_an_outsider_cannot, an_outsider_cannot_post_to_a_thread}` (both verified to fail with no policy registered, the pre-fix state).
+
 ## [0.1.0-alpha.247] - 2026-06-22
 
 ### Fixed

--- a/docs/specs/messaging.md
+++ b/docs/specs/messaging.md
@@ -1,5 +1,6 @@
 # Messaging — L3 Chat Substrate
 
+<!-- Spec reviewed 2026-06-22 - WP14 (alpha245 security, audit #31): the participant-only access guarantee (only participants can read or post) is now BACKED BY CODE. MessagingAccessPolicy (implements AccessPolicyInterface + FieldAccessPolicyInterface, #[PolicyAttribute(['message_thread','thread_message','thread_participant'])], EntityTypeManager injected by the policy dependency resolver) enforces: read via access('view') participant-only; post/modify via fieldAccess('edit') Forbidden-unless-participant (store() runs the field-edit check on the constructed message, which carries thread_id — the only create-time hook that sees the target thread; createAccess() does not); thread creation via createAccess() for any authenticated account. Admins (administer content) bypass. Participation is checked with an accessCheck(false) system query against thread_participant. Spec text was already accurate; this records that the enforcing code now exists. Acceptance: MessagingAccessPolicyTest. -->
 <!-- Spec reviewed 2026-05-25 - l2-content-types-consolidation-01KSEFTX - WP03 - messaging L3 graduation -->
 
 **Package:** `waaseyaa/messaging`  

--- a/packages/messaging/composer.json
+++ b/packages/messaging/composer.json
@@ -6,6 +6,10 @@
     "repositories": [
         {
             "type": "path",
+            "url": "../access"
+        },
+        {
+            "type": "path",
             "url": "../entity"
         },
         {
@@ -19,6 +23,7 @@
     ],
     "require": {
         "php": ">=8.5",
+        "waaseyaa/access": "^0.1.0-alpha.247",
         "waaseyaa/entity": "^0.1.0-alpha.247",
         "waaseyaa/foundation": "^0.1.0-alpha.247"
     },

--- a/packages/messaging/src/MessagingAccessPolicy.php
+++ b/packages/messaging/src/MessagingAccessPolicy.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Messaging;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\FieldAccessPolicyInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+/**
+ * Participant-only access for direct messaging.
+ *
+ * Backs the README/spec guarantee that "only participants can read or post" with
+ * actual policy code (previously nothing enforced it):
+ *
+ * - **Read** ({@see access()}, `view`) — a `message_thread`, `thread_message`, or
+ *   `thread_participant` is viewable only by an account that is a participant of
+ *   the relevant thread. `JsonApiController::index()/show()` gate reads on
+ *   `check(entity, 'view', account)->isAllowed()`, so non-participant rows are
+ *   filtered out / 403'd.
+ * - **Post / modify** ({@see fieldAccess()}, `edit`) — editing the fields of a
+ *   `thread_message`/`thread_participant` (which is how a message is *created*
+ *   too: `JsonApiController::store()` runs `checkFieldAccess('edit')` on the
+ *   constructed entity, which already carries `thread_id`) is **Forbidden**
+ *   unless the acting account is a participant of that thread. This is the only
+ *   create-time hook that sees the target thread — `createAccess()` does not.
+ *
+ * Creating a brand-new `message_thread` is permitted to any authenticated
+ * account ({@see createAccess()}): a new thread has no participants yet, and the
+ * creator is establishing it. Account holders with `administer content` bypass.
+ *
+ * The {@see EntityTypeManagerInterface} is injected by the kernel's policy
+ * dependency resolver; it is nullable so the policy is constructible standalone,
+ * in which case participation cannot be proven and access fails closed.
+ */
+#[PolicyAttribute(entityType: ['message_thread', 'thread_message', 'thread_participant'])]
+final class MessagingAccessPolicy implements AccessPolicyInterface, FieldAccessPolicyInterface
+{
+    /** @var list<string> */
+    private const TYPES = ['message_thread', 'thread_message', 'thread_participant'];
+
+    public function __construct(
+        private readonly ?EntityTypeManagerInterface $entityTypeManager = null,
+    ) {}
+
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return in_array($entityTypeId, self::TYPES, true);
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return match ($operation) {
+            'view', 'update', 'delete' => $this->isParticipant($this->threadIdFor($entity), $account)
+                ? AccessResult::allowed('Thread participant.')
+                : AccessResult::neutral('Not a thread participant.'),
+            default => AccessResult::neutral('No opinion.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        // createAccess() cannot see the target thread, so per-thread posting is
+        // gated by fieldAccess() on the constructed entity. Here we only block
+        // anonymous writes; the participant check happens at field level.
+        if ($account->isAuthenticated()) {
+            return AccessResult::allowed('Authenticated account.');
+        }
+
+        return AccessResult::neutral('Anonymous accounts cannot write messaging entities.');
+    }
+
+    public function fieldAccess(
+        EntityInterface $entity,
+        string $fieldName,
+        string $operation,
+        AccountInterface $account,
+    ): AccessResult {
+        // Reads are gated by access('view'); field-access is open-by-default for
+        // view. Only restrict edits (which includes create, per store()).
+        if ($operation !== 'edit') {
+            return AccessResult::neutral('Field view handled by entity view access.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::neutral('Admin permission.');
+        }
+
+        // A brand-new message_thread has no participants yet; its creation is
+        // gated by createAccess(), not field-level participation.
+        if ($entity->getEntityTypeId() === 'message_thread') {
+            return AccessResult::neutral('Thread creation/edit is not field-gated.');
+        }
+
+        // thread_message / thread_participant carry a thread_id referencing an
+        // existing thread: only a participant of that thread may post/modify.
+        $threadId = $this->threadIdFor($entity);
+        if ($threadId <= 0) {
+            return AccessResult::neutral('No resolvable thread.');
+        }
+
+        return $this->isParticipant($threadId, $account)
+            ? AccessResult::neutral('Thread participant may post/modify.')
+            : AccessResult::forbidden('Only thread participants may post to or modify this thread.');
+    }
+
+    private function threadIdFor(EntityInterface $entity): int
+    {
+        if ($entity->getEntityTypeId() === 'message_thread') {
+            return (int) $entity->id();
+        }
+
+        return (int) ($entity->get('thread_id') ?? 0);
+    }
+
+    private function isParticipant(int $threadId, AccountInterface $account): bool
+    {
+        if ($threadId <= 0 || $this->entityTypeManager === null) {
+            return false;
+        }
+
+        try {
+            // System integrity query (the policy IS the access boundary), so it
+            // opts out of the per-query account gate via accessCheck(false).
+            $ids = $this->entityTypeManager->getStorage('thread_participant')->getQuery()
+                ->accessCheck(false)
+                ->condition('thread_id', $threadId)
+                ->condition('user_id', (int) $account->id())
+                ->range(0, 1)
+                ->execute();
+
+            return $ids !== [];
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/packages/messaging/tests/Unit/MessagingAccessPolicyTest.php
+++ b/packages/messaging/tests/Unit/MessagingAccessPolicyTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Messaging\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+use Waaseyaa\Messaging\MessagingAccessPolicy;
+
+/**
+ * The README/spec promise that "only participants can read or post". These tests
+ * exercise that promise through the same EntityAccessHandler surface the
+ * JSON:API controller uses: `check(..., 'view')` for reads, `checkFieldAccess(...,
+ * 'edit')` for posts/edits (store() runs the field check on the constructed
+ * message, which already carries thread_id).
+ */
+#[CoversClass(MessagingAccessPolicy::class)]
+final class MessagingAccessPolicyTest extends TestCase
+{
+    private const THREAD_ID = 1;
+    private const PARTICIPANT_UID = 100;
+    private const OUTSIDER_UID = 200;
+
+    #[Test]
+    public function a_participant_can_read_a_thread_message_but_an_outsider_cannot(): void
+    {
+        $handler = $this->handler();
+        $message = $this->threadMessage(self::THREAD_ID);
+
+        self::assertTrue(
+            $handler->check($message, 'view', $this->account(self::PARTICIPANT_UID))->isAllowed(),
+            'A thread participant must be able to read the message.',
+        );
+        self::assertFalse(
+            $handler->check($message, 'view', $this->account(self::OUTSIDER_UID))->isAllowed(),
+            'A non-participant must NOT be able to read the message.',
+        );
+    }
+
+    #[Test]
+    public function an_outsider_cannot_post_to_a_thread(): void
+    {
+        // store() runs checkFieldAccess('edit') on the constructed message, which
+        // carries the target thread_id — the only create-time hook that sees it.
+        $handler = $this->handler();
+        $message = $this->threadMessage(self::THREAD_ID);
+
+        self::assertTrue(
+            $handler->checkFieldAccess($message, 'body', 'edit', $this->account(self::OUTSIDER_UID))->isForbidden(),
+            'A non-participant must NOT be able to post to the thread.',
+        );
+        self::assertFalse(
+            $handler->checkFieldAccess($message, 'body', 'edit', $this->account(self::PARTICIPANT_UID))->isForbidden(),
+            'A participant must be able to post to the thread.',
+        );
+    }
+
+    #[Test]
+    public function any_authenticated_account_may_start_a_new_thread_but_anonymous_may_not(): void
+    {
+        $policy = new MessagingAccessPolicy($this->entityTypeManager());
+
+        self::assertTrue($policy->createAccess('message_thread', 'message_thread', $this->account(self::OUTSIDER_UID, authenticated: true))->isAllowed());
+        self::assertFalse($policy->createAccess('message_thread', 'message_thread', $this->account(0, authenticated: false))->isAllowed());
+    }
+
+    private function handler(): EntityAccessHandler
+    {
+        return new EntityAccessHandler([new MessagingAccessPolicy($this->entityTypeManager())]);
+    }
+
+    /** EntityTypeManager whose thread_participant query returns a row only for (THREAD_ID, PARTICIPANT_UID). */
+    private function entityTypeManager(): EntityTypeManagerInterface
+    {
+        $captured = ['thread_id' => null, 'user_id' => null];
+
+        $query = $this->createMock(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
+        $query->method('range')->willReturnSelf();
+        $query->method('condition')->willReturnCallback(
+            function (string $field, mixed $value) use (&$captured, $query): EntityQueryInterface {
+                $captured[$field] = $value;
+
+                return $query;
+            },
+        );
+        $query->method('execute')->willReturnCallback(
+            function () use (&$captured): array {
+                return ((int) $captured['thread_id'] === self::THREAD_ID
+                    && (int) $captured['user_id'] === self::PARTICIPANT_UID) ? ['1'] : [];
+            },
+        );
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+
+        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm->method('getStorage')->willReturn($storage);
+
+        return $etm;
+    }
+
+    private function threadMessage(int $threadId): EntityInterface
+    {
+        $entity = $this->createMock(EntityInterface::class);
+        $entity->method('getEntityTypeId')->willReturn('thread_message');
+        $entity->method('bundle')->willReturn('');
+        $entity->method('get')->willReturnCallback(
+            static fn (string $f): mixed => $f === 'thread_id' ? $threadId : null,
+        );
+
+        return $entity;
+    }
+
+    private function account(int $uid, bool $authenticated = true): AccountInterface
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('id')->willReturn($uid);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('isAuthenticated')->willReturn($authenticated);
+
+        return $account;
+    }
+}


### PR DESCRIPTION
## Summary

The messaging README and `docs/specs/messaging.md` promise **"only participants can read or post,"** but **no `AccessPolicy` / `#[PolicyAttribute]` existed** for the thread entities ([README.md:9](packages/messaging/README.md#L9)) — the security guarantee was unbacked by code (audit #31).

## Fix

New `MessagingAccessPolicy` implements **both** `AccessPolicyInterface` and `FieldAccessPolicyInterface`, attributed `#[PolicyAttribute(['message_thread', 'thread_message', 'thread_participant'])]` (auto-discovered by the kernel):

- **Read** — `access('view')` allows a `message_thread`/`thread_message`/`thread_participant` only for a **participant** of its thread. `JsonApiController::index()`/`show()` already gate reads on `check(entity, 'view', account)->isAllowed()`, so non-participant rows are filtered / 403'd.
- **Post / modify** — `fieldAccess('edit')` returns **Forbidden** unless the account is a participant of the message's `thread_id`. This is the create-time hook that works: `store()` constructs the entity *with* the submitted `thread_id` and runs `checkFieldAccess('edit')` on it — whereas `createAccess()` never sees the target thread.
- **New thread** — `createAccess()` allows any **authenticated** account (a new thread has no participants yet; the creator establishes it). `administer content` bypasses all.

Participation is resolved with an `accessCheck(false)` system query against `thread_participant` (`thread_id` + `user_id`). The `EntityTypeManager` is injected by the kernel's policy dependency resolver (nullable → **fail-closed** when constructed standalone). `messaging` now declares its previously-undeclared `waaseyaa/access` dependency. The README/spec text was already accurate — this ships the enforcing code.

## Test-first

`MessagingAccessPolicyTest` — both **verified to fail against the no-policy (pre-fix) state**:

- `a_participant_can_read_a_thread_message_but_an_outsider_cannot` — pre-fix: a participant's `view` is *not* allowed (no policy → Neutral), and an outsider's is also not (broken + claim false).
- `an_outsider_cannot_post_to_a_thread` — pre-fix: an outsider's `edit` is *not* Forbidden (open-by-default → could post).

Plus `any_authenticated_account_may_start_a_new_thread_but_anonymous_may_not`. Full `messaging` suite: 16 green; repo-root `tests/Integration` 962 green (policy auto-discovers + boots).

## Gates

- `composer cs-check` + `composer phpstan -- packages/messaging/src` clean
- `bin/check-package-layers`, `bin/check-composer-policy`, `composer validate` OK
- drift exit 0 (`docs/specs/messaging.md` review note added; messaging unmapped → advisory); changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)