### PR TITLE
fix(messaging): seed thread creator as participant (#1915, R16)

### DIFF
--- a/.symfony-import-allowlist.json
+++ b/.symfony-import-allowlist.json
@@ -89,6 +89,7 @@
     "packages/media/src/Http/Router/MediaRouter.php",
     "packages/media/src/Version/MediaCascadeDeleteSubscriber.php",
     "packages/media/src/Version/MediaVersionStorageDriver.php",
+    "packages/messaging/src/EventSubscriber/ThreadParticipantBootstrapSubscriber.php",
     "packages/migration/src/Plugin/Destination/EntityDestination.php",
     "packages/migration/src/Runner/MigrationRunner.php",
     "packages/northcloud/src/Command/NcSyncCommand.php",

--- a/docs/specs/messaging.md
+++ b/docs/specs/messaging.md
@@ -1,5 +1,6 @@
 # Messaging — L3 Chat Substrate
 
+<!-- Spec reviewed 2026-07-06 - #1915 R16 (audit L3-messaging.md): closed the participant-bootstrap deadlock. Nothing previously seeded the first thread_participant row, so MessagingAccessPolicy::fieldAccess()'s "must already be a participant to create the first row" gate made messaging unusable for non-admins. Fix: ThreadParticipantBootstrapSubscriber (packages/messaging/src/EventSubscriber/) subscribes to EntityEvents::PRE_SAVE/POST_SAVE for MessageThread and, on genuine creation, seeds the acting account (from AccountContextInterface, never the entity's own created_by field) as a thread_participant with role 'owner'. Wired in MessagingServiceProvider::boot(). Acceptance: ThreadParticipantBootstrapSubscriberTest (real EntityRepository + real EventDispatcher, no mocked persistence). -->
 <!-- Spec reviewed 2026-06-22 - WP14 (alpha245 security, audit #31): the participant-only access guarantee (only participants can read or post) is now BACKED BY CODE. MessagingAccessPolicy (implements AccessPolicyInterface + FieldAccessPolicyInterface, #[PolicyAttribute(['message_thread','thread_message','thread_participant'])], EntityTypeManager injected by the policy dependency resolver) enforces: read via access('view') participant-only; post/modify via fieldAccess('edit') Forbidden-unless-participant (store() runs the field-edit check on the constructed message, which carries thread_id — the only create-time hook that sees the target thread; createAccess() does not); thread creation via createAccess() for any authenticated account. Admins (administer content) bypass. Participation is checked with an accessCheck(false) system query against thread_participant. Spec text was already accurate; this records that the enforcing code now exists. Acceptance: MessagingAccessPolicyTest. -->
 <!-- Spec reviewed 2026-05-25 - l2-content-types-consolidation-01KSEFTX - WP03 - messaging L3 graduation -->
 
@@ -50,7 +51,11 @@ Field-level access follows the open-by-default rule (`FieldAccessPolicyInterface
 
 ## Service Provider
 
-`MessagingServiceProvider` is auto-discovered via `extra.waaseyaa.providers` in `composer.json`. It registers the three entity types with `EntityTypeManager`.
+`MessagingServiceProvider` is auto-discovered via `extra.waaseyaa.providers` in `composer.json`. It registers the three entity types with `EntityTypeManager` (`register()`) and, in `boot()`, subscribes `ThreadParticipantBootstrapSubscriber` to the entity event dispatcher.
+
+### Participant bootstrap (`ThreadParticipantBootstrapSubscriber`)
+
+`createAccess()` allows any authenticated account to create a `message_thread`, but `fieldAccess()` requires the acting account to already be a `thread_participant` before it may create a `thread_participant`/`thread_message` row for that thread — a deliberate chicken-and-egg gate with no bypass baked into the policy itself. `ThreadParticipantBootstrapSubscriber` closes the gap from outside the policy: it listens for `EntityEvents::PRE_SAVE`/`POST_SAVE` on `MessageThread`, and on genuine creation (captured via `isNew()` at PRE_SAVE, the same two-phase pattern `Waaseyaa\Audit\Listener\EntityLifecycleAuditListener` uses) inserts a `thread_participant` row for the creator with `role: 'owner'`. The seeded account is read from `AccountContextInterface::current()`, never the entity's own `created_by` field, so a spoofed `created_by` value cannot seed membership for a different account (the same discipline #1645 established for audit actor attribution). If no acting account exists (CLI/system context), the thread is created with no participants — consistent with the existing admin-bypass-only creation path.
 
 ---
 

--- a/packages/messaging/src/EventSubscriber/ThreadParticipantBootstrapSubscriber.php
+++ b/packages/messaging/src/EventSubscriber/ThreadParticipantBootstrapSubscriber.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Messaging\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Waaseyaa\Access\Context\AccountContextInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Messaging\MessageThread;
+
+/**
+ * Seeds the creating account as the first `thread_participant` (role: owner)
+ * when a `message_thread` is created.
+ *
+ * Closes the participant-bootstrap deadlock documented in the L3-messaging
+ * audit (#1915, R16): `MessagingAccessPolicy::fieldAccess()` requires the
+ * acting account to already be a participant before it may create the FIRST
+ * `thread_participant` row for a thread, and nothing anywhere auto-seeded
+ * that first membership — so an ordinary non-admin account could create a
+ * `message_thread` (allowed by `createAccess()`) but could never populate it,
+ * making direct messaging unusable for non-admins through the documented API.
+ *
+ * The acting account is read from {@see AccountContextInterface}, NOT from
+ * the saved entity's own `created_by` field — the same discipline
+ * `Waaseyaa\Audit\Listener\EntityLifecycleAuditListener` documents (#1645):
+ * trusting a mutable entity field for "who is acting" is spoofable, the
+ * request-scoped acting-account holder is not.
+ *
+ * `isNew()` is captured at PRE_SAVE (the same two-phase pattern
+ * `EntityLifecycleAuditListener` uses) because by POST_SAVE the entity has
+ * already been assigned a real id and `enforceIsNew(false)`, so `isNew()`
+ * no longer distinguishes create from update at that point.
+ *
+ * Best-effort: seeding failures are logged, never thrown, so a storage hiccup
+ * degrades to "thread has no participants yet" rather than breaking thread
+ * creation (NFR-001 best-effort side-effect convention).
+ */
+final class ThreadParticipantBootstrapSubscriber implements EventSubscriberInterface
+{
+    private bool $pendingIsNew = false;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+        private readonly ?AccountContextInterface $accountContext = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EntityEvents::PRE_SAVE->value  => 'onPreSave',
+            EntityEvents::POST_SAVE->value => 'onPostSave',
+        ];
+    }
+
+    public function onPreSave(EntityEvent $event): void
+    {
+        if (!$event->entity instanceof MessageThread) {
+            return;
+        }
+
+        try {
+            $this->pendingIsNew = $event->entity->isNew();
+        } catch (\Throwable $e) {
+            $this->logger->warning('messaging.participant_bootstrap_failed', [
+                'phase' => 'pre_save',
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public function onPostSave(EntityEvent $event): void
+    {
+        $entity = $event->entity;
+        if (!$entity instanceof MessageThread) {
+            return;
+        }
+
+        $wasNew = $this->pendingIsNew;
+        $this->pendingIsNew = false;
+
+        if (!$wasNew) {
+            return;
+        }
+
+        $account = $this->accountContext?->current();
+        if ($account === null || !$account->isAuthenticated()) {
+            // No acting account (CLI/queue/system context) — nothing to seed;
+            // an admin (or the CLI operator) can add participants explicitly.
+            return;
+        }
+
+        $threadId = (int) $entity->id();
+        if ($threadId <= 0) {
+            return;
+        }
+
+        $userId = (int) $account->id();
+
+        try {
+            $repository = $this->entityTypeManager->getRepository('thread_participant');
+
+            // Defensive dedupe: this subscriber only fires for a genuinely new
+            // thread, so no participant row should exist yet, but guard against
+            // an unexpected re-dispatch rather than risk a duplicate row.
+            $existing = $repository->getQuery()
+                ->accessCheck(false) // bootstrap step, runs before any participant exists to check access against.
+                ->condition('thread_id', $threadId)
+                ->condition('user_id', $userId)
+                ->range(0, 1)
+                ->execute();
+
+            if ($existing !== []) {
+                return;
+            }
+
+            $participant = $repository->create([
+                'thread_id' => $threadId,
+                'user_id' => $userId,
+                'thread_creator_id' => $userId,
+                'role' => 'owner',
+            ]);
+
+            $repository->save($participant);
+        } catch (\Throwable $e) {
+            $this->logger->error('messaging.participant_bootstrap_failed', [
+                'phase' => 'post_save',
+                'thread_id' => $threadId,
+                'user_id' => $userId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/packages/messaging/src/MessagingServiceProvider.php
+++ b/packages/messaging/src/MessagingServiceProvider.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Messaging;
 
+use Waaseyaa\Access\Context\AccountContextInterface;
 use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Foundation\Event\EventDispatcherInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Messaging\EventSubscriber\ThreadParticipantBootstrapSubscriber;
 
 final class MessagingServiceProvider extends ServiceProvider
 {
@@ -16,5 +21,33 @@ final class MessagingServiceProvider extends ServiceProvider
         $this->entityType(EntityType::fromClass(MessageThread::class, group: 'messaging'));
         $this->entityType(EntityType::fromClass(ThreadParticipant::class, group: 'messaging'));
         $this->entityType(EntityType::fromClass(ThreadMessage::class, group: 'messaging'));
+    }
+
+    public function boot(): void
+    {
+        // Seed the creating account as the first thread_participant so an
+        // ordinary non-admin can populate a thread they just created (#1915,
+        // R16 — see ThreadParticipantBootstrapSubscriber for the full story).
+        $dispatcher = $this->resolveOptional(\Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class);
+        if (!$dispatcher instanceof EventDispatcherInterface) {
+            return;
+        }
+
+        $entityTypeManager = $this->resolveOptional(EntityTypeManagerInterface::class);
+        if (!$entityTypeManager instanceof EntityTypeManagerInterface) {
+            return;
+        }
+
+        $accountContext = $this->resolveOptional(AccountContextInterface::class);
+        $resolvedContext = $accountContext instanceof AccountContextInterface ? $accountContext : null;
+
+        $logger = $this->resolveOptional(LoggerInterface::class);
+        $resolvedLogger = $logger instanceof LoggerInterface ? $logger : null;
+
+        $dispatcher->addSubscriber(new ThreadParticipantBootstrapSubscriber(
+            $entityTypeManager,
+            $resolvedContext,
+            $resolvedLogger,
+        ));
     }
 }

--- a/packages/messaging/tests/Unit/EventSubscriber/ThreadParticipantBootstrapSubscriberTest.php
+++ b/packages/messaging/tests/Unit/EventSubscriber/ThreadParticipantBootstrapSubscriberTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Messaging\Tests\Unit\EventSubscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Context\AccountContextInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Field\FieldDefinitionRegistry;
+use Waaseyaa\Messaging\EventSubscriber\ThreadParticipantBootstrapSubscriber;
+use Waaseyaa\Messaging\MessageThread;
+use Waaseyaa\Messaging\MessagingAccessPolicy;
+use Waaseyaa\Messaging\ThreadMessage;
+use Waaseyaa\Messaging\ThreadParticipant;
+
+/**
+ * End-to-end regression test for the participant-bootstrap deadlock
+ * (audit L3-messaging.md, #1915, R16): `MessagingAccessPolicy::fieldAccess()`
+ * required the acting account to already be a `thread_participant` before it
+ * could create the FIRST such row for a thread, and nothing seeded that first
+ * membership — so an ordinary non-admin could create a `message_thread` but
+ * could never read or post to it afterwards. These tests exercise the real
+ * `EntityRepository` save pipeline (not mocks) so the fix is proven against
+ * the actual event-dispatch order, not an assumption about it.
+ */
+#[CoversClass(ThreadParticipantBootstrapSubscriber::class)]
+final class ThreadParticipantBootstrapSubscriberTest extends TestCase
+{
+    private const CREATOR_UID = 100;
+    private const OUTSIDER_UID = 200;
+
+    protected function tearDown(): void
+    {
+        ContentEntityBase::setFieldRegistry(null);
+    }
+
+    #[Test]
+    public function creating_a_thread_seeds_the_creator_as_owner_participant(): void
+    {
+        [$manager] = $this->makeManagerAndSubscriber(self::CREATOR_UID);
+
+        $threadRepository = $manager->getRepository('message_thread');
+        $participantRepository = $manager->getRepository('thread_participant');
+
+        $thread = $threadRepository->create(['created_by' => self::CREATOR_UID]);
+        $threadRepository->save($thread, validate: false);
+
+        $rows = $participantRepository->findBy([
+            'thread_id' => (int) $thread->id(),
+            'user_id' => self::CREATOR_UID,
+        ]);
+
+        self::assertCount(1, $rows, 'The creating account must be auto-seeded as a thread_participant.');
+        self::assertSame('owner', $rows[0]->get('role'));
+    }
+
+    #[Test]
+    public function the_creator_can_immediately_read_and_post_while_an_outsider_still_cannot(): void
+    {
+        [$manager] = $this->makeManagerAndSubscriber(self::CREATOR_UID);
+
+        $threadRepository = $manager->getRepository('message_thread');
+        $messageRepository = $manager->getRepository('thread_message');
+
+        $thread = $threadRepository->create(['created_by' => self::CREATOR_UID]);
+        $threadRepository->save($thread, validate: false);
+
+        $handler = new EntityAccessHandler([new MessagingAccessPolicy($manager)]);
+        $creator = $this->account(self::CREATOR_UID);
+        $outsider = $this->account(self::OUTSIDER_UID);
+
+        // Read access: the creator can see the thread they just created; an
+        // outsider (not a participant) cannot — no manual seeding step needed.
+        self::assertTrue(
+            $handler->check($thread, 'view', $creator)->isAllowed(),
+            'The thread creator must be able to read the thread they just created.',
+        );
+        self::assertFalse(
+            $handler->check($thread, 'view', $outsider)->isAllowed(),
+            'A non-participant must not be able to read the thread.',
+        );
+
+        // Post access: constructing a thread_message and checking field-level
+        // 'edit' access mirrors how JsonApiController::store() gates creation.
+        $message = $messageRepository->create([
+            'thread_id' => (int) $thread->id(),
+            'sender_id' => self::CREATOR_UID,
+            'body' => 'hello',
+        ]);
+
+        self::assertFalse(
+            $handler->checkFieldAccess($message, 'body', 'edit', $creator)->isForbidden(),
+            'The thread creator must be able to post to the thread they just created.',
+        );
+        self::assertTrue(
+            $handler->checkFieldAccess($message, 'body', 'edit', $outsider)->isForbidden(),
+            'A non-participant must not be able to post to the thread.',
+        );
+    }
+
+    #[Test]
+    public function no_acting_account_leaves_the_thread_without_a_seeded_participant(): void
+    {
+        // Null AccountContextInterface (CLI/system context) — degrade gracefully,
+        // never throw, and leave the thread without an auto-seeded participant.
+        [$manager] = $this->makeManagerAndSubscriber(actingAccountId: null);
+
+        $threadRepository = $manager->getRepository('message_thread');
+        $participantRepository = $manager->getRepository('thread_participant');
+
+        $thread = $threadRepository->create(['created_by' => self::CREATOR_UID]);
+        $threadRepository->save($thread, validate: false);
+
+        self::assertSame([], $participantRepository->findBy(['thread_id' => (int) $thread->id()]));
+    }
+
+    #[Test]
+    public function updating_an_existing_thread_does_not_reseed_a_participant(): void
+    {
+        [$manager] = $this->makeManagerAndSubscriber(self::CREATOR_UID);
+
+        $threadRepository = $manager->getRepository('message_thread');
+        $participantRepository = $manager->getRepository('thread_participant');
+
+        $thread = $threadRepository->create(['created_by' => self::CREATOR_UID]);
+        $threadRepository->save($thread, validate: false);
+
+        $thread->set('title', 'Renamed');
+        $threadRepository->save($thread, validate: false);
+
+        self::assertCount(
+            1,
+            $participantRepository->findBy(['thread_id' => (int) $thread->id(), 'user_id' => self::CREATOR_UID]),
+            'An update to an existing thread must not create a second participant row.',
+        );
+    }
+
+    /**
+     * @return array{0: EntityTypeManager}
+     */
+    private function makeManagerAndSubscriber(?int $actingAccountId): array
+    {
+        EntityType::clearFromClassCache();
+        $database = DBALDatabase::createSqlite();
+        $dispatcher = new EventDispatcher();
+        $registry = new FieldDefinitionRegistry();
+
+        $resolver = new SingleConnectionResolver($database);
+        $manager = new EntityTypeManager(
+            $dispatcher,
+            null,
+            function (string $entityTypeId, EntityTypeInterface $definition) use ($dispatcher, $resolver, $database, $registry): EntityRepository {
+                (new SqlSchemaHandler($definition, $database, $registry))->ensureTable();
+
+                $idKey = $definition->getKeys()['id'] ?? 'id';
+
+                return new EntityRepository(
+                    $definition,
+                    new SqlStorageDriver($resolver, $idKey),
+                    $dispatcher,
+                    database: $database,
+                    fieldRegistry: $registry,
+                );
+            },
+            fieldRegistry: $registry,
+        );
+
+        ContentEntityBase::setFieldRegistry($registry);
+
+        $manager->registerEntityType(EntityType::fromClass(MessageThread::class, group: 'messaging'));
+        $manager->registerEntityType(EntityType::fromClass(ThreadParticipant::class, group: 'messaging'));
+        $manager->registerEntityType(EntityType::fromClass(ThreadMessage::class, group: 'messaging'));
+
+        $accountContext = $this->accountContext($actingAccountId);
+        $dispatcher->addSubscriber(new ThreadParticipantBootstrapSubscriber($manager, $accountContext));
+
+        return [$manager];
+    }
+
+    private function accountContext(?int $actingAccountId): ?AccountContextInterface
+    {
+        if ($actingAccountId === null) {
+            return null;
+        }
+
+        $account = $this->account($actingAccountId);
+
+        $context = $this->createMock(AccountContextInterface::class);
+        $context->method('current')->willReturn($account);
+
+        return $context;
+    }
+
+    private function account(int $uid): AccountInterface
+    {
+        $account = $this->createMock(AccountInterface::class);
+        $account->method('id')->willReturn($uid);
+        $account->method('hasPermission')->willReturn(false);
+        $account->method('isAuthenticated')->willReturn(true);
+
+        return $account;
+    }
+}


### PR DESCRIPTION
**Active Spec Kitty mission (if any):** none — Spec Kitty is retired in this repo (see .claude/CLAUDE.md); tracked via anchoring issue #1915.

Ref #1915 (R16 — messaging-participant-bootstrap, CRITICAL functional finding from docs audit L3-messaging.md)

## Summary

- Nothing seeded the first `thread_participant` row when a `message_thread` was created. `MessagingAccessPolicy::fieldAccess()` requires the acting account to already be a participant before it may create the FIRST `thread_participant`/`thread_message` row for a thread, and `createAccess()` cannot see the target thread to grant a bypass there. Net effect: an ordinary non-admin could create a thread but could never read or post to it afterwards — messaging was unusable for non-admin accounts through the documented API.
- Added `Waaseyaa\Messaging\EventSubscriber\ThreadParticipantBootstrapSubscriber`, subscribed in `MessagingServiceProvider::boot()`. It listens for `EntityEvents::PRE_SAVE`/`POST_SAVE` on `MessageThread` and, on genuine creation (`isNew()` captured at PRE_SAVE, mirroring `EntityLifecycleAuditListener`'s two-phase pattern), inserts a `thread_participant` row for the creator with `role: 'owner'`.
- The seeded account comes from `AccountContextInterface::current()`, **not** the entity's own `created_by` field — matching the discipline `EntityLifecycleAuditListener` established for actor attribution (#1645): a mutable entity field is spoofable, the request-scoped acting-account holder is not.
- No acting account (CLI/queue/system context) → the thread is created with no participants, same as today; an admin can add participants explicitly.
- Updated `docs/specs/messaging.md` to document the new bootstrap subscriber and its role.

## Test plan

- [x] `packages/messaging/tests/Unit/EventSubscriber/ThreadParticipantBootstrapSubscriberTest.php` — new, 4 tests, exercised against a real `EntityRepository` + real `EventDispatcher` (SQLite in-memory), not mocks:
  - `creating_a_thread_seeds_the_creator_as_owner_participant`
  - `the_creator_can_immediately_read_and_post_while_an_outsider_still_cannot` — the acceptance scenario from the audit finding, using the real `MessagingAccessPolicy` + `EntityAccessHandler`.
  - `no_acting_account_leaves_the_thread_without_a_seeded_participant`
  - `updating_an_existing_thread_does_not_reseed_a_participant`
  - Confirmed red-then-green: temporarily disabled the subscriber wiring and reran — 3 of 4 tests failed as expected (the null-account-context test still passed trivially), confirming the tests actually exercise the fix.
- [x] `./vendor/bin/phpunit packages/messaging/tests/` — full package suite, 20 tests, green.
- [x] `composer phpstan` — clean.
- [x] `composer cs-check` — clean.
- [x] `bin/check-dead-code` — clean (new subscriber is wired, not orphaned).
- [x] Full pre-push hook suite (phpunit, phpstan, composer-policy, spec-drift) — green, 9392 tests.

## Checklist

- [x] **Traceability:** anchored to #1915 (audit R16, messaging-participant-bootstrap finding, L3-messaging.md)
- [ ] If this PR closes a **GitHub issue**, that issue is assigned to a Track milestone (N/A — #1915 stays open as the anchor for the R16 batch)
- [x] PR title includes `#1915`

## Review notes

**Hardening notes for the record (adversarial review — follow-ups, not blockers):**

1. **The participant dedupe is SELECT-then-INSERT with no DB-level unique constraint.** `ThreadParticipantBootstrapSubscriber` guards against duplicate seeding with an `accessCheck(false)` existence query before insert, but there is no unique constraint on `(thread_id, user_id)` in the `thread_participant` table as defense-in-depth. Two concurrent writers (or a future second seeding path) could race the SELECT and insert duplicate membership rows. Follow-up: add a composite unique index on `(thread_id, user_id)` at the schema layer so the invariant is enforced by the database, not just the read-check.

2. **A pre-set-id import path would skip the bootstrap.** The subscriber keys on `isNew()` at PRE_SAVE. A future import/migration path constructing `new MessageThread(['mtid' => N, ...])` with a pre-set id and saving WITHOUT calling `enforceIsNew()` would (a) hit this repo's documented pre-set-ID gotcha (UPDATE instead of INSERT, silently affecting 0 rows) and (b) even when handled, read as an update to the subscriber — so no participant is seeded. Acceptable for imports (importers should carry their own participant rows), but worth knowing: the bootstrap covers the interactive creation path, not bulk import. Follow-up consideration: an `ensureCreatorParticipant()` helper importers can call explicitly.



no-changelog: entry carried by the R16 batch changelog PR #1928 (ten concurrent [Unreleased] edits would conflict; see stability-charter §8.2 override)
