### PR TITLE
fix(frankenphp): checksum-unavailable install now fails closed with explicit opt-out (#1915, R16)

### DIFF
--- a/packages/frankenphp/README.md
+++ b/packages/frankenphp/README.md
@@ -22,7 +22,11 @@ never the operator's problem.
 - Per-OS/arch asset selection (Linux `x86_64`/`aarch64`, macOS `arm64`/`x86_64`,
   Windows `x86_64`), pinned to a known-good version (default `v1.12.4`; override
   with `--frankenphp-version` or `FRANKENPHP_VERSION`).
-- Verifies the download's sha256 against the GitHub release digest when available.
+- Verifies the download's sha256 against the GitHub release digest, fail-closed: a
+  checksum mismatch always refuses to install, and so does an **unavailable**
+  digest (GitHub API unreachable/rate-limited, malformed response, or an asset
+  with no published digest) — pass `--allow-unverified` to accept that risk
+  explicitly and install anyway (the result is reported as unverified).
 - Windows: the release is a full PHP-for-Windows SDK zip — the **whole** archive
   is extracted into `vendor/bin/frankenphp-dist/` so `frankenphp.exe` finds its
   sibling DLLs. POSIX: a bare binary with the executable bit set.

--- a/packages/frankenphp/src/Binary/Installer.php
+++ b/packages/frankenphp/src/Binary/Installer.php
@@ -40,11 +40,14 @@ final class Installer
     private \Closure $makeExecutable;
 
     /**
-     * @param \Closure(string,string):void|null    $download       fn(url, destFile)
-     * @param \Closure(string,string):?string|null $fetchDigest    fn(apiUrl, assetName) → sha256 hex or null
-     * @param \Closure(string):string|null         $sha256File     fn(file) → sha256 hex
-     * @param \Closure(string,string):void|null    $extractAll     fn(zipFile, destDir) — extract the whole archive
-     * @param \Closure(string):void|null           $makeExecutable fn(file)
+     * @param \Closure(string,string):void|null    $download        fn(url, destFile)
+     * @param \Closure(string,string):?string|null $fetchDigest     fn(apiUrl, assetName) → sha256 hex or null
+     * @param \Closure(string):string|null         $sha256File      fn(file) → sha256 hex
+     * @param \Closure(string,string):void|null    $extractAll      fn(zipFile, destDir) — extract the whole archive
+     * @param \Closure(string):void|null           $makeExecutable  fn(file)
+     * @param bool                                 $allowUnverified explicit operator opt-out: proceed with an
+     *                                                               unverified install when the release digest is
+     *                                                               unavailable, instead of the fail-closed default
      */
     public function __construct(
         ?\Closure $download = null,
@@ -52,6 +55,7 @@ final class Installer
         ?\Closure $sha256File = null,
         ?\Closure $extractAll = null,
         ?\Closure $makeExecutable = null,
+        private readonly bool $allowUnverified = false,
     ) {
         $this->download = $download ?? self::realDownload();
         $this->fetchDigest = $fetchDigest ?? self::realFetchDigest();
@@ -84,11 +88,16 @@ final class Installer
      * Install the asset under `$baseDir` (a project's vendor/bin), returning the
      * outcome (the path is the runnable binary).
      *
-     * Idempotent: an existing binary is kept unless `$force`. Checksum is enforced
-     * when the GitHub release publishes a digest; if the API is unreachable the
-     * install proceeds unverified (the caller warns).
+     * Idempotent: an existing binary is kept unless `$force`. Checksum verification
+     * is fail-closed by default: a mismatch always refuses to install, and when the
+     * digest itself is unavailable (GitHub API unreachable/rate-limited, malformed
+     * response, or the asset publishes no digest) the install now also refuses,
+     * unless the operator has explicitly opted out via `$allowUnverified` in the
+     * constructor — in which case the install proceeds and `InstallOutcome`
+     * reports `checksumVerified: false` for the caller to warn on.
      *
-     * @throws \RuntimeException on download failure, checksum mismatch, or extraction failure
+     * @throws \RuntimeException on download failure, checksum mismatch, extraction
+     *                           failure, or an unavailable checksum with no opt-out
      */
     public function install(FrankenPhpAsset $asset, string $baseDir, bool $force = false): InstallOutcome
     {
@@ -125,7 +134,17 @@ final class Installer
                 ));
             }
             $verified = true;
+        } elseif (!$this->allowUnverified) {
+            @unlink($tmp);
+            throw new \RuntimeException(sprintf(
+                'Could not verify the checksum for %s: the GitHub release digest was unavailable '
+                . '(API unreachable/rate-limited, or the asset publishes no digest). Refusing to install an '
+                . 'unverified binary. Pass --allow-unverified to accept this risk explicitly.',
+                $asset->assetName,
+            ));
         }
