### PR TITLE
refactor(entity-storage): canonical ColumnSpecMap dedupe (Wave 1 · W1-4)

### DIFF
--- a/packages/entity-storage/src/Backend/SqlColumnSchemaBuilder.php
+++ b/packages/entity-storage/src/Backend/SqlColumnSchemaBuilder.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\EntityStorage\Backend;
 
 use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\EntityStorage\Schema\ColumnSpecMap;
 use Waaseyaa\Field\FieldDefinition;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
@@ -180,22 +181,8 @@ final class SqlColumnSchemaBuilder
      */
     private function buildColumnSpec(string $fieldType, array $settings): array
     {
-        $type = strtolower($fieldType);
-
         // Map §8.2 field type → Waaseyaa abstract type understood by DBALSchema.
-        $abstractType = match ($type) {
-            'string'                  => 'varchar',
-            'text'                    => 'text',
-            'int', 'integer'          => 'int',
-            'bigint'                  => 'int',    // DBALSchema maps to integer; Doctrine emits BIGINT via its own type resolution
-            'bool', 'boolean'         => 'boolean',
-            'datetime'                => 'text',   // ISO 8601 TEXT per §8.2
-            'json'                    => 'text',   // TEXT in SQLite, JSONB semantics via app layer
-            'uuid'                    => 'varchar',
-            'float'                   => 'float',
-            'decimal', 'numeric'      => 'text',   // lossless TEXT per §8.2 (SQLite); Postgres gets NUMERIC via Doctrine
-            default                   => 'text',
-        };
+        $abstractType = ColumnSpecMap::abstractTypeFor($fieldType);
 
         $spec = [
             'type'     => $abstractType,

--- a/packages/entity-storage/src/Schema/ColumnSpecMap.php
+++ b/packages/entity-storage/src/Schema/ColumnSpecMap.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Schema;
+
+/**
+ * Canonical map from a FieldDefinition type string to the Waaseyaa abstract
+ * DBAL column type understood by DBALSchema::createTable()/mapFieldType().
+ *
+ * Single source of truth for the field-type → column-type mapping that was
+ * previously duplicated in RevisionTableBuilder::columnSpecForType(),
+ * SqlColumnSchemaBuilder::buildColumnSpec(), and
+ * TranslationSchemaHandler::deriveValueColumnSpec(). Those call sites assemble
+ * their own full column spec (not null / default / length) around this type, but
+ * they all derive the abstract type from here so the mapping can never re-drift.
+ */
+final class ColumnSpecMap
+{
+    /**
+     * Map a FieldDefinition type string (case-insensitive) to the abstract DBAL
+     * column type. Unknown types fall back to 'text' (widest safety).
+     */
+    public static function abstractTypeFor(string $fieldType): string
+    {
+        return match (strtolower($fieldType)) {
+            'string'             => 'varchar',
+            'text'               => 'text',
+            'int', 'integer'     => 'int',
+            'bigint'             => 'int',
+            'bool', 'boolean'    => 'boolean',
+            'datetime'           => 'text',
+            'json'               => 'text',
+            'uuid'               => 'varchar',
+            'float'              => 'float',
+            'decimal', 'numeric' => 'text',
+            default              => 'text',
+        };
+    }
+}

--- a/packages/entity-storage/src/Schema/RevisionTableBuilder.php
+++ b/packages/entity-storage/src/Schema/RevisionTableBuilder.php
@@ -344,21 +344,7 @@ final class RevisionTableBuilder
      */
     private function columnSpecForType(string $fieldType, array $settings): array
     {
-        $type = strtolower($fieldType);
-
-        $abstractType = match ($type) {
-            'string'             => 'varchar',
-            'text'               => 'text',
-            'int', 'integer'     => 'int',
-            'bigint'             => 'int',
-            'bool', 'boolean'    => 'boolean',
-            'datetime'           => 'text',
-            'json'               => 'text',
-            'uuid'               => 'varchar',
-            'float'              => 'float',
-            'decimal', 'numeric' => 'text',
-            default              => 'text',
-        };
+        $abstractType = ColumnSpecMap::abstractTypeFor($fieldType);
 
         $spec = [
             'type'     => $abstractType,

--- a/packages/entity-storage/src/Schema/TranslationSchemaHandler.php
+++ b/packages/entity-storage/src/Schema/TranslationSchemaHandler.php
@@ -390,16 +390,12 @@ final class TranslationSchemaHandler
     private function deriveValueColumnSpec(FieldDefinitionInterface $field): array
     {
         $settings = $field->getSettings();
-        $typeKey = strtolower($field->getType());
 
-        $spec = match ($typeKey) {
-            'string', 'uuid' => ['type' => 'varchar', 'length' => (int) ($settings['length'] ?? 255)],
-            'text', 'datetime', 'json', 'decimal', 'numeric' => ['type' => 'text'],
-            'int', 'integer', 'bigint' => ['type' => 'int'],
-            'bool', 'boolean' => ['type' => 'boolean'],
-            'float' => ['type' => 'float'],
-            default => ['type' => 'text'],
-        };
+        $abstractType = ColumnSpecMap::abstractTypeFor($field->getType());
+        $spec = ['type' => $abstractType];
+        if ($abstractType === 'varchar') {
+            $spec['length'] = (int) ($settings['length'] ?? 255);
+        }
 
         $spec['not null'] = (bool) ($settings['not_null'] ?? false);
         if (\array_key_exists('default', $settings)) {

--- a/packages/entity-storage/tests/Unit/Schema/ColumnSpecMapTest.php
+++ b/packages/entity-storage/tests/Unit/Schema/ColumnSpecMapTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\EntityStorage\Backend\SqlColumnSchemaBuilder;
+use Waaseyaa\EntityStorage\Schema\ColumnSpecMap;
+use Waaseyaa\EntityStorage\Schema\RevisionTableBuilder;
+use Waaseyaa\EntityStorage\Schema\TranslationSchemaHandler;
+use Waaseyaa\Field\FieldDefinition;
+
+#[CoversClass(ColumnSpecMap::class)]
+final class ColumnSpecMapTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function abstractTypeProvider(): array
+    {
+        return [
+            'string→varchar'         => ['string', 'varchar'],
+            'STRING→varchar (case)'  => ['STRING', 'varchar'],
+            'text→text'              => ['text', 'text'],
+            'int→int'                => ['int', 'int'],
+            'integer→int'            => ['integer', 'int'],
+            'bigint→int'             => ['bigint', 'int'],
+            'bool→boolean'           => ['bool', 'boolean'],
+            'boolean→boolean'        => ['boolean', 'boolean'],
+            'datetime→text'          => ['datetime', 'text'],
+            'json→text'              => ['json', 'text'],
+            'uuid→varchar'           => ['uuid', 'varchar'],
+            'float→float'            => ['float', 'float'],
+            'decimal→text'           => ['decimal', 'text'],
+            'numeric→text'           => ['numeric', 'text'],
+            'unknown→text'           => ['mystery_type', 'text'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('abstractTypeProvider')]
+    public function itMapsFieldTypeToAbstractType(string $fieldType, string $expectedAbstractType): void
+    {
+        self::assertSame($expectedAbstractType, ColumnSpecMap::abstractTypeFor($fieldType));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function supportedTypeProvider(): array
+    {
+        return [
+            'string'   => ['string'],
+            'text'     => ['text'],
+            'int'      => ['int'],
+            'integer'  => ['integer'],
+            'bigint'   => ['bigint'],
+            'bool'     => ['bool'],
+            'boolean'  => ['boolean'],
+            'datetime' => ['datetime'],
+            'json'     => ['json'],
+            'uuid'     => ['uuid'],
+            'float'    => ['float'],
+            'decimal'  => ['decimal'],
+            'numeric'  => ['numeric'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('supportedTypeProvider')]
+    public function allThreeCallSitesAgreeOnAbstractType(string $fieldType): void
+    {
+        $expected = ColumnSpecMap::abstractTypeFor($fieldType);
+
+        // --- RevisionTableBuilder::columnSpecForType (private) ---
+        $rtb = new \ReflectionClass(RevisionTableBuilder::class)->newInstanceWithoutConstructor();
+        $rtbMethod = new \ReflectionMethod(RevisionTableBuilder::class, 'columnSpecForType');
+        /** @var array<string, mixed> $rtbSpec */
+        $rtbSpec = $rtbMethod->invoke($rtb, $fieldType, []);
+        self::assertSame($expected, $rtbSpec['type'], "RevisionTableBuilder disagrees for type '{$fieldType}'");
+
+        // --- SqlColumnSchemaBuilder::buildColumnSpec (private) ---
+        $scsb = new \ReflectionClass(SqlColumnSchemaBuilder::class)->newInstanceWithoutConstructor();
+        $scsbMethod = new \ReflectionMethod(SqlColumnSchemaBuilder::class, 'buildColumnSpec');
+        /** @var array<string, mixed> $scsbSpec */
+        $scsbSpec = $scsbMethod->invoke($scsb, $fieldType, []);
+        self::assertSame($expected, $scsbSpec['type'], "SqlColumnSchemaBuilder disagrees for type '{$fieldType}'");
+
+        // --- TranslationSchemaHandler::deriveValueColumnSpec (private) ---
+        $tsh = new \ReflectionClass(TranslationSchemaHandler::class)->newInstanceWithoutConstructor();
+        $tshMethod = new \ReflectionMethod(TranslationSchemaHandler::class, 'deriveValueColumnSpec');
+        $fieldDef = new FieldDefinition(name: '_test', type: $fieldType);
+        /** @var array<string, mixed> $tshSpec */
+        $tshSpec = $tshMethod->invoke($tsh, $fieldDef);
+        self::assertSame($expected, $tshSpec['type'], "TranslationSchemaHandler disagrees for type '{$fieldType}'");
+    }
+}


### PR DESCRIPTION
**Remediation Wave 1 — W1-4** · finding `L1-entity-storage.md` m1

## Summary
The `match` mapping a FieldDefinition type → abstract DBAL column type was triplicated in `RevisionTableBuilder::columnSpecForType`, `SqlColumnSchemaBuilder::buildColumnSpec`, and `TranslationSchemaHandler::deriveValueColumnSpec` (the last literally carrying the note *"Don't duplicate the type map."*).

- New canonical helper `Waaseyaa\EntityStorage\Schema\ColumnSpecMap::abstractTypeFor()`.
- All three call sites now delegate to it; each keeps its own spec assembly (`not null` / `default` / `length`), so output is **byte-identical**. In particular `TranslationSchemaHandler` keeps its length-after-`type` key order **and** its `getDefaultValue()` default fallback.
- New `ColumnSpecMapTest`: a table-driven test pinning the full type table (case-insensitivity + unknown→text) **plus** a reflection-based test asserting all three call sites derive the same abstract type for every supported field type — so the map can never re-drift.

## Gate output
- `composer cs-check` (php-cs-fixer, 5 files) → **green** (`files:[]`).
- `composer phpstan` (5 files) → **green** (`[OK] No errors`).
- `./vendor/bin/phpunit packages/entity-storage/tests` → **791 tests OK** (+28 new; benign warnings: abstract contract base, no-coverage-driver).
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED untouched).

no-changelog: internal refactor — no public API, behaviour, or schema-emission change (byte-identical column specs, pinned by a new agreement test), so no CHANGELOG/upgrade-guide entry applies.

spec-reviewed: docs/specs/entity-system.md — internal dedupe with byte-identical output; no documented contract or schema-emission behaviour changed.

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-4**
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`