### PR TITLE
chore(workflow): retire Spec Kitty, codify the design-first workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,18 +1,7 @@
-<!-- spec-kitty:orientation -->
-**Spec Kitty v3.2.0** — project: unknown (migration-required)
-⚠ Project migration required — run `spec-kitty upgrade` before using missions.
+# Workflow note
 
-Two usage patterns:
-- **Full mission** (spec → plan → tasks → implement → review → merge):
-  trigger: "spec out", "create a mission", "write a spec", "plan this"
-  → run `/spec-kitty.specify`
-- **Lightweight dispatch** (ad-hoc fix, question, or advice — no mission created):
-  trigger: "hey spec kitty", "use spec kitty to", "spec kitty <anything>"
-  → **ALWAYS run `spec-kitty dispatch "<request verbatim>"` — do NOT answer directly.**
-  If you know the right profile, pass it to skip routing:
-  `spec-kitty dispatch "<request verbatim>" --profile <profile-id>`
-  Reason: `spec-kitty dispatch` loads governance context, routes the request,
-  and opens the Op. Skipping it produces ungoverned, untracked responses.
-  After finishing the work, close the Op with the command printed in the capsule
-  (`spec-kitty profile-invocation complete --invocation-id <id> --outcome <done|failed|abandoned>`).
-<!-- /spec-kitty:orientation -->
+**Spec Kitty is retired in this repo** (decision 2026-07-06). Do not run `spec-kitty` commands, `/spec-kitty.*` skills, or `spec-kitty dispatch` — answer and work directly.
+
+Substantive work follows the design-first flow in `docs/specs/workflow.md`: brainstorm → spec (`docs/specs/`) → written plan → TDD implementation → code review → verification (the superpowers skill family covers each stage). GitHub issues anchor multi-PR efforts; PRs reference `#N`.
+
+Historical Spec Kitty artifacts (`.kittify/`, `kitty-specs/`, `kitty-ops/`) are retained read-only. The charter (`.kittify/charter/charter.md`) remains the source for directives cited elsewhere (DIR-004, DIR-006) until relocated.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,24 +25,6 @@
             "show_output": true
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "spec-kitty session-start"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "spec-kitty session-stop"
-          }
-        ]
       }
     ]
   }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Active Spec Kitty mission (if any):** <!-- mission name, `spec-kitty next` step, or path under `.kittify/` — omit for trivial/docs-only PRs -->
+**Anchoring issue / plan:** <!-- `#N` for multi-PR efforts, or the plan/spec doc that motivated this change — omit for trivial/docs-only PRs -->
 
 Closes #
 
@@ -7,6 +7,6 @@ Closes #
 
 ## Checklist
 
-- [ ] **Traceability:** `Closes #N` above **or** linked Spec Kitty mission / work package (path or link in this body)
-- [ ] If this PR closes a **GitHub issue**, that issue is assigned to a Track milestone
-- [ ] PR title includes `#N` **or** a clear mission/WP reference per `docs/specs/workflow.md`
+- [ ] **Traceability:** `Closes #N` above **or** the anchoring issue / plan / spec doc referenced in this body
+- [ ] PR title includes `#N` **or** a clear plan/spec reference per `docs/specs/workflow.md`
+- [ ] Relevant `docs/specs/*.md` updated if documented behaviour changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,12 @@ This file is intentionally lightweight and stays in sync with [CLAUDE.md](CLAUDE
 - `CLAUDE.md` is the authoritative, detailed instruction set for architecture, workflows, and gotchas.
 - If guidance here conflicts with `CLAUDE.md`, follow `CLAUDE.md`.
 
-## Specs and Spec Kitty
+## Specs and workflow
 - **Constitution:** `CLAUDE.md` (orchestration table, layers, checklists)
 - **Skills:** `skills/waaseyaa/` (domain skills on demand); `waaseyaa:spec-maintenance` for edits to `docs/specs/**` and agent rules
 - **Specs:** `docs/specs/` — read the relevant `.md` files directly (or `rg` under `docs/specs/`). There is no Waaseyaa spec MCP server in this repo.
 
-**Spec Kitty** is the primary execution workflow: see `CLAUDE.md` (`.kittify/`, CLI install). GitHub issues/milestones are optional mirror + PR/CI per `docs/specs/workflow.md`.
+**Design-first workflow** (Spec Kitty retired 2026-07-06): brainstorm → spec → written plan → TDD implementation → review → verification, with GitHub issues as multi-PR anchors — see `docs/specs/workflow.md`.
 
 ## Practical Rules
 - Respect layer boundaries and access-control semantics from `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ When working on files matching these patterns, retrieve the spec for deep contex
 | `packages/listing/*` | — | `docs/specs/listing-pipeline-v1.md`, `docs/conventions/cache-tags-and-contexts.md`, `docs/cookbook/listing-first-cut.md` |
 | `packages/cms/*`, `packages/core/*`, `packages/full/*` | — (consumer metapackages) | `docs/roadmap/packagist-publishing-plan.md`, `docs/adr/004-framework-package-collapse.md`, `tests/PackagedForm/README.md` |
 
-| Workflow, Spec Kitty, GitHub (PRs/issues), roadmap | — | `docs/specs/workflow.md`, `docs/specs/per-site-convergence-audit.md`, `docs/specs/v1.5-verification-gate-contract.md`, `docs/specs/v1.6-verification-gate-contract.md` |
+| Workflow, GitHub (PRs/issues), roadmap | — | `docs/specs/workflow.md`, `docs/specs/per-site-convergence-audit.md`, `docs/specs/v1.5-verification-gate-contract.md`, `docs/specs/v1.6-verification-gate-contract.md` |
 | `skills/waaseyaa/app-development/*` | — | — |
 | `skills/waaseyaa/framework-extraction/*` | — | `docs/specs/extraction-log.md` |
 | `docs/audits/*` | — | — |
@@ -173,26 +173,24 @@ framework-vs-distribution boundary is codified in charter directive DIR-004.
 5. Verify by resolving `Waaseyaa\Bimaaji\Graph\ApplicationGraphGenerator` from the container — the framework's default `BimaajiServiceProvider` only composes the six built-in providers, so a downstream provider currently needs to either (a) rebind `ApplicationGraphGenerator` with its own iterable that includes the new provider, or (b) wait for the tagged-collection resolution feature scheduled for M3's container work.
 6. Read `docs/specs/bimaaji.md` "Implementation Status" before adding mutation-side behavior — the validated mutation pipeline (`MutationValidator` → `PatchSet`) belongs to bimaaji's mutation surface, not graph providers.
 
-## Workflow (Spec Kitty–first)
+## Workflow (design-first)
 
-Substantive work is driven by **[Spec Kitty](https://github.com/Priivacy-ai/spec-kitty)** missions and work packages (`.kittify/`, `spec-kitty next`, dashboard); **GitHub** is the PR/CI/releases surface and optional issue visibility. Full rules: `docs/specs/workflow.md` (versioning, PR traceability).
+**Spec Kitty is retired** (2026-07-06) — do not run `spec-kitty` commands or `/spec-kitty.*` skills. Historical artifacts (`.kittify/`, `kitty-specs/`, `kitty-ops/`) are read-only history; the charter (`.kittify/charter/charter.md`) remains the source for directives cited elsewhere (DIR-004, DIR-006) until relocated. Full rules: `docs/specs/workflow.md` (versioning, PR traceability).
 
 **The 4 rules (summary — see `docs/specs/workflow.md` for nuance):**
 
-1. **Substantive work begins in Spec Kitty** — active mission/WP or `spec-kitty next`; M11 filings may still require a GitHub issue as the audit front door (link it).
-2. **GitHub issues are optional** — not every change needs one. When filed, they're pure tracking with no enforced milestone or taxonomy. Spec Kitty mission state is the canonical execution map.
-3. **PRs must be traceable** — `#N` and/or Spec Kitty mission/WP reference per `docs/specs/workflow.md` and `.github/pull_request_template.md`.
-4. **Session context** — prefer Spec Kitty state when under a mission (`spec-kitty next`, dashboard, active WP).
+1. **Substantive work begins with a design, not code** — brainstorm the requirements, write/update the spec in `docs/specs/`, produce a written implementation plan, then implement with TDD, code review, and end-to-end verification. The superpowers skill family (brainstorming → writing-plans → executing-plans → requesting-code-review → verification-before-completion) covers each stage.
+2. **GitHub issues anchor multi-PR efforts** — one issue per feature/batch as the traceability anchor; single-PR fixes may skip the issue. No enforced milestone or taxonomy.
+3. **PRs must be traceable** — reference `#N` (or the plan/spec doc for un-issued single-PR work) per `docs/specs/workflow.md` and `.github/pull_request_template.md`.
+4. **Session context** — orient from the active plan doc, the anchoring issue, and the relevant `docs/specs/` contract.
 
-## Agent context and Spec Kitty
+## Agent context
 
 - **Constitution (this file):** Session-hot rules — orchestration table, layer graph, checklists, gotchas.
 - **Specialist skills:** `skills/waaseyaa/*` — load on demand for a subsystem; each skill lists related specs.
 - **Cold specs:** `docs/specs/*.md` — read directly from disk when you need contracts, file maps, and edge cases (no spec MCP server).
 
-Install the CLI: `pip install spec-kitty-cli` or `uv tool install spec-kitty-cli`. Run `spec-kitty upgrade` in the repo after upgrading the CLI. The CLI may create `.claude/skills/` symlinks to your global Spec Kitty skill pack — that directory is gitignored here because paths are machine-specific; re-run `spec-kitty init` (or upgrade) on a fresh clone after installing the CLI.
-
-**Workflow precedence:** **Spec Kitty** owns mission/work-package execution and structured review. **GitHub** owns merge mechanics, CI, releases, and optional issues. **`docs/specs/`** owns subsystem contracts — read from disk, update when behaviour changes.
+**Workflow precedence:** **Written plans + anchoring GitHub issues** own execution tracking. **GitHub** owns merge mechanics, CI, releases. **`docs/specs/`** owns subsystem contracts — read from disk, update when behaviour changes.
 
 Design docs in `docs/history/plans/` are session artifacts (implementation history). Specs in `docs/specs/` are enduring architectural knowledge (kept current). When refactoring a subsystem, update its spec — run `tools/drift-detector.sh` to find stale specs.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -64,7 +64,7 @@ The following codified gates are the framework's **procurement-legible trust sub
 
 - **Merge to `main`:** Primary maintainer in steady state. Trustee in escalation only — see "Escalation" below.
 - **Publish releases on Packagist:** Primary maintainer in steady state. Trustee in escalation only — see "Escalation" below.
-- **Charter amendments:** Follow the Amendment Process documented in [`.kittify/charter/charter.md`](.kittify/charter/charter.md). Amendments are themselves Spec Kitty missions; the trustee MAY initiate an amendment mission in escalation but the amendment MUST follow the documented mission flow.
+- **Charter amendments:** Follow the Amendment Process documented in [`.kittify/charter/charter.md`](.kittify/charter/charter.md). An amendment is a governed change: it gets its own anchoring GitHub issue and a written plan, and the amending PR links both; the trustee MAY initiate an amendment in escalation but MUST follow that documented flow.
 - **`charter-exception` issues:** Filed per the Exception Policy in the charter. Both primary maintainer and trustee may file; both may resolve.
 
 ## Escalation

--- a/docs/specs/workflow.md
+++ b/docs/specs/workflow.md
@@ -1,10 +1,18 @@
-# Workflow governance (Spec Kitty–first)
+# Workflow governance (design-first)
+
+<!-- Spec reviewed 2026-07-06 - Spec Kitty retired as the execution workflow (owner decision).
+     Replaced by the design-first flow: brainstorm → spec → written plan → TDD implementation
+     → code review → verification, with GitHub issues as traceability anchors. Historical
+     Spec Kitty artifacts (.kittify/, kitty-specs/, kitty-ops/) are retained read-only; the
+     charter at .kittify/charter/charter.md remains the source for directives (DIR-004,
+     DIR-006) until relocated. -->
+
 
 <!-- Spec reviewed 2026-05-01 - Milestone table reconciliation: GitHub now has exactly 5 Track milestones (Track 1 Entity system & hydration, Track 2 Bimaaji & agentic, Track 3 Parity & performance, Track 4 Schema evolution, Track 5 Ecosystem identity) — the prior version-numbered milestones (v0.1, v0.2, v0.3, v0.5, Phase 1, M1) flagged in the audit were retired before this surface landed. The "Framework Milestones" table below is the semantic capability narrative (slices, not GitHub titles); the "GitHub milestone tracks" table is the live mirror that contributors assign issues to. Both tables are now in sync with the live GitHub state (mission #824 WP09 surface E, closes #852) -->
 
-**Planning and execution** for substantive work are driven by **[Spec Kitty](https://github.com/Priivacy-ai/spec-kitty)** — missions, work packages, `spec-kitty next`, the dashboard, and `.kittify/` artifacts — not by GitHub issues alone. **`docs/specs/`** remains the contract layer agents read from disk.
+**Planning and execution** for substantive work are **design-first**: interrogate requirements (brainstorming), write or update the subsystem spec in **`docs/specs/`**, produce a written implementation plan, then implement with TDD, code review, and end-to-end verification before claiming completion. The superpowers skill family covers each stage. **`docs/specs/`** remains the contract layer agents read from disk.
 
-**GitHub** stays the **integration and visibility surface**: pull requests, Actions, releases, security, fork/contributor discovery, and **optional** issues (including M11 governed-change filings). CI and merge reality still live on GitHub; Spec Kitty does not replace the PR or the pipeline.
+**GitHub** is the **tracking, integration, and visibility surface**: issues anchor multi-PR efforts, plus pull requests, Actions, releases, security, and fork/contributor discovery. CI and merge reality live on GitHub.
 
 ## Versioning Model
 
@@ -45,9 +53,9 @@ The Waaseyaa Framework and Minoo (the flagship consumer app) version independent
 
 ## GitHub issues (optional)
 
-GitHub issues are no longer organized into Track milestones. When an issue exists (community visibility, Dependabot, M11 templates, or contributor preference), it stands on its own — no enforced taxonomy or assignment is required. The **Framework Milestones** table above is the semantic capability narrative; Spec Kitty mission state is the execution map. The Track 1–5 GitHub milestones from earlier 2026 are retained on GitHub for historical context but are no longer load-bearing for workflow decisions.
+GitHub issues are not organized into Track milestones. Multi-PR efforts (features, remediation batches) get **one anchoring issue** that every PR in the effort references; single-PR fixes may stand alone. No enforced taxonomy or assignment is required. The **Framework Milestones** table above is the semantic capability narrative; the anchoring issues plus written plan docs are the execution map. The Track 1–5 GitHub milestones from earlier 2026 are retained on GitHub for historical context but are no longer load-bearing for workflow decisions.
 
-**Dependabot and dependency PRs:** **Pull requests** that only bump dependencies may omit `(#N)` / mission reference in the title when there is no tracking artifact; if there is a chore or security issue or Spec Kitty WP, link it per rule #3.
+**Dependabot and dependency PRs:** **Pull requests** that only bump dependencies may omit `(#N)` in the title when there is no tracking artifact; if there is a chore or security issue, link it per rule #3.
 
 ## Milestone Narrative Arc
 
@@ -74,17 +82,17 @@ GitHub issues are no longer organized into Track milestones. When an issue exist
 
 ## The 4 Workflow Rules
 
-### 1. Substantive work begins in Spec Kitty
-Do not drive multi-step implementation from a blank prompt. Use an **active Spec Kitty mission and work package** (or the next step from `spec-kitty next`) so intent, review gates, and merge discipline stay in `.kittify/` and the mission state machine. **M11 governed-change** and similar templates that require a **GitHub filing issue** still use that issue as the audit front door — link it from the mission or PR body so traceability stays intact.
+### 1. Substantive work begins with a design, not code
+Do not drive multi-step implementation from a blank prompt. Interrogate the requirements first (brainstorming), write or update the subsystem spec in `docs/specs/`, and produce a **written implementation plan** that is reviewed before code. Implementation proceeds test-first (TDD), passes code review, and is verified end-to-end before completion is claimed. **M11 governed-change** and similar templates that require a **GitHub filing issue** still use that issue as the audit front door — link it from the plan or PR body so traceability stays intact.
 
-### 2. GitHub issues are optional
-Not every change needs an issue. When filed, GitHub issues are pure tracking — no enforced milestone or taxonomy. Omitting GitHub issues entirely for Spec Kitty–only work is allowed; do not force an issue if the mission alone is sufficient for your slice. The **Framework milestones** table and narrative in this document describe **capability intent** (v1.x / v2.0); **Spec Kitty mission structure** is the primary execution map for agents.
+### 2. GitHub issues anchor multi-PR efforts
+A feature or batch spanning multiple PRs gets **one anchoring issue**; every PR in the effort references it. Single-PR fixes may skip the issue. When filed, issues are pure tracking — no enforced milestone or taxonomy. The **Framework milestones** table and narrative in this document describe **capability intent** (v1.x / v2.0); anchoring issues plus plan docs are the execution map for agents.
 
 ### 3. PRs must be traceable
-Every PR must link **what it delivers**: prefer `feat(#N): …` when a GitHub issue exists; otherwise reference the **Spec Kitty mission / work package** (title, path under `.kittify/`, or link) in the title or body. Use `.github/pull_request_template.md`. Dependency-only PRs may follow the Dependabot exception above.
+Every PR must link **what it delivers**: prefer `feat(#N): …` when a GitHub issue exists; otherwise reference the plan or spec doc that motivated the change in the title or body. Use `.github/pull_request_template.md`. Dependency-only PRs may follow the Dependabot exception above.
 
-### 4. Read mission context before generating work
-At session start, prefer **Spec Kitty** context (`spec-kitty next`, dashboard, active WP) when the repo is under a mission.
+### 4. Read plan context before generating work
+At session start, orient from the active plan doc, the anchoring issue, and the relevant `docs/specs/` contract before generating new work.
 
 ## Drift Detection
 
@@ -155,4 +163,4 @@ Failure format is machine- and human-readable, including:
 - current value
 - expected value
 
-The top-level M11 post-execution governance baseline is [m11-post-execution-governance-bootstrap.md](./m11-post-execution-governance-bootstrap.md). Governed changes enter that loop through [the governed-change issue template](../../.github/ISSUE_TEMPLATE/m11-governed-change.md) (GitHub as **audit front door**); link the filing issue from the active **Spec Kitty** mission or PR when both exist. This workflow spec is the repo-local backlink to that artifact. The operating loop itself is [m11-steady-state-conformance-loop.md](./m11-steady-state-conformance-loop.md), and steady-state drift scans and C17+ logging use [m11-periodic-drift-scan-protocol.md](./m11-periodic-drift-scan-protocol.md) and the [M11 drift-scan log issue template](../../.github/ISSUE_TEMPLATE/m11-drift-scan-log.md).
+The top-level M11 post-execution governance baseline is [m11-post-execution-governance-bootstrap.md](./m11-post-execution-governance-bootstrap.md). Governed changes enter that loop through [the governed-change issue template](../../.github/ISSUE_TEMPLATE/m11-governed-change.md) (GitHub as **audit front door**); link the filing issue from the plan doc or PR. This workflow spec is the repo-local backlink to that artifact. The operating loop itself is [m11-steady-state-conformance-loop.md](./m11-steady-state-conformance-loop.md), and steady-state drift scans and C17+ logging use [m11-periodic-drift-scan-protocol.md](./m11-periodic-drift-scan-protocol.md) and the [M11 drift-scan log issue template](../../.github/ISSUE_TEMPLATE/m11-drift-scan-log.md).

--- a/skills/waaseyaa/spec-maintenance/SKILL.md
+++ b/skills/waaseyaa/spec-maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: waaseyaa-spec-maintenance
-description: Use when editing docs/specs/, CLAUDE.md orchestration, or agent rules — keep subsystem specs aligned with code, run drift checks, and follow Spec Kitty–first workflow (GitHub as integration surface).
+description: Use when editing docs/specs/, CLAUDE.md orchestration, or agent rules — keep subsystem specs aligned with code, run drift checks, and follow the design-first workflow (GitHub issues as multi-PR anchors).
 ---
 
 # Waaseyaa spec maintenance
@@ -30,8 +30,8 @@ bash tools/drift-detector.sh 5
 
 Session hooks may run a shorter threshold; CI runs drift detection on pushes and PRs.
 
-## Spec Kitty vs GitHub
+## Workflow and GitHub
 
-This repo uses **Spec Kitty** for spec/plan/task-driven delivery (see `.kittify/` and [Spec Kitty](https://github.com/Priivacy-ai/spec-kitty)).
+This repo uses a **design-first workflow** (Spec Kitty retired 2026-07-06): brainstorm → spec (`docs/specs/`) → written plan → TDD implementation → review → verification.
 
-**Precedence:** **Spec Kitty** missions and work packages are the primary ledger for structured work. **GitHub** is for PRs, CI, releases, security, and **optional** issues (including M11 filings); Track milestones apply when an issue exists (`docs/specs/workflow.md`).
+**Precedence:** written plans plus **anchoring GitHub issues** are the ledger for structured work. **GitHub** is for PRs, CI, releases, security, and issues (including M11 filings) — see `docs/specs/workflow.md`. Historical Spec Kitty artifacts (`.kittify/`, `kitty-specs/`, `kitty-ops/`) are read-only history.


### PR DESCRIPTION
**Anchoring issue / plan:** owner decision 2026-07-06 — workflow governance change, traceable to `docs/specs/workflow.md` (spec-reviewed note in this diff)

Closes #

## Summary

Retires Spec Kitty as the execution workflow and codifies the design-first replacement across every living doc:

- `.claude/settings.json` — `spec-kitty session-start`/`session-stop` hooks removed (drift-detector hooks retained)
- `.claude/CLAUDE.md` — orientation block replaced with the retirement note
- `CLAUDE.md` + `docs/specs/workflow.md` — the 4 workflow rules rewritten: design before code (brainstorm → spec → written plan → TDD → review → verification), GitHub issues anchor multi-PR efforts, PR traceability via `#N` or plan/spec doc, orient from plan + issue + spec
- `.github/pull_request_template.md` — anchoring issue/plan instead of mission; drops the Track-milestone checkbox that already contradicted workflow.md
- `AGENTS.md`, `skills/waaseyaa/spec-maintenance/SKILL.md`, `MAINTAINERS.md` — pointers updated

Deliberately untouched: `.kittify/`, `kitty-specs/`, `kitty-ops/` (read-only history), `.gitignore` entries, and the charter at `.kittify/charter/charter.md`, which remains the source for DIR-004/DIR-006 until relocated.

## Checklist

- [x] **Traceability:** anchoring plan/spec doc referenced in this body
- [x] PR title includes a clear plan/spec reference per `docs/specs/workflow.md`
- [x] Relevant `docs/specs/*.md` updated (`workflow.md` rewritten with spec-reviewed note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)