### PR TITLE
fix(api): QueueController::retry() dispatches before forgetting failed record (#1915, R16)

### DIFF
--- a/packages/api/src/Controller/QueueController.php
+++ b/packages/api/src/Controller/QueueController.php
@@ -212,31 +212,29 @@ final class QueueController
      *
      * Semantics: `FailedJobRepositoryInterface::retry()` returns the record
      * AND removes it from the failed table — it does NOT re-enqueue. We
-     * mirror the CLI `QueueRetryHandler` and dispatch the unserialized
-     * message onto `QueueInterface` ourselves.
+     * mirror the CLI `QueueRetryHandler` (see `Waaseyaa\CLI\Handler\QueueRetryHandler`,
+     * PR #1908): find + unserialize + dispatch first, and only forget the
+     * failed-table row once dispatch succeeds. This closes a data-loss gap
+     * (audit R10b sweep, #1915, R16) where the old order forgot the record
+     * BEFORE unserializing/dispatching, so a corrupt payload or a dispatch
+     * failure destroyed the job permanently.
      *
      * Returns 204 on success, 404 if the id is unknown, 422 if the payload
-     * is corrupt (cannot be unserialized).
+     * is corrupt (cannot be unserialized, record is left in place), 502 if
+     * dispatch itself throws (record is left in place).
      */
     public function retry(string $id): Response
     {
-        // Check existence *before* the destructive retry() call to avoid races
-        // and to allow a clean 404 without consuming the record.
-        if ($this->failedJobRepository->find($id) === null) {
-            return self::errorResponse(404, 'Not Found', sprintf('Unknown failed job id: %s', $id));
-        }
-
-        $record = $this->failedJobRepository->retry($id);
+        $record = $this->failedJobRepository->find($id);
         if ($record === null) {
-            // Race: another caller forgot/retried between find() and retry().
             return self::errorResponse(404, 'Not Found', sprintf('Unknown failed job id: %s', $id));
         }
 
         $message = @unserialize($record['payload']);
         if ($message === false || !is_object($message)) {
-            // Payload is irrecoverable. We've already removed it from the
-            // failed table (retry() is destructive); surface a 422 so the
-            // operator sees the corruption rather than a silent success.
+            // Payload is irrecoverable. Leave the record in the failed table
+            // (unlike the pre-#1915-R16 behavior) so the operator can inspect
+            // or explicitly discard it rather than losing it silently.
             return self::errorResponse(
                 422,
                 'Unprocessable Entity',
@@ -244,7 +242,21 @@ final class QueueController
             );
         }
 
-        $this->queue->dispatch($message);
+        try {
+            $this->queue->dispatch($message);
+        } catch (\Throwable $e) {
+            // Dispatch failed — leave the record in the failed table so the
+            // job is not lost; the operator can retry again once the
+            // underlying issue (e.g. a transport outage) is resolved.
+            return self::errorResponse(
+                502,
+                'Bad Gateway',
+                sprintf('Failed job [%s] could not be re-dispatched: %s', $id, $e->getMessage()),
+            );
+        }
+
+        // Only forget the failed-table row after a successful dispatch.
+        $this->failedJobRepository->retry($id);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/packages/api/tests/Unit/Controller/QueueControllerTest.php
+++ b/packages/api/tests/Unit/Controller/QueueControllerTest.php
@@ -127,7 +127,7 @@ final class QueueControllerTest extends TestCase
     }
 
     #[Test]
-    public function retryReturns422WhenPayloadIsCorrupt(): void
+    public function retryReturns422WhenPayloadIsCorruptAndKeepsRecord(): void
     {
         $repo = $this->makeRepo([self::record('99', 'default', 'not-valid-php-serialize')]);
         $queue = $this->makeQueue();
@@ -138,6 +138,28 @@ final class QueueControllerTest extends TestCase
         self::assertInstanceOf(JsonResponse::class, $response);
         self::assertSame(422, $response->getStatusCode());
         self::assertCount(0, $queue->dispatched);
+        // Data-loss regression guard (#1915, R16): a corrupt payload must NOT
+        // be forgotten from the failed table — the operator needs the row to
+        // inspect or discard it explicitly.
+        self::assertNotNull($repo->find('99'));
+    }
+
+    #[Test]
+    public function retryLeavesRecordInPlaceWhenDispatchThrows(): void
+    {
+        $message = new \stdClass();
+        $serialized = serialize($message);
+        $repo = $this->makeRepo([self::record('55', 'default', $serialized)]);
+        $queue = $this->makeThrowingQueue();
+        $controller = new QueueController($repo, $queue);
+
+        $response = $controller->retry('55');
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(502, $response->getStatusCode());
+        // Data-loss regression guard (#1915, R16): a failed dispatch must NOT
+        // forget the record — the job would otherwise be lost permanently.
+        self::assertNotNull($repo->find('55'));
     }
 
     #[Test]
@@ -340,6 +362,20 @@ final class QueueControllerTest extends TestCase
             public function dispatch(object $message): void
             {
                 $this->dispatched[] = $message;
+            }
+        };
+    }
+
+    /**
+     * A `QueueInterface` fake whose `dispatch()` always throws, for exercising
+     * the retry() path where re-enqueue fails after the record was fetched.
+     */
+    private function makeThrowingQueue(): QueueInterface
+    {
+        return new class implements QueueInterface {
+            public function dispatch(object $message): void
+            {
+                throw new \RuntimeException('transport unavailable');
             }
         };
     }


### PR DESCRIPTION
**Active Spec Kitty mission (if any):** none — Spec Kitty is retired in this repo (see .claude/CLAUDE.md); tracked via anchoring issue #1915.

Ref #1915 (R16 — queuecontroller-retry-dataloss)

## Summary

- `QueueController::retry()` called `FailedJobRepositoryInterface::retry()` — which deletes the failed-job row — *before* unserializing and dispatching the payload. A corrupt payload or a `dispatch()` failure permanently destroyed the job.
- Mirrors the CLI fix already shipped in #1908 (`QueueRetryHandler`): find the record, unserialize, dispatch, and only forget the record from the failed table after a successful dispatch.
- 404 (unknown id) and the overall happy-path 204 semantics are unchanged. The 422 (corrupt payload) response now leaves the record in the failed table instead of destroying it. Added a 502 response for a caught dispatch failure, which also leaves the record in place (previously an uncaught exception from `dispatch()` after the destructive `retry()` call would have lost the job with no HTTP response at all).

## Test plan

- [x] `./vendor/bin/phpunit packages/api/tests/Unit/Controller/QueueControllerTest.php` — 17 tests, including two new/updated ones:
  - `retryReturns422WhenPayloadIsCorruptAndKeepsRecord` — asserts 422 AND the record is still present in the repo.
  - `retryLeavesRecordInPlaceWhenDispatchThrows` — asserts 502 AND the record is still present when `dispatch()` throws.
  - `retryDispatchesAndReturns204` (existing) — still asserts 204 and the record is gone after a successful dispatch.
- [x] `./vendor/bin/phpunit packages/api/tests/` — full api package suite, 606 tests, green.
- [x] `composer phpstan` — clean.
- [x] `composer cs-check` — clean.
- [x] Full pre-push hook suite (phpunit, phpstan, composer-policy, spec-drift) — green.

## Checklist

- [x] **Traceability:** anchored to #1915 (audit R16, queuecontroller-retry-dataloss finding)
- [ ] If this PR closes a **GitHub issue**, that issue is assigned to a Track milestone (N/A — #1915 stays open as the anchor for the R16 batch)
- [x] PR title includes `#1915`

## Review notes

**Disclosed trade-off (adversarial review): the fix reopens a double-dispatch window.** The old destructive order (`retry()` deletes the row BEFORE dispatch) was, accidentally, a compare-and-delete lock: of two concurrent retries of the same id, exactly one won the `retry()` delete and the loser got a clean 404. With the corrected order (find → dispatch → forget), two concurrent retries can both `find()` the record and both `dispatch()` it — the second `retry()` forget silently no-ops — so the failure mode under concurrency is now **duplicate job execution** instead of the old behavior's clean 404 for the loser. This is accepted deliberately: it is exact parity with the already-merged CLI fix (#1908, same ordering, same window), and duplicate dispatch of an idempotent-ish queue job is the safer failure mode versus the bug being fixed here (permanent, silent job loss on a corrupt payload or transport outage).

**Follow-up (not in this PR):** add an atomic claim primitive to `FailedJobRepositoryInterface` — e.g. a conditional UPDATE-style "claim" (`claim(id): ?record` that atomically marks-and-returns the row, or delete-returning semantics) — and use it from BOTH the API controller and the CLI `QueueRetryHandler`, so the retry order stays dispatch-before-forget while restoring single-winner semantics under concurrency.



no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
