### PR TITLE
docs(media): correct source-plugin claim + note media bytes serve from public:// (claim-vs-code)

### DIFF
--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -7,3 +7,9 @@ Media entity type for Waaseyaa applications.
 Defines the `media` entity type for images, documents, and other binary assets. Includes upload handling, file metadata storage, and access policy integration. Managed via the admin SPA and JSON:API endpoint.
 
 Key classes: `Media`, `MediaAccessPolicy`, `MediaServiceProvider`.
+
+## Access scope (important)
+
+`MediaAccessPolicy` gates the media **record** (the entity row) on the JSON:API surface — view/create/update/delete of the `media` entity. It does **not** gate the file **bytes**: uploads are written to the `public://` scheme (`storage/files`, returned as a `/files/<name>` URL) and are served by the host's normal static path, **not** through an access-checked download route. There is currently **no `private://` scheme or authorized-download path for media** (unlike `attachment`, which got `GET /attachment/{id}/download` with deny-by-default access in #1761). So a media entity's access policy does not protect its file contents from direct URL access — do not store sensitive bytes as `public://` media expecting the entity policy to guard them.
+
+The `MediaType.source` plugin id (`file`/`image`/`oembed`) is **metadata only** — the media source-plugin system (resolution, derivatives, gated downloads) is not implemented. Both — the source-plugin substrate and an authorized media download reusing the attachment `PrivateFileStore` — are tracked as a future feature in #1762.

--- a/packages/media/src/MediaType.php
+++ b/packages/media/src/MediaType.php
@@ -10,13 +10,25 @@ use Waaseyaa\Entity\ConfigEntityBase;
  * Defines a media type configuration entity.
  *
  * Media types define the different kinds of media (image, video, file, etc.)
- * that can be created. Each media type is associated with a media source
- * plugin that handles the specific media handling logic.
+ * that can be created.
+ *
+ * NOTE (claim-vs-code): `$source`/`$sourceConfiguration` are stored as METADATA
+ * only. The media source-plugin system they describe — a `MediaSourceInterface`,
+ * a plugin registry, and a resolver that maps a media entity to its file
+ * location — is NOT implemented in this package today: nothing consults `$source`
+ * to handle media, resolve a file URI, or generate thumbnails/derivatives. These
+ * fields exist for forward compatibility; building the substrate (and an
+ * authorized media download, reusing the attachment `PrivateFileStore` from
+ * #1761) is tracked as a future feature in #1762. Do not rely on source-plugin
+ * resolution until then.
  */
 final class MediaType extends ConfigEntityBase
 {
     /**
-     * The media source plugin ID (e.g. 'file', 'image', 'oembed').
+     * The intended media source plugin ID (e.g. 'file', 'image', 'oembed').
+     *
+     * Metadata only — no source-plugin system consumes this yet (see the class
+     * docblock + #1762).
      */
     protected string $source = '';
 


### PR DESCRIPTION
Doc-only claim-vs-code correction (no behavior change). Removes two false/incomplete claims about media so nothing advertises unimplemented source-plugin resolution or implies gated media downloads.

- **`MediaType` docblock** advertised that "each media type is associated with a media source plugin that handles the specific media handling logic." **Not implemented** — there is no `MediaSourceInterface`, registry, or resolver, and nothing consults `MediaType.source`. The docblock now states `source`/`sourceConfiguration` are **metadata only** (forward-compat), not a working mechanism.
- **README** said "access policy integration" without qualifying scope. Clarified: `MediaAccessPolicy` gates the media **record**, not the file **bytes** — uploads are `public://` (served by the host's static `/files` path, not an access-checked route), and there is **no `private://` scheme or authorized media download** (unlike `attachment`, #1761). So a media access policy does **not** protect its file contents from direct URL access.

The media **versions** API (`api-layer.md`) already honestly documents *"Binary-stream download deferred"* + gates version metadata, so no false download claim remained there. Confirmed: no residual false security claim about media downloads.

Both the source-plugin substrate and an authorized media download (reusing the attachment `PrivateFileStore`) are tracked as a **future feature** in #1762 — net-new product work, not remediation.

no-changelog: docblock + README claim-vs-code correction; no behavior, contract, or surface change (the corrected text describes already-current reality).