### PR TITLE
docs(cli): correct ImportRollbackCommand docblock — reverse last-imported, not reverse-creation (C-27)

### DIFF
--- a/packages/cli/src/Command/Import/ImportRollbackCommand.php
+++ b/packages/cli/src/Command/Import/ImportRollbackCommand.php
@@ -18,8 +18,11 @@ use Waaseyaa\Migration\Runner\RollbackWalker;
  *
  * Destructive operation: requires `--confirm` to proceed. Without it, the
  * command prints a count and a hint and exits 0 (no-op preview). With it,
- * the {@see RollbackWalker} walks the id-map in reverse-creation order
- * (FR-043), asks the destination plugin to delete each entity (FR-041),
+ * the {@see RollbackWalker} walks the id-map in reverse last-imported order
+ * (FR-043 — `last_imported_at DESC`, tie-broken by `last_run_id DESC`; the
+ * id-map carries no immutable creation-order column, and `upsert()` refreshes
+ * `last_imported_at` on every re-import), asks the destination plugin to delete
+ * each entity (FR-041),
  * and drops the id-map row on success.
  *
  * Best-effort semantics (FR-044): per-record failures are captured in
@@ -36,7 +39,7 @@ use Waaseyaa\Migration\Runner\RollbackWalker;
  * @api
  *
  * @spec FR-035 — `import:rollback` entry point
- * @spec FR-043 — reverse-creation walk
+ * @spec FR-043 — reverse last-imported walk
  * @spec FR-044 — best-effort per-record rollback
  * @spec FR-061 — per-migration concurrency lock
  */


### PR DESCRIPTION
Docblock-only claim-vs-code correction (no behavior change). `ImportRollbackCommand`'s docblock claimed `import:rollback` walks the id-map in *reverse-creation order*, but FR-043 (spec) and the `RollbackWalker` both define it as reverse **last-imported** order (`last_imported_at DESC`, tie-broken by `last_run_id DESC`) — the id-map has no immutable creation-order column and `upsert()` refreshes `last_imported_at` on every re-import. The two stale mentions (class docblock + the FR-043 @spec line) now match the spec and the walker's own docblocks.

no-changelog: docblock-only claim-vs-code correction, no behavior/contract change (the spec already documents reverse last-imported order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)