### PR TITLE
fix(#1934): pin split fan-out verification and checkouts to the tagged SHA

### DIFF
--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -43,7 +43,15 @@ jobs:
       packages: ${{ steps.scan.outputs.packages }}
       tag: ${{ steps.target.outputs.tag }}
     steps:
+      # Pinned to github.sha so the tag-push trigger always reads the
+      # tagged commit's packages/*/composer.json (#1934). This is safe on
+      # workflow_dispatch too: github.sha there resolves to the HEAD of
+      # whichever ref the dispatch was run against, so the pin never breaks
+      # manual runs — it just documents/guarantees the same checkout ref
+      # the default behavior would have used anyway.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
 
       - name: Resolve target tag
         id: target

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -108,6 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -179,25 +180,35 @@ jobs:
           fi
 
   verify-monorepo-main-intact:
-    name: Verify monorepo main still points at the tagged commit
+    name: Verify the tagged commit is still reachable from monorepo main
     needs: split
     runs-on: ubuntu-latest
     steps:
-      - name: Assert origin main SHA unchanged
+      # This does NOT require main == github.sha. Legitimate PRs can merge to
+      # main while the split fan-out for this tag is still running (main only
+      # moves forward — "ahead"/"identical" are fine). What must NEVER happen
+      # is the tagged commit falling off main's history ("behind"/"diverged"),
+      # which only happens if a split target force-overwrote this monorepo's
+      # own main (self-split collision) and rewrote it out from under the tag.
+      # See #1934 — alpha.257 false-failed here on a same-day forward merge.
+      - name: Assert tagged SHA is still an ancestor of main
         env:
           MONOREPO: ${{ github.repository }}
           EXPECTED_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          actual_sha=$(gh api "repos/${MONOREPO}/commits/main" --jq '.sha')
-          if [ "${actual_sha}" != "${EXPECTED_SHA}" ]; then
-            echo "::error::Monorepo main SHA changed during split!"
-            echo "::error::Expected: ${EXPECTED_SHA}"
-            echo "::error::Actual:   ${actual_sha}"
-            echo "::error::A split target likely collided with this monorepo's repo name."
-            exit 1
-          fi
-          echo "OK — monorepo main still at ${EXPECTED_SHA}"
+          compare_status=$(gh api "repos/${MONOREPO}/compare/${EXPECTED_SHA}...main" --jq '.status')
+          case "${compare_status}" in
+            identical|ahead)
+              echo "OK — tagged commit ${EXPECTED_SHA} is still an ancestor of main (status: ${compare_status})."
+              ;;
+            *)
+              echo "::error::Monorepo main no longer contains the tagged commit!"
+              echo "::error::Expected ${EXPECTED_SHA} to be an ancestor of main; compare status was '${compare_status}'."
+              echo "::error::A split target likely collided with this monorepo's repo name and force-overwrote main."
+              exit 1
+              ;;
+          esac
 
   verify-tag-parity:
     needs: split
@@ -205,6 +216,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Verify split tag parity across package repos
@@ -227,6 +239,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - name: Verify root require / split parity
         env:
@@ -245,6 +258,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Create GitHub Release
@@ -268,6 +282,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
 
       - name: Discover waaseyaa/* packages
         id: scan

--- a/.github/workflows/sync-skeleton.yml
+++ b/.github/workflows/sync-skeleton.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout framework
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           path: framework
 
       - name: Checkout skeleton

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Split fan-out verification no longer races `main` (#1934).** `verify-monorepo-main-intact` in `.github/workflows/split.yml` previously required live `main` to equal the tagged `github.sha` exactly, so any PR merged to `main` mid-fan-out failed the release even though nothing was wrong (v0.1.0-alpha.257: PR #1933 merged between the tag and the check, tag at `f0cf33c2d`, main at `b4630eee9`). The check now verifies the tagged SHA is still an ancestor of `main` via `gh api .../compare/${EXPECTED_SHA}...main` — `identical`/`ahead` pass (main only moved forward), `behind`/`diverged` fail (main was rewritten/overwritten, the real self-split-collision signal this check exists to catch). All `split.yml` fan-out checkouts (`split`, `verify-tag-parity`, `verify-require-parity`, `publish-github-release`, `publish-packagist`) are now pinned to `ref: ${{ github.sha }}`, as is the framework checkout in `sync-skeleton.yml` and the tag-triggered checkout in `packagist-update.yml`.
+
 ## [0.1.0-alpha.258] - 2026-07-10
 
 ### Fixed


### PR DESCRIPTION
## Summary
- `verify-monorepo-main-intact` in `.github/workflows/split.yml` no longer requires live `main` to equal the tagged `github.sha` exactly. It now asserts the tagged SHA is still an ancestor of `main` via `gh api repos/<repo>/compare/<tag>...main`, accepting `identical`/`ahead` (main only moved forward — a normal merge mid-fan-out) and failing on `behind`/`diverged` (main was rewritten/overwritten — the real self-split-collision signal this check exists to catch).
- Every `actions/checkout` in the tag-triggered fan-out (`split`, `verify-tag-parity`, `verify-require-parity`, `publish-github-release`, `publish-packagist` jobs in `split.yml`; the framework checkout in `sync-skeleton.yml`; the discover-job checkout in `packagist-update.yml`) is now pinned to `ref: ${{ github.sha }}`, so every job in the fan-out reads the exact tagged commit regardless of what happens to `main` afterward.
- `CHANGELOG.md` `### Fixed` entry under `[Unreleased]` (appended alongside the existing alpha.258 release-recovery bullet added by #1935).

## Traceability
- Issue: #1934
- Post-mortem: v0.1.0-alpha.257's split fan-out failed `verify-monorepo-main-intact` because PR #1933 merged to `main` between the tag push and the verification step (tag at `f0cf33c2d`, `main` at `b4630eee9`), even though nothing was actually wrong — the tagged commit was still fully present in `main`'s history.

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open(f))"` passes for `split.yml`, `sync-skeleton.yml`, `packagist-update.yml`.
- [x] Reasoned through the `compare` API semantics: `identical`/`ahead` accepted, `behind`/`diverged` rejected — matches GitHub's documented `status` field for `GET /repos/{owner}/{repo}/compare/{base}...{head}`.
- [ ] The real proof is the next release cut (`v*` tag push) completing `verify-monorepo-main-intact` cleanly even if `main` advances mid-fan-out, and still failing loudly on an actual self-split collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)