### PR TITLE
fix(workflows): WorkflowVisibility::isEntityPublic fails closed on missing status key (#1915, R16)

### DIFF
--- a/packages/api/tests/Unit/Http/DiscoveryApiHandlerTest.php
+++ b/packages/api/tests/Unit/Http/DiscoveryApiHandlerTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Waaseyaa\Api\Http\DiscoveryApiHandler;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Media\Media;
 use Waaseyaa\User\AnonymousUser;
 
 #[CoversClass(DiscoveryApiHandler::class)]
@@ -179,6 +180,29 @@ final class DiscoveryApiHandlerTest extends TestCase
         $handler = $this->createHandler();
         $result = $handler->normalizeForCacheKey([3, 1, 2]);
         $this->assertSame([3, 1, 2], $result);
+    }
+
+    #[Test]
+    public function media_without_explicit_status_is_discovery_public(): void
+    {
+        // Regression for audit #1915 R16: WorkflowVisibility::isEntityPublic()
+        // now fails closed on a missing 'status' key. That flip is only safe
+        // because Media::__construct() backfills 'status' => true (matching its
+        // documented isPublished()-defaults-true semantics), so a media entity
+        // built without an explicit status must still clear the discovery gate.
+        $handler = $this->createHandler();
+        $media = new Media(['mid' => 1, 'bundle' => 'image']);
+
+        $this->assertTrue($handler->isDiscoveryEntityPublic($media));
+    }
+
+    #[Test]
+    public function media_explicitly_unpublished_is_not_discovery_public(): void
+    {
+        $handler = $this->createHandler();
+        $media = new Media(['mid' => 1, 'bundle' => 'image', 'status' => false]);
+
+        $this->assertFalse($handler->isDiscoveryEntityPublic($media));
     }
 
     private function createHandler(): DiscoveryApiHandler

--- a/packages/media/src/Media.php
+++ b/packages/media/src/Media.php
@@ -37,6 +37,16 @@ final class Media extends ContentEntityBase
         array $entityKeys = [],
         array $fieldDefinitions = [],
     ) {
+        // Ensure a default for the optional published-status property. Media is
+        // published-by-default (see isPublished()); backfilling here — mirroring
+        // Term's and Node's constructors — makes the entity class itself the
+        // single canonical source of that default, instead of leaving a missing
+        // 'status' key for every downstream consumer (e.g. WorkflowVisibility) to
+        // reinterpret independently.
+        if (!array_key_exists('status', $values)) {
+            $values['status'] = true;
+        }
+
         parent::__construct($values, $entityTypeId, $entityKeys, $fieldDefinitions);
     }
 

--- a/packages/media/tests/Unit/MediaTest.php
+++ b/packages/media/tests/Unit/MediaTest.php
@@ -121,6 +121,15 @@ final class MediaTest extends TestCase
         $this->assertFalse($media->isPublished());
     }
 
+    public function testStatusBackfilledWhenAbsentFromConstructor(): void
+    {
+        $media = new Media(['mid' => 1, 'bundle' => 'image']);
+
+        $this->assertTrue($media->isPublished());
+        $this->assertArrayHasKey('status', $media->toArray());
+        $this->assertTrue($media->toArray()['status']);
+    }
+
     public function testGetAndSetCreatedTime(): void
     {
         $media = new Media(['mid' => 1, 'bundle' => 'image']);

--- a/packages/workflows/src/WorkflowVisibility.php
+++ b/packages/workflows/src/WorkflowVisibility.php
@@ -51,7 +51,7 @@ final class WorkflowVisibility
         }
 
         if (!array_key_exists('status', $values)) {
-            return true;
+            return false;
         }
 
         return $this->isStatusPublic($values['status']);

--- a/packages/workflows/tests/Unit/WorkflowVisibilityTest.php
+++ b/packages/workflows/tests/Unit/WorkflowVisibilityTest.php
@@ -51,7 +51,40 @@ final class WorkflowVisibilityTest extends TestCase
         $this->assertTrue($visibility->isEntityPublic('relationship', ['status' => 1]));
         $this->assertFalse($visibility->isEntityPublic('relationship', ['status' => 0]));
         $this->assertTrue($visibility->isEntityPublic('relationship', ['status' => 'yes']));
