### PR TITLE
fix(#1920): bind ConfigFactoryInterface in production boot

### DIFF
--- a/.symfony-import-allowlist.json
+++ b/.symfony-import-allowlist.json
@@ -53,6 +53,7 @@
     "packages/bimaaji/src/Introspection/Routing/RoutingIntrospectionProvider.php",
     "packages/cache/src/Listener/EntityCacheSubscriber.php",
     "packages/config/src/ConfigFactory.php",
+    "packages/config/src/ConfigServiceProvider.php",
     "packages/config/src/ConfigManager.php",
     "packages/config/src/Event/ConfigEvent.php",
     "packages/config/src/EventAwareStorage.php",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Waaseyaa\Config\ConfigFactoryInterface` was bound in NO production ServiceProvider, so any consumer reaching for it via `resolveOptional()` silently no-opped in a real boot** (#1920, CW-v1 WP-1 follow-up). Grepping the framework confirmed the gap: neither `packages/config` nor any other package's `ServiceProvider::register()` bound `ConfigFactoryInterface`/`ConfigFactory` anywhere — `Waaseyaa\SSR\ThemeServiceProvider` even carried a dead comment noting the factory "will be available at runtime," but it never was. This made the CW-v1 engine's forthcoming `WorkflowServiceProvider` guard/seed wiring — which depends on `resolveOptional(ConfigFactoryInterface::class)` — unreachable in production once #1929 (WP-1) merges. New `Waaseyaa\Config\ConfigServiceProvider` (`packages/config/src/ConfigServiceProvider.php`, registered via `packages/config/composer.json`'s `extra.waaseyaa.providers`) binds `ConfigFactoryInterface` as a container singleton backed by `FileStorage` at `<projectRoot>/config/active` — the same active store `OptimizeServiceProvider` already compiles for `optimize:config`, so this does not construct a second store instance. New integration test `tests/Integration/Config/ConfigFactoryProductionBindingTest.php` boots a real kernel (mirrors `DefinitionValidatorBootTest`'s pattern) and proves a third-party consumer provider's `resolveOptional(ConfigFactoryInterface::class)` resolves to a working factory, and that `get()`/`getEditable()->set()->save()`/`get()` round-trips through the active store.
+
 ## [0.1.0-alpha.255] - 2026-07-06
 
 ### Security

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -1472,6 +1472,10 @@ interface ConfigFactoryInterface
 
 `get()` returns cached immutable Config. `getEditable()` always creates a new mutable Config wrapped in EventAwareStorage.
 
+**Production binding:** `Waaseyaa\Config\ConfigServiceProvider` (`packages/config/src/ConfigServiceProvider.php`, declared in `packages/config/composer.json`'s `extra.waaseyaa.providers`) binds `ConfigFactoryInterface` as a container singleton, backed by `FileStorage` pointed at `<projectRoot>/config/active` — the same active store `Waaseyaa\CLI\Provider\OptimizeServiceProvider` compiles for `optimize:config`; there is exactly one active store, not a second instance. Before this provider existed, no production ServiceProvider bound the interface at all, so any consumer resolving it via `resolveOptional(ConfigFactoryInterface::class)` (e.g. `Waaseyaa\SSR\ThemeServiceProvider`) silently received `null` and no-opped in a real boot (#1920 WP-1 follow-up).
+
+<!-- Spec reviewed 2026-07-06 - fix(#1920): bind ConfigFactoryInterface in production boot -->
+
 ### ConfigManagerInterface
 
 File: `packages/config/src/ConfigManagerInterface.php`

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -25,6 +25,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "waaseyaa": {
+            "providers": [
+                "Waaseyaa\\Config\\ConfigServiceProvider"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"

--- a/packages/config/src/ConfigServiceProvider.php
+++ b/packages/config/src/ConfigServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Config;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyComponentEventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyContractEventDispatcherInterface;
+use Waaseyaa\Config\Storage\FileStorage;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+/**
+ * Binds `ConfigFactoryInterface` to a singleton `ConfigFactory` backed by the
+ * same active config store the rest of the boot uses: `<projectRoot>/config/active`
+ * via `FileStorage` — the exact directory `Waaseyaa\CLI\Provider\OptimizeServiceProvider`
+ * compiles from for `optimize:config` (there is exactly one active store; this
+ * binding does not construct a second one).
+ *
+ * Before this provider existed, NO production ServiceProvider bound
+ * `ConfigFactoryInterface`/`ConfigFactory` anywhere in the framework (confirmed
+ * by grep across packages/*\/src and the kernel bootstrappers). Any consumer
+ * reaching for it via `resolveOptional(ConfigFactoryInterface::class)` —
+ * `Waaseyaa\SSR\ThemeServiceProvider`, and the CW-v1 `WorkflowServiceProvider`
+ * guard/seed wiring — silently received `null` and no-opped in a real boot.
+ * See #1920 WP-1 follow-up.
+ */
+final class ConfigServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $root = $this->projectRoot !== '' ? $this->projectRoot : (string) getcwd();
+
+        $this->singleton(ConfigFactoryInterface::class, function () use ($root): ConfigFactory {
+            $storage = new FileStorage($root . '/config/active');
+
+            return new ConfigFactory($storage, $this->resolveEventDispatcher());
+        });
+    }
+
+    /**
+     * The kernel-services bus only recognizes the Symfony-contracts FQCN
+     * (`Symfony\Contracts\EventDispatcher\EventDispatcherInterface`) — see
+     * `ProviderRegistryKernelServices::get()`. `ConfigFactory` itself is typed
+     * against the wider Symfony-component interface
+     * (`Symfony\Component\EventDispatcher\EventDispatcherInterface`, which
+     * extends the contracts one). The kernel's real dispatcher
+     * (`SymfonyEventDispatcherAdapter`) implements both, so resolving through
+     * the contracts FQCN and handing the same instance to `ConfigFactory`
+     * satisfies both type-checks. Falls back to a fresh dispatcher only when
+     * no kernel context exposes one at all (e.g. unit construction sites),
+     * matching the null-safe defaults used elsewhere in this package's tests.
+     */
+    private function resolveEventDispatcher(): SymfonyComponentEventDispatcherInterface
+    {
+        $dispatcher = $this->resolveOptional(SymfonyContractEventDispatcherInterface::class);
+
+        if ($dispatcher instanceof SymfonyComponentEventDispatcherInterface) {
+            return $dispatcher;
+        }
+
+        return new EventDispatcher();
+    }
+}

--- a/tests/Integration/Config/ConfigFactoryProductionBindingTest.php
+++ b/tests/Integration/Config/ConfigFactoryProductionBindingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Config;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Config\ConfigFactoryInterface;
+use Waaseyaa\Config\ConfigServiceProvider;
+use Waaseyaa\Foundation\Discovery\PackageManifest;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+
+/**
+ * Proves `Waaseyaa\Config\ConfigFactoryInterface` is reachable from a real
+ * kernel boot, the way any consumer ServiceProvider reaches it: via
+ * `resolveOptional(ConfigFactoryInterface::class)` in its own `boot()`.
+ *
+ * Before this fix, NO production ServiceProvider bound
+ * `ConfigFactoryInterface`, so every `resolveOptional()` consumer (e.g.
+ * `Waaseyaa\SSR\ThemeServiceProvider`, and the forthcoming CW-v1
+ * `WorkflowServiceProvider` guard/seed wiring) silently received `null` and
+ * no-opped in a real boot (#1920 WP-1 follow-up).
+ *
+ * This test drives `AbstractKernel::boot()` directly (mirrors
+ * `DefinitionValidatorBootTest`) rather than requiring a full composer
+ * install, injecting `ConfigServiceProvider` plus a tiny probe provider into
+ * the manifest so we can observe exactly what a real consumer sees.
+ */
+#[CoversNothing]
+final class ConfigFactoryProductionBindingTest extends TestCase
+{
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->projectRoot = $this->createMinimalProjectRoot();
+        ConfigFactoryProbeProvider::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function configFactoryInterfaceResolvesForAnyConsumerProviderAtBoot(): void
+    {
+        $kernel = $this->buildKernel();
+
+        $kernel->publicBoot();
+
+        self::assertTrue(
+            ConfigFactoryProbeProvider::$probed,
+            'probe provider boot() must have run',
+        );
+        self::assertInstanceOf(
+            ConfigFactoryInterface::class,
+            ConfigFactoryProbeProvider::$resolvedFactory,
+            'ConfigFactoryInterface must resolve via resolveOptional() at boot, not silently return null',
+        );
+    }
+
+    #[Test]
+    public function resolvedFactoryRoundTripsASetSaveGetCycle(): void
+    {
+        $kernel = $this->buildKernel();
+        $kernel->publicBoot();
+
+        $factory = ConfigFactoryProbeProvider::$resolvedFactory;
+        self::assertNotNull($factory);
+
+        $config = $factory->get('workflows.assignments');
+        self::assertTrue($config->isNew(), 'a never-written config name starts out new');
+
+        $editable = $factory->getEditable('workflows.assignments');
+        $editable->set('example_key', 'example_value')->save();
+
+        // A fresh get() must observe the saved value (cache invalidated by
+        // EventAwareStorage on save, storage read from the same active store).
+        $reread = $factory->get('workflows.assignments');
+        self::assertFalse($reread->isNew());
+        self::assertSame('example_value', $reread->get('example_key'));
+    }
+
+    private function buildKernel(): object
+    {
+        $projectRoot = $this->projectRoot;
+
+        return new class ($projectRoot) extends AbstractKernel {
+            public function publicBoot(): void
+            {
+                $this->boot();
+            }
+
+            protected function compileManifest(): void
+            {
+                parent::compileManifest();
+
+                $this->manifest = new PackageManifest(
+                    providers: array_merge(
+                        $this->manifest->providers,
+                        [ConfigServiceProvider::class, ConfigFactoryProbeProvider::class],
+                    ),
+                    migrations: $this->manifest->migrations,
+                    fieldTypes: $this->manifest->fieldTypes,
+                    formatters: $this->manifest->formatters,
+                    middleware: $this->manifest->middleware,
+                    permissions: $this->manifest->permissions,
+                    policies: $this->manifest->policies,
+                    packageDeclarations: $this->manifest->packageDeclarations,
+                    attributeEntityTypes: $this->manifest->attributeEntityTypes,
+                    consoleCommandProviders: $this->manifest->consoleCommandProviders,
+                );
+            }
+        };
+    }
+
+    private function createMinimalProjectRoot(): string
+    {
+        $projectRoot = sys_get_temp_dir() . '/waaseyaa_configbinding_test_' . uniqid();
+        mkdir($projectRoot . '/config', 0o755, true);
+        mkdir($projectRoot . '/storage', 0o755, true);
+
+        file_put_contents(
+            $projectRoot . '/config/waaseyaa.php',
+            "<?php return ['database' => ':memory:'];",
+        );
+
+        file_put_contents(
+            $projectRoot . '/config/entity-types.php',
+            <<<'PHP'
+                <?php
+                return [
+                    new \Waaseyaa\Entity\EntityType(
+                        id: 'probe_type',
+                        label: 'Probe Type',
+                        class: \stdClass::class,
+                    ),
+                ];
+                PHP,
+        );
+
+        return $projectRoot;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test-only fixture provider — defined here (not under src/) for autoload-dev.
+// ---------------------------------------------------------------------------
+
+/**
+ * Stand-in for a real consumer ServiceProvider (e.g. the CW-v1
+ * `WorkflowServiceProvider`). Its `boot()` calls `resolveOptional()` exactly
+ * the way a real consumer would — the framework-wide contract this test
+ * exists to prove.
+ */
+final class ConfigFactoryProbeProvider extends ServiceProvider
+{
+    public static bool $probed = false;
+    public static ?ConfigFactoryInterface $resolvedFactory = null;
+
+    public function register(): void {}
+
+    public function boot(): void
+    {
+        self::$probed = true;
+        self::$resolvedFactory = $this->resolveOptional(ConfigFactoryInterface::class);
+    }
+
+    public static function reset(): void
+    {
+        self::$probed = false;
+        self::$resolvedFactory = null;
+    }
+}


### PR DESCRIPTION
## Summary

- `Waaseyaa\Config\ConfigFactoryInterface` was bound in **no production `ServiceProvider` anywhere** in the framework — confirmed by grepping `packages/*/src` and the kernel bootstrappers (`packages/foundation/src/Kernel/`). Any consumer reaching for it via `resolveOptional(ConfigFactoryInterface::class)` silently received `null` and no-opped in a real boot. `Waaseyaa\SSR\ThemeServiceProvider` even carries a dead comment claiming the factory "will be available at runtime" — it never was. This gap was surfaced by CW-v1 WP-1 (#1929): the forthcoming `WorkflowServiceProvider` guard/seed wiring depends on this same `resolveOptional()` call, which would make the whole CW-v1 engine unreachable in production once WP-1 merges.
- New `Waaseyaa\Config\ConfigServiceProvider` (`packages/config/src/ConfigServiceProvider.php`) binds `ConfigFactoryInterface` as a container **singleton**, backed by `FileStorage` pointed at `<projectRoot>/config/active` — the *same* active store `Waaseyaa\CLI\Provider\OptimizeServiceProvider` already compiles for `optimize:config`. This does not construct a second store instance; there is exactly one active store. Registered via `packages/config/composer.json`'s `extra.waaseyaa.providers` for auto-discovery (same mechanism as every other package's provider registration, e.g. `waaseyaa/audit`, `waaseyaa/ssr`).
- The dispatcher wiring has one subtlety worth flagging for review: the kernel-services bus (`ProviderRegistryKernelServices::get()`) only recognizes `Symfony\Contracts\EventDispatcher\EventDispatcherInterface` (the *contracts* FQCN), while `ConfigFactory`'s constructor is typed against the wider `Symfony\Component\EventDispatcher\EventDispatcherInterface` (which extends the contracts one). The kernel's real dispatcher (`SymfonyEventDispatcherAdapter`) implements both, so resolving through the contracts FQCN and handing that same instance to `ConfigFactory` satisfies both type-checks — documented inline in `ConfigServiceProvider::resolveEventDispatcher()`.

## Why this is safe

- `packages/config`'s own `PackageManifestCompiler::hydrateInstalledPackageMetadata()` already self-heals around Composer's `installed.json`/`composer.lock` staleness for path-repo `extra.waaseyaa.providers` metadata (it re-reads each path package's on-disk `composer.json` at manifest-compile time) — this is the same mechanism every other provider registration in this monorepo already relies on, so no `composer.lock` churn was needed for this fix (verified: `composer.lock` hasn't tracked provider registrations for other packages either, e.g. `waaseyaa/audit`'s `AuditServiceProvider` was added without a lock update).
- `FileStorage::read()` returns `false` (→ `isNew()` config) when `config/active` doesn't exist yet, so a fresh install with no active store never errors — it just gets new/empty configs until the first `save()`.

## TDD: red → green

New `tests/Integration/Config/ConfigFactoryProductionBindingTest.php` boots a **real kernel** (mirrors the existing `DefinitionValidatorBootTest` pattern: `AbstractKernel` anonymous subclass + a `compileManifest()` override that injects providers into the manifest) and proves — from the perspective of a *third-party consumer provider* calling `resolveOptional(ConfigFactoryInterface::class)` in its own `boot()`, exactly like `WorkflowServiceProvider` will — that:
1. The call resolves to a non-null `ConfigFactoryInterface` instance (not silently `null`).
2. `get()` / `getEditable()->set()->save()` / `get()` round-trips through the active store.

**Red** (before `ConfigServiceProvider` existed): both assertions failed — `null` is not an instance of `ConfigFactoryInterface`.
**Green** (after): both tests pass, 6 assertions.

## Test plan

- [x] New integration test: red confirmed, then green after the fix (`./vendor/bin/phpunit tests/Integration/Config/ConfigFactoryProductionBindingTest.php`)
- [x] Existing config suite unaffected: `./vendor/bin/phpunit packages/config/tests/ tests/Integration/Phase4/ConfigEntityLifecycleTest.php` — 429 tests, all green
- [x] Full `--testsuite Unit` — 9426 tests, all green
- [x] Full `--testsuite Integration` — 1377 tests, all green (one `packages/listing` TTL-timing test flaked once under parallel load, reproduced independently of this change, and passed consistently on repeated runs and in isolation — pre-existing flakiness, not a regression)
- [x] `bin/check-package-layers` — OK (only pre-existing warn-only same-layer cycles)
- [x] `bin/check-dead-code` — OK, no new findings
- [x] `composer phpstan` — OK, no errors
- [x] `composer check-composer-policy` — OK
- [x] `php bin/check-getquery-bindings` — OK, 0 new offenders
- [x] `composer cs-check` — OK (after `composer cs-fix`)
- [x] `tools/drift-detector.sh` — confirms `docs/specs/entity-system.md` was updated for the changed source
- [x] Pre-push hook (spec-drift, composer-policy, phpstan, full Unit suite) — all green

## Deviations / notes for the reviewer

- `Waaseyaa\SSR\ThemeServiceProvider`'s dead `$configFactory = null` wiring is now stale in a different way (the interface *is* bound, but that provider still doesn't consume it) — left untouched as out of scope for this binding-only fix; flagging as a natural follow-up now that the binding exists.
- `docs/specs/entity-system.md`'s `ConfigFactoryInterface` section gained a "Production binding" paragraph with a `spec-reviewed` HTML trailer documenting the new binding location.
- `CHANGELOG.md` `[Unreleased]` → `### Fixed` entry references #1920 and the CW-v1 WP-1 dependency (#1929).

Refs #1920 (CW-v1). Unblocks WP-1 (#1929)'s `WorkflowServiceProvider` from being production-reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
