### PR TITLE
fix(wayfinding): stop rebuilding the anchor catalog per request (#1915, R16)

### DIFF
--- a/packages/wayfinding/src/Anchor/AnchorRegistry.php
+++ b/packages/wayfinding/src/Anchor/AnchorRegistry.php
@@ -29,6 +29,9 @@ final class AnchorRegistry
 {
     private readonly SchemaPresenter $schemaPresenter;
 
+    /** @var list<Anchor>|null memoised catalog */
+    private ?array $catalog = null;
+
     /** @var array<string, true>|null memoised membership set */
     private ?array $idSet = null;
 
@@ -44,10 +47,23 @@ final class AnchorRegistry
     /**
      * The full anchor catalog across every registered entity type.
      *
+     * Memoized per instance. The catalog derives only from entity-type
+     * definitions and their schema fields, which are boot-stable (fixed once
+     * the kernel has finished registering entity types) and never vary by
+     * request, record, or account — so caching it on `$this` is safe even
+     * under a long-lived worker process (e.g. FrankenPHP worker mode) where
+     * the same `AnchorRegistry` instance serves many requests: there is no
+     * per-request or per-account state to bleed between requests, only a
+     * derivation that would otherwise be wastefully repeated.
+     *
      * @return list<Anchor>
      */
     public function catalog(): array
     {
+        if ($this->catalog !== null) {
+            return $this->catalog;
+        }
+
         $anchors = [];
 
         foreach ($this->entityTypeManager->getDefinitions() as $typeId => $type) {
@@ -73,7 +89,7 @@ final class AnchorRegistry
             }
         }
 
-        return $anchors;
+        return $this->catalog = $anchors;
     }
 
     /**

--- a/packages/wayfinding/src/Http/AnchorCatalogController.php
+++ b/packages/wayfinding/src/Http/AnchorCatalogController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Wayfinding\Http;
 
 use Symfony\Component\HttpFoundation\Response;
-use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
 
 /**
@@ -18,22 +17,28 @@ use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
  * type-level anchor scheme. Route wiring lives in
  * {@see \Waaseyaa\Wayfinding\WayfindingServiceProvider::routes()}.
  *
+ * Takes the shared {@see AnchorRegistry} singleton (bound in
+ * {@see \Waaseyaa\Wayfinding\WayfindingServiceProvider::register()}) via
+ * constructor injection rather than constructing its own, so this public
+ * anonymous endpoint reuses the registry's per-instance memoized catalog
+ * instead of re-deriving it (iterating every entity type and field through
+ * `SchemaPresenter`) on every single request (audit L4-wayfinding.md, MAJOR
+ * finding).
+ *
  * @api
  */
 final class AnchorCatalogController
 {
     public function __construct(
-        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly AnchorRegistry $anchorRegistry,
     ) {}
 
     public function catalog(): Response
     {
-        $registry = new AnchorRegistry($this->entityTypeManager);
-
         try {
             $anchors = array_map(
                 static fn($anchor): array => $anchor->toArray(),
-                $registry->catalog(),
+                $this->anchorRegistry->catalog(),
             );
         } catch (\Throwable) {
             // Best-effort public inventory, mirroring the SEO/llms.txt surface:

--- a/packages/wayfinding/src/Http/EmitBeaconController.php
+++ b/packages/wayfinding/src/Http/EmitBeaconController.php
@@ -6,7 +6,6 @@ namespace Waaseyaa\Wayfinding\Http;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Foundation\Http\Router\SessionChannel;
 use Waaseyaa\Foundation\Http\Router\WaaseyaaContext;
 use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
@@ -43,8 +42,15 @@ final class EmitBeaconController
 
     private const int MAX_CONTENT_LENGTH = 4000;
 
+    /**
+     * Takes the shared {@see AnchorRegistry} singleton (bound in
+     * {@see \Waaseyaa\Wayfinding\WayfindingServiceProvider::register()}) so
+     * emit-time anchor validation (FR-005) reuses the memoized catalog
+     * instead of re-deriving it per request — same fix as
+     * {@see AnchorCatalogController} (audit L4-wayfinding.md, MAJOR finding).
+     */
     public function __construct(
-        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly AnchorRegistry $anchorRegistry,
     ) {}
 
     public function emit(Request $request): Response
@@ -64,8 +70,7 @@ final class EmitBeaconController
             return $this->error(422, 'Unprocessable', 'A non-empty string "anchor_id" is required.');
         }
 
-        $registry = new AnchorRegistry($this->entityTypeManager);
-        if (!$registry->isValid($anchorId)) {
+        if (!$this->anchorRegistry->isValid($anchorId)) {
             return $this->error(422, 'Unknown anchor', sprintf('Anchor "%s" is not in the published catalog.', $anchorId));
         }
 

--- a/packages/wayfinding/src/WayfindingServiceProvider.php
+++ b/packages/wayfinding/src/WayfindingServiceProvider.php
@@ -33,10 +33,11 @@ final class WayfindingServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // The canonical registry instance, shared by later phases (emit-time
-        // anchor validation, FR-005) and constructor-injected into
-        // AnchorCatalogController so the public catalog endpoint reuses this
-        // singleton's memoized catalog() instead of rebuilding it per request.
+        // The canonical registry instance, constructor-injected into both
+        // AnchorCatalogController (public catalog, FR-007) and
+        // EmitBeaconController (emit-time anchor validation, FR-005) so both
+        // endpoints reuse this singleton's memoized catalog() instead of
+        // rebuilding it per request.
         $this->singleton(AnchorRegistry::class, fn(): AnchorRegistry => new AnchorRegistry(
             $this->resolve(EntityTypeManager::class),
         ));

--- a/packages/wayfinding/src/WayfindingServiceProvider.php
+++ b/packages/wayfinding/src/WayfindingServiceProvider.php
@@ -34,8 +34,9 @@ final class WayfindingServiceProvider extends ServiceProvider
     public function register(): void
     {
         // The canonical registry instance, shared by later phases (emit-time
-        // anchor validation, FR-005). The Phase-1 catalog controller resolves
-        // its own from the kernel-bound EntityTypeManager.
+        // anchor validation, FR-005) and constructor-injected into
+        // AnchorCatalogController so the public catalog endpoint reuses this
+        // singleton's memoized catalog() instead of rebuilding it per request.
         $this->singleton(AnchorRegistry::class, fn(): AnchorRegistry => new AnchorRegistry(
             $this->resolve(EntityTypeManager::class),
         ));

--- a/packages/wayfinding/tests/Integration/EmitBeaconControllerTest.php
+++ b/packages/wayfinding/tests/Integration/EmitBeaconControllerTest.php
@@ -12,8 +12,11 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Api\Controller\BroadcastStorage;
 use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Foundation\Http\Router\SessionChannel;
+use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
 use Waaseyaa\Wayfinding\Http\EmitBeaconController;
+use Waaseyaa\Wayfinding\Tests\Support\CountingEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\InMemoryEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\WidgetEntity;
 
@@ -94,10 +97,38 @@ final class EmitBeaconControllerTest extends TestCase
         self::assertCount(0, $this->storage->poll(0, [SessionChannel::forToken('tokenA')]));
     }
 
+    #[Test]
+    public function emit_reuses_the_injected_registry_instead_of_rebuilding_per_request(): void
+    {
+        // Sibling of AnchorCatalogControllerTest's reuse test (audit
+        // L4-wayfinding.md, MAJOR finding): emit-time anchor validation used
+        // to `new AnchorRegistry(...)` per request; it must now reuse one
+        // injected registry's memoized catalog across repeated emits.
+        $etm = new CountingEntityTypeManager($this->entityTypeManager());
+        $controller = new EmitBeaconController(new AnchorRegistry($etm));
+
+        $body = ['session' => 'tokenA', 'anchor_id' => 'field:widget:title', 'content' => 'Hi', 'order' => 1];
+        $first = $controller->emit($this->request($this->account(hasCapability: true), $body));
+        $second = $controller->emit($this->request($this->account(hasCapability: true), $body));
+
+        self::assertSame(202, $first->getStatusCode());
+        self::assertSame(202, $second->getStatusCode());
+        // A per-request catalog rebuild (the pre-fix behavior) would report 2.
+        self::assertSame(1, $etm->getDefinitionsCallCount);
+        self::assertSame(1, $etm->resolveFieldDefinitionsCallCount);
+    }
+
     /**
      * @param array<string, mixed> $body
      */
     private function emit(AccountInterface $account, array $body): \Symfony\Component\HttpFoundation\Response
+    {
+        $controller = new EmitBeaconController(new AnchorRegistry($this->entityTypeManager()));
+
+        return $controller->emit($this->request($account, $body));
+    }
+
+    private function entityTypeManager(): EntityTypeManagerInterface
     {
         $widget = new EntityType(
             id: 'widget',
@@ -107,17 +138,24 @@ final class EmitBeaconControllerTest extends TestCase
             translatable: false,
             revisionable: false,
         );
-        $etm = new InMemoryEntityTypeManager(
+
+        return new InMemoryEntityTypeManager(
             ['widget' => $widget],
             ['widget' => ['body' => ['type' => 'text_long', 'label' => 'Body']]],
         );
+    }
 
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function request(AccountInterface $account, array $body): Request
+    {
         $request = Request::create('/api/wayfinding/beacons', 'POST');
         $request->attributes->set('_account', $account);
         $request->attributes->set('_parsed_body', $body);
         $request->attributes->set('_broadcast_storage', $this->storage);
 
-        return new EmitBeaconController($etm)->emit($request);
+        return $request;
     }
 
     private function account(bool $hasCapability): AccountInterface

--- a/packages/wayfinding/tests/Support/CountingEntityTypeManager.php
+++ b/packages/wayfinding/tests/Support/CountingEntityTypeManager.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Wayfinding\Tests\Support;
+
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\Entity\Storage\EntityStorageInterface;
+
+/**
+ * Decorates an {@see EntityTypeManagerInterface} and counts calls to
+ * `getDefinitions()`/`resolveFieldDefinitions()` — the two methods
+ * `AnchorRegistry::catalog()` reads once per catalog build (the latter is the
+ * immediate predecessor of each `SchemaPresenter::present()` call, which is
+ * `final` and cannot be mocked/spied directly per house convention).
+ *
+ * Used to prove `AnchorRegistry::catalog()` is memoized per instance: a
+ * rebuilt-every-call regression would multiply these counts by the number of
+ * `catalog()`/`isValid()`/`anchorIds()` invocations instead of holding steady.
+ */
+final class CountingEntityTypeManager implements EntityTypeManagerInterface
+{
+    public int $getDefinitionsCallCount = 0;
+
+    public int $resolveFieldDefinitionsCallCount = 0;
+
+    public function __construct(
+        private readonly EntityTypeManagerInterface $inner,
+    ) {}
+
+    public function getDefinitions(): array
+    {
+        $this->getDefinitionsCallCount++;
+
+        return $this->inner->getDefinitions();
+    }
+
+    public function getDefinition(string $entityTypeId): EntityTypeInterface
+    {
+        return $this->inner->getDefinition($entityTypeId);
+    }
+
+    public function hasDefinition(string $entityTypeId): bool
+    {
+        return $this->inner->hasDefinition($entityTypeId);
+    }
+
+    public function resolveFieldDefinitions(string $entityTypeId, ?string $bundle = null): array
+    {
+        $this->resolveFieldDefinitionsCallCount++;
+
+        return $this->inner->resolveFieldDefinitions($entityTypeId, $bundle);
+    }
+
+    public function registerEntityType(EntityTypeInterface $type, ?string $registrant = null): void
+    {
+        $this->inner->registerEntityType($type, $registrant);
+    }
+
+    public function registerCoreEntityType(EntityTypeInterface $type, ?string $registrant = null): void
+    {
+        $this->inner->registerCoreEntityType($type, $registrant);
+    }
+
+    public function getStorage(string $entityTypeId): EntityStorageInterface
+    {
+        return $this->inner->getStorage($entityTypeId);
+    }
+
+    public function getRepository(string $entityTypeId): EntityRepositoryInterface
+    {
+        return $this->inner->getRepository($entityTypeId);
+    }
+}

--- a/packages/wayfinding/tests/Unit/AnchorCatalogControllerTest.php
+++ b/packages/wayfinding/tests/Unit/AnchorCatalogControllerTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
 use Waaseyaa\Wayfinding\Http\AnchorCatalogController;
+use Waaseyaa\Wayfinding\Tests\Support\CountingEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\InMemoryEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\WidgetEntity;
 
@@ -31,7 +33,7 @@ final class AnchorCatalogControllerTest extends TestCase
             ['widget' => ['body' => ['type' => 'text_long', 'label' => 'Body']]],
         );
 
-        $response = new AnchorCatalogController($etm)->catalog();
+        $response = new AnchorCatalogController(new AnchorRegistry($etm))->catalog();
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('application/json', (string) $response->headers->get('Content-Type'));
@@ -44,5 +46,37 @@ final class AnchorCatalogControllerTest extends TestCase
         self::assertContains('list:widget', $ids);
         self::assertContains('field:widget:body', $ids);
         self::assertContains('action:widget:submit', $ids);
+    }
+
+    #[Test]
+    public function reuses_the_injected_registry_instead_of_rebuilding_per_request(): void
+    {
+        // MAJOR finding (audit L4-wayfinding.md): this public anonymous
+        // endpoint used to `new AnchorRegistry(...)` fresh inside catalog(),
+        // discarding the shared singleton and rebuilding the full catalog
+        // (SchemaPresenter over every entity type/field) on every request.
+        // The controller must now take one AnchorRegistry via constructor
+        // injection and reuse its memoized catalog across repeated calls.
+        $widget = new EntityType(
+            id: 'widget',
+            label: 'Widget',
+            class: WidgetEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+            translatable: false,
+            revisionable: false,
+        );
+        $etm = new CountingEntityTypeManager(new InMemoryEntityTypeManager(
+            ['widget' => $widget],
+            ['widget' => ['body' => ['type' => 'text_long', 'label' => 'Body']]],
+        ));
+
+        $controller = new AnchorCatalogController(new AnchorRegistry($etm));
+
+        $controller->catalog();
+        $controller->catalog();
+
+        // A per-request rebuild (the pre-fix behavior) would report 2, not 1.
+        self::assertSame(1, $etm->getDefinitionsCallCount);
+        self::assertSame(1, $etm->resolveFieldDefinitionsCallCount);
     }
 }

--- a/packages/wayfinding/tests/Unit/AnchorRegistryTest.php
+++ b/packages/wayfinding/tests/Unit/AnchorRegistryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Wayfinding\Anchor\AnchorRegistry;
+use Waaseyaa\Wayfinding\Tests\Support\CountingEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\InMemoryEntityTypeManager;
 use Waaseyaa\Wayfinding\Tests\Support\WidgetEntity;
 
@@ -95,5 +96,44 @@ final class AnchorRegistryTest extends TestCase
         self::assertFalse($registry->isValid('field:widget:nonexistent'));
         self::assertFalse($registry->isValid('list:other_type'));
         self::assertFalse($registry->isValid('not-an-anchor'));
+    }
+
+    #[Test]
+    public function catalog_is_memoized_per_instance(): void
+    {
+        // MAJOR perf finding (audit L4-wayfinding.md): a public anonymous
+        // endpoint was rebuilding the full catalog, iterating every entity
+        // type and field through SchemaPresenter, on every request. Prove
+        // catalog() only derives the anchor set once per AnchorRegistry
+        // instance no matter how many times it (or isValid()/anchorIds(),
+        // which call it internally) are invoked.
+        $widget = new EntityType(
+            id: 'widget',
+            label: 'Widget',
+            class: WidgetEntity::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title'],
+            translatable: false,
+            revisionable: false,
+        );
+
+        $etm = new CountingEntityTypeManager(new InMemoryEntityTypeManager(
+            ['widget' => $widget],
+            ['widget' => ['body' => ['type' => 'text_long', 'label' => 'Body']]],
+        ));
+
+        $registry = new AnchorRegistry($etm);
+
+        $first = $registry->catalog();
+        $second = $registry->catalog();
+        self::assertTrue($registry->isValid('field:widget:body'));
+        $registry->anchorIds();
+
+        self::assertSame($first, $second);
+        // One entity type ("widget"): resolveFieldDefinitions() is called
+        // exactly once per type per catalog build, immediately preceding the
+        // SchemaPresenter::present() call it feeds. A rebuild on every one of
+        // the four calls above would report 4, not 1.
+        self::assertSame(1, $etm->getDefinitionsCallCount);
+        self::assertSame(1, $etm->resolveFieldDefinitionsCallCount);
     }
 }


