### PR TITLE
WP18: label three built-but-unwired features honestly (inertia partial-reload, note-ingestion, ingestion pkg)

### DIFF
--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -12,9 +12,17 @@ Server-side Inertia.js v3 protocol adapter. A controller returns
 Inertia page object. `InertiaMiddleware` reads the `X-Inertia-*` headers to tell an
 initial full-page load (HTML via `RootTemplateRenderer`) from an XHR navigation (JSON
 page object), and returns `409` + `X-Inertia-Location` on an asset-version mismatch.
-`OptionalProp` / `PropResolver` defer expensive props so partial reloads (`only` /
-`except`) recompute only requested keys. Implements the foundation contracts
-`InertiaPageResultInterface` and `InertiaFullPageRendererInterface`.
+Implements the foundation contracts `InertiaPageResultInterface` and
+`InertiaFullPageRendererInterface`.
+
+> **Partial reloads are not yet wired (experimental).** `OptionalProp` and
+> `PropResolver` are provided as standalone building blocks for deferring expensive
+> props (`PropResolver::resolve($props, $only, $except)`), but nothing in this package
+> invokes them: `InertiaMiddleware` reads only `X-Inertia` / `X-Inertia-Version` (not
+> the `X-Inertia-Partial-Data` partial-reload header), and `InertiaResponse` carries the
+> full prop set unchanged. So a partial reload currently returns **all** props, not just
+> the requested keys. Honoring `only` / `except` automatically is unbuilt — call
+> `PropResolver` directly in a controller if you need it today.
 
 ## Install
 

--- a/packages/ingestion/README.md
+++ b/packages/ingestion/README.md
@@ -7,3 +7,5 @@ Payload validation and ingestion utilities for Waaseyaa applications.
 `EnvelopeValidator` enforces the canonical ingestion envelope shape (envelope version, source identification, dedupe key, payload, signature); `PayloadValidatorInterface` is the per-domain hook for content-specific validation. `ValidationResult` carries structured error codes — `ENVELOPE_*`, `PAYLOAD_SCHEMA_NOT_FOUND`, `PAYLOAD_SCHEMA_LOAD_FAILED`, etc. — for editorial dashboard surfacing rather than free-form strings.
 
 Key classes: `EnvelopeValidator`, `PayloadValidatorInterface`, `ValidationResult`.
+
+> **No framework consumer yet.** These validators are self-contained and unit-tested, but **nothing in the framework currently depends on or invokes this package** — no other package requires `waaseyaa/ingestion`, and no provider, route, or CLI wires `EnvelopeValidator`/`PayloadValidatorInterface`. It is a standalone building block an application can adopt directly, not a wired pipeline. (Note: the foundation-layer ingestion pipeline described in `docs/specs/ingestion-defaults.md` is a separate `Waaseyaa\Foundation\Ingestion\*` stack, not this package.)

--- a/packages/note/README.md
+++ b/packages/note/README.md
@@ -7,3 +7,7 @@ Note entity type for Waaseyaa applications.
 Defines the `note` entity type for lightweight, unstructured content entries (e.g. editorial annotations, internal notes). Simpler than `node` — no bundles, no editorial workflow. See `docs/specs/ingestion-defaults.md` for ingestion context.
 
 Key classes: `Note`, `NoteAccessPolicy`, `NoteServiceProvider`.
+
+## Ingestion (`Note\Ingestion\*`) — experimental, not wired
+
+The `Note\Ingestion\` classes (`NoteIngester`, `IngestionEnvelope`, `IngestionEnvelopeValidator`, `ValidationError`) build a `note` entity from a validated ingestion envelope. They are **experimental and not wired into any runtime path** — no service provider, route, CLI command, or queue handler constructs `NoteIngester` or calls `->ingest()`; only the package's own unit tests and `tests/Integration/Phase19/NoteIngestionIntegrationTest.php` exercise them. The `ingestion.envelope` **schema** itself is live but marked `experimental` (registered in `defaults/ingestion.envelope.schema.json`, surfaced by the `schema:list` CLI). To ingest a note today you must call `NoteIngester` directly; there is no end-to-end ingestion entry point.


### PR DESCRIPTION
## What

README-only corrections so three features' docs match the code. No code change. Grounded in reference checks.

### 1. inertia partial-reload — was over-claimed

README claimed *"`OptionalProp` / `PropResolver` defer expensive props so partial reloads (`only`/`except`) recompute only requested keys."* But:
- `PropResolver`/`OptionalProp` are **unreferenced** by the package (only their own definitions exist — verified).
- `InertiaMiddleware` reads `X-Inertia` / `X-Inertia-Version` only, **not** `X-Inertia-Partial-Data`.
- `InertiaResponse` carries the full prop set; a partial reload returns **all** props.

Reworded to: the classes are standalone building blocks; auto-honoring `only`/`except` is **unbuilt (experimental)** — call `PropResolver` directly if you need it.

### 2. note-ingestion impl — experimental, not wired

`Note\Ingestion\*` (`NoteIngester`, `IngestionEnvelope`, `IngestionEnvelopeValidator`) is **not wired** — no provider/route/CLI/queue constructs `NoteIngester` or calls `->ingest()` (only its own unit tests + `Phase19/NoteIngestionIntegrationTest`). The `ingestion.envelope` **schema** is live but `experimental` (in `defaults/`, surfaced by `schema:list`). Added an honest "experimental, not wired" section to the note README.

### 3. ingestion package — no consumer yet (not broken)

`EnvelopeValidator`/`PayloadValidatorInterface`/`ValidationResult` are self-contained + unit-tested, but **nothing in the framework requires or wires `waaseyaa/ingestion`** (verified: no dependents). Noted "no consumer yet — a standalone building block," and disambiguated it from the separate `Waaseyaa\Foundation\Ingestion\*` pipeline documented in `ingestion-defaults.md`.

## Scope note

`media` version/CAS and `ai-observability` trace are **deliberately excluded** — investigation showed they are *actually wired* (entity types, subscribers, bindings, listeners), not unwired. Labeling them "unwired" would be the opposite claim-mismatch. They get a light claim-check + tracked-gap issues separately.

## Verification

Doc-only (3 READMEs). All three claims verified against code. changelog-discipline + spec-drift are exempt (READMEs aren't `src`/mapped source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)