### PR TITLE
test(listing): guard the C-28 pagination pushdown — fast path must push SQL count + bounded findBy

### DIFF
--- a/packages/listing/tests/Contract/Fixtures/FastPathArticlePolicy.php
+++ b/packages/listing/tests/Contract/Fixtures/FastPathArticlePolicy.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Listing\Tests\Contract\Fixtures;
+
+use Waaseyaa\Access\Gate\ListingFastPathProbeInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+
+/**
+ * Allow-all `article` policy that OPTS INTO the listing access fast-path by
+ * declaring {@see ListingFastPathProbeInterface::FAST_PATH_CONST} = true.
+ *
+ * With this policy bound, the resolver's `canUseAccessFastPath()` returns true
+ * for the default `{'view'}` access ops, so a paged, exact-total listing pushes
+ * pagination down to the driver (SQL `count()` + bounded `findBy()`) instead of
+ * hydrating every row. Mirrors a production policy that has reviewed its row
+ * access as expressible purely through the listing's filters.
+ */
+#[PolicyAttribute(entityType: 'article')]
+final class FastPathArticlePolicy
+{
+    public const bool SUPPORTS_LISTING_FAST_PATH = true;
+
+    public function view(?object $user, mixed $subject): bool
+    {
+        return true;
+    }
+
+    public function update(?object $user, mixed $subject): bool
+    {
+        return true;
+    }
+
+    public function delete(?object $user, mixed $subject): bool
+    {
+        return true;
+    }
+
+    public function translate(?object $user, mixed $subject): bool
+    {
+        return true;
+    }
+}

--- a/packages/listing/tests/Contract/Fixtures/SpyStorageDriver.php
+++ b/packages/listing/tests/Contract/Fixtures/SpyStorageDriver.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Listing\Tests\Contract\Fixtures;
+
+use Waaseyaa\EntityStorage\Driver\EntityStorageDriverInterface;
+
+/**
+ * Records `count()` + `findBy()` calls (and the `$limit` each findBy received)
+ * while delegating everything to an inner driver.
+ *
+ * Used to assert the listing access fast-path actually pushes pagination down to
+ * the driver — a SQL `count()` plus a bounded `findBy()` — instead of hydrating
+ * the whole result set and counting/slicing in PHP (audit C-28). A regression
+ * that silently fell back to full hydration would otherwise pass unnoticed: the
+ * returned rows/total are identical either way; only the call pattern differs.
+ */
+final class SpyStorageDriver implements EntityStorageDriverInterface
+{
+    public int $countCalls = 0;
+
+    /** @var list<int|null> the `$limit` argument of each findBy() call, in order */
+    public array $findByLimits = [];
+
+    public function __construct(private readonly EntityStorageDriverInterface $inner) {}
+
+    public function count(string $entityType, array $criteria = []): int
+    {
+        $this->countCalls++;
+
+        return $this->inner->count($entityType, $criteria);
+    }
+
+    public function findBy(
+        string $entityType,
+        array $criteria = [],
+        ?array $orderBy = null,
+        ?int $limit = null,
+    ): array {
+        $this->findByLimits[] = $limit;
+
+        return $this->inner->findBy($entityType, $criteria, $orderBy, $limit);
+    }
+
+    public function read(string $entityType, string $id, ?string $langcode = null): ?array
+    {
+        return $this->inner->read($entityType, $id, $langcode);
+    }
+
+    public function readMultiple(string $entityType, array $ids, ?string $langcode = null): array
+    {
+        return $this->inner->readMultiple($entityType, $ids, $langcode);
+    }
+
+    public function write(string $entityType, string $id, array $values): string
+    {
+        return $this->inner->write($entityType, $id, $values);
+    }
+
+    public function remove(string $entityType, string $id): void
+    {
+        $this->inner->remove($entityType, $id);
+    }
+
+    public function exists(string $entityType, string $id): bool
+    {
+        return $this->inner->exists($entityType, $id);
+    }
+
+    public function findTranslations(
+        string $entityType,
+        string $id,
+        ?string $defaultLangcode = null,
+    ): array {
+        return $this->inner->findTranslations($entityType, $id, $defaultLangcode);
+    }
+}

--- a/packages/listing/tests/Contract/ListingResolverContract.php
+++ b/packages/listing/tests/Contract/ListingResolverContract.php
@@ -29,6 +29,8 @@ use Waaseyaa\Listing\Sort;
 use Waaseyaa\Listing\Tests\Contract\Fixtures\AllowAllArticlePolicy;
 use Waaseyaa\Listing\Tests\Contract\Fixtures\ArticleEntity;
 use Waaseyaa\Listing\Tests\Contract\Fixtures\DenyEvenIdsArticlePolicy;