-        $this->assertTrue($visibility->isEntityPublic('taxonomy_term', []));
+
+        // A non-node entity type without a `status` key at all must fail closed
+        // (not-visibly-published), the same as a present-but-garbage status value.
+        // Previously this returned true (fail-open); audit #1915 R16.
+        $this->assertFalse($visibility->isEntityPublic('taxonomy_term', []));
+    }
+
+    #[Test]
+    public function nonNodeEntityMissingStatusKeyFailsClosed(): void
+    {
+        $visibility = new WorkflowVisibility();
+
+        $this->assertFalse($visibility->isEntityPublic('workflow', []));
+        $this->assertFalse($visibility->isEntityPublic('workflow', ['other_field' => 'x']));
+    }
+
+    #[Test]
+    public function nonNodeEntityRecognizedPublishedStatusValuesArePublic(): void
+    {
+        $visibility = new WorkflowVisibility();
+
+        $this->assertTrue($visibility->isEntityPublic('workflow', ['status' => 1]));
+        $this->assertTrue($visibility->isEntityPublic('workflow', ['status' => true]));
+        $this->assertTrue($visibility->isEntityPublic('workflow', ['status' => 'published']));
+    }
+
+    #[Test]
+    public function nonNodeEntityUnrecognizedStatusValuesAreNotPublic(): void
+    {
+        $visibility = new WorkflowVisibility();
+
+        $this->assertFalse($visibility->isEntityPublic('workflow', ['status' => 0]));
+        $this->assertFalse($visibility->isEntityPublic('workflow', ['status' => false]));
+        $this->assertFalse($visibility->isEntityPublic('workflow', ['status' => 'garbage']));
     }
 
     #[Test]


### PR DESCRIPTION
**Active Spec Kitty mission (if any):** none — Spec Kitty is retired in this repo (2026-07-06); this follows the direct design->TDD->review flow.

Refs #1915 (R16 audit — workflows-visibility-fail-open)

## Summary