+        // else: operator explicitly opted into an unverified install; $verified stays
+        // false and InstallOutcome::checksumVerified reports it for the caller to warn on.
 
         if ($asset->isArchive) {
             $distDir = \dirname($binary);
@@ -246,7 +265,7 @@ final class Installer
             ]);
             $json = @file_get_contents($apiUrl, false, $context);
             if (!is_string($json) || $json === '') {
-                return null; // API unreachable / rate-limited → install proceeds unverified.
+                return null; // API unreachable / rate-limited → caller decides fail-closed vs opt-out.
             }
             try {
                 $data = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);

--- a/packages/frankenphp/src/Command/DevCommand.php
+++ b/packages/frankenphp/src/Command/DevCommand.php
@@ -85,9 +85,15 @@ final class DevCommand extends Command
 
         if ($interactive && $io->confirm('Download the FrankenPHP binary now?', true)) {
             try {
+                // `dev`'s auto-install always fails closed on an unverifiable checksum
+                // (no --allow-unverified opt-out here, deliberately — this is the
+                // "just works" inner-loop path; an operator who wants to accept the
+                // supply-chain risk runs `frankenphp:install --allow-unverified`
+                // explicitly instead).
                 $outcome = InstallCommand::performInstall($this->projectRoot, force: false, version: null, output: $io);
             } catch (\Throwable $e) {
                 $io->error($e->getMessage());
+                $io->note('Run `frankenphp:install --allow-unverified` to accept this risk explicitly, or retry once the GitHub API is reachable.');
 
                 return null;
             }

--- a/packages/frankenphp/src/Command/InstallCommand.php
+++ b/packages/frankenphp/src/Command/InstallCommand.php
@@ -35,7 +35,8 @@ final class InstallCommand extends Command
         $this
             ->setDescription('Download the FrankenPHP binary for this OS/arch into vendor/bin (for `composer run dev`).')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Re-download even if a managed binary already exists.')
-            ->addOption('frankenphp-version', null, InputOption::VALUE_REQUIRED, 'FrankenPHP release tag to install (default: pinned ' . AssetSelector::DEFAULT_VERSION . '; or set FRANKENPHP_VERSION).');
+            ->addOption('frankenphp-version', null, InputOption::VALUE_REQUIRED, 'FrankenPHP release tag to install (default: pinned ' . AssetSelector::DEFAULT_VERSION . '; or set FRANKENPHP_VERSION).')
+            ->addOption('allow-unverified', null, InputOption::VALUE_NONE, 'Proceed with the install when the GitHub release checksum is unavailable (API unreachable/rate-limited). Without this flag, an unverifiable download now refuses to install.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -44,7 +45,13 @@ final class InstallCommand extends Command
         $version = $this->resolveVersion($input->getOption('frankenphp-version'));
 
         try {
-            $outcome = self::performInstall($this->projectRoot, (bool) $input->getOption('force'), $version, $io);
+            $outcome = self::performInstall(
+                $this->projectRoot,
+                (bool) $input->getOption('force'),
+                $version,
+                $io,
+                (bool) $input->getOption('allow-unverified'),
+            );
         } catch (\Throwable $e) {
             $io->error($e->getMessage());
 
@@ -59,10 +66,20 @@ final class InstallCommand extends Command
     /**
      * Reusable install routine (also called by `dev` when it offers to install).
      *
-     * @throws \RuntimeException on unsupported platform, download, or checksum failure
+     * @param bool $allowUnverified explicit opt-out: proceed even when the GitHub
+     *                              release checksum is unavailable, instead of the
+     *                              fail-closed default
+     *
+     * @throws \RuntimeException on unsupported platform, download failure, checksum
+     *                           mismatch, or an unavailable checksum with no opt-out
      */
-    public static function performInstall(string $projectRoot, bool $force, ?string $version, ?OutputInterface $output = null): InstallOutcome
-    {
+    public static function performInstall(
+        string $projectRoot,
+        bool $force,
+        ?string $version,
+        ?OutputInterface $output = null,
+        bool $allowUnverified = false,
+    ): InstallOutcome {
         $asset = new AssetSelector()->select(\PHP_OS_FAMILY, php_uname('m'), $version);
 
         if ($output !== null) {
@@ -77,7 +94,7 @@ final class InstallCommand extends Command
 
         $baseDir = BinaryResolver::managedBaseDir($projectRoot);
 
-        return new Installer()->install($asset, $baseDir, $force);
+        return new Installer(allowUnverified: $allowUnverified)->install($asset, $baseDir, $force);
     }
 
     private function resolveVersion(mixed $optionValue): ?string
@@ -99,7 +116,15 @@ final class InstallCommand extends Command
         }
 
         if (!$outcome->checksumVerified) {
-            $io->warning('Could not verify the download checksum (GitHub API unreachable or rate-limited); installed unverified.');
+            // Reaching here with checksumVerified: false means --allow-unverified was
+            // passed: Installer::install() now throws before producing an outcome
+            // when the checksum is unavailable and that opt-out was not given.
+            $io->caution(
+                'Installed WITHOUT verifying the download checksum. The GitHub release digest was unavailable '
+                . '(API unreachable/rate-limited, or the asset publishes no digest) and --allow-unverified was set, '
+                . 'so the binary was installed anyway. Re-run without --allow-unverified once the digest is '
+                . 'reachable to get a verified install.',
+            );
         }
 
         $io->success(sprintf('FrankenPHP installed at %s. Run `composer run dev` to serve.', $outcome->path));

--- a/packages/frankenphp/tests/Unit/Binary/InstallerTest.php
+++ b/packages/frankenphp/tests/Unit/Binary/InstallerTest.php
@@ -125,7 +125,7 @@ final class InstallerTest extends TestCase
     }
 
     #[Test]
-    public function a_missing_release_digest_installs_unverified(): void
+    public function a_missing_release_digest_refuses_to_install_by_default(): void
     {
         $installer = new Installer(
             download: static function (string $url, string $dest): void {
@@ -134,11 +134,72 @@ final class InstallerTest extends TestCase
             fetchDigest: static fn() => null, // API unreachable / rate-limited
         );
 
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/could not verify the checksum/i');
+
+        try {
+            $installer->install($this->bareAsset(), $this->dir, force: false);
+        } finally {
+            self::assertFileDoesNotExist($this->dir . '/frankenphp', 'an unverifiable download must not be left installed');
+            $leftover = glob($this->dir . '/.frankenphp-*.download');
+            self::assertEmpty($leftover === false ? [] : $leftover, 'the temp download must be cleaned up on refusal');
+        }
+    }
+
+    #[Test]
+    public function a_missing_release_digest_installs_unverified_when_explicitly_allowed(): void
+    {
+        $installer = new Installer(
+            download: static function (string $url, string $dest): void {
+                file_put_contents($dest, 'BYTES');
+            },
+            fetchDigest: static fn() => null, // API unreachable / rate-limited
+            allowUnverified: true,
+        );
+
         $outcome = $installer->install($this->bareAsset(), $this->dir, force: false);
 
         self::assertFalse($outcome->skipped);
         self::assertFalse($outcome->checksumVerified);
         self::assertFileExists($outcome->path);
+    }
+
+    #[Test]
+    public function allow_unverified_does_not_bypass_checksum_verification_when_a_digest_is_available(): void
+    {
+        $payload = 'FRANKENPHP-BINARY-BYTES';
+        $installer = new Installer(
+            download: static function (string $url, string $dest) use ($payload): void {
+                file_put_contents($dest, $payload);
+            },
+            fetchDigest: static fn() => hash('sha256', $payload),
+            allowUnverified: true,
+        );
+
+        $outcome = $installer->install($this->bareAsset(), $this->dir, force: false);
+
+        self::assertTrue($outcome->checksumVerified, 'a matching digest must still be verified even with allowUnverified set');
+    }
+
+    #[Test]
+    public function allow_unverified_does_not_bypass_a_checksum_mismatch(): void
+    {
+        $installer = new Installer(
+            download: static function (string $url, string $dest): void {
+                file_put_contents($dest, 'TAMPERED');
+            },
+            fetchDigest: static fn() => hash('sha256', 'ORIGINAL'),
+            allowUnverified: true,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/[Cc]hecksum mismatch/');
+
+        try {
+            $installer->install($this->bareAsset(), $this->dir, force: false);
+        } finally {
+            self::assertFileDoesNotExist($this->dir . '/frankenphp', 'a tampered download must not be left installed even with allowUnverified set');
+        }
     }
 
     #[Test]
@@ -156,6 +217,9 @@ final class InstallerTest extends TestCase
                 file_put_contents($destDir . '/frankenphp.exe', 'WINDOWS-EXE-BYTES');
                 file_put_contents($destDir . '/php8ts.dll', 'SIBLING-DLL');
             },
+            // This test exercises archive extraction, not checksum enforcement — opt
+            // out of the fail-closed default so a null digest doesn't abort it.
+            allowUnverified: true,
         );
 
         $outcome = $installer->install($this->zipAsset(), $this->dir, force: false);

--- a/packages/frankenphp/tests/Unit/Command/InstallCommandTest.php
+++ b/packages/frankenphp/tests/Unit/Command/InstallCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\FrankenPhp\Tests\Unit\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\FrankenPhp\Command\InstallCommand;
+
+/**
+ * CLI-surface coverage for the checksum-unavailable fail-closed change: the
+ * Installer-level behavior (packages/frankenphp/tests/Unit/Binary/InstallerTest.php)
+ * is exercised offline with injected closures; here we only pin that
+ * `frankenphp:install` actually wires up the `--allow-unverified` opt-out flag it
+ * threads into `Installer`, since `performInstall()` constructs a real network-backed
+ * `Installer` internally and so cannot be exercised offline via `execute()`.
+ */
+#[CoversClass(InstallCommand::class)]
+final class InstallCommandTest extends TestCase
+{
+    #[Test]
+    public function the_allow_unverified_option_is_registered_as_a_no_value_flag_defaulting_to_false(): void
+    {
+        $command = new InstallCommand('/tmp/does-not-matter');
+        $definition = $command->getDefinition();
+
+        self::assertTrue($definition->hasOption('allow-unverified'));
+
+        $option = $definition->getOption('allow-unverified');
+        self::assertFalse($option->acceptValue(), '--allow-unverified must be a bare flag (InputOption::VALUE_NONE)');
+        self::assertFalse($option->getDefault(), '--allow-unverified must default to false (fail-closed by default)');
+    }
+
+    #[Test]
+    public function the_force_and_version_options_are_unaffected_by_the_new_flag(): void
+    {
+        $command = new InstallCommand('/tmp/does-not-matter');
+        $definition = $command->getDefinition();
+
+        self::assertTrue($definition->hasOption('force'));
+        self::assertTrue($definition->hasOption('frankenphp-version'));
+    }
+}


### PR DESCRIPTION
**Active Spec Kitty mission (if any):** none — direct fix per audit finding

Refs #1915 (R16 audit), #1750 (original checksum fail-open report)

## Summary

- Audit record `L6-frankenphp.md` (MAJOR, supply-chain) found that `Installer::install()` correctly fails closed on a checksum **mismatch**, but silently installed an **unverified** binary whenever the GitHub release digest was simply unavailable (API unreachable/rate-limited — 60 req/hr unauthenticated is trivially exhausted by CI/dev machines — malformed response, missing `assets`, or an asset with no `digest` field). The CLI only warned about this *after* the fact, which gates nothing.
- `Installer` now takes a constructor flag, `allowUnverified` (default `false`). When the digest is unavailable and the flag is unset, `install()` throws a `\RuntimeException` naming the asset and pointing at the opt-out, before any bytes are moved into place. A checksum **mismatch** is unaffected either way — always fail-closed, never bypassable by the new flag.
- `frankenphp:install` gains `--allow-unverified` (`InputOption::VALUE_NONE`, default false), threaded through `performInstall()` into the `Installer` it constructs. The existing "installed unverified" warning in `report()` is upgraded from `$io->warning()` to `$io->caution()` (more visually prominent), since reaching that branch now only happens when the operator explicitly passed the flag.
- `dev`'s auto-install path (offered interactively when the binary is missing) **does not** get the opt-out flag, deliberately: `dev` is the "just works" inner loop, so it always fails closed on an unverifiable checksum and points the operator at running `frankenphp:install --allow-unverified` by hand instead if they want to accept the risk. `DevCommand::execute()` already wrapped `performInstall()` in try/catch printing `$io->error()`, so the new exception surfaces as a clean actionable error, not an uncaught crash — a `$io->note()` was added restating the opt-out path.
- Docblocks on `Installer::install()` and the class-level construct param list updated to describe the new fail-closed default. README updated to document the `--allow-unverified` flag and its risk.

## Test evidence

`InstallerTest`:
- Existing "missing digest installs unverified" test **inverted** to assert the fail-closed throw (the corrected default), asserting no binary and no leftover temp-download file remain.
- New: missing digest + `allowUnverified: true` → installs, `checksumVerified: false`.
- New: `allowUnverified: true` does **not** bypass verification when a digest **is** available (still verifies, `checksumVerified: true`).
- New: `allowUnverified: true` does **not** bypass a checksum **mismatch** (still throws).
- The pre-existing Windows-archive-extraction test (unrelated to checksum behavior) now passes `allowUnverified: true` so its null-digest fixture doesn't abort it.

New `InstallCommandTest`: pins that `--allow-unverified` is registered as a bare flag defaulting to `false` (an `execute()`-level end-to-end test isn't practical offline — `performInstall()` constructs a real network-backed `Installer` internally with no injection seam, which is out of scope for this fix).

```
$ ./vendor/bin/phpunit packages/frankenphp/tests/
...
Tests: 42, Assertions: 114, PHPUnit Warnings: 1.
OK, but there were issues! (1 == "No code coverage driver available", environmental)
```

`composer phpstan`: `[OK] No errors` (1671 files analysed).
`bin/check-dead-code`: OK, no new findings beyond baseline.
`bin/check-getquery-bindings`: OK, no new offenders.
Full pre-push gate (`spec-drift`, `composer-policy`, `phpstan`, `phpunit`) passed: `OK (9393 tests, 222992 assertions)`.

`spec-reviewed: docs/specs/operations-playbooks.md` — reviewed; that spec describes `frankenphp:install`'s binary-download/location behavior at a high level and does not document the checksum-verification failure mode, so no spec text needed updating for this change.

## Checklist

- [x] **Traceability:** linked via `Refs #1915 (R16 audit), #1750 (original checksum fail-open report)` above (explicitly *not* `Closes`, per instruction — these are shared anchoring issues, not fully resolved by this single fix)
- [ ] If this PR closes a **GitHub issue**, that issue is assigned to a Track milestone — N/A, this PR references but does not close either issue
- [x] PR title includes a clear reference (`#1915, R16`)


no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