### PR DESCRIPTION
**Anchoring issue:** #1915

## Summary

- `AnchorCatalogController::catalog()` constructed a fresh `new AnchorRegistry($this->entityTypeManager)` on every request instead of resolving the singleton already bound in `WayfindingServiceProvider::register()` (whose own comment claimed the catalog controller shared it — it did not). `AnchorRegistry::catalog()` iterates every registered entity type and field through `SchemaPresenter::present()`, so the public, unauthenticated `/.well-known/waaseyaa-anchors.json` endpoint re-derived the entire catalog from scratch on every single hit.
- `AnchorCatalogController` now takes `AnchorRegistry` via constructor injection instead of `EntityTypeManagerInterface`; the container autowires it from the existing singleton binding (confirmed the same autowiring mechanism used by `SsrPageHandler::resolveControllerInstance()` for other HTTP controllers, e.g. `SchedulerController`).
- `AnchorRegistry::catalog()` is now memoized on the instance (`private ?array $catalog = null`). The catalog derives only from boot-stable entity-type/field definitions — never from request/record/account state — so per-instance caching is safe even under a long-lived worker process (documented inline).
- Fixed the service provider's stale comment claiming the controller already resolved the shared instance.
- **Review follow-up (adversarial review):** `EmitBeaconController::emit()` had the identical per-request `new AnchorRegistry(...)` on the authenticated emit path (also named in the audit finding). Folded in here: the controller now takes the shared `AnchorRegistry` via constructor injection (replacing its `EntityTypeManagerInterface` dependency, which was only used to build the registry), so emit-time anchor validation (FR-005) reuses the memoized catalog too. Both injected consumers are now named in the service-provider comment.
- Audit record: `L4-wayfinding.md`, MAJOR finding "the canonical `AnchorRegistry` singleton is dead-wired; a public anonymous endpoint rebuilds the catalog per request."