- Audit record `L3-workflows.md` (finding tag MAJOR, anchoring issue #1915, tag R16) found a fail-open bug in `packages/workflows/src/WorkflowVisibility.php::isEntityPublic()`.
- For non-`node` entity types, a **missing** `status` key returned `true` (public/visible), while a **present-but-unrecognized** status value correctly returned `false` via `isStatusPublic()`. An entity that never set a status was treated as *more* public than one with a garbage status value — backwards for a visibility gate.
- Fix: the missing-key branch now returns `false` (fail closed), matching the audit's suggested fix #3. One-line production change.
- Node entities are unaffected — the framework's field scaffolder always projects `status` for nodes (and forbids user fields named `status`), and `isNodePublic()`/`nodeState()` were intentionally left untouched. This only changes behavior for hand-registered non-node entity types without a `status` key, e.g. this package's own `workflow` entity type.

## Live-consumer risk checked

Read (no production changes needed) and ran the test suites for every consumer of `WorkflowVisibility` / `WorkflowVisibilityFilter`:

- `packages/workflows/src/WorkflowVisibilityFilter.php` — thin delegating wrapper.
- `packages/relationship/src/RelationshipTraversalService.php` via `VisibilityFilterInterface` — already fail-closed on an *unwired* filter (alpha245/audit #36); this PR only changes the wired filter's own missing-status-key behavior, tightening it further in the same direction.
- `packages/api/src/Http/DiscoveryApiHandler.php` — constructs `WorkflowVisibility` directly.
- `packages/ai-vector/*` (`EntityEmbeddingListener`, `SearchController`, `SemanticIndexWarmer`, `AiVectorServiceProvider`) — inject/construct directly.
- `packages/cli/src/Ingestion/ValidationGateValidator.php` — injects `WorkflowVisibility`.
- `packages/genealogy/src/Access/GenealogyContentAccessPolicy.php` — injects `WorkflowVisibility`, calls `isEntityPublic()` for content entities and `genealogy_tree`.
- `packages/ssr/src/SsrPageHandler.php` — consumes `WorkflowVisibilityFilter`.

None of these needed production-code changes, and none of their existing fixtures asserted the old fail-open behavior — all consumer suites pass unchanged.

`packages/workflows/README.md` was checked for documentation of the old "missing status → public" semantics; it doesn't mention this specific behavior, so no doc update was needed.

## Test plan

- [x] Added tests to `packages/workflows/tests/Unit/WorkflowVisibilityTest.php` for `isEntityPublic()` on a non-node entity type: missing `status` key → `false` (written first, confirmed it failed against pre-fix code), recognized published-like values (`1`, `true`, `'published'`) → `true`, unrecognized/garbage values (`0`, `false`, `'garbage'`) → `false`. Existing node-path tests untouched.
- [x] `./vendor/bin/phpunit packages/workflows/tests/` — pass
- [x] `php -d memory_limit=1G ./vendor/bin/phpunit packages/relationship/tests/ packages/api/tests/ packages/ai-vector/tests/ packages/cli/tests/ packages/genealogy/tests/ packages/ssr/tests/` — all pass (123 / 605 / 78 / 532 / 29 / 300 tests respectively)
- [x] `composer phpstan` (level 5) — no errors
- [x] Full pre-push gate (`lefthook` pre-push: spec-drift, composer-policy, phpstan, phpunit) — green, 9391 tests / 222987 assertions

## Checklist

- [x] **Traceability:** `Refs #1915` above (anchoring audit issue, shared across three separate fixes — this PR does not close it) plus PR title references `#1915`
- [ ] N/A — this PR does not close a GitHub issue (it references a shared anchoring audit issue)
- [x] PR title includes `#1915`

## Review amendments

Adversarial review (audit A7 R16 follow-up) found the fail-closed flip above contradicted `Media`'s documented design: `Media::isPublished()` (`packages/media/src/Media.php`) returns `(bool) ($this->get('status') ?? true)` — missing status = published, by design — but unlike `Term` (`packages/taxonomy/src/Term.php`) and `Node` (`packages/node/src/Node.php`), `Media::__construct()` had no backfill for a missing `status` key. Consequence: `DiscoveryApiHandler::isDiscoveryEntityPublic()` (`packages/api/src/Http/DiscoveryApiHandler.php`) calls the now-fail-closed `WorkflowVisibility::isEntityPublic()` **before** the access check, so any un-status'd media 404'd through every discovery route, for every caller including admins — the flip silently regressed a working, by-design consumer.

**Fix:** `Media::__construct()` now backfills `$values['status'] = true` when the key is absent, mirroring `Term`'s `array_key_exists()` pattern exactly. This makes the entity class itself the single canonical source of its published-default, instead of leaving `WorkflowVisibility` (or any other consumer reading the raw values map) to reinterpret a missing key independently of `isPublished()`.

**Sweep for the same gap** (`rg -n "get\('status'\) ?? true" packages/*/src` plus a `public bool $status = true` property-default sweep) across every content entity with publish-status semantics:

| Entity | Default-true accessor? | Constructor backfills `status`? | Action |
|---|---|---|---|
| `Media` (`packages/media/src/Media.php`) | yes, `?? true` | no (gap) | **Fixed** — backfill added, regression test added |
| `Term` (`packages/taxonomy/src/Term.php`) | yes, `?? true` | yes, `array_key_exists()` guard | already safe, no change |
| `PathAlias` (`packages/path/src/PathAlias.php`) | yes, `?? true` | yes, `$values += ['status' => true, ...]` | already safe, no change |
| `Node` (`packages/node/src/Node.php`) | effectively yes (`(int)(status ?? 0) === 1`, and `status` always backfilled to `1`) | yes, `array_key_exists()` guard sets `1` | already safe, no change; also exempt from the `WorkflowVisibility` gate entirely (`isEntityPublic()` special-cases `node` → `isNodePublic()`) |
| `Comment` (`packages/engagement/src/Comment.php`) | no dedicated accessor, but field defaults `true` | yes, `array_key_exists()` guard sets `1` | already safe, no change |
| `ThreadMessage` (`packages/messaging/src/ThreadMessage.php`) | no dedicated accessor, but field defaults `true` | yes, `array_key_exists()` guard sets `1` | already safe, no change |
| `Relationship` (`packages/relationship/src/Relationship.php`) | no dedicated accessor, but published-by-default intent | yes, constructor defaults `'status' => 1` | already safe, no change |
| `Group` (`packages/groups/src/Group.php`) | no accessor; `#[Field(type: 'integer', default: 1)]` declares published-by-default | no constructor backfill — the field-definition default is applied by `EntityInstantiator::applyFieldDefinitionDefaults()` on the canonical `EntityRepository::create()` / `SqlEntityStorage::create()` path, so repository-created groups always carry `status = 1` | no change: the field definition is the single canonical source of Group's default; adding a constructor backfill would create the dual-source pattern CLAUDE.md forbids. A `new Group([])` constructed outside the repository path fails closed until saved/statused — treated as anomalous, consistent with this PR's rationale |
| `User` (`packages/user/src/User.php`) | **no** — `isActive()` explicitly does `?? false` despite the `$status = true` property default | n/a | out of scope: already fail-closed on a missing key, consistent with (not contradicting) this PR's direction; the property-default/accessor-default mismatch is a pre-existing, separate asymmetry not touched here |
| `GenealogyEvent`/`GenealogyPerson`/`GenealogyFamily`/`GenealogyTree` (`packages/genealogy/src/Entity/*.php`) | no — property default is `false` | n/a | out of scope: already fail-closed by default |
| `MenuLink` (`packages/menu/src/MenuLink.php`) | field is named `enabled`, not `status`; already backfilled to `true` in the constructor | n/a (different key) | out of scope: `WorkflowVisibility::isEntityPublic()` only reads the literal `status` key, so `MenuLink` is never consumed by this gate regardless |

Non-entity `?? true` usages found by the broader grep (`NodeType::display_submitted`, `RevisionableEntityTrait::is_default_revision`/`is_latest_revision`, `ObservabilityServiceProvider`/`TelescopeServiceProvider` config `enabled` flags) are unrelated to entity publish-status semantics and out of scope.

**New tests:**
- `packages/media/tests/Unit/MediaTest.php::testStatusBackfilledWhenAbsentFromConstructor` — a `Media` built without `status` reports `isPublished() === true` and has a `status` key present in `toArray()`.
- `packages/api/tests/Unit/Http/DiscoveryApiHandlerTest.php::media_without_explicit_status_is_discovery_public` — the real regression path: a `Media` built without `status`, passed through `DiscoveryApiHandler::isDiscoveryEntityPublic()` (which internally calls `WorkflowVisibility::isEntityPublic('media', EntityValues::toCastAwareMap($media))`), now clears the gate.
- `packages/api/tests/Unit/Http/DiscoveryApiHandlerTest.php::media_explicitly_unpublished_is_not_discovery_public` — companion negative case, `status: false` still fails the gate.

**Why the fail-closed flip is safe now:** every entity type with publish-status semantics guarantees a `status` key at construction (backfilled in the entity class itself, the single canonical source of that default). A `status` key that is still missing at the point `WorkflowVisibility::isEntityPublic()` runs is therefore a genuine data anomaly — not an expected state for any known entity type — so failing closed on it is the correct, safe behavior.

Verified: `./vendor/bin/phpunit packages/workflows/tests/ packages/media/tests/ packages/taxonomy/tests/ packages/api/tests/` — all green (107 / 181 / 111 / 607 tests respectively) — plus `composer phpstan` (level 5, no errors).




no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
