### PR TITLE
docs(#1920): CW-v1 content-workflow design spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ When working on files matching these patterns, retrieve the spec for deep contex
 | `packages/error-handler/*` | — | `docs/specs/debugging-dx.md` |
 | `packages/debug/*` | — | `docs/specs/debugging-dx.md` |
 | `packages/telescope/*` (agent-context / codified-context telemetry, Prometheus) | — | `docs/specs/telescope-agent-context-telemetry.md`, `docs/specs/api-layer.md` |
-| `packages/workflows/*` | — | `packages/workflows/README.md` |
+| `packages/workflows/*` | — | `docs/specs/content-workflow.md` (CW-v1 engine — read first), `packages/workflows/README.md` |
 | `packages/billing/*` | — | `packages/billing/README.md` |
 | `packages/github/*` | — | `packages/github/README.md` |
 | `packages/deployer/*` | — | `packages/deployer/README.md` |

--- a/docs/history/plans/2026-07-06-content-workflow-wp0-wp1.md
+++ b/docs/history/plans/2026-07-06-content-workflow-wp0-wp1.md
@@ -1,0 +1,588 @@
+# CW-v1 WP-0 + WP-1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** WP-0 closes the self-publish hole with an interim field gate; WP-1 builds the content-workflow engine core (config schema extensions, TransitionService, save-path guard, events, default editorial workflow) per `docs/specs/content-workflow.md`.
+
+**Architecture:** Extend the existing `Workflow` config entity (`ConfigEntityBase`, already registered as entity type `workflow`) with state flags, transition permissions, and an initial state; add a `TransitionService` as the single enforcement door plus a `PRE_SAVE` guard listener; introduce a minimal request-scoped `AccountContext` in the access package so the guard knows the acting account.
+
+**Tech Stack:** PHP 8.5, Symfony EventDispatcher (contracts FQCN via kernel-services bus), PHPUnit 10.5, existing waaseyaa entity/access/config/audit packages.
+
+## Global Constraints
+
+- `declare(strict_types=1)` in every file; `final class` for concrete implementations; `final readonly class` for value objects.
+- No psr/log: `Waaseyaa\Foundation\Log\LoggerInterface`, accepted as `?LoggerInterface $logger = null`, defaulted to `NullLogger`.
+- PHPUnit 10.5 attributes (`#[Test]`, `#[CoversClass]`); NEVER pass `-v` to phpunit.
+- Entity queries need `->setAccount()` or `->accessCheck(false)` + justification comment (`bin/check-getquery-bindings` gates new offenders).
+- Layer rule: `workflows` (L3) imports only L0–L2 + same-layer; `access`/`user` are L1. No upward imports.
+- Anchoring issue: **#1920**. PR titles: `feat(#1920): …` / `fix(#1920): …`. PR bodies reference #1920, never `Closes #1920`.
+- Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- The pre-push hook runs phpstan + the full 9,4xx-test suite; keep it green at every push.
+- Permission name constant (spec-pinned, do not vary): `use editorial transition publish`.
+- New behavior documented in `docs/specs/content-workflow.md` — flip the relevant WP row to `landed` in the same PR that ships it.
+
+---
+
+# WP-0: Interim status/workflow_state field gate
+
+Branch: `fix/cw-wp0-status-gate` from `origin/main`. One PR at the end.
+
+### Task 0.1: NodeAccessPolicy publish gate
+
+**Files:**
+- Modify: `packages/node/src/NodeAccessPolicy.php`
+- Test: `packages/node/tests/Unit/NodeAccessPolicyTest.php` (extend existing)
+
+**Interfaces:**
+- Consumes: `AccessResult::forbidden(string)/neutral(string)`, `AccountInterface::hasPermission(string): bool` — existing.
+- Produces: `NodeAccessPolicy::PUBLISH_PERMISSION = 'use editorial transition publish'` public const (Task 0.2 and WP-1 reference it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `NodeAccessPolicyTest` (follow the file's existing account-double pattern — accounts are built with explicit permission lists):
+
+```php
+#[Test]
+public function status_edit_is_forbidden_without_the_publish_permission(): void
+{
+    $policy = new NodeAccessPolicy();
+    $node = new Node(['nid' => 1, 'type' => 'article', 'uid' => 7, 'status' => 0]);
+    $account = $this->accountWithPermissions(7, ['edit own article content']);
+
+    $result = $policy->fieldAccess($node, 'status', 'edit', $account);
+
+    $this->assertTrue($result->isForbidden());
+}
+
+#[Test]
+public function workflow_state_edit_is_forbidden_without_the_publish_permission(): void
+{
+    $policy = new NodeAccessPolicy();
+    $node = new Node(['nid' => 1, 'type' => 'article', 'uid' => 7]);
+    $account = $this->accountWithPermissions(7, ['edit own article content']);
+
+    $this->assertTrue($policy->fieldAccess($node, 'workflow_state', 'edit', $account)->isForbidden());
+}
+
+#[Test]
+public function status_edit_is_open_with_the_publish_permission(): void
+{
+    $policy = new NodeAccessPolicy();
+    $node = new Node(['nid' => 1, 'type' => 'article', 'uid' => 7, 'status' => 0]);
+    $account = $this->accountWithPermissions(7, ['edit own article content', NodeAccessPolicy::PUBLISH_PERMISSION]);
+
+    $this->assertFalse($policy->fieldAccess($node, 'status', 'edit', $account)->isForbidden());
+}
+
+#[Test]
+public function status_gate_applies_on_create_too(): void
+{
+    $policy = new NodeAccessPolicy();
+    $node = new Node(['type' => 'article', 'uid' => 7, 'status' => 1]);
+    $node->enforceIsNew();
+    $account = $this->accountWithPermissions(7, ['create article content']);
+
+    $this->assertTrue($policy->fieldAccess($node, 'status', 'edit', $account)->isForbidden());
+}
+```
+
+If the test file has no `accountWithPermissions()` helper, add one returning an anonymous class implementing `AccountInterface` with the given id + permission list (PHPUnit `createMock()` cannot mock intersection types used elsewhere in this suite — follow the file's existing approach).
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `./vendor/bin/phpunit packages/node/tests/ --filter NodeAccessPolicyTest`
+Expected: the 4 new tests FAIL (gate not implemented); existing tests PASS.
+
+- [ ] **Step 3: Implement the gate**
+
+In `NodeAccessPolicy`, add below `ADMIN_ONLY_EDIT_FIELDS`:
+
+```php
+/**
+ * Interim CW-v1 publish gate (WP-0, spec: docs/specs/content-workflow.md).
+ * Named after the engine's editorial publish transition so nothing renames
+ * when TransitionService lands.
+ */
+public const string PUBLISH_PERMISSION = 'use editorial transition publish';
+
+/** @var list<string> */
+private const PUBLISH_GATED_FIELDS = ['status', 'workflow_state'];
+```
+
+In `fieldAccess()`, after the `administer nodes` early-return, before the `!$entity->isNew()` block:
+
+```php
+// CW-v1 WP-0: publication is permission-gated on create AND update. An
+// account with only edit/create permissions must not self-publish to
+// anonymous visibility (audit D1). Unlike ADMIN_ONLY_EDIT_FIELDS below,
+// this gate has no isNew() carve-out.
+if (\in_array($fieldName, self::PUBLISH_GATED_FIELDS, true)
+    && !$account->hasPermission(self::PUBLISH_PERMISSION)) {
+    return AccessResult::forbidden(\sprintf(
+        "Field '%s' requires the '%s' permission.",
+        $fieldName,
+        self::PUBLISH_PERMISSION,
+    ));
+}
+```
+
+Update the class docblock: replace the sentence "The editorial booleans `status`/`promote`/`sticky` are intentionally NOT gated here (a separate permission-model decision)." with "The publication fields `status`/`workflow_state` are permission-gated (CW-v1 WP-0, `docs/specs/content-workflow.md`); `promote`/`sticky` remain ungated pending the engine."
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/phpunit packages/node/tests/`
+Expected: PASS. If pre-existing tests assumed ungated status edits, update them to grant `NodeAccessPolicy::PUBLISH_PERMISSION` — list every such change in the PR body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/node/src/NodeAccessPolicy.php packages/node/tests/Unit/NodeAccessPolicyTest.php
+git commit -m "fix(#1920): permission-gate node status/workflow_state edits (CW-v1 WP-0)"
+```
+
+### Task 0.2: Unpublished default on gated create
+
+**Files:**
+- Modify: `packages/api/src/JsonApiController.php` (create path, near line 481–530)
+- Test: `packages/api/tests/` — extend the controller create tests (find via `rg -l "checkCreateAccess" packages/api/tests/`)
+
+**Interfaces:**
+- Consumes: `EntityAccessHandler::checkFieldAccess($entity, string $field, string $op, AccountInterface): AccessResult` — existing; `NodeAccessPolicy::PUBLISH_PERMISSION` (Task 0.1).
+- Produces: generic controller behavior — no new public surface.
+
+- [ ] **Step 1: Write the failing test**
+
+In the api controller create test file, add: creating a node (no explicit `status` in the payload) as an account holding only `create article content` + `access content` must yield an UNPUBLISHED entity; the same create by an account also holding `use editorial transition publish` stays published-by-default. Follow the test file's existing fixture pattern for registering the node type + policy; assert via the stored entity's `status` value.
+
+```php
+#[Test]
+public function create_without_status_defaults_unpublished_for_accounts_that_may_not_publish(): void
+{
+    // Arrange per this file's existing create-test fixture (entity type
+    // 'node', NodeAccessPolicy registered, account WITHOUT the publish perm).
+    $document = $this->controller->create('node', [
+        'type' => 'article',
+        'title' => 'Draft by author',
+    ]);
+
+    $stored = $this->storage->load($this->idFrom($document));
+    $this->assertSame(0, (int) $stored->get('status'));
+}
+
+#[Test]
+public function create_without_status_stays_published_for_publishers(): void
+{
+    // Same fixture, account WITH NodeAccessPolicy::PUBLISH_PERMISSION.
+    $document = $this->controller->create('node', [
+        'type' => 'article',
+        'title' => 'Published by editor',
+    ]);
+
+    $stored = $this->storage->load($this->idFrom($document));
+    $this->assertSame(1, (int) $stored->get('status'));
+}
+```
+
+Adapt names/fixture calls to the real test file — the two behaviors above are the requirement.
+
+- [ ] **Step 2: Run to verify the first test fails**
+
+Run: `./vendor/bin/phpunit packages/api/tests/ --filter create_without_status`
+Expected: first test FAILS (status is 1 — Node constructor default); second PASSES.
+
+- [ ] **Step 3: Implement**
+
+In `JsonApiController::create()`, after the entity is constructed from `$data` and after the per-supplied-field access checks, add:
+
+```php
+// CW-v1 WP-0 (docs/specs/content-workflow.md): an entity constructor may
+// default `status` to published (Node does), but an account forbidden from
+// editing `status` must not create born-published content. Applies only
+// when the client did not supply `status` (a supplied value was already
+// access-checked above).
+if (!\array_key_exists('status', $data)
+    && $entity->get('status') !== null
+    && $this->accessHandler->checkFieldAccess($entity, 'status', 'edit', $this->account)->isForbidden()) {
+    $entity->set('status', 0);
+}
+```
+
+Match the surrounding code's actual variable names (`$entity`, `$data`, `$this->accessHandler`, `$this->account` — verify against the file).
+
+- [ ] **Step 4: Run tests**
+
+Run: `./vendor/bin/phpunit packages/api/tests/ && ./vendor/bin/phpunit packages/node/tests/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/JsonApiController.php packages/api/tests/
+git commit -m "fix(#1920): gated accounts create unpublished by default (CW-v1 WP-0)"
+```
+
+### Task 0.3: Gates, spec row, PR
+
+- [ ] **Step 1: Full verification**
+
+Run: `set -o pipefail; composer phpstan && ./vendor/bin/phpunit --testsuite Unit && ./vendor/bin/phpunit --testsuite Integration`
+Expected: green. Also run `php bin/check-getquery-bindings` (no new offenders expected — no queries added).
+
+- [ ] **Step 2: Flip the spec WP row**
+
+In `docs/specs/content-workflow.md`, WP table: WP-0 status `pending (ships on R16 timeline)` → `landed (PR pending review)`.
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git add docs/specs/content-workflow.md
+git commit -m "docs(#1920): mark WP-0 landed in content-workflow spec"
+git push -u origin fix/cw-wp0-status-gate
+gh pr create --title "fix(#1920): CW-v1 WP-0 — permission-gate publication (status/workflow_state)" \
+  --body "$(printf '**Anchoring issue / plan:** #1920 (CW-v1), docs/history/plans/2026-07-06-content-workflow-wp0-wp1.md\n\n## Summary\n- NodeAccessPolicy: status/workflow_state edits require `use editorial transition publish` (create AND update); docblock posture updated\n- JsonApiController::create: constructor-defaulted published status is floored to unpublished for accounts forbidden from editing status\n- Deny-path tests for both\n\nBehavior change: accounts with only edit/create permissions can no longer self-publish. Existing-test adjustments are listed below.\n')"
+```
+
+---
+
+# WP-1: Engine core
+
+Branch: `feat/cw-wp1-engine` from `origin/main` (rebase onto main after WP-0 merges if it lands first — WP-1 Task 1.7 reuses `NodeAccessPolicy::PUBLISH_PERMISSION` only in tests; no hard dependency). One PR at the end; commit per task.
+
+New file layout in `packages/workflows/src/`:
+
+```
+src/
+  Workflow.php                    (modify: initial_state, flags hydration, permissionFor())
+  WorkflowState.php               (modify: published/defaultRevision flags)
+  WorkflowTransition.php          (modify: permission)
+  Validation/WorkflowValidator.php
+  Binding/WorkflowBindingResolver.php
+  Transition/TransitionService.php
+  Transition/TransitionResult.php
+  Transition/TransitionDeniedException.php
+  Event/WorkflowEvents.php
+  Event/WorkflowTransitionEvent.php
+  Listener/WorkflowStateGuard.php
+  DefaultWorkflows.php            (declarative seed data)
+  WorkflowServiceProvider.php     (modify: bindings + boot() wiring + seed)
+```
+
+No new access-package files: `Waaseyaa\Access\Context\AccountContextInterface` (`current(): ?AccountInterface`, `set(?AccountInterface): void`) and `RequestAccountContext` ALREADY EXIST — SessionMiddleware already overwrites the context unconditionally on every request, MCP endpoint and agent executor set-and-restore, and the revision save pipeline reads it for revision authorship. Consume, don't create.
+
+### Task 1.1: WorkflowState flags
+
+**Files:**
+- Modify: `packages/workflows/src/WorkflowState.php`, `packages/workflows/src/Workflow.php` (hydration)
+- Test: `packages/workflows/tests/Unit/WorkflowStateTest.php`, `WorkflowTest.php`
+
+**Interfaces:**
+- Produces: `WorkflowState::__construct(string $id, string $label, int $weight = 0, array $metadata = [], bool $published = false, bool $defaultRevision = false)` — later tasks read `$state->published` / `$state->defaultRevision`.
+
+- [ ] **Step 1: Failing tests** — `WorkflowState` exposes `published`/`defaultRevision` (default false); `Workflow` hydrates them from array config:
+
+```php
+#[Test]
+public function states_hydrate_published_and_default_revision_flags(): void
+{
+    $workflow = new Workflow(['id' => 'editorial', 'states' => [
+        'draft' => ['label' => 'Draft'],
+        'published' => ['label' => 'Published', 'published' => true, 'default_revision' => true],
+    ]]);
+
+    $this->assertFalse($workflow->getState('draft')->published);
+    $this->assertTrue($workflow->getState('published')->published);
+    $this->assertTrue($workflow->getState('published')->defaultRevision);
+}
+```
+
+(Verify the accessor name — `getState()`/`getStates()` — against the existing `Workflow` class and use what exists.)
+
+- [ ] **Step 2: Run; expect FAIL** — `./vendor/bin/phpunit packages/workflows/tests/ --filter hydrate_published`
+- [ ] **Step 3: Implement** — add the two readonly constructor params (defaults false); in `Workflow::__construct` array-hydration branch pass `published: (bool) ($stateData['published'] ?? false), defaultRevision: (bool) ($stateData['default_revision'] ?? false)`.
+- [ ] **Step 4: Run; expect PASS** — whole workflows suite: `./vendor/bin/phpunit packages/workflows/tests/`
+- [ ] **Step 5: Commit** — `feat(#1920): workflow states carry published/default_revision flags (WP-1)`
+
+### Task 1.2: Transition permissions + initial state
+
+**Files:**
+- Modify: `packages/workflows/src/WorkflowTransition.php`, `packages/workflows/src/Workflow.php`
+- Test: `packages/workflows/tests/Unit/WorkflowTest.php`
+
+**Interfaces:**
+- Produces: `WorkflowTransition::$permission` (string, may be `''`); `Workflow::getInitialState(): string`; `Workflow::permissionFor(WorkflowTransition $t): string` (returns `$t->permission` or derives `use {workflowId} transition {transitionId}`); `Workflow::getTransition(string $id): ?WorkflowTransition` (add if absent).
+
+- [ ] **Step 1: Failing tests:**
+
+```php
+#[Test]
+public function transition_permission_defaults_to_the_derived_name(): void
+{
+    $workflow = new Workflow(['id' => 'editorial',
+        'states' => ['draft' => ['label' => 'Draft'], 'review' => ['label' => 'Review']],
+        'transitions' => ['submit' => ['label' => 'Submit', 'from' => ['draft'], 'to' => 'review']],
+    ]);
+
+    $this->assertSame('use editorial transition submit',
+        $workflow->permissionFor($workflow->getTransition('submit')));
+}
+
+#[Test]
+public function explicit_transition_permission_wins(): void
+{
+    $workflow = new Workflow(['id' => 'editorial',
+        'states' => ['draft' => ['label' => 'Draft'], 'review' => ['label' => 'Review']],
+        'transitions' => ['submit' => ['label' => 'Submit', 'from' => ['draft'], 'to' => 'review', 'permission' => 'custom perm']],
+    ]);
+
+    $this->assertSame('custom perm', $workflow->permissionFor($workflow->getTransition('submit')));
+}
+
+#[Test]
+public function initial_state_hydrates_and_defaults_to_the_first_state(): void
+{
+    $explicit = new Workflow(['id' => 'w', 'initial_state' => 'draft',
+        'states' => ['x' => ['label' => 'X'], 'draft' => ['label' => 'Draft']]]);
+    $implicit = new Workflow(['id' => 'w', 'states' => ['x' => ['label' => 'X']]]);
+
+    $this->assertSame('draft', $explicit->getInitialState());
+    $this->assertSame('x', $implicit->getInitialState());
+}
+```
+
+- [ ] **Step 2: Run; expect FAIL.**
+- [ ] **Step 3: Implement** — `permission: (string) ($transitionData['permission'] ?? '')` in hydration; `permissionFor()` = `$t->permission !== '' ? $t->permission : sprintf('use %s transition %s', (string) $this->id(), $t->id)`; store `initial_state` value with first-state fallback.
+- [ ] **Step 4: Run workflows suite; expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1920): transition permissions + workflow initial state (WP-1)`
+
+### Task 1.3: WorkflowValidator
+
+**Files:**
+- Create: `packages/workflows/src/Validation/WorkflowValidator.php`
+- Test: `packages/workflows/tests/Unit/Validation/WorkflowValidatorTest.php`
+
+**Interfaces:**
+- Produces: `WorkflowValidator::validate(Workflow $workflow): list<string>` — empty list = valid; each string a human-readable violation. Used by Task 1.8 (seed) and the config-import surface later.
+
+- [ ] **Step 1: Failing tests** — violations for: transition `from` state unknown; transition `to` state unknown; `initial_state` not a defined state; zero states; more than one state flagged `published && default_revision`… no — multiple published states ARE legal (published, archived is not published; two published default-revision states are legal in Drupal too). Validate exactly: unknown from/to, unknown initial_state, zero states, duplicate transition targeting (same id handled by keying). Write one test per violation + one valid-workflow test asserting `[]`.
+
+```php
+#[Test]
+public function a_transition_from_an_unknown_state_is_a_violation(): void
+{
+    $workflow = new Workflow(['id' => 'w',
+        'states' => ['draft' => ['label' => 'Draft']],
+        'transitions' => ['bad' => ['label' => 'Bad', 'from' => ['nope'], 'to' => 'draft']]]);
+
+    $violations = new WorkflowValidator()->validate($workflow);
+
+    $this->assertCount(1, $violations);
+    $this->assertStringContainsString("unknown state 'nope'", $violations[0]);
+}
+```
+
+- [ ] **Step 2: Run; expect FAIL** (class missing).
+- [ ] **Step 3: Implement** — final class, no dependencies, pure checks over `$workflow->getStates()/getTransitions()/getInitialState()`.
+- [ ] **Step 4: Run; expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1920): workflow definition validator (WP-1)`
+
+### Task 1.4: WorkflowBindingResolver
+
+**Files:**
+- Create: `packages/workflows/src/Binding/WorkflowBindingResolver.php`
+- Test: `packages/workflows/tests/Unit/Binding/WorkflowBindingResolverTest.php`
+
+**Interfaces:**
+- Consumes: `ConfigFactoryInterface::get('workflows.assignments'): ConfigInterface` (raw data shape: `['node.article' => 'editorial', 'node.*' => 'editorial']`); `EntityTypeManager::getEntityType()/isRevisionable()`; workflow storage `EntityTypeManager::getStorage('workflow')->load($id)`.
+- Produces: `WorkflowBindingResolver::resolve(string $entityTypeId, string $bundle): ?Workflow` (null = unbound); throws `\RuntimeException` when a binding names a non-revisionable type or an unknown workflow. Exact-bundle key wins over `{type}.*` wildcard.
+
+- [ ] **Step 1: Failing tests** — bound exact, bound wildcard, unbound returns null, non-revisionable bound type throws, unknown workflow id throws. Build with in-memory doubles: a stub ConfigFactory returning fixed raw data; an EntityTypeManager fixture with a revisionable + non-revisionable test type (follow existing workflows tests for EntityTypeManager fixtures, or use anonymous stubs of the interfaces actually consumed).
+- [ ] **Step 2: Run; expect FAIL.**
+- [ ] **Step 3: Implement** (final class; constructor `(ConfigFactoryInterface $configFactory, EntityTypeManager $entityTypeManager)`; memoize resolved workflows per instance — boot-stable like the wayfinding registry; comment why worker-mode safe).
+- [ ] **Step 4: Run; expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1920): workflow bindings resolver (WP-1)`
+
+### Task 1.5: AccountContext — verify-and-consume (NO new code)
+
+`Waaseyaa\Access\Context\AccountContextInterface` already exists with exactly the contract later tasks need (`current(): ?AccountInterface`, `set(?AccountInterface): void`; three-state semantics documented on the interface: account N / anonymous 0 / null = no acting context). SessionMiddleware already overwrites it unconditionally per request; MCP endpoint and agent executor set-and-restore in `finally`; `SaveContext`/`EntityRepository` already read it for revision authorship.
+
+- [ ] **Step 1:** Read `packages/access/src/Context/AccountContextInterface.php` and one existing consumer (`packages/search/src/Access/EntitySearchAccessChecker.php` or `packages/mcp/src/McpEndpoint.php`) to copy the injection pattern (how the binding is resolved in a service provider).
+- [ ] **Step 2:** No implementation, no commit. Tasks 1.7/1.8 inject `AccountContextInterface` following that pattern.
+
+### Task 1.6: Events + denial exception + result
+
+**Files:**
+- Create: `packages/workflows/src/Event/WorkflowEvents.php`, `Event/WorkflowTransitionEvent.php`, `Transition/TransitionDeniedException.php`, `Transition/TransitionResult.php`
+- Test: `packages/workflows/tests/Unit/Event/WorkflowTransitionEventTest.php`
+
+**Interfaces:**
+- Produces:
+
+```php
+enum WorkflowEvents: string
+{
+    case PRE_TRANSITION = 'waaseyaa.workflow.pre_transition';
+    case POST_TRANSITION = 'waaseyaa.workflow.post_transition';
+}
+
+// extends Symfony\Contracts\EventDispatcher\Event, mirroring EntityEvent
+final class WorkflowTransitionEvent extends Event
+{
+    public function __construct(
+        public readonly EntityInterface $entity,
+        public readonly string $workflowId,
+        public readonly string $transitionId,
+        public readonly string $fromState,
+        public readonly string $toState,
+        public readonly ?AccountInterface $account,
+    ) {}
+}
+
+final class TransitionDeniedException extends \RuntimeException
+{
+    // machine-readable reason codes; exact set:
+    public const string REASON_UNBOUND = 'unbound';
+    public const string REASON_UNKNOWN_TRANSITION = 'unknown_transition';
+    public const string REASON_ILLEGAL_EDGE = 'illegal_edge';
+    public const string REASON_PERMISSION = 'permission';
+    public function __construct(public readonly string $reason, string $message) { parent::__construct($message); }
+}
+
+final readonly class TransitionResult
+{
+    public function __construct(
+        public string $fromState,
+        public string $toState,
+        public string $transitionId,
+    ) {}
+}
+```
+
+- [ ] Steps: tests (event carries values; exception exposes reason) → red → implement → green → commit `feat(#1920): workflow transition events + typed denial (WP-1)`.
+
+### Task 1.7: TransitionService
+
+**Files:**
+- Create: `packages/workflows/src/Transition/TransitionService.php`
+- Test: `packages/workflows/tests/Unit/Transition/TransitionServiceTest.php`
+
+**Interfaces:**
+- Consumes: `WorkflowBindingResolver::resolve()` (1.4), `Workflow::permissionFor()/getTransition()/getState()` (1.1–1.2), `WorkflowEvents`/`WorkflowTransitionEvent`/`TransitionDeniedException`/`TransitionResult` (1.6), Symfony contracts `EventDispatcherInterface`, `AuditWriterInterface::record(AuditEventDescriptor)` (nullable), entity persistence via `EntityTypeManager::getStorage($entity->getEntityTypeId())->save($entity)`.
+- Produces:
+
+```php
+final class TransitionService
+{
+    public function __construct(
+        private readonly WorkflowBindingResolver $bindings,
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly ?EventDispatcherInterface $dispatcher = null,
+        private readonly ?AuditWriterInterface $auditWriter = null,
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /** @throws TransitionDeniedException */
+    public function transition(EntityInterface $entity, string $transitionId, AccountInterface $account): TransitionResult;
+
+    /** @return list<WorkflowTransition> transitions the account may fire from the entity's current state */
+    public function getAvailableTransitions(EntityInterface $entity, AccountInterface $account): array;
+}
+```
+
+Behavior (validate → apply → announce, in this order):
+1. Resolve workflow; none → deny `REASON_UNBOUND`.
+2. `getTransition($transitionId)`; missing → `REASON_UNKNOWN_TRANSITION`.
+3. Current state = `(string) ($entity->get('workflow_state') ?? $workflow->getInitialState())`; not in `$transition->from` → `REASON_ILLEGAL_EDGE`.
+4. `$account->hasPermission($workflow->permissionFor($transition))` false → `REASON_PERMISSION`. (Group constraints: WP-3 — do NOT stub them here.)
+5. Dispatch PRE event; set `workflow_state` = `$transition->to`; set `status` = target state `published` flag (1/0); persist via storage save. Revision promotion (`default_revision` mechanics) is WP-2 — v1 apply sets fields on the entity as-is.
+6. Dispatch POST event; audit best-effort (try/catch + logger — CLAUDE.md best-effort rule):
+
+```php
+$this->auditWriter?->record(new AuditEventDescriptor(
+    kind: AuditEventKind::WorkflowTransition,
+    accountUid: $account->isAuthenticated() ? (int) $account->id() : 0,
+    subjectUri: sprintf('entity:%s/%s', $entity->getEntityTypeId(), (string) $entity->id()),
+    outcome: 'allowed',
+    severity: 'notice',
+    entityTypeId: $entity->getEntityTypeId(),
+    attributes: ['workflow' => $workflowId, 'transition' => $transitionId, 'from' => $from, 'to' => $to],
+));
+```
+
+Requires adding `case WorkflowTransition = 'workflow.transition';` to `packages/audit/src/Enum/AuditEventKind.php` (one-line, plus its test if the enum has one). Denied transitions also audit with `outcome: 'denied'` before throwing.
+
+- [ ] **Step 1: Failing tests** — happy transition (state+status set, storage save called, PRE+POST dispatched in order, audit recorded); each deny reason (4 tests, assert reason + no save + no POST event + denied audit); `getAvailableTransitions` filters by from-state and permission. Use a revisionable in-memory fixture entity type and stub bindings/storage per the package's existing test doubles.
+- [ ] **Step 2: Run; expect FAIL.** — `./vendor/bin/phpunit packages/workflows/tests/ --filter TransitionService`
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run workflows + audit suites; expect PASS.**
+- [ ] **Step 5: Commit** — `feat(#1920): TransitionService — the one enforcement door (WP-1)`
+
+### Task 1.8: Save-path guard + provider wiring + seed + wiring regression test
+
+**Files:**
+- Create: `packages/workflows/src/Listener/WorkflowStateGuard.php`, `packages/workflows/src/DefaultWorkflows.php`
+- Modify: `packages/workflows/src/WorkflowServiceProvider.php` (bind resolver/service/guard; add `boot()`; seed default workflow)
+- Test: `packages/workflows/tests/Unit/Listener/WorkflowStateGuardTest.php`, `packages/workflows/tests/Integration/GuardWiringTest.php`
+
+**Interfaces:**
+- Consumes: `EntityEvents::PRE_SAVE` (value `'waaseyaa.entity.pre_save'`), `EntityEvent { entity, originalEntity }`, existing `AccountContextInterface` (1.5), `WorkflowBindingResolver` (1.4), `TransitionService` validation pieces (1.7).
+- Produces: `WorkflowStateGuard::onPreSave(EntityEvent $event): void`.
+
+NOTE: entity-storage also dispatches its own `BeforeSaveEvent`/`AfterSaveEvent` (`Waaseyaa\EntityStorage\Event\`). Verify which event the real content save path fires (check what `EntityLifecycleAuditListener` subscribes to — it is a known-live listener) and hook the guard to that one; the wiring regression test in this task is what catches a wrong choice.
+
+Guard rules (only for entities whose type+bundle resolve to a workflow; everything else returns immediately):
+1. **New entity:** force `workflow_state` to `getInitialState()` when unset; if set to anything else, allow only if it is `initial_state` OR the context account may reach it via a single legal+permitted transition from initial state; otherwise throw `TransitionDeniedException`. Force `status` to the state's `published` flag.
+2. **Existing entity, `workflow_state` unchanged:** force `status` consistent with the current state's `published` flag (state owns status on bound types).
+3. **Existing entity, `workflow_state` changed:** find a transition with `from` containing the original state and `to` equal to the new state; none → `REASON_ILLEGAL_EDGE`. If `AccountContextInterface::current()` returns an account → require its permission (`REASON_PERMISSION` otherwise). Null context (CLI/queue/programmatic) → edge-legality only; docblock states programmatic callers should use `TransitionService`.
+
+Provider `boot()` — mirror `RelationshipServiceProvider::boot()` exactly (the dispatcher MUST be resolved by the Symfony-contracts FQCN; the foundation FQCN silently no-ops — that bug killed this package's previous listener):
+
+```php
+public function boot(): void
+{
+    $dispatcher = $this->resolveOptional(\Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class);
+    if ($dispatcher === null) {
+        return;
+    }
+    $dispatcher->addListener(
+        \Waaseyaa\Entity\Event\EntityEvents::PRE_SAVE->value,
+        [$this->resolve(WorkflowStateGuard::class), 'onPreSave'],
+    );
+}
+```
+
+`DefaultWorkflows::EDITORIAL` = the spec's YAML block as a PHP const array (states draft/review/published/archived with flags, initial_state draft, 5 transitions with derived permissions). Seeding: in `boot()`, if `getStorage('workflow')->load('editorial')` is null, create+save `new Workflow(DefaultWorkflows::EDITORIAL)` (validate with `WorkflowValidator` first; log-and-skip on violations rather than crash boot — best-effort rule).
+
+**`GuardWiringTest` (the wiring regression test — REQUIRED, this is a spec invariant):** boot a real kernel/container the way existing integration tests do (see `tests/Integration/` fixtures or the workflows package's existing integration tests), save a bound fixture entity through the real repository, and assert the guard actually fired (e.g. a born-published save by a permissionless context got floored to initial state). A unit test on the guard class does NOT satisfy this.
+
+- [ ] **Step 1: Failing unit tests for the guard rules above** (one per rule branch, deny paths included).
+- [ ] **Step 2: Run; expect FAIL.**
+- [ ] **Step 3: Implement guard + provider wiring + seed.**
+- [ ] **Step 4: Failing wiring regression test → make it pass.**
+- [ ] **Step 5: Run workflows suite + full Unit suite; expect PASS.**
+- [ ] **Step 6: Commit** — `feat(#1920): PRE_SAVE workflow guard, provider wiring, default editorial seed (WP-1)`
+
+### Task 1.9: Integration spine + spec truth-up + PR
+
+**Files:**
+- Create: `packages/workflows/tests/Integration/EditorialFlowTest.php`
+- Modify: `docs/specs/content-workflow.md` (WP-1 row → landed; correct any drift between spec and as-built), `packages/workflows/README.md` (document the new engine surface; mark the legacy machinery "superseded, removal tracked as WP-5 / #1920")
+
+- [ ] **Step 1: Integration spine test** — real SQLite (`DBALDatabase::createSqlite()`), revisionable fixture entity type bound to the seeded editorial workflow, real dispatcher + guard + TransitionService: create (forced draft + unpublished) → `submit_for_review` as an account with only that permission → `publish` DENIED for that account (assert reason `permission`) → `publish` as a publisher account → entity published → `archive` → unpublished. Assert audit entries exist for each fired transition (in-memory audit writer double).
+- [ ] **Step 2: Run integration suite; expect PASS.** `./vendor/bin/phpunit packages/workflows/tests/`
+- [ ] **Step 3: Full gates:** `set -o pipefail; composer phpstan && ./vendor/bin/phpunit --testsuite Unit && ./vendor/bin/phpunit --testsuite Integration && php bin/check-getquery-bindings && bin/check-package-layers`
+- [ ] **Step 4: Spec + README truth-up commit** — `docs(#1920): content-workflow spec/README reflect WP-1 as built`
+- [ ] **Step 5: Push + PR**
+
+```bash
+git push -u origin feat/cw-wp1-engine
+gh pr create --title "feat(#1920): CW-v1 WP-1 — content-workflow engine core" \
+  --body "$(printf '**Anchoring issue / plan:** #1920, docs/history/plans/2026-07-06-content-workflow-wp0-wp1.md\n\n## Summary\nEngine core per docs/specs/content-workflow.md: state flags + transition permissions + initial state on the Workflow config entity, WorkflowValidator, WorkflowBindingResolver, AccountContext (access) set by SessionMiddleware, TransitionService (validate→apply→events→audit), PRE_SAVE WorkflowStateGuard wired via the Symfony-contracts dispatcher FQCN with a wiring regression test, default editorial workflow seeded as data, integration spine test.\n\nRevision promotion (default_revision mechanics) is WP-2; group constraints are WP-3.\n')"
+```
+
+---
+
+## Self-review notes (done at plan-writing time)
+
+- **Spec coverage:** config schema (1.1–1.3), bindings (1.4), TransitionService + getAvailableTransitions (1.7), save-path guard + create-initial-state (1.8), events (1.6), permissions (1.2), default editorial as data (1.8), wiring regression + deny-path testing invariants (1.7/1.8/1.9), audit downward-import (1.7), WP-0 gate + unpublished default (0.1/0.2). NOT in these WPs by design: revision promotion (WP-2), group constraints (WP-3), API endpoints/admin UI (WP-4), cleanup (WP-5).
+- **Known judgment calls an implementer must NOT re-decide:** permission name string; fail-closed deny reasons; guard's null-account-context = edge-legality-only; seeding is log-and-skip on invalid, never boot-crash.
+- **Verify-don't-trust:** exact accessor names on `Workflow` (`getState`, `getTransitions`), the api create-test fixture shape, and how SessionMiddleware's deps are bound — confirmed to exist but signatures may have drifted; adjust code to match reality and note deviations in the PR body.

--- a/docs/history/plans/2026-07-06-content-workflow-wp2.md
+++ b/docs/history/plans/2026-07-06-content-workflow-wp2.md
@@ -1,0 +1,109 @@
+# CW-v1 WP-2 Implementation Plan — node revisions + forward drafts
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Opt node into revisionable storage with a safe migration path for existing data, implement the forward-draft mechanic (`WorkflowState::defaultRevision`), and close the revision-pointer-path bypass of the workflow guard.
+
+**Architecture:** Node's `EntityType` flips `revisionable: true` (schema handled by the existing idempotent `revisions:enable` machinery); `TransitionService`/`WorkflowStateGuard` learn the two-pointer model (current vs published revision) so a draft edit of published content never clobbers the live version; a new L1 pre-pointer-move event closes the `rollback()`/`setCurrentRevision()`/`setPublishedRevision()` guard bypass; a CLI backfill handler + ops runbook make binding activation safe on deployments with existing content.
+
+**Tech Stack:** existing two-axis revision substrate (`docs/specs/revision-system-unified.md` — LIVE canonical, read first), `Waaseyaa\Foundation\Migration\Migration` schema migrations, WP-1 engine (merged, alpha.256).
+
+## Global Constraints
+
+Everything from the WP-0/WP-1 plan's Global Constraints applies verbatim (strict_types, final, PHPUnit 10.5 attributes/no `-v`, Waaseyaa LoggerInterface pattern, getquery gate, layer rules, commit trailer, PR references `#1920` never `Closes`). Additionally:
+
+- **Baseline is `origin/main`** (alpha.256, WP-0 #1927 + WP-1 #1929 + binding #1931 merged). Local `main` refs may be stale — always branch from `origin/main`.
+- CI includes: Changelog discipline (add the `[Unreleased]` entry IN this PR), spec-drift (commit-trailer `spec-reviewed:` acks or real spec updates — PR-body acks do not work), `check-symfony-imports` (new subscriber/event files may need `.symfony-import-allowlist.json` `legacy_files` entries), dead-code gate (`@api` conventions).
+- Layering: entity-storage (L1) must NOT import workflows (L3) — the bypass closure is an L1-dispatched event that L3 subscribes to (mirroring how `cache` listens to entity events), NOT a workflows import in the repository.
+- One PR at the end (`feat(#1920): CW-v1 WP-2 — node revisions + forward drafts`), commit per task.
+
+## Design decisions (locked — do not re-decide)
+
+1. **`revisionDefault: true` for node** — every ordinary save creates a new revision (Drupal parity). Per-bundle opt-out comes from wiring the currently-inert `NodeType::isNewRevision()` (Task 2.3).
+2. **Two-pointer status semantics:** the base row's `status` reflects the **published-pointer revision's** workflow state, not the tip's. A forward draft (new tip revision in a non-`default_revision` state) leaves `status` and `published_revision_id` untouched; entering a `default_revision: true` state moves the published pointer to the acting revision and sets `status` from that state's `published` flag (`published` state → 1; `archived` → 0).
+3. **Bypass closure = new L1 event `BeforeRevisionPointerMoveEvent`** dispatched by `rollback()`, `setCurrentRevision()`, `setPublishedRevision()` (and the `saveTranslation*` trio) BEFORE any write; workflows subscribes and validates the implied state change like a transition. Deliberately NOT reusing `PRE_SAVE` — these are pointer moves, not saves, and reusing the name would silently activate save-semantics listeners.
+4. **Backfill is binding-scoped, not framework-scoped:** the framework cannot know which workflow a site binds, so `workflow_state` backfill is a CLI handler (`workflows:backfill-state`) run as part of the documented binding-activation runbook, not a node-package migration. The node migration only guarantees revision schema.
+5. **Adjacent gap included intentionally:** pointer-move paths currently invalidate no cache tags and `rollback()` is invisible to audit — Task 2.5 closes both while in the area, called out as deliberate side-scope in the PR body.
+
+---
+
+### Task 2.1: Node opts into revisionable storage
+
+**Files:** Modify `packages/node/src/Node.php` (ContentEntityKeys + a declared `workflow_state` field), `packages/node/src/NodeServiceProvider.php` (fromClass flags). Tests: node package schema/registration tests.
+
+- `#[ContentEntityKeys(id: 'nid', uuid: 'uuid', label: 'title', bundle: 'type', revision: 'revision_id')]` (`packages/entity/src/Attribute/ContentEntityKeys.php:19`).
+- `EntityType::fromClass(Node::class, group: 'content', bundleEntityType: 'node_type', revisionable: true, revisionDefault: true)` (`packages/node/src/NodeServiceProvider.php:14-18`; override params exist at the call site per `EntityType::fromClass()`, `packages/entity/src/EntityType.php:196-242`).
+- Declare `workflow_state` as a real `#[Field(type: 'string')]` on Node (today it rides the `_data` blob undeclared — works, but invisible to SchemaPresenter/JSON:API discovery).
+- `ContentEntityBase` already provides the revision capability structurally — zero Node class changes beyond the attribute/field.
+- TDD: failing test asserting `getEntityType('node')->isRevisionable()` and revision key `revision_id`; then a storage test that a save on a fresh SQLite schema creates a `node_revision` row (live dialect: single-underscore `<table>_revision`, `SqlSchemaHandler::getRevisionTableName()`, `packages/entity-storage/src/SqlSchemaHandler.php:314-317` — NOT the dormant `RevisionTableBuilder` double-underscore dialect).
+- Commit: `feat(#1920): node opts into revisionable storage (WP-2)`.
+
+### Task 2.2: Node revision-schema migration (existing deployments)
+
+**Files:** Create `packages/node/migrations/2026_07_06_000001_node_revision_schema.php`; modify `packages/node/composer.json` (add `extra.waaseyaa.migrations: "migrations"` — currently ABSENT). Tests: migration idempotency test following media's pattern.
+
+- Follow `packages/media/migrations/2026_07_01_000001_add_media_version_vid_unique_index.php` exactly: additive, shape-guarded (`if (!$schema->hasTable(...)) return;`), `down()` documented no-op.
+- The migration ensures the `node_revision` table + base-row `revision_id`/`published_revision_id` pointer columns exist (delegate to the same idempotent primitives `revisions:enable` uses — `EntitySchemaSyncRunner` / `SqlSchemaHandler::ensureRevisionTable()` at `:256-268`), then seeds initial revisions for rows lacking history via `EntityRepository::backfillInitialRevisions()` (the exact machinery `RevisionsEnableHandler` runs, `packages/cli/src/Handler/RevisionsEnableHandler.php:70-83`). If invoking the runner inside a `Migration::up()` is awkward, the migration ensures schema only and the runbook (Task 2.7) mandates `bin/waaseyaa revisions:enable node` — implementer picks whichever is cleaner and documents the choice; either way the outcome must be provably idempotent.
+- Commit: `feat(#1920): node revision schema migration (WP-2)`.
+
+### Task 2.3: Wire the inert `NodeType::isNewRevision()` knob
+
+**Files:** Create `packages/node/src/Listener/NodeRevisionDefaultListener.php`; modify `packages/node/src/NodeServiceProvider.php` (boot() wiring — Symfony-contracts dispatcher FQCN, mirror `RelationshipServiceProvider`). Tests: unit + a wiring test.
+
+- Fact: `EntityRepository::shouldCreateRevision()` (`packages/entity-storage/src/EntityRepository.php:1805-1832`) consults `$entity instanceof RevisionableInterface ? $entity->isNewRevision() : null`, and NO `ContentEntityBase` subclass declares that legacy interface — so the per-entity branch is dead and everything falls to the type-wide `revisionDefault`. `NodeType::isNewRevision()` (`packages/node/src/NodeType.php:98-111`) is currently a knob wired to nothing.
+- Fix: Node `implements RevisionableInterface` (the trait already supplies the methods); a `PRE_SAVE` listener in the node package resolves the node's `NodeType` and calls `$node->setNewRevision($nodeType->isNewRevision())` — UNLESS the save already carries an explicit per-save decision (respect an already-set value; check the trait's default-vs-set semantics and preserve explicit `setNewRevision()` calls by earlier actors like TransitionService).
+- Deny-path/edge tests: bundle with `new_revision: false` → in-place update, no new revision row; default bundle → new revision per save.
+- Commit: `feat(#1920): NodeType new_revision actually controls revision creation (WP-2)`.
+
+### Task 2.4: `BeforeRevisionPointerMoveEvent` (L1) — the bypass choke point
+
+**Files:** Create `packages/entity-storage/src/Event/BeforeRevisionPointerMoveEvent.php`; modify `packages/entity-storage/src/EntityRepository.php` (`rollback()` :1043-1099, `setCurrentRevision()` :1137-1200, `setPublishedRevision()` :1237-1317, `saveTranslationRevision()`/`saveTranslationRevisions()`/`saveTranslation()` :1335-1501). Tests: entity-storage unit tests per method.
+
+- Event shape (mirror `RevisionPointerMovedEvent`'s payload, add the pre-phase semantics): `entityTypeId`, `entityId`, `operation` (`'rollback'|'revert'|'publish'|'translation_save'`), `fromRevisionId: ?int`, `toRevisionId: ?int`, `actorUid: ?int`, plus the loaded target revision's values array so subscribers can read its `workflow_state` without a second load. Extends Symfony contracts `Event` (stoppable is not enough — subscribers deny by THROWING, same convention as the guard).
+- Dispatch BEFORE any write in each of the four call sites (fact: they currently dispatch nothing before writing; only `REVISION_*`/`RevisionPointerMovedEvent` after). No `SaveContext` change — the event carries what validators need.
+- These methods are L1; the event is L1; no upward import. Test: each method dispatches the event with correct operation + a subscriber that throws aborts the write (assert storage unchanged).
+- `.symfony-import-allowlist.json`: new event file needs a `legacy_files` entry (Symfony `Event` parent), same as `WorkflowTransitionEvent`.
+- Commit: `feat(#1920): pre-pointer-move event on all revision pointer paths (WP-2)`.
+
+### Task 2.5: Workflows subscribes — bypass closed; cache/audit ride along
+
+**Files:** Create `packages/workflows/src/Listener/WorkflowPointerMoveGuard.php`; modify `packages/workflows/src/WorkflowServiceProvider.php` (boot). Modify `packages/cache/src/Listener/EntityCacheSubscriber.php` (subscribe invalidation to `RevisionPointerMovedEvent` + `REVISION_REVERTED` — fact: zero cache invalidation on pointer moves today) and add audit coverage for `rollback()` (fact: `PublishPointerAuditListener` covers only revert/publish pointer moves; rollback is invisible). Tests per listener.
+
+- Guard logic: resolve binding (unbound type → return). Compute the implied state change: target revision's `workflow_state` vs the currently-effective state (for `'publish'` operations compare against the published-pointer revision's state; for `'rollback'`/`'revert'` against the current-pointer's). Same validation as a transition: edge must exist, permission required when `AccountContextInterface` has an account, null context = edge-legality only. Deny by `TransitionDeniedException`.
+- Cache/audit additions are the flagged intentional side-scope: state them in the PR body as closing a pre-existing gap (pointer moves serving stale cache and unaudited rollbacks), with their own tests.
+- Commit: `feat(#1920): pointer-move workflow guard + cache/audit coverage (WP-2)`.
+
+### Task 2.6: Forward-draft mechanics in TransitionService + guard reconciliation
+
+**Files:** Modify `packages/workflows/src/Transition/TransitionService.php`, `packages/workflows/src/Listener/WorkflowStateGuard.php` (`applyState()`). Tests: transition-service + guard suites.
+
+- Fact: `transition()` today does `set('workflow_state') + set('status') + save()` — no `defaultRevision` awareness (README flags this as WP-2 debt). Implement decision 2:
+  - Target state `defaultRevision: false` on an entity whose published pointer exists and stays (forward draft): save creates the new tip revision carrying the state; do NOT touch `status` or the published pointer. The live version keeps serving.
+  - Target state `defaultRevision: true`: save the revision, then `EntityRepository::setPublishedRevision($entityId, $newRevisionId)` (:1237) to move the pointer, and set `status` per the state's `published` flag. (The pointer move fires Task 2.4's event; TransitionService is the sanctioned caller — its own validation already ran, so the pointer guard revalidating is harmless/idempotent, same as the WP-1 save-guard double-check.)
+  - Entity with no published revision yet (never published): current WP-1 behavior stands (status follows state directly).
+- `WorkflowStateGuard::applyState()` gets the same rule — it must stop unconditionally setting `status` when the save is a forward draft on published content.
+- Integration test: publish a node → edit via raw save into `draft` (forward draft) → assert public read path (published pointer + status) still serves the OLD content and `status=1` → transition draft revision to `published` → assert pointer moved, new content live.
+- Commit: `feat(#1920): forward drafts — default_revision drives the published pointer (WP-2)`.
+
+### Task 2.7: `workflows:backfill-state` CLI + binding-activation runbook
+
+**Files:** Create `packages/cli/src/Handler/WorkflowsBackfillStateHandler.php` (+ command registration mirroring `RevisionsEnableHandler`); modify `docs/specs/operations-playbooks.md` (runbook section). Tests: CliTester coverage.
+
+- Handler: `workflows:backfill-state <entity_type> <workflow_id> [--bundle=]` — for every row of the type/bundle missing a non-empty `workflow_state`: set it to the workflow's published-flagged `default_revision` state where `status = 1`, else the workflow's `initial_state`. Idempotent (skips rows with state), reports counts, exits nonzero on partial failure (the R16 fail-fast lesson). Entity queries: `->accessCheck(false)` with justification comment (system-level backfill).
+- Runbook (ops playbook): the safe activation sequence for existing deployments — (1) deploy WP-2 code, (2) `migrate:up`, (3) `revisions:enable node` if the migration deferred it, (4) `workflows:backfill-state node editorial`, (5) only THEN add the `workflows.assignments` binding. Include the failure mode it prevents (fact: `currentState()` falls back to `initial_state`, so binding before backfill makes every legacy published row read as `draft` — and note `WorkflowBindingResolver` hard-throws on non-revisionable types, so mis-ordering fails loudly at step 5, not silently).
+- Commit: `feat(#1920): workflows:backfill-state + binding activation runbook (WP-2)`.
+
+### Task 2.8: Integration spine + docs + PR
+
+**Files:** Create `packages/workflows/tests/Integration/ForwardDraftFlowTest.php`; update `packages/workflows/README.md` (WP-2 debt notes resolved), CHANGELOG `[Unreleased]` entry, spec truth-ups.
+
+- Spine: real SQLite, node bound to seeded editorial — create (forced draft, unpublished) → publish (pointer + status) → forward-draft edit (live untouched) → review → publish (promotion) → archive (pointer moves, status 0) → rollback attempt without permission DENIED via the pointer guard → rollback with permission succeeds and audits.
+- Read-side note: `WorkflowVisibility` deriving published-ness from bound-workflow state flags (README flags it "tracked for WP-2") — implement if small once the above lands, else record explicitly as WP-4-adjacent with rationale in the PR body; do not silently drop it.
+- Spec-drift: entity-storage changes map to `docs/specs/entity-system.md` (+ revision spec) — update `docs/specs/revision-system-unified.md` for the new pre-event (it documents the pointer methods' event behavior at §4a); `docs/specs/content-workflow.md` truth-up rides #1921 or a follow-up if still unmerged.
+- Full gates, push, ONE PR: `feat(#1920): CW-v1 WP-2 — node revisions + forward drafts`. No auto-merge.
+
+## Self-review notes (plan-writing time)
+
+- Spec coverage: node opt-in + migration (2.1/2.2), forward drafts (2.6), tracker requirement (a) pointer bypass (2.4/2.5), (b) WP-0-vs-guard authority (documented in 2.6/2.7 runbook; field gate stays defense-in-depth), (c) `SaveContext::isImport` — the guard's create rule already denies null-context non-initial creates; the backfill handler is the sanctioned import path, so no guard change needed — implementer verifies imports via `isImport` saves don't hit the create guard incorrectly and reports, (d) state backfill (2.7).
+- Known judgment calls locked in the Design decisions block; the one place the implementer may choose is 2.2's migration-vs-runbook split for `revisions:enable`.
+- Verify-don't-trust: exact `applyState()` shape post-WP-1 amendments, the trait's `isNewRevision()` default semantics (2.3), and whether `setPublishedRevision()` accepts the just-created revision id atomically after `save()` in one request (check `TransitionResult` needs the new revision id — `doSave()` sets it on the entity's revision key).

--- a/docs/specs/content-workflow.md
+++ b/docs/specs/content-workflow.md
@@ -1,0 +1,123 @@
+# Content Workflow (CW-v1)
+
+<!-- Spec reviewed 2026-07-06 - Initial design spec, approved by Russell pre-implementation
+     (anchoring issue #1920, resolves audit decision D1). Status: DESIGN — no engine code
+     exists yet; the code this spec describes REPLACES the dead editorial machinery in
+     packages/workflows (see "Cleanup inventory"). Update this spec as WPs land. -->
+
+**Status: DESIGN (approved 2026-07-06).** Anchoring issue: [#1920](https://github.com/waaseyaa/framework/issues/1920). Resolves audit decision D1 (wire-or-delete the dead editorial machinery) as a client-driven build-fresh. Design bar: Drupal content-moderation parity and beyond.
+
+| WP | Delivers | Status |
+|---|---|---|
+| WP-0 | Interim `status`/`workflow_state` field gate (self-publish fix) | pending (ships on R16 timeline) |
+| WP-1 | Config schema, TransitionService, save-path guard, events, permissions, default `editorial` workflow | pending |
+| WP-2 | Node opt-in to revisionable storage + migration; forward-draft flow end-to-end | pending |
+| WP-3 | Group (department) transition constraints | pending (groups readiness assessment first) |
+| WP-4 | API transition endpoints + admin SPA transition UI | pending |
+| WP-5 | Delete dead machinery + README truth-up | pending (never before its replacement lands) |
+
+## Purpose
+
+A general content-workflow engine: named editorial states, permission- and group-gated transitions between them, enforced in the write path, with transition audit history. The v1 consumer case is department routing — content drafted in one department routes to decision-makers for approval before publication — but nothing in the engine knows about any specific department: departments, states, and approval chains are site configuration.
+
+**What Drupal core does that we match:** workflows as config, moderation state on revisions, forward drafts of published content, per-transition permissions.
+**What Drupal needs contrib for that we ship (the "beyond"):** group-scoped transition constraints (department routing) as a first-class optional dimension.
+
+## Concepts and config schema
+
+A **workflow** is a config entity (CMI-syncable, validated on import):
+
+```yaml
+# config: workflows.workflow.editorial
+id: editorial
+label: Editorial
+states:
+  draft:      { label: Draft,     published: false, default_revision: false }
+  review:     { label: In review, published: false, default_revision: false }
+  published:  { label: Published, published: true,  default_revision: true }
+  archived:   { label: Archived,  published: false, default_revision: true }
+initial_state: draft
+transitions:
+  submit_for_review: { label: Submit for review, from: [draft],            to: review,    permission: 'use editorial transition submit_for_review' }
+  publish:           { label: Publish,           from: [draft, review],    to: published, permission: 'use editorial transition publish' }
+  reject:            { label: Send back,         from: [review],           to: draft,     permission: 'use editorial transition reject' }
+  archive:           { label: Archive,           from: [published],        to: archived,  permission: 'use editorial transition archive' }
+  restore:           { label: Restore to draft,  from: [archived],         to: draft,     permission: 'use editorial transition restore' }
+```
+
+A transition MAY additionally carry `group_constraint: content_groups` (WP-3): fireable only by members of the group(s) the content belongs to (departments are `groups` entities; content carries a department relationship). Permission answers *may this kind of person do this*; the group constraint answers *may they do it to this content*. A workflow with no group constraints behaves exactly like Drupal core.
+
+**Bindings** map `entity_type` + `bundle` → workflow id (config: `workflows.assignments`). Binding requires the entity type to be revisionable — rejected at config-import validation otherwise.
+
+The default `editorial` workflow ships as **config data, not code**. The retired machinery's preset-in-code (`EditorialWorkflowPreset` as canonical definition) is an explicit anti-pattern here: replacing a self-contained populated default with an empty generic silently broke consumers once already (CLAUDE.md gotcha).
+
+## State lives on revisions
+
+`workflow_state` is stored **per revision** on workflow-bound types (two-axis storage substrate: `RevisionableStorageDriver`, `docs/specs/revision-system-unified.md`).
+
+- A state flagged `published: true` sets the entity's `status` accordingly when its revision is the default.
+- `default_revision: true` states promote their revision to default on entry — this is the **forward draft** mechanic: editing published content creates a new non-default revision in `initial_state`; the live revision stays published; the `publish` transition promotes the draft revision to default.
+- Creating content starts it in `initial_state` (see save-path guard).
+
+**Staged limitation (documented, not hidden):** v1 state is per *revision*, not per revision-*translation*. Drupal moderates per translation; per-translation state is a post-v1 stage on the same storage axis. Until then, translations share their revision's state.
+
+## TransitionService — the one door
+
+`Waaseyaa\Workflows\Transition\TransitionService` (final, container-bound):
+
+- `transition(ContentEntityInterface $entity, string $transitionId, AccountInterface $account): TransitionResult`
+  1. **Validate:** binding exists for the entity type/bundle; transition exists in the bound workflow; current revision state ∈ `from[]`; `$account` holds the transition's permission; group constraint (if any) satisfied. Failure → typed exception (`TransitionDeniedException` with a machine-readable reason), never a silent no-op.
+  2. **Apply:** set `workflow_state` on the target revision; set `status` and promote to default revision per the target state's flags; persist through `EntityRepository` (the canonical pipeline — no direct storage writes).
+  3. **Announce:** dispatch `WorkflowTransitionEvent` (pre + post, Symfony `Event` subclasses like the live `EntityEvent` lifecycle events); write a transition audit entry (see Integration).
+- `getAvailableTransitions(ContentEntityInterface $entity, AccountInterface $account): array<TransitionDefinition>` — the read-side the admin UI renders buttons from. This resurrects the *concept* behind the retired dry-run/guards controllers as a real engine method.
+
+## Save-path guard
+
+An entity pre-save subscriber makes the raw write path equivalent to the service:
+
+- A save that mutates `workflow_state` is validated as if `TransitionService::transition()` had been called by the acting account (`_account` semantics) — same denial, same exception. A raw `PATCH /api/node/{id}` cannot do what the service would refuse.
+- **Create forces `initial_state`** and, for workflow-bound types, a non-published `status` unless the acting account holds a transition permission into a published state. This closes the born-published hole (`Node` defaults `status = 1` in its constructor) for workflow-bound types.
+
+**Wiring invariants (both are lessons from the machinery this replaces):**
+1. The subscriber registers against the **Symfony-contracts dispatcher FQCN** via the kernel-services bus — resolving the foundation FQCN silently no-ops (this exact bug left `DomainValidationListener` dead and is still latent in Media/Field). A **wiring regression test** asserts the subscriber actually fires on a real kernel-dispatched save; a unit test on the subscriber class alone does not count.
+2. **Deny-path tests are first-class:** every gate (permission, from-state, group, create-initial-state) has an explicit test proving denial, not just tests proving the happy path.
+
+## Permissions
+
+One permission string per transition, registered through the standard permission surface, named `use <workflow_id> transition <transition_id>`. Roles grant permissions as usual. `getAvailableTransitions()` is the only sanctioned way for UIs to decide what to offer.
+
+**WP-0 interim gate** (ships first, on the R16 timeline): `NodeAccessPolicy::fieldAccess()` returns Forbidden for `status` and `workflow_state` writes unless the account holds `use editorial transition publish` (exact engine-compatible name — nothing renames when the engine lands), and node create forces `status = 0` for accounts lacking it. The save-path guard supersedes this gate for workflow-bound types in WP-1/2; the field gate remains as defense-in-depth for unbound types. This changes the documented "editorial booleans intentionally NOT gated" stance in `NodeAccessPolicy` — that docblock is updated as part of WP-0.
+
+## Integration
+
+- **Audit (L3 → L1, downward):** `TransitionService` writes transition entries (who, entity/revision, from → to, timestamp) through the audit package's public API. Deliberately *not* implemented as an audit-side subscriber to a workflows event — that would be an upward type import requiring a `KERNEL_EXEMPT_FILES` entry.
+- **Notifications (L3 → L3):** the notification package (or app code) subscribes to `WorkflowTransitionEvent`. The framework ships the event surface; recipient routing is app configuration.
+- **Visibility (read side):** unchanged ownership — `WorkflowVisibility` / `WorkflowVisibilityFilter` / `EditorialVisibilityResolver` remain the read gates (fail-closed per R16 #1915). For workflow-bound types they derive published-semantics from the bound workflow's state flags instead of assuming `status === 1`.
+- **API (WP-4):** `POST /api/{type}/{id}/workflow/transition` (`_gate` + service validation; body `{ transition: "publish" }`) and `GET /api/{type}/{id}/workflow/transitions` (available transitions for `_account`). Raw `PATCH` of `workflow_state` stays legal-but-guarded (see save-path guard) for parity with generic clients.
+- **Admin SPA (WP-4):** transition buttons on the content edit/view surface fed by the available-transitions endpoint; state badge in listings. (Nuxt nested-dir component prefix gotcha applies; test the populated path.)
+
+## Layering
+
+`workflows` stays **L3 (Services)**. Imports: entity/entity-storage/access/audit/config (L1, downward), groups (L2, downward — WP-3), relationship (L2, downward — WP-3). Nothing upward; no new `PL006` same-layer cycles.
+
+## Cleanup inventory (WP-5 — only after the replacement lands)
+
+Delete: `EditorialWorkflowService` (+ `transitionNode`), `EditorialTransitionAccessResolver`, `AuthoringRoleMatrix`, `DomainValidationListener` (never subscribed; kept alive in the dead-code gate only by its own unit test), `packages/api/src/Workflow/WorkflowDryRunController.php`, `packages/api/src/Controller/WorkflowGuardsController.php`, their route registrations and ~950 lines of tests. Evaluate in WP-1 and delete here if unused: `ContentModerator`, `ContentModerationState`, `EditorialWorkflowPreset`.
+Keep: `Workflow`/`WorkflowState`/`WorkflowTransition` primitives where they fit the new engine; the visibility classes (live).
+Truth-up: `packages/workflows/README.md` currently advertises `transitionNode` as live API — rewrite around the new engine.
+
+## Testing requirements
+
+- **Integration spine:** one end-to-end editorial story — create draft (forced initial state) → submit for review → publish → forward-draft edit of published content → approve → promoted default revision — driven through the real save path and `TransitionService`, real SQLite (`DBALDatabase::createSqlite()`).
+- **Deny paths at every gate** (permission, from-state mismatch, group constraint, create-born-published attempt, raw-PATCH bypass attempt).
+- **Wiring regression test** (subscriber fires on kernel-dispatched save; correct dispatcher FQCN).
+- **Config validation tests:** unknown state in `from`/`to`, binding a non-revisionable type, missing `initial_state` — all rejected at import.
+- Unit tests per component; access-policy tests use anonymous classes for intersection types (PHPUnit `createMock()` limitation).
+
+## Design invariants (why it looks like this)
+
+1. **One door.** Every state change flows through `TransitionService` validation — the service directly, or the save-path guard proving equivalence. The predecessor died precisely because enforcement was optional.
+2. **Definitions are data.** No preset-in-code as the canonical definition.
+3. **Revision-aware from day one.** Retrofitting revisions under a state-on-entity engine is a redesign; shipping revision-aware with staged delivery is not.
+4. **Nothing generalizes from `node`.** The engine addresses entity type + bundle via bindings; `node` is just the first bound type (WP-2).
+5. **Fail closed, deny loudly.** Typed denial exceptions with machine-readable reasons; no silent no-ops, no fail-open defaults.

--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -126,6 +126,7 @@ declare -A PATTERN_TO_SPEC=(
   ["packages/graphql/"]="docs/specs/api-layer.md"
   ["packages/routing/"]="docs/specs/api-layer.md"
   ["packages/wayfinding/"]="docs/specs/wayfinding.md"
+  ["packages/workflows/"]="docs/specs/content-workflow.md"
   ["packages/foundation/"]="docs/specs/infrastructure.md"
   ["packages/cache/"]="docs/specs/infrastructure.md"
   ["packages/debug/"]="docs/specs/debugging-dx.md"


### PR DESCRIPTION
**Anchoring issue / plan:** #1920 (CW-v1 content workflow engine)

## Summary

The approved CW-v1 design spec at `docs/specs/content-workflow.md`:

- Workflow definitions as CMI-syncable config entities; default `editorial` workflow ships as data, not code
- Workflow state on **revisions** (forward drafts; approval promotes) on the existing two-axis substrate
- `TransitionService` as the single enforcement door + save-path guard making raw PATCH equivalent to the service
- Per-transition permissions, optional group (department) constraints — Drupal parity and beyond
- Staged WP-0..WP-5 delivery; cleanup of the dead editorial machinery only after its replacement lands
- Design invariants encode the audit's lessons: one door, definitions-as-data, revision-aware from day one, nothing generalizes from node, fail closed

Also wires `packages/workflows/` into `tools/drift-detector.sh` PATTERN_TO_SPEC (it was unmapped) and points the CLAUDE.md orchestration row at the new spec.

## Checklist

- [x] **Traceability:** anchoring issue #1920
- [x] PR title includes `#N`
- [x] Relevant `docs/specs/*.md` updated (this PR adds the spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)