### PR TITLE
fix(entity): declare missing waaseyaa/field dependency (Wave 1 · W1-1)

### DIFF
--- a/packages/entity/composer.json
+++ b/packages/entity/composer.json
@@ -26,6 +26,10 @@
         },
         {
             "type": "path",
+            "url": "../field"
+        },
+        {
+            "type": "path",
             "url": "../foundation"
         },
         {
@@ -38,6 +42,7 @@
         "waaseyaa/access": "^0.1.0-alpha.249",
         "waaseyaa/cache": "^0.1.0-alpha.249",
         "waaseyaa/config": "^0.1.0-alpha.249",
+        "waaseyaa/field": "^0.1.0-alpha.249",
         "waaseyaa/foundation": "^0.1.0-alpha.249",
         "waaseyaa/plugin": "^0.1.0-alpha.249",
         "waaseyaa/typed-data": "^0.1.0-alpha.249",


### PR DESCRIPTION
**Remediation Wave 1 — W1-1** · finding `L1-entity.md` M2 (craftsmanship roadmap `REMEDIATION-WAVE-1.md`)

## Summary
Nine `packages/entity/src/*` files `use Waaseyaa\Field\*`, but `packages/entity/composer.json` did not declare `waaseyaa/field` in `require`. A standalone install of `waaseyaa/entity` would fatal; today it only resolves via the metapackages pulling field in transitively.

This PR adds:
- `"waaseyaa/field": "^0.1.0-alpha.249"` to `require` (matches the CP-NEW internal-constraint rule = `^` + current `git describe` tag; kept current by `bin/sync-internal-versions`).
- the `../field` path repository, so standalone/split resolution works like every other waaseyaa dep in this file.

`field` is L1, the same layer as `entity`, so the edge is permitted. It surfaces a **warn-only** `entity <-> field` PL006 cycle — which only makes explicit a coupling that already exists in source (`entity` uses `Field` types; `field` uses `entity`). `bin/check-package-layers` only *fails* on upward edges, so it stays green.

## Gate output
- `bin/check-package-layers` → **green** (exit 0); new `WARN [PL006] entity <-> field (layer 1)` is expected and warn-only.
- `composer check-composer-policy` → **green** (`OK: Composer policy checks passed`).
- `./vendor/bin/phpunit packages/entity/tests` → **520/520 OK** (only the benign "No code coverage driver" warning).
- `composer cs-check` / `composer phpstan` → unaffected (metadata-only change, zero PHP delta).
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED is not touched by this change).

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-1** referenced above
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`