### PR TITLE
docs(entity-storage): correct false SqlEntityStorage docblock (Wave 1 · W1-2)

### DIFF
--- a/packages/entity-storage/src/SqlEntityStorage.php
+++ b/packages/entity-storage/src/SqlEntityStorage.php
@@ -29,15 +29,35 @@ use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
 
 /**
- * SQL-based entity storage implementation.
+ * SQL-backed entity storage driver.
  *
- * Stores entities in SQL tables using the waaseyaa/database-legacy package.
- * Supports CRUD operations and dispatches entity lifecycle events.
+ * Persists entities through the {@see DatabaseInterface} query builder
+ * (waaseyaa/database-legacy) and dispatches the entity lifecycle events on
+ * {@see EntityEvents}. Implements the full {@see EntityStorageInterface} CRUD
+ * surface: create, load, loadByKey, loadMultiple, save, delete and getQuery.
  *
- * For v0.1.0:
- * - Flat table schema (all fields in one table)
- * - No revision support
- * - No translation support
+ * Schema model:
+ * - A flat base table keyed by the entity's id key. Core fields map to real
+ *   columns; the remaining field values are folded into a single JSON `_data`
+ *   blob (see {@see splitForStorage()}).
+ * - Optional per-bundle subtables, merged into the loaded row on read via the
+ *   {@see BundleSubtableGateway} (see {@see mergeBundleSubtableRow()}).
+ *
+ * Translation (two strategies, selected per entity type):
+ * - Default "sql-blob" strategy keeps per-langcode field values inside the base
+ *   row's `_data` blob via {@see TranslationSchemaHandler}.
+ * - Optional "sql-column" strategy stores translations in a dedicated
+ *   translation table with real columns (see {@see saveSqlColumnTranslatable()}
+ *   / {@see loadSqlColumnTranslatable()}), hydrated by
+ *   {@see SqlColumnTranslationHydrator}.
+ *
+ * Cross-cutting: created/changed timestamps are populated through the injected
+ * {@see EntityClockInterface}; reads run through an access-aware
+ * {@see EntityQueryInterface} (optional {@see EntityAccessHandler}); list
+ * queries are served from {@see SqlEntityQueryResultCache}.
+ *
+ * Revisions are out of scope for this class — revisionable entities are handled
+ * by the RevisionableStorageDriver, not here.
  */
 final class SqlEntityStorage implements EntityStorageInterface
 {


### PR DESCRIPTION
**Remediation Wave 1 — W1-2** · finding `L1-entity-storage.md` M3

## Summary
`SqlEntityStorage`'s class docblock claimed *"No revision support; No translation support"* directly above ~600 lines of translation handling. This rewrites the docblock to describe what the class actually implements:

- flat base table + JSON `_data` blob (`splitForStorage()`), optional per-bundle subtables (`BundleSubtableGateway`);
- the two translation strategies — default **sql-blob** (`TranslationSchemaHandler`) and optional **sql-column** (dedicated translation table, `SqlColumnTranslationHydrator`);
- clock-driven timestamps, access-aware cached queries;
- and the fact that **revisions are out of scope** here (handled by `RevisionableStorageDriver`).

Comment-only change; zero behavioural delta.

## Gate output
- `composer cs-check` (php-cs-fixer on the file) → **green** (no fixes).
- `composer phpstan` (on the file) → **green** (`[OK] No errors`).
- `./vendor/bin/phpunit packages/entity-storage/tests` → **763/763 OK**.
- Full pre-push Unit suite locally → **8522 tests OK**.
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED untouched).

no-changelog: comment-only docblock correction — no public API, behaviour, or surface change, so no CHANGELOG/upgrade-guide entry applies.

spec-reviewed: docs/specs/entity-system.md — docblock-only correction; the comment now matches the long-standing implementation. No documented contract or behaviour changed, so the spec needs no update.

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-2**
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`