### PR TITLE
fix(telescope): make request recording best-effort (#1915, R16)

### DIFF
--- a/packages/telescope/src/Middleware/TelescopeRequestMiddleware.php
+++ b/packages/telescope/src/Middleware/TelescopeRequestMiddleware.php
@@ -7,6 +7,8 @@ namespace Waaseyaa\Telescope\Middleware;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\Telescope\TelescopeServiceProvider;
@@ -20,9 +22,14 @@ use Waaseyaa\Telescope\TelescopeServiceProvider;
 #[AsMiddleware(pipeline: 'http', priority: 100)]
 final class TelescopeRequestMiddleware implements HttpMiddlewareInterface
 {
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly TelescopeServiceProvider $telescope,
-    ) {}
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
@@ -32,13 +39,23 @@ final class TelescopeRequestMiddleware implements HttpMiddlewareInterface
 
         $durationMs = (hrtime(true) - $startTime) / 1_000_000;
 
-        $this->recordRequest(
-            method: $request->getMethod(),
-            uri: $request->getPathInfo(),
-            statusCode: $response->getStatusCode(),
-            durationMs: $durationMs,
-            controller: $this->resolveController($request),
-        );
+        // Telemetry is a non-critical side effect: a storage failure (full
+        // disk, locked SQLite file, JSON-encode error) must never turn an
+        // already-successful response into a 500. Best-effort only.
+        try {
+            $this->recordRequest(
+                method: $request->getMethod(),
+                uri: $request->getPathInfo(),
+                statusCode: $response->getStatusCode(),
+                durationMs: $durationMs,
+                controller: $this->resolveController($request),
+            );
+        } catch (\Throwable $exception) {
+            $this->logger->warning('Telescope request recording failed: {message}', [
+                'message' => $exception->getMessage(),
+                'exception' => $exception,
+            ]);
+        }
 
         return $response;
     }

--- a/packages/telescope/tests/Unit/Middleware/TelescopeRequestMiddlewareTest.php
+++ b/packages/telescope/tests/Unit/Middleware/TelescopeRequestMiddlewareTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Telescope\Tests\Unit\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\LogLevel;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Telescope\Middleware\TelescopeRequestMiddleware;
+use Waaseyaa\Telescope\Storage\TelescopeStoreInterface;
+use Waaseyaa\Telescope\TelescopeServiceProvider;
+
+/**
+ * A telemetry write failure must never turn a successful response into a
+ * 500 (audit A11 / L6-telescope.md, CRITICAL finding).
+ */
+#[CoversClass(TelescopeRequestMiddleware::class)]
+final class TelescopeRequestMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function a_store_failure_does_not_crash_the_response(): void
+    {
+        $store = new class implements TelescopeStoreInterface {
+            public function store(string $type, array $data): void
+            {
+                throw new \RuntimeException('disk full');
+            }
+
+            public function query(string $type, int $limit = 50, int $offset = 0): array
+            {
+                return [];
+            }
+
+            public function prune(\DateTimeInterface $before): int
+            {
+                return 0;
+            }
+
+            public function clear(): void {}
+        };
+
+        $logger = new class implements LoggerInterface {
+            /** @var list<array{level: LogLevel, message: string|\Stringable}> */
+            public array $records = [];
+
+            public function emergency(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::EMERGENCY, $message, $context);
+            }
+
+            public function alert(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::ALERT, $message, $context);
+            }
+
+            public function critical(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::CRITICAL, $message, $context);
+            }
+
+            public function error(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::ERROR, $message, $context);
+            }
+
+            public function warning(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::WARNING, $message, $context);
+            }
+
+            public function notice(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::NOTICE, $message, $context);
+            }
+
+            public function info(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::INFO, $message, $context);
+            }
+
+            public function debug(string|\Stringable $message, array $context = []): void
+            {
+                $this->log(LogLevel::DEBUG, $message, $context);
+            }
+
+            public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => $message];
+            }
+        };
+
+        $provider = new TelescopeServiceProvider(store: $store);
+        $middleware = new TelescopeRequestMiddleware($provider, $logger);
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('ok', 200);
+            }
+        };
+
+        $response = $middleware->process(Request::create('/foo'), $next);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('ok', $response->getContent());
+        $this->assertNotEmpty($logger->records, 'expected the store failure to be logged, not swallowed silently');
+        $this->assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+    }
+
+    #[Test]
+    public function it_still_records_successfully_when_the_store_does_not_throw(): void
+    {
+        $middleware = new TelescopeRequestMiddleware(new TelescopeServiceProvider());
+
+        $next = new class implements HttpHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response('ok', 200);
+            }
+        };
+
+        $response = $middleware->process(Request::create('/foo'), $next);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
**Anchoring issue:** #1915

## Summary

- `TelescopeRequestMiddleware::process()` called `recordRequest()` -> `RequestRecorder::record()` -> `SqliteTelescopeStore::store()` (raw PDO, `ERRMODE_EXCEPTION`) with no try/catch anywhere in the chain. A telemetry write failure (locked SQLite file, full disk, JSON-encode error on response metadata) turned an already-successful 200 into an uncaught 500. Auto-wired via `#[AsMiddleware(pipeline: 'http', priority: 100)]` and enabled by default, so this was live the moment the telescope package was installed.
- Wrapped the `recordRequest()` call in `TelescopeRequestMiddleware::process()` in a try/catch. On failure it logs via the framework `LoggerInterface` (accepted as `?LoggerInterface $logger = null`, defaulting to `NullLogger`) and the response proceeds unchanged.
- Audit record: `L6-telescope.md`, CRITICAL finding "the one live path has no fault isolation around a raw-PDO write."

## Test plan

- [x] New test `packages/telescope/tests/Unit/Middleware/TelescopeRequestMiddlewareTest.php`:
  - `a_store_failure_does_not_crash_the_response` — a `TelescopeStoreInterface` double that throws on `store()` is wired through a real `TelescopeServiceProvider`; asserts the response is still 200 with the original body, and that the failure was logged at `WARNING`.
  - `it_still_records_successfully_when_the_store_does_not_throw` — happy-path regression guard.
- [x] `./vendor/bin/phpunit packages/telescope/tests/` — 206 tests, 497 assertions, all green.
- [x] `composer phpstan` — no errors.
- [x] `composer cs-check` — clean.
- [x] `bin/check-dead-code` — no new findings.
- [x] Pre-push hook ran the full suite (9390 tests) — green.

## Checklist

- [x] **Traceability:** anchored to #1915 (batch of three independent audit fixes; not closing the issue since it anchors the whole batch)
- [ ] N/A — no GitHub issue being closed by this PR
- [x] PR title includes `#1915`


no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
