### PR TITLE
docs(entity): drop redundant @method PHPDoc on EntityInterface (Wave 1 · W1-3)

### DIFF
--- a/packages/entity/src/EntityInterface.php
+++ b/packages/entity/src/EntityInterface.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Entity;
 
-/**
- * @method mixed get(string $name)
- * @method static set(string $name, mixed $value)
- */
 interface EntityInterface
 {
     public function id(): int|string|null;


### PR DESCRIPTION
**Remediation Wave 1 — W1-3** · finding `L1-entity.md` n1

## Summary
`EntityInterface`'s docblock carried `@method mixed get(...)` / `@method static set(...)` annotations that duplicate the concrete `get()` (:25) and `set()` (:27) declarations on the same interface. They are vestigial and prone to drift (the `@method set` even read `static` with no return type vs the declared `: static`). Removed; the real method declarations remain the single source of truth.

Comment-only change; zero behavioural delta.

## Gate output
- `composer cs-check` (php-cs-fixer on the file) → **green** (no fixes).
- `composer phpstan` (on the file) → **green** (`[OK] No errors`) — methods are still concretely declared.
- `./vendor/bin/phpunit packages/entity/tests` → **520/520 OK**.
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED untouched).

no-changelog: PHPDoc-only cleanup — no public API, behaviour, or surface change, so no CHANGELOG/upgrade-guide entry applies.

spec-reviewed: docs/specs/entity-system.md — PHPDoc-only cleanup on EntityInterface; concrete declarations unchanged, no documented contract or behaviour changed.

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-3**
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`