### PR TITLE
docs(#1934): changelog entry for the alpha.258 re-cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release recovery: v0.1.0-alpha.258 re-publishes the never-published v0.1.0-alpha.257 (#1934).** The alpha.257 split fan-out failed its `verify-monorepo-main-intact` check because PR #1933 merged to main between the tag push and the verification (tag at `f0cf33c2d`, main at `b4630eee9`) — the check compares live main HEAD against the tagged SHA, so any mid-fan-out merge fails it and blocks the Packagist publish stage. No alpha.257 package was ever published; per the forward-only rule (VERSIONING.md §8) the dead tag stays in place and alpha.258 ships the same content plus this entry. The underlying race (fan-out verification pinned to a moving ref), the fire-once auto-merge bot, and the bot-token downstream-trigger suppression are tracked in #1934.
+
 ## [0.1.0-alpha.257] - 2026-07-10
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds the `[Unreleased]` changelog bullet required by the Cut Release gate so v0.1.0-alpha.258 can be cut (the alpha.257 cut consumed the section, and alpha.257 was never published — see #1934).

## Traceability
- Issue: #1934 (alpha.257 fan-out failure post-mortem / release-plumbing fixes)

## Test plan
- Docs-only change; `release-cut.yml`'s "Verify CHANGELOG [Unreleased] has content" gate passes once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)