### PR TITLE
WP18: note ai-observability trace recording is dormant (no producer)

### DIFF
--- a/packages/ai-observability/README.md
+++ b/packages/ai-observability/README.md
@@ -1,7 +1,11 @@
 # waaseyaa/ai-observability
 
-Trace recording, cost tracking, budget enforcement, outcome logging, and anomaly detection for the Waaseyaa agentic framework.
+Cost tracking, budget enforcement, outcome logging, and anomaly detection for the Waaseyaa agentic framework, plus a (currently dormant) trace recorder.
 
 Layer 5 (AI). Zero dependencies on other AI packages.
+
+The **cost / outcome / metrics** path is wired and live: `AgentRunTelemetryListener` (subscribed in `AgentTelemetryServiceProvider::boot()`) consumes the `AgentRun*` lifecycle events that `ai-agent` fires (`AgentExecutor`, `RunAgentHandler`) and feeds metrics + Telescope; `LlmCallListener` feeds the cost accountant.
+
+> **Trace recording is not active yet.** `TraceRecorderInterface` is bound to `TraceRecorder` (and `NullTraceRecorder` when disabled), but **no production code calls `TraceRecorder::startTrace()`** — nothing opens a trace, so the trace engine is dormant. This is a known functional gap tracked in [#1743](https://github.com/waaseyaa/framework/issues/1743) for a post-beta pass; it does not affect the cost/outcome telemetry above.
 
 See the design at `docs/history/superpowers/specs/2026-04-14-ai-observability-design.md`.


### PR DESCRIPTION
## What

Light claim-check correction (WP18) to `packages/ai-observability/README.md`. Doc-only.

The README led with *"Trace recording, cost tracking, budget enforcement, outcome logging, and anomaly detection."* Investigation:

- **Cost / outcome / metrics — wired and live.** `AgentRunTelemetryListener` (subscribed in `AgentTelemetryServiceProvider::boot()`) consumes the `AgentRun*` events `ai-agent` fires (`AgentExecutor`, `RunAgentHandler`) → metrics + Telescope; `LlmCallListener` → cost accountant.
- **Trace recording — dormant.** `TraceRecorderInterface` is bound to `TraceRecorder` (`NullTraceRecorder` when disabled), but **no production code calls `TraceRecorder::startTrace()`** — the only references are the binding + `TraceHandle`'s docblock. Nothing opens a trace.

So only the *"trace recording"* claim over-states reality. Reworded the summary to demote it to "(currently dormant)" and added an explicit note linking the tracked gap.

## Tracked gaps (NOT fixed here — post-beta functional pass)

- [#1743](https://github.com/waaseyaa/framework/issues/1743) — ai-observability `TraceRecorder` has no production producer.
- [#1742](https://github.com/waaseyaa/framework/issues/1742) — media versioning/CAS trigger dormant (`setPendingUpload` uncalled) + per-request in-memory pending store (latent data loss). The **media README is intentionally unchanged** — it makes no versioning claim, so there is no over-claim to retract.

## Verification

Doc-only. The cost/outcome/metrics wiring claims left intact are grounded in `AgentTelemetryServiceProvider` + the listeners; the dormant-trace claim is grounded in the absence of any `startTrace()` caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)