## Test plan

- [x] New/updated tests:
  - `packages/wayfinding/tests/Unit/AnchorRegistryTest.php::catalog_is_memoized_per_instance` — proves `catalog()` builds the anchor list once regardless of how many times `catalog()`/`isValid()`/`anchorIds()` are called, via a new `CountingEntityTypeManager` test double.
  - `packages/wayfinding/tests/Unit/AnchorCatalogControllerTest.php::reuses_the_injected_registry_instead_of_rebuilding_per_request` — proves the controller reuses one injected `AnchorRegistry` across repeated `catalog()` calls instead of rebuilding.
  - `packages/wayfinding/tests/Integration/EmitBeaconControllerTest.php::emit_reuses_the_injected_registry_instead_of_rebuilding_per_request` — sibling coverage for the emit path (two emits, catalog derived once).
  - Verified the first two tests fail against the pre-fix source (temporarily reverted, ran red, restored) before landing the fix.
- [x] `./vendor/bin/phpunit packages/wayfinding/tests/` — 27 tests, 128 assertions, all green.
- [x] `composer phpstan` — no errors.
- [x] `composer cs-check` — clean.
- [x] `bin/check-dead-code` — no new findings.
- [x] `bin/check-package-layers` — OK.
- [x] Pre-push hook ran the full suite — green.

## Checklist

- [x] **Traceability:** anchored to #1915 (batch of three independent audit fixes; not closing the issue since it anchors the whole batch)
- [ ] N/A — no GitHub issue being closed by this PR
- [x] PR title includes `#1915`


no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
