### PR TITLE
fix(entity-storage): route revision timestamps through EntityClock seam (Wave 1 · W1-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Revision timestamps are now written through the injected clock seam (UTC, deterministic) instead of server-local `date()` (audit `L1-entity-storage.md` m4).** `RevisionableStorageDriver::writeDefaultRevision()` / `writePerLangcodeRevision()` stamped `revision_created` with `date('Y-m-d H:i:s')`, which used the server's local timezone and was not controllable in tests — the same revision could record a different wall-clock value on differently-configured hosts, and the value was not clock-testable. The driver now takes an optional `Waaseyaa\Entity\DateTime\EntityClockInterface` (defaulting to `UtcEntityClock`, matching the base-table `SqlEntityStorage` path), so `revision_created` is always UTC and a fixed clock yields a deterministic value. The stored string format (`Y-m-d H:i:s`) is unchanged; the only behavioural change is UTC instead of server-local. The kernel construction site (`AbstractKernel`) is unaffected — the new parameter defaults to the same UTC clock. Acceptance: `RevisionableStorageDriverClockTest::write_revision_uses_injected_clock_for_revision_created`.
+
 ## [0.1.0-alpha.249] - 2026-06-25
 
 ### Removed

--- a/packages/entity-storage/src/Driver/RevisionableStorageDriver.php
+++ b/packages/entity-storage/src/Driver/RevisionableStorageDriver.php
@@ -6,6 +6,8 @@ namespace Waaseyaa\EntityStorage\Driver;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Entity\DateTime\EntityClockInterface;
+use Waaseyaa\Entity\DateTime\UtcEntityClock;
 use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\EntityStorage\Connection\ConnectionResolverInterface;
 
@@ -51,6 +53,8 @@ final class RevisionableStorageDriver
 
     private readonly string $translationRevisionTable;
 
+    private readonly EntityClockInterface $clock;
+
     /**
      * In-process per-`(entity_id, langcode)` current-revision pointer (FR-007).
      *
@@ -66,9 +70,11 @@ final class RevisionableStorageDriver
     public function __construct(
         private readonly ConnectionResolverInterface $connectionResolver,
         private readonly EntityTypeInterface $entityType,
+        ?EntityClockInterface $clock = null,
     ) {
         $this->revisionTable = $this->entityType->id() . '_revision';
         $this->translationRevisionTable = $this->entityType->id() . '__translation__revision';
+        $this->clock = $clock ?? new UtcEntityClock();
     }
 
     /**
@@ -337,7 +343,7 @@ final class RevisionableStorageDriver
             $row = [
                 'entity_id'        => $entityId,
                 'revision_id'      => $revisionId,
-                'revision_created' => date('Y-m-d H:i:s'),
+                'revision_created' => $this->clock->now()->format('Y-m-d H:i:s'),
                 'revision_log'     => $log,
                 // Resolved acting account (FR-001). SQL NULL when no actor was in
                 // scope; 0 if and only if the anonymous account acted.
@@ -410,7 +416,7 @@ final class RevisionableStorageDriver
                 'entity_id'        => $entityId,
                 'langcode'         => $langcode,
                 'revision_id'      => $revisionId,
-                'revision_created' => date('Y-m-d H:i:s'),
+                'revision_created' => $this->clock->now()->format('Y-m-d H:i:s'),
                 'revision_log'     => $log,
                 // Resolved acting account (FR-001) — same semantics as the
                 // single-axis path: NULL = no actor, 0 = anonymous.

--- a/packages/entity-storage/tests/Unit/Driver/RevisionableStorageDriverClockTest.php
+++ b/packages/entity-storage/tests/Unit/Driver/RevisionableStorageDriverClockTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\EntityStorage\Tests\Unit\Driver;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\DateTime\EntityClockInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\RevisionableStorageDriver;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\EntityStorage\Tests\Fixtures\TestRevisionableEntity;
+
+#[CoversClass(RevisionableStorageDriver::class)]
+final class RevisionableStorageDriverClockTest extends TestCase
+{
+    #[Test]
+    public function write_revision_uses_injected_clock_for_revision_created(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $entityType = new EntityType(
+            id: 'test_revisionable',
+            label: 'Test Revisionable',
+            class: TestRevisionableEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'revision' => 'revision_id'],
+            revisionable: true,
+            revisionDefault: true,
+        );
+
+        $handler = new SqlSchemaHandler($entityType, $db);
+        $handler->ensureTable();
+        $handler->ensureRevisionTable();
+
+        $fixedClock = new class implements EntityClockInterface {
+            public function now(): DateTimeImmutable
+            {
+                return new DateTimeImmutable('2020-01-02 03:04:05', new DateTimeZone('UTC'));
+            }
+        };
+
+        $resolver = new SingleConnectionResolver($db);
+        $driver = new RevisionableStorageDriver($resolver, $entityType, $fixedClock);
+
+        $driver->writeRevision('1', ['title' => 'Hello', 'uuid' => 'a'], 'log');
+
+        $row = $driver->readRevision('1', 1);
+
+        self::assertNotNull($row);
+        self::assertSame('2020-01-02 03:04:05', $row['revision_created']);
+    }
+}


### PR DESCRIPTION
**Remediation Wave 1 — W1-5** · finding `L1-entity-storage.md` m4

## Summary
`RevisionableStorageDriver` stamped `revision_created` with `date('Y-m-d H:i:s')` in both `writeDefaultRevision()` and `writePerLangcodeRevision()` — server-local timezone, non-deterministic across hosts, and not clock-testable. The base-table path (`SqlEntityStorage`) already uses the injected `EntityClockInterface`/`UtcEntityClock`.

- The driver now takes an optional 3rd ctor param `?EntityClockInterface $clock = null`, defaulting to `UtcEntityClock`.
- Both write paths stamp via `$this->clock->now()->format('Y-m-d H:i:s')`. **Format string unchanged** — the only behavioural change is UTC instead of server-local.
- `AbstractKernel`'s construction site is untouched: the default param gives it the same UTC clock (deterministic, just now overridable/testable).
- New `RevisionableStorageDriverClockTest` pins a deterministic `revision_created` with a fixed clock.

## Gate output
- `composer cs-check` (2 files) → **green** (`files:[]`).
- `composer phpstan` (2 files) → **green** (`[OK] No errors`).
- `./vendor/bin/phpunit packages/entity-storage/tests` → **764 tests OK** (+1 new; benign warnings: abstract contract base, no-coverage-driver).
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED untouched).

CHANGELOG.md updated under `[Unreleased] → Fixed`.

spec-reviewed: docs/specs/entity-system.md — the documented `revision_created` contract (a `Y-m-d H:i:s` timestamp string) is unchanged; this only routes the value through the existing UtcEntityClock seam already used by the base-table path.

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-5**
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`