### PR TITLE
fix(foundation): clear boot error when SQLite dir can't be created (Wave 1 · W1-6)

### DIFF
--- a/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
+++ b/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
@@ -87,8 +87,13 @@ final class DatabaseBootstrapper
 
         // Ensure the parent directory exists so SQLite can create the file.
         $dir = dirname($dbPath);
-        if (!is_dir($dir)) {
-            @mkdir($dir, 0o755, recursive: true);
+        if (!is_dir($dir) && !mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
+            throw new \RuntimeException(sprintf(
+                'Failed to create the database directory "%s" for the SQLite database at "%s". '
+                . 'Check that the parent path exists and is writable.',
+                $dir,
+                $dbPath,
+            ));
         }
 
         return $dbPath;

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/DatabaseBootstrapperTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/DatabaseBootstrapperTest.php
@@ -366,6 +366,45 @@ final class DatabaseBootstrapperTest extends TestCase
         $this->assertInstanceOf(DatabaseInterface::class, $database);
     }
 
+    #[Test]
+    public function bootThrowsWhenParentDirectoryCannotBeCreated(): void
+    {
+        // Simulate an uncreatable parent by placing the database path under a
+        // regular FILE — mkdir will fail with ENOTDIR because a path component
+        // is not a directory. This works even as root (it is not a permission
+        // trick; the filesystem rejects the operation structurally).
+        $file = tempnam(sys_get_temp_dir(), 'wsdb');
+        if ($file === false) {
+            self::markTestSkipped('tempnam() failed — cannot proceed');
+        }
+
+        try {
+            // $file is a regular file; asking for $file/sub/db.sqlite means
+            // dirname() is $file/sub, which cannot be mkdir'd.
+            $dbPath = $file . '/sub/db.sqlite';
+
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessageMatches('/Failed to create the database directory/');
+
+            // Suppress the E_WARNING that mkdir() emits on ENOTDIR — this is the
+            // OS-level signal that mkdir failed; our production code converts it to
+            // a RuntimeException, which is what this test asserts.
+            set_error_handler(static fn() => true, \E_WARNING);
+            try {
+                new DatabaseBootstrapper()->boot(
+                    sys_get_temp_dir(),
+                    ['database' => $dbPath, 'environment' => 'dev'],
+                );
+            } finally {
+                restore_error_handler();
+            }
+        } finally {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
     /**
      * @return LoggerInterface&object{warnings: list<string>}
      */


### PR DESCRIPTION
**Remediation Wave 1 — W1-6** · finding `L0-foundation-kernel.md` m4

## Summary
`DatabaseBootstrapper::resolvePath()` created the DB parent directory with `@mkdir($dir, 0o755, recursive: true)` — the `@` swallowed the warning and nothing verified the directory existed, so a failed mkdir surfaced only later as an opaque SQLite "unable to open database file" error.

- Drop the `@`; use the race-safe checked idiom `!is_dir($dir) && !mkdir(...) && !is_dir($dir)` (tolerates a concurrent creator) and throw a clear `\RuntimeException` naming the directory + db path — matching the existing boot-failure style of `guardMissingProductionSqliteDatabase()` in the same file.
- New test drives the failure deterministically across environments (incl. as root) by placing the db under a regular file so the recursive mkdir fails with ENOTDIR.

## Gate output
- `composer cs-check` (2 files) → **green** (`files:[]`).
- `composer phpstan` (source; the gate analyses only `packages/*/src`) → **green** (`[OK] No errors`).
- `./vendor/bin/phpunit packages/foundation/tests` → **1050 tests OK** (incl. the new test; benign no-coverage-driver warning).
- `composer verify` → unchanged vs main (pre-existing `check-admin-dist-fresh` RED untouched).

no-changelog: internal boot-path hardening — no public API, signature, or normal-operation behaviour change; it only converts an already-failing mkdir into a clear immediate exception instead of a later opaque SQLite error.

spec-reviewed: docs/specs/infrastructure.md — robustness-only change; boot still creates the parent dir, now failing fast with a clear exception. No documented contract or behaviour changed.

## Checklist
- [x] **Traceability:** Remediation Wave 1 work package **W1-6**
- [x] PR title includes a clear WP reference per `docs/specs/workflow.md`