+use Waaseyaa\Listing\Tests\Contract\Fixtures\FastPathArticlePolicy;
+use Waaseyaa\Listing\Tests\Contract\Fixtures\SpyStorageDriver;
 use Waaseyaa\Listing\Tests\Contract\Fixtures\TranslatableArticleEntity;
 
 /**
@@ -644,6 +646,70 @@ abstract class ListingResolverContract extends TestCase
 
         // Sentinel — do not fail. Just record the budget.
         self::assertLessThan(5.0, $elapsed, 'access fast-path benchmark sentinel');
+    }
+
+    // ------------------------------------------------------------------
+    // C-28 — pagination pushdown guard (the fast path must push LIMIT + SQL COUNT)
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function fastPathPushesSqlCountAndBoundedFindBy(): void
+    {
+        $inner = $this->createDriver();
+        $rows = [];
+        for ($i = 1; $i <= 50; $i++) {
+            $rows[] = ['id' => (string) $i, 'title' => 't' . $i, 'status' => 1, 'weight' => $i];
+        }
+        $this->seed($inner, 'article', $rows);
+
+        // A fast-path-opted-in policy + a paged, exact-total listing engages the
+        // pushdown branch (resolvePushedPage): SQL count() for the total, bounded
+        // findBy() for the page window — not full hydration + array_slice/count.
+        $spy = new SpyStorageDriver($inner);
+        $resolver = $this->buildResolver($spy, gate: new Gate([new FastPathArticlePolicy()]));
+        $def = new ListingDefinition(id: 'pushed', entityType: 'article', pageSize: 10);
+
+        $result = $resolver->resolve($def);
+
+        self::assertGreaterThan(0, $spy->countCalls, 'fast path must issue a SQL count(), not count() over hydrated rows (C-28).');
+        self::assertNotEmpty($spy->findByLimits);
+        self::assertNotContains(
+            null,
+            $spy->findByLimits,
+            'fast path must push a LIMIT to findBy(), not hydrate the whole result set (C-28).',
+        );
+        // Correctness is preserved: total from the SQL count, page bounded to pageSize.
+        self::assertSame(50, $result->pagination->totalRows);
+        self::assertCount(10, $this->materialise($result));
+    }
+
+    #[Test]
+    public function perRowPolicyDoesNotUseTheFastPath(): void
+    {
+        // A policy that has NOT opted into the fast path keeps the always-correct
+        // per-row access loop: full hydration (unbounded findBy), and the total is
+        // count() over the access-filtered survivors — no SQL count() pushdown.
+        // This pins the contrast so the fast path can't silently become the only
+        // path (which would skip per-row access filtering).
+        $inner = $this->createDriver();
+        $rows = [];
+        for ($i = 1; $i <= 50; $i++) {
+            $rows[] = ['id' => (string) $i, 'title' => 't' . $i, 'status' => 1, 'weight' => $i];
+        }
+        $this->seed($inner, 'article', $rows);
+
+        $spy = new SpyStorageDriver($inner);
+        $resolver = $this->buildResolver($spy, gate: new Gate([new AllowAllArticlePolicy()]));
+        $def = new ListingDefinition(id: 'per_row', entityType: 'article', pageSize: 10);
+
+        $resolver->resolve($def);
+
+        self::assertSame(0, $spy->countCalls, 'a non-opted-in policy must not use the SQL-count fast path.');
+        self::assertContains(
+            null,
+            $spy->findByLimits,
+            'a non-opted-in policy must hydrate the full set (unbounded findBy) so the per-row access loop can run.',
+        );
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## What

A regression guard for **C-28** (already fixed in Wave 4 #1675). `ListingResolver::resolvePushedPage()` pushes a SQL `count()` + a bounded `findBy()` when a fast-path-opted-in policy is bound and the listing is paged with an exact total — but **nothing asserted the pushdown actually happens**. A regression that silently fell back to full hydration would pass unnoticed: rows + total are identical either way, only the driver call-pattern differs.

## How

- `SpyStorageDriver` decorator — records `count()` calls and each `findBy()`'s `$limit`.
- Two contract tests (run on **both** the in-memory and SQLite backends):
  - **`fastPathPushesSqlCountAndBoundedFindBy`** — with a `FastPathArticlePolicy` (`SUPPORTS_LISTING_FAST_PATH = true`), a paged listing issues a SQL `count()` and a `findBy()` with a non-null LIMIT — never an unbounded full-table hydration — while still returning the correct total (50) and a bounded page (10).
  - **`perRowPolicyDoesNotUseTheFastPath`** — a non-opted-in (`AllowAll`) policy keeps the always-correct per-row loop: full hydration (unbounded `findBy`), `count()` over survivors, no SQL-count pushdown. Pins the contrast so the fast path can't silently become the *only* path (which would skip per-row access filtering).

Test-only; fails if the pushdown regresses. Listing contract suite 58/58 green (both backends); cs-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)