### PR TITLE
WP18: README claim-mismatch sweep (geo, validation, github, http-client)

### DIFF
--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -2,8 +2,8 @@
 
 **Layer 0 — Foundation**
 
-Geospatial utilities for Waaseyaa: distance calculations, coordinate helpers.
+Geospatial utilities for Waaseyaa: great-circle distance calculation.
 
-`GeoDistance` ships haversine and equirectangular approximations for lat/lon pairs in metres or kilometres, plus a small set of coordinate parsers for common formats. Pure utility — no storage, no service, no global state.
+`GeoDistance::haversine($lat1, $lon1, $lat2, $lon2)` returns the great-circle distance between two lat/lon points **in kilometres**, using the Haversine formula. That is currently the package's only utility — there is no equirectangular variant, no metres option, and no coordinate parsers (despite earlier docs). Pure utility — no storage, no service, no global state.
 
 Key classes: `GeoDistance`, `GeoServiceProvider`.

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -4,6 +4,6 @@
 
 GitHub API client for issues, milestones, and pull requests.
 
-`GitHubClient` wraps the REST v3 endpoints used by repo automation tooling: list issues, create/edit milestones, comment on PRs. `Issue`, `Milestone`, and `PullRequest` are typed value objects rather than raw arrays. Authentication is via personal access token or GitHub App installation token passed at construction.
+`GitHubClient` wraps the REST v3 endpoints used by repo automation tooling. Reads: `getIssue`, `listIssues`, `getMilestone`, `listMilestones`. Writes: `createComment` (comment on an issue or PR), `updateIssueState` (close/reopen), `createPullRequest` (open a PR). Milestones are **read-only** — there is no create/edit-milestone method. `Issue`, `Milestone`, and `PullRequest` are typed value objects rather than raw arrays. Authentication is via personal access token or GitHub App installation token passed at construction.
 
 Key classes: `GitHubClient`, `Issue`, `Milestone`, `PullRequest`, `GitHubException`.

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -4,6 +4,6 @@
 
 Minimal HTTP client for JSON APIs and webhooks.
 
-`HttpClientInterface` defines the GET/POST/PUT/DELETE/PATCH surface; `StreamHttpClient` is the production implementation backed by PHP streams. Returns `HttpResponse` value objects (no shared state) and throws `HttpRequestException` on transport failures. Designed as an injectable seam — tests replace `HttpClientInterface` with a fake rather than mocking PHP's stream layer.
+`HttpClientInterface` exposes a generic `request(string $method, string $url, …)` plus `get()` / `post()` convenience helpers — other verbs (PUT/DELETE/PATCH/…) go through `request()`; there are no dedicated `put()`/`delete()`/`patch()` methods. `StreamHttpClient` is the production implementation backed by PHP streams. Returns `HttpResponse` value objects (no shared state) and throws `HttpRequestException` on transport failures. Designed as an injectable seam — tests replace `HttpClientInterface` with a fake rather than mocking PHP's stream layer.
 
 Key classes: `HttpClientInterface`, `StreamHttpClient`, `HttpResponse`, `HttpRequestException`.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -4,6 +4,6 @@
 
 Input validation for Waaseyaa applications.
 
-Wraps Symfony Validator with Waaseyaa conventions for validating request data, entity field values, and configuration inputs. Provides a `ValidatorInterface` and constraint set aligned with the typed-data layer.
+Builds on Symfony Validator (`symfony/validator`) with a set of Waaseyaa-specific constraints for validating request data, entity field values, and configuration inputs. The package ships **constraints + a factory**, not a wrapper validator: there is no `ValidatorInterface`/`ValidationResult`/`ValidationViolation` here — you run the constraints through Symfony's own `Validator` (which returns Symfony `ConstraintViolation`s).
 
-Key classes: `ValidatorInterface`, `ValidationResult`, `ValidationViolation`.
+Key classes: `ConstraintFactory`, and the constraint set under `Constraint/` — `AllowedValues`, `EntityExists`, `NotEmpty`, `SafeMarkup`, `UniqueField` (each with its paired `*Validator`).


### PR DESCRIPTION
## What

Corrects aspirational README claims to match code across the WP18 `owned_files`. Doc-only; each correction grounded in the source.

| Package | Claim | Reality | Fix |
|---|---|---|---|
| **geo** | "haversine **and equirectangular** … in **metres or kilometres**, plus **coordinate parsers**" | `GeoDistance` has **only** `haversine()` returning **km** | km-haversine only; no equirectangular/metres/parsers |
| **validation** | "Provides a `ValidatorInterface`"; Key classes `ValidatorInterface`/`ValidationResult`/`ValidationViolation` | src is **only** `Constraint/` + `ConstraintFactory.php` — those classes **don't exist** | ships constraints + factory on Symfony Validator (dep confirmed); run via Symfony's `Validator` |
| **github** | "**create/edit milestones**" | **no** milestone-write method (only `getMilestone`/`listMilestones`) | reads + real writes (`createComment`/`updateIssueState`/`createPullRequest`); milestones read-only |
| **http-client** | "GET/POST/**PUT/DELETE/PATCH** surface" | interface is `request()` + `get()`/`post()` only | `request()` for any verb + get/post helpers |

**Left unchanged (verified accurate):** `groups` (README correctly attributes `addBundleFields` to `EntityTypeManager`; `MISSING_BUNDLE_SUBTABLE` is emitted by `HealthChecker`/`DiagnosticCode`) and `i18n` (the `AcceptHeaderNegotiator`/`UrlPrefixNegotiator` are used by SSR's `LanguageResolver`).

**Security check:** none of these are security guarantees-without-code (the `validation` package's `SafeMarkup` constraint *does* have backing code). No redaction-style flag needed.

## Verification

Doc-only (4 READMEs). Each fix verified against the package source (method lists / `src/` listing / composer deps). changelog-discipline + spec-drift are exempt (READMEs aren't `src`/mapped source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)