### PR TITLE
docs(audits): residual security re-sweep ledger + runtime-adapter scoping

### DIFF
--- a/docs/audits/residual-security-sweep-2026-06-23.md
+++ b/docs/audits/residual-security-sweep-2026-06-23.md
@@ -1,0 +1,244 @@
+# Residual Security Re-Sweep — 2026-06-23 (post-C-24)
+
+Adversarial claim-vs-code + reachability sweep run after the C-24 dead-layer
+removal, to answer honestly: *is the reachable defect surface truly exhausted?*
+Method: (1) re-verify the merged security/data-integrity fixes still hold on
+current `main`; (2) a fresh reachability + claim-vs-code pass across all 75
+packages (grouped into 5 buckets); (3) spot-check the audit Mediums that were
+leads-only. Reachable findings are fixed failing-first as their own PRs;
+everything else is recorded here with code evidence and a verdict.
+
+**Grounding note:** findings marked **[confirmed]** were independently
+ground-verified in code by the author. Findings marked **[agent-reported]** come
+from the bucket sweep with the cited file:line evidence but were not yet
+re-derived by hand — they are recorded for triage, not yet acted on.
+
+---
+
+## 0. Regression baseline — the merged fixes still hold
+
+Full `Unit` (8467) + `Integration` (1305) suites are **green on current `main`**,
+and the static gates (dead-code, phpstan, surface-parity, cs, package-layers,
+symfony-imports, composer-policy) pass. Every merged security fix is guarded by a
+regression test in those suites, so a green run is positive evidence that **no
+fix was reverted or regressed**. Spot-checked fix *markers* in code (not just
+tests): C-6 deny-by-default (`SqlEntityQuery:411` uses `isAllowed()`); messaging
+participant policy present; #1648 audit-guard unquoting present; genealogy SSR
+system-context topology present. **No regression found.**
+
+---
+
+## 1. Fixed this sweep (failing-first PRs)
+
+| Finding | Severity | PR | Status |
+|---------|----------|----|--------|
+| `relationship.traverse` agent tool enumerated rows with **no** per-entity view gate; anon-reachable via the default MCP allowlist | High (anon info-disclosure) | #1768 | **merged** |
+| `node` system fields (`uid`/`type`/`created`/`changed`) edit-unprotected → JSON:API mass-assignment on update | High (privilege/integrity) | #1769 | **merged** |
+
+Both **[confirmed]** end-to-end (failing-first tests verified red against pre-fix
+code).
+
+---
+
+## 2. Reachable, fix-recommended (not yet done)
+
+These are framework-owned and reachable; each warrants its own failing-first PR.
+
+### 2.1 `VectorSearchTool` returns results with no per-entity view filter — **[agent-reported]**
+- Evidence: `ai-tools/src/Vector/VectorSearchTool.php:60-97` checks only
+  `requireCapability('tool.vector.search')`, then returns `$storage->search(...)`
+  raw (entity ids + metadata) with no `canViewEntity` filter.
+- Reachability: NOT in the anon allowlist (so not anon-reachable), but reachable
+  by any authenticated initiator granted `tool.vector.search` without `view` on
+  the matched entities. Same class as #1768.
+- Recommendation: apply `canViewEntity()` + `applyFieldAccessFilter()` per result
+  (mirror #1768). Low risk.
+
+### 2.2 Search `totalHits`/`totalPages`/facets leak access-restricted counts + metadata — **[agent-reported]**
+- Evidence: `search/src/Fts5/Fts5SearchProvider.php:100-102` computes `totalHits`
+  via raw `COUNT(*)` with no access predicate; `buildFacets()` (`:281-318`)
+  aggregates `content_type`/`source_name`/`topics` over the unfiltered `WHERE`.
+  Only the per-row `hits` loop applies the checker (`:137-145`). An in-code
+  comment concedes the count "may include documents the caller cannot view."
+- Reachability: exposed to templates via the `search()` Twig function
+  (`SearchTwigExtension`), the intended public-search surface — an anon user
+  varying `q`/filters reads counts + facet buckets as an existence/metadata
+  oracle (row bodies are filtered).
+- Recommendation: filter the count + facet aggregation through the same access
+  predicate as the hit loop, or document + cap. Medium effort.
+
+### 2.3 GraphQL emits `internal: true` fields (no internal-field stripping) — **[agent-reported]**
+- Evidence: every other surface drops internal fields
+  (`api/src/ResourceSerializer.php:33,189`, ai-tools `EntityReadTool.php:167`),
+  but `graphql/src/Schema/EntityTypeBuilder.php:90-149` emits every field and the
+  resolvers (`EntityResolver.php:130-131`) apply only the open-by-default
+  `FieldAccessPolicy`. Known credential fields are saved today only by a
+  *coincident* policy forbid — any entity marking a field `internal:true` without
+  also writing a FieldAccessPolicy forbid leaks via GraphQL while hidden
+  everywhere else. Introspection also discloses internal field *names*.
+- Recommendation: add an internal-field drop + `ALWAYS_INTERNAL_FIELDS` backstop
+  in the GraphQL output builder/resolvers, matching the REST serializer. Medium.
+
+### 2.4 SSR `EntityRenderer` emits all fields with no internal-drop / field filter — **[agent-reported]**
+- Evidence: `ssr/src/EntityRenderer.php:33-78,111-133` formats every field;
+  `entity.html.twig` prints `field.formatted|raw`; no account/access/internal
+  check. The stock content route only resolves `content`-group types (User not
+  reachable today), so no credential leak now — but it is unsafe-by-construction
+  vs its JSON:API/MCP siblings (a content entity with an `internal:true` field
+  leaks). Defense-in-depth fix recommended.
+
+### 2.5 `PathAlias` view ignores its own `status` flag — **[agent-reported]**, low
+- Evidence: `path/src/PathAliasAccessPolicy.php:27-28` returns `allowed` for
+  `view` to everyone with no status check, though `PathAlias` carries a `status`
+  ("active") field. Leaks inactive internal path mappings. Low sensitivity.
+
+### 2.6 Media upload silent overwrite/clobber under predictable public name — **[agent-reported]**, low
+- Evidence: `media/src/Http/MediaRouter.php:84-98` builds the dest from the
+  client filename (traversal blocked, base name preserved) and `move()`s with no
+  uniqueness check; the hardened `UploadHandler::generateSafeFilename()`
+  (`random_bytes(4)`) exists but is **not wired** to the route. Two `logo.png`
+  uploads overwrite; SVG is allowed → predictable `/files/<name>.svg`. Low-priv
+  authenticated; integrity/stored-XSS-file concern, not private-byte disclosure.
+
+### 2.7 `/oidc/revoke` not bound to the authenticating client (RFC 7009) — **[confirmed via agent]**, low
+- Evidence: `oidc/src/Revoke/RevocationController.php:78-129` revokes any token
+  matching the submitted value without checking `record->clientId ===
+  authenticated client`. Denial-only, attacker needs the high-entropy token
+  value; spec-conformance gap, not escalation/disclosure.
+
+### 2.8 `llms.txt` emits unescaped URL/summary/title — **[agent-reported]**, low
+- Evidence: `seo/src/Llms/LlmsTxtGenerator.php:54-64` emits entity-derived
+  `summary`/`title`/URL raw; `escape()` only strips `[`/`]`. Agent-facing
+  `text/plain` (link/content spoofing, not browser XSS). Harden: validate URL
+  scheme, escape newlines.
+
+---
+
+## 3. Capability defects — real weaknesses, reachability depends on app wiring
+
+Framework primitives that are unsafe-by-default; whether they are *live* depends
+on consuming-app route/caller wiring beyond the framework packages. Hardening
+recommended; not a confirmed live framework hole.
+
+### 3.1 `EntityParamConverter` injects route-bound entities with NO access check — **[agent-reported]**
+- Evidence: `routing/src/ParamConverter/EntityParamConverter.php:61-70` does
+  `getStorage()->load($rawId)` and injects; `SqlEntityStorage::load()` is a direct
+  PK select that does **not** route through `SqlEntityQuery` (the #1751 deny-by-
+  default layer) and never calls the access handler. Any route wiring
+  `entityParameter()` without also requiring auth/permission (or whose controller
+  doesn't re-check) is an IDOR primitive. Recommend: view-check in the converter.
+
+### 3.2 `EntityDeepLinkRouteBuilder` emits auth-less entity routes by default — **[agent-reported]**
+- Evidence: `routing/src/EntityDeepLinkRouteBuilder.php:54-62` returns a builder
+  pre-wired with `entityParameter()+GET` and **no** access option. Forgetting to
+  chain `requireAuthentication()` → anon-reachable raw entity load (compounds
+  3.1). Insecure default; recommend a secure-by-default posture.
+
+### 3.3 `http-client` is an unmitigated SSRF / scheme-read / redirect / header-injection capability — **[agent-reported]**
+- Evidence: `http-client/src/StreamHttpClient.php:46` (`@file_get_contents`) and
+  `PhpStreamSseClient.php:52` (`@fopen`) pass the URL to PHP stream wrappers with
+  no scheme validation (`file://`/`php://`/`data://`/`phar://` accepted), no
+  host/IP allowlist (metadata/loopback/RFC1918 reachable), redirects followed by
+  default, CRLF-unsanitized header interpolation, and full URL in exception
+  messages. Exploitable wherever an untrusted URL/header reaches it (webhooks,
+  unfurlers, AI fetch). Recommend: scheme allowlist, host/IP guard, `max_redirects`,
+  CRLF strip.
+
+### 3.4 `#[GateAttribute]` is inert — its docblock promises enforcement no code provides — **[confirmed]**
+- Evidence: the Gate enforcement path works (`AccessChecker` consumes the `_gate`
+  option → `checkGate` → `GateInterface`; `GateAccessTest` passes), but
+  `AccessChecker::applyGateToRoute()` — the only transfer of `#[GateAttribute]` →
+  `_gate` — has **zero production callers**, and there is no `RouteBuilder::gate()`
+  setter. The attribute's `@api` docblock ("the AccessChecker reads this attribute
+  and calls the Gate") is **false**. No framework route relies on it, so it is a
+  consumer *footgun*, not a live hole.
+- Recommendation (decision): either (a) **wire** it — add a `RouteBuilder::gate()`
+  setter and/or an attribute-scan compilation step calling `applyGateToRoute()`,
+  making the documented behavior real; or (b) **deprecate/mark `@internal`** and
+  correct the docblock. (b) is the smaller honest fix if the attribute path was
+  never finished; (a) is a small feature. Recommend (a)'s `RouteBuilder::gate()`
+  setter (the enforcement already works) + docblock correction.
+
+---
+
+## 4. Decision-needed (design / product / editorial policy)
+
+### 4.1 `relationship` is `group: 'content'` → published relationships are anon-viewable
+- Evidence: `relationship/src/Relationship.php:11` (`#[ContentEntityType]`,
+  `status=1` default) + `RelationshipServiceProvider.php:25` (`group: 'content'`).
+  The framework-default `PublishedContentAccessPolicy` (`access/.../PublishedContentAccessPolicy.php:39`,
+  `PUBLIC_GROUP='content'`) returns `allowed` for anon `view` of any published
+  content-group entity, **overriding** `RelationshipAccessPolicy`'s own intent
+  that `view` requires `access content`. So the policy's `access content` gate is
+  silently nullified. **[confirmed]**
+- Decision: is a relationship between published content itself public? If yes,
+  this is by-design and `RelationshipAccessPolicy`'s view branch is dead; if no,
+  `relationship` should not be content-group (it affects discovery/SSR too — has
+  blast radius), or the policy precedence should change. Not changed unilaterally.
+  (#1768 already closed the tool-level *bypass* regardless of this decision.)
+
+### 4.2 Node editorial booleans `status`/`promote`/`sticky` writable by `edit own` authors
+- Companion to #1769 (which gated the system fields). Whether an author may
+  self-publish (`status`) or self-promote to the front page (`promote`/`sticky`)
+  via the API is an editorial-permission decision; the framework has no
+  publish-specific permission today. Recommend deciding whether to introduce a
+  `administer nodes`-gated (or publish-permission-gated) field forbid for these.
+
+### 4.3 Admin `SurfaceQuery` filter/sort is a field-access oracle — **[agent-reported]**, admin-gated
+- Evidence: `admin-surface/src/Query/SurfaceQueryParser.php:29-66` accepts any
+  `filter[<field>]`/`sort=<field>` with no allow-list; row membership/order leaks
+  hidden field values (per-character oracle). Reachable only by `administer
+  content`. Low severity (admin-only); recommend a field allow-list.
+
+### 4.4 `billing` latent hardening before activation — **[agent-reported]**
+- The package is v0.1 scaffolding (StripeClient unbound, webhook unrouted, DTOs
+  not entities) → no reachable defect today. Before activation it needs:
+  timing-safe webhook signature verify, `event.id` idempotency, owner-scoped
+  AccessPolicy + `internal:true` on amounts/Stripe ids, owner from session not
+  request, and an env gate preventing `FakeStripeClient` binding in prod.
+
+---
+
+## 5. Verified clean / by-design (high-value checks that PASSED)
+
+- **Auth / OIDC crypto + lifecycle** (bucket A): constant-time compares
+  (`hash_equals`/`password_verify`), single-use auth codes, PKCE S256-only,
+  refresh-token rotation + theft detection, JWT alg-pinned (no `alg:none`),
+  2FA replay/recovery handling, JWKS emits only public key material. Credential
+  fields (`User` 2FA, `oidc_client.client_secret_hash`) double-layered
+  (policy-forbidden + `internal:true`). Mass-assignment of user privilege fields
+  closed (UserAccessPolicy).
+- **MCP** (bucket B): anon surface read-only + deny-by-default; `ReadOnlyToolRegistry`
+  hides destructive/off-allowlist tools; `/mcp/write` fails closed to 401. #1711
+  GraphQL total-count leak FIXED; #1752 schema/openapi auth gate HOLDS; JsonApiController
+  index/show/store/update/destroy all access-gate + 404-not-403 (no oracle).
+- **AI agent tools** (bucket D): #1638 per-field edit-access + #1637 audit/list-arg
+  fixes present & not bypassable; entity read/write/revision tools all enforce the
+  per-entity gate + internal-field drop, fail-closed wiring; bimaaji + wayfinding
+  guardrails gate correctly; observability logs no secrets/payloads; embedding
+  providers config-fixed (no SSRF).
+- **Content/ingress** (bucket C): attachment private-byte download deny-by-default
+  + realpath containment + 404-only (#1761) CLEAN; structured-import has no write
+  path; northcloud base URL env-only (no request-derived SSRF); SEO JSON-LD/meta/
+  sitemap escaped + status-filtered; path-alias creation admin-gated, no open
+  redirect.
+- **Infra/ops** (bucket E): messaging participant-only policy (the prior no-policy
+  defect FIXED); genealogy SSR system-context topology + per-person redaction
+  FIXED; #1648 audit-guard bypass FIXED; telescope/debug admin-gated or
+  APP_DEBUG-gated, no body/secret capture; mail no CRLF/SSTI/recipient-override;
+  listing filters strictly allowlisted; mercure publish-only.
+
+---
+
+## 6. Honest conclusion
+
+The reachable surface is **substantially but not fully exhausted.** Two genuine
+reachable defects were found and fixed (#1768, #1769). The §2 items are real and
+fix-recommended but lower-severity or non-anon; the §3 items are capability
+footguns whose live reachability depends on app wiring; the §4 items are design/
+product decisions. The cryptographic, token-lifecycle, MCP-allowlist, and
+agent-tool access surfaces are solid, and the previously-merged fixes all hold.
+The remaining §2 fixes plus the §3/§4 decisions are the honest tail — none are
+critical anon-reachable data-disclosure holes of the #1768 class, but the sweep
+was **not** a rubber stamp: it surfaced eight new reachable/footgun items and two
+design contradictions that should be triaged rather than assumed absent.

--- a/docs/audits/runtime-adapter-scoping.md
+++ b/docs/audits/runtime-adapter-scoping.md
@@ -1,0 +1,205 @@
+# Runtime-Adapter Scoping (audit "runtime adapter" architecture-debt item)
+
+**Status:** SCOPE ONLY — no refactor performed. Awaiting a go/no-go decision.
+**Date:** 2026-06-23
+**Grounded against:** `main` @ the C-24 completion commit.
+
+This is the deliberate "scope it and report before diving in" output for the
+named architecture-debt item *runtime adapter* (FrankenPHP-in-`index.php`). It
+describes the current shape, a target design, the risk map, the test strategy,
+the BC surface, and a recommendation. It does **not** change any code.
+
+---
+
+## 1. What exists today (grounded)
+
+The "runtime adapter" is the **front controller**, `public/index.php` (104
+lines). One file boots the app correctly under three runtimes; only the
+request-loop wrapper differs:
+
+1. **FrankenPHP worker mode** (production: local demo, Web Networks, Waaseyaa
+   Cloud) — boots the `$handler` once, then loops on
+   `frankenphp_handle_request($handler)` so the app stays warm and requests are
+   served concurrently across threads (a long-lived `/api/broadcast` SSE stream
+   pins one thread). Launched by the **native** `frankenphp run --config
+   config/frankenphp/Caddyfile` (the Caddyfile's `worker ./public/index.php`).
+2. **FrankenPHP / FPM classic** — one request per invocation.
+3. **`php -S` (cli-server)** — one request per invocation with static-file
+   passthrough; this is what `waaseyaa serve` runs (single-worker dev only).
+
+The runtime-specific logic embedded in the file:
+
+- a `cli-server` static-file `return false` passthrough;
+- autoload + `Dotenv::loadEnv(...)` (APP_ENV defaults to `production`);
+- the `$handler` closure: **fresh `HttpKernel` per request** (no container/entity
+  state bleeds across requests in a long-lived worker) + a **debug-gated**
+  boot-failure JSON:API 500 (never leaks `$e->getMessage()` outside `APP_DEBUG`);
+- the worker loop: `function_exists('frankenphp_handle_request')` guard,
+  `ignore_user_abort(true)`, an optional `FRANKENPHP_WORKER_MAX_REQUESTS`
+  recycle bound, `gc_collect_cycles()` each turn, and a **first-call-throw
+  heuristic** — because `frankenphp_handle_request()` is *also* defined under
+  classic FrankenPHP (where calling it throws "not in worker mode"), a throw
+  **before** the first handled request means "not a worker → fall through to one
+  synchronous request"; a throw **after** is a real worker-loop error and is
+  re-raised.
+
+### The byte-locked copies (the actual debt)
+
+This file is duplicated **four times** and pinned byte-identical by
+`tests/Architecture/FrontControllerRuntimeDispatchTest.php`:
+
+| Copy | Path | Role |
+|------|------|------|
+| repo dev | `public/index.php` | the framework repo's own front controller |
+| make:public stub | `packages/cli/templates/public/index.php.stub` | emitted verbatim by `waaseyaa make:public` (`MakePublicHandler`) |
+| skeleton | `skeleton/public/index.php` | the scaffolded app's front controller |
+| golden | `skeleton/bin/maintenance/golden-public-index.php` | drift reference the test compares against |
+
+The only intended divergence: the repo-dev + stub copies **inline** the
+APP_DEBUG boot-failure gate (no `App\` namespace), while skeleton/golden delegate
+to `App\Http\BootFailureResponder`. `FrontControllerRuntimeDispatchTest` enforces
+both the byte-identity and the "no copy leaks the raw boot message" invariant
+(the latter was a real audit-Medium residual, fixed in #1755).
+
+**The debt:** runtime-serving logic lives in application space, copied four ways,
+so every change to the worker loop / boot-failure handling / runtime detection
+must be made in lockstep across four files and re-pinned by an architecture test.
+
+### What `waaseyaa/frankenphp` is today
+
+`packages/frankenphp` is **console commands + binary management only**
+(`DevCommand`, `InstallCommand`, `BinaryResolver`, `Installer`). Its README is
+explicit: *"It adds two console commands and nothing else; the framework core
+stays runtime-agnostic (no FrankenPHP coupling)."* It contains **no**
+request-serving / worker-loop code. It is **optional** — not part of
+`waaseyaa/core` / `cms` / `full`; apps opt in with `composer require
+waaseyaa/frankenphp`. The runtime-agnostic `waaseyaa serve` (`php -S`) is the
+zero-dependency fallback in core.
+
+---
+
+## 2. The central design tension (why this is not a trivial move)
+
+The obvious target — *"move the worker loop into `waaseyaa/frankenphp`"* —
+collides with two existing, deliberate constraints:
+
+1. **The package is optional.** The php-S / FPM fallback **must** keep working
+   for apps that never install `waaseyaa/frankenphp`. So the serving entry point
+   cannot hard-depend on a class from that package.
+2. **Core is runtime-agnostic by charter.** Coupling the front controller to a
+   FrankenPHP-specific class reverses the README's stated invariant.
+
+So any adapter must keep a **runtime-agnostic core serving path** that works with
+zero optional packages, and treat FrankenPHP worker mode as an **opt-in
+enhancement** that activates only when the symbol/package is present. The
+current single-file design already achieves runtime-agnosticism — its cost is
+the four byte-locked copies, not a coupling.
+
+---
+
+## 3. Target design (proposed, not built)
+
+**Goal:** reduce each `public/index.php` to a thin, rarely-changing bootstrap and
+move the runtime-specific serving logic into one framework-owned, unit-testable
+class — without coupling the bootstrap to the optional FrankenPHP package and
+without breaking the php-S/FPM fallback.
+
+Proposed shape (Symfony-Runtime / Laravel-Octane-style, adapted):
+
+- A **core** `RuntimeServer` (in `waaseyaa/foundation`, runtime-agnostic) that
+  owns: the per-request fresh-kernel `$handler`, the debug-gated boot-failure
+  responder, and a `serveOnce()` path for classic FPM / `php -S`. This is the
+  zero-dependency default — no optional package required.
+- A **runtime detector** that selects a serving strategy: if
+  `frankenphp_handle_request` exists, use the worker-loop strategy (incl. the
+  first-call-throw fallthrough heuristic, `ignore_user_abort`, the recycle
+  bound); else `serveOnce()`. The worker strategy is the *only* FrankenPHP-aware
+  code; it can live in foundation guarded purely by `function_exists()` (no
+  dependency on `waaseyaa/frankenphp`), OR — cleaner separation — in
+  `waaseyaa/frankenphp` as a strategy the detector loads **only if class_exists**,
+  preserving the optional-package contract.
+- `public/index.php` shrinks to roughly: `require autoload; (new RuntimeServer(
+  $projectRoot))->run();` — a handful of lines that essentially never change, so
+  the byte-locked duplication stops mattering (the stub/skeleton/golden become
+  trivial and stable).
+- The `App\Http\BootFailureResponder` seam stays (apps can still override the
+  500 body), injected into `RuntimeServer`.
+
+**Recommended variant:** keep the worker-loop strategy in **foundation**, gated
+by `function_exists('frankenphp_handle_request')` only. Rationale: it is ~25
+lines, has no FrankenPHP *code* dependency (only the runtime-injected global
+function), and keeping it in core avoids a foundation→optional-package indirection
+while still leaving `waaseyaa/frankenphp` as binary-management-only. This holds
+the runtime-agnostic invariant (the code is inert when the symbol is absent) and
+collapses the four-copy duplication to a one-line bootstrap.
+
+---
+
+## 4. Risk map
+
+| Risk | Severity | Notes |
+|------|----------|-------|
+| Worker-loop semantics regressions | **High** | The first-call-throw fallthrough heuristic, `ignore_user_abort`, fresh-kernel-per-request, and the recycle bound are load-bearing for production concurrency + the SSE stream. A subtle change (e.g. catching the wrong throw, or reusing a kernel) breaks prod warmth or leaks request state. Hard to cover in CI (no FrankenPHP worker in the test runner). |
+| Boot-failure leak re-introduction | **High** | The debug-gate is a fixed audit-Medium (#1755). Any refactor must preserve "never emit `$e->getMessage()` outside APP_DEBUG" across **every** entry path, and keep `FrontControllerRuntimeDispatchTest`'s no-leak invariant green. |
+| Breaking the php-S / FPM fallback | **Med-High** | The zero-dependency path must keep working for apps without `waaseyaa/frankenphp`. Easy to regress if the bootstrap accidentally references an optional symbol. |
+| Scaffolding drift (`make:public`, skeleton, golden) | **Med** | Four copies + the architecture test must move together; the stub generator (`MakePublicHandler`) emits the new thin bootstrap; the golden/byte-identity test must be re-pinned to the new content. |
+| `Dotenv` / APP_ENV default behavior | **Med** | The "default APP_ENV to production, not Symfony dev" subtlety must survive the move. |
+| Existing-app upgrade churn | **Med** | Apps already scaffolded carry the old fat `index.php`; they keep working (no forced change), but they won't benefit until they re-scaffold or hand-edit. Document as opt-in. |
+
+---
+
+## 5. Test strategy
+
+- **Unit:** `RuntimeServerTest` — classic `serveOnce()` returns the handler's
+  response; boot-failure produces a debug-gated 500 (production hides the
+  message, debug shows it); the recycle bound stops after N; the worker-detection
+  branch is selected when the global function is present (inject a fake).
+- **Worker-loop heuristic:** unit-test the first-call-throw fallthrough by
+  injecting a fake `frankenphp_handle_request` that throws on the first call
+  (→ falls through to one synchronous serve) vs throws after the first
+  (→ re-raises). This is the riskiest logic and is the prime regression target.
+- **Architecture:** keep `FrontControllerRuntimeDispatchTest` — re-pin the
+  byte-identity to the new thin bootstrap, keep the no-raw-boot-leak invariant
+  across all four copies.
+- **Manual / out-of-CI:** a documented smoke check under real `frankenphp run`
+  worker mode (concurrency + SSE warmth) since CI has no FrankenPHP worker.
+
+---
+
+## 6. BC surface
+
+- **Public API:** `RuntimeServer` (+ any strategy interface) would be **new
+  public/`@api`** surface in `waaseyaa/foundation` → surface-map + CHANGELOG
+  `### Added`. `App\Http\BootFailureResponder` seam unchanged.
+- **Scaffolding:** the `make:public` stub, skeleton, and golden change to the
+  thin bootstrap (a generated-output change, not a runtime BC break). Already-
+  scaffolded apps are unaffected until they re-scaffold.
+- **Drift gate:** `packages/frankenphp/` maps to `operations-playbooks.md`;
+  `packages/foundation/` maps to `infrastructure.md` — both specs would need
+  the runtime-adapter section + `spec-reviewed:` notes.
+- **No runtime BC break** for running apps (the fat `index.php` keeps working).
+
+---
+
+## 7. Recommendation
+
+**Defer — low urgency, real (but bounded) risk; not a blocker.**
+
+- It is **cosmetic/architectural debt, not a defect**: the current four-copy
+  design is correct and secure (the boot-leak invariant is enforced by an
+  architecture test). Nothing is broken or reachable; this is purely about
+  collapsing duplication and tidying the runtime seam.
+- The highest-risk surface (worker-loop semantics, boot-leak gate) is **load-
+  bearing for production** and **under-covered by CI** (no FrankenPHP worker in
+  the runner), so a refactor trades a tidier seam for genuine production-
+  regression risk that the test suite cannot fully catch.
+- If undertaken, do it as a **single, self-contained mission** with the test
+  strategy above landed *first* (unit-cover the worker heuristic before moving
+  it), the recommended "worker strategy stays in foundation, `function_exists`-
+  gated" variant, and a real out-of-CI FrankenPHP smoke check before merge.
+
+**Suggested trigger to revisit:** when the worker loop next needs a *behavioral*
+change anyway (e.g. a new recycle policy, graceful-drain on SSE, or a second
+concurrent runtime), fold this refactor into that work so the duplication cost
+and the change land together rather than paying the regression risk for a
+pure-tidy pass.


### PR DESCRIPTION
Two audit artifacts from the post-C-24 work — **docs only, no code change**.

## `residual-security-sweep-2026-06-23.md`
The findings ledger from an adversarial claim-vs-code + reachability re-sweep across all 75 packages, run to answer honestly whether the reachable defect surface is exhausted.

- **Regression baseline:** merged security fixes all hold (full suites + gates green; markers spot-checked).
- **Fixed failing-first:** [#1768](https://github.com/waaseyaa/framework/pull/1768) (`relationship.traverse` anon disclosure), [#1769](https://github.com/waaseyaa/framework/pull/1769) (`node` system-field mass-assignment).
- **Recorded with code evidence:** 8 more reachable/fix-recommended items, 4 capability footguns (incl. the inert `#[GateAttribute]`), and 4 design/product decisions.
- **Verdict:** substantially-but-not-fully exhausted — no remaining critical anon-disclosure holes of the #1768 class, but 8 new reachable items + 2 design contradictions surfaced. Not a rubber stamp.

## `runtime-adapter-scoping.md`
Scope-and-report for the FrankenPHP runtime-adapter debt (**plan only, no refactor**): the four byte-locked `public/index.php` copies, the optional-package design tension (the worker loop can't move into `waaseyaa/frankenphp` without breaking the php-S/FPM fallback), a target design, risk map, test strategy, BC surface, and a **DEFER** recommendation (cosmetic, not a defect; load-bearing + CI-under-covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)