### PR TITLE
chore: remove the auto-merge milestone gate

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -104,15 +104,6 @@ jobs:
               return;
             }
 
-            // Gate: milestone
-            if (!pr.milestone) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber,
-                body: '**Auto-merge blocked**: no milestone assigned.',
-              });
-              return;
-            }
-
             // All gates passed — merge
             try {
               const { data: merge } = await github.rest.pulls.merge({


### PR DESCRIPTION
A fully-green PR (#1932) stalled on the auto-merge milestone gate — process ceremony with no correctness value, per Russell's call. Correctness gates (required checks `ci/lint`, `ci/unit-tests`, `ci/playwright-smoke`), the `auto-merge-when-green` label opt-in, and the open/mergeable gates are untouched.

No Spec Kitty mission — trivial workflow-policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)