### PR TITLE
fix(taxonomy): honor published status on term view (audit Medium — unpublished terms leaked)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unpublished taxonomy terms no longer leak to general readers — `TermAccessPolicy` ignored the term's published status (audit Medium, live-HTTP reachable).** `Term` carries a `status` (Published) boolean (`Term::isPublished()`), but `TermAccessPolicy::checkViewAccess()` gated `view` purely on the `access content` permission and never consulted `status` — so an **unpublished** term was viewable by any account with `access content` (including anonymous, on the `view`-gated read surfaces: JSON:API `taxonomy_term` collections, controllers). `checkViewAccess()` now mirrors `NodeAccessPolicy`'s published/unpublished split: a published term stays viewable with `access content`; an **unpublished** term is viewable only by an editor of its vocabulary (`edit terms in {vid}`) or an `administer taxonomy` admin (absent `status` still defaults to published, matching `Term::isPublished()`). Acceptance: `TermAccessPolicyTest::{testViewOfUnpublishedTermIsDeniedToAccessContentOnly, testViewOfUnpublishedTermAllowedForVocabularyEditor, testViewOfPublishedTermStillAllowedWithAccessContent}` (the leak case verified to return `allowed` against the pre-fix code).
+
 ## [0.1.0-alpha.248] - 2026-06-23
 
 ### Fixed

--- a/packages/taxonomy/src/TermAccessPolicy.php
+++ b/packages/taxonomy/src/TermAccessPolicy.php
@@ -38,7 +38,7 @@ final class TermAccessPolicy implements AccessPolicyInterface
         }
 
         return match ($operation) {
-            'view' => $this->checkViewAccess($account),
+            'view' => $this->checkViewAccess($entity, $account),
             'update' => $this->checkEditAccess($entity, $account),
             'delete' => $this->checkDeleteAccess($entity, $account),
             default => AccessResult::neutral("No opinion for operation '{$operation}'."),
@@ -63,14 +63,34 @@ final class TermAccessPolicy implements AccessPolicyInterface
 
     /**
      * Check view access for a taxonomy term.
+     *
+     * Published terms are viewable with 'access content' (the public reading
+     * permission). Unpublished terms are hidden from general readers — only an
+     * editor of the term's vocabulary (or an `administer taxonomy` admin, handled
+     * in {@see access()}) may view them. This mirrors NodeAccessPolicy's
+     * published/unpublished split so unpublished terms do not leak via the
+     * `view`-gated read surfaces (JSON:API collections, controllers).
      */
-    private function checkViewAccess(AccountInterface $account): AccessResult
+    private function checkViewAccess(EntityInterface $entity, AccountInterface $account): AccessResult
     {
-        if ($account->hasPermission('access content')) {
-            return AccessResult::allowed('User has "access content" permission.');
+        // Absent status defaults to published — mirrors Term::isPublished().
+        $published = (bool) ($entity->get('status') ?? true);
+
+        if ($published) {
+            if ($account->hasPermission('access content')) {
+                return AccessResult::allowed('Published term and user has "access content" permission.');
+            }
+
+            return AccessResult::neutral('User lacks "access content" permission.');
         }
 
-        return AccessResult::neutral('User lacks "access content" permission.');
+        // Unpublished term: visible only to an editor of its vocabulary.
+        $vid = $entity->bundle();
+        if ($account->hasPermission("edit terms in {$vid}")) {
+            return AccessResult::allowed("Editor with \"edit terms in {$vid}\" may view its unpublished terms.");
+        }
+
+        return AccessResult::neutral('User cannot view this unpublished term.');
     }
 
     /**

--- a/packages/taxonomy/tests/Unit/TermAccessPolicyTest.php
+++ b/packages/taxonomy/tests/Unit/TermAccessPolicyTest.php
@@ -36,11 +36,15 @@ class TermAccessPolicyTest extends TestCase
         return $account;
     }
 
-    private function createTermEntity(string $vocabularyId = 'tags'): EntityInterface
+    private function createTermEntity(string $vocabularyId = 'tags', ?bool $published = null): EntityInterface
     {
         $entity = $this->createMock(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('taxonomy_term');
         $entity->method('bundle')->willReturn($vocabularyId);
+        // Mirror Term::isPublished() — absent status defaults to published (true).
+        $entity->method('get')->willReturnCallback(
+            static fn(string $field): mixed => $field === 'status' ? $published : null,
+        );
 
         return $entity;
     }
@@ -98,6 +102,40 @@ class TermAccessPolicyTest extends TestCase
         $result = $this->policy->access($entity, 'view', $account);
 
         $this->assertTrue($result->isAllowed());
+    }
+
+    // --- Unpublished-term view (security: must not leak unpublished terms) ---
+
+    public function testViewOfUnpublishedTermIsDeniedToAccessContentOnly(): void
+    {
+        // An unpublished term must NOT be viewable by an anonymous/regular account
+        // that holds only 'access content' — pre-fix this returned allowed (leak).
+        $entity = $this->createTermEntity('tags', published: false);
+        $account = $this->createAccount(['access content']);
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        $this->assertTrue($result->isNeutral(), 'unpublished term must not be viewable with only access content');
+    }
+
+    public function testViewOfUnpublishedTermAllowedForVocabularyEditor(): void
+    {
+        $entity = $this->createTermEntity('tags', published: false);
+        $account = $this->createAccount(['access content', 'edit terms in tags']);
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        $this->assertTrue($result->isAllowed(), 'an editor of the vocabulary may view its unpublished terms');
+    }
+
+    public function testViewOfPublishedTermStillAllowedWithAccessContent(): void
+    {
+        $entity = $this->createTermEntity('tags', published: true);
+        $account = $this->createAccount(['access content']);
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        $this->assertTrue($result->isAllowed(), 'published terms remain viewable with access content');
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Finding (audit Medium, live-HTTP reachable)

`TermAccessPolicy::checkViewAccess()` gated `view` purely on the `access content` permission and **never consulted the term's published status** — even though `Term` carries a `status` (Published) boolean (`Term.php:33`, `Term::isPublished()`). So an **unpublished** taxonomy term was viewable by any account with `access content`, including anonymous, on the `view`-gated read surfaces (JSON:API `taxonomy_term` collections, controllers).

## Fix (grounded in the existing policy layer)

`checkViewAccess($entity, $account)` now mirrors `NodeAccessPolicy`'s published/unpublished split:
- **published** term → viewable with `access content` (unchanged);
- **unpublished** term → viewable only by an editor of its vocabulary (`edit terms in {vid}`) or an `administer taxonomy` admin;
- absent `status` defaults to published (matches `Term::isPublished()`).

No new engine, no BC shim — just the missing status check on the existing policy.

## Failing-first

`TermAccessPolicyTest::testViewOfUnpublishedTermIsDeniedToAccessContentOnly` returns **allowed** (the leak) against the pre-fix code; passes after. Added editor-can-view + published-still-viewable cases.

## Verification

`TermAccessPolicyTest` 27 / full taxonomy suite 108 — green. cs + phpstan clean. No release cut (accumulating on main per the sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)