### PR TITLE
docs(#1971): pin standing agent process rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,14 @@
-# Waaseyaa Agent Notes
+# Waaseyaa Agent Rules
 
-This file is intentionally lightweight and stays in sync with [CLAUDE.md](CLAUDE.md).
-
-## Canonical Source
-- `CLAUDE.md` is the authoritative, detailed instruction set for architecture, workflows, and gotchas.
-- If guidance here conflicts with `CLAUDE.md`, follow `CLAUDE.md`.
-
-## Specs and workflow
-- **Constitution:** `CLAUDE.md` (orchestration table, layers, checklists)
-- **Skills:** `skills/waaseyaa/` (domain skills on demand); `waaseyaa:spec-maintenance` for edits to `docs/specs/**` and agent rules
-- **Specs:** `docs/specs/` — read the relevant `.md` files directly (or `rg` under `docs/specs/`). There is no Waaseyaa spec MCP server in this repo.
-
-Substantive work follows the **anchor-issue + design-first workflow**: see `CLAUDE.md` and `docs/specs/workflow.md` (GitHub anchor issues, `#N`-traceable PRs). Spec Kitty is retired; do not run `spec-kitty` commands.
-
-## Practical Rules
-- Respect layer boundaries and access-control semantics from `CLAUDE.md`.
-- Treat `HttpKernel` and `ConsoleKernel` as composition roots; test via seams/integration points.
-- Keep changes paired with tests and update relevant `docs/specs/` when architecture shifts.
-
-## Sync Policy
-- Update this file only to keep pointers accurate.
-- Put operational detail changes in `CLAUDE.md` (not duplicated here).
+- `CLAUDE.md` is authoritative. Read it, the relevant `docs/specs/` contracts, and `docs/specs/workflow.md`; do not run retired Spec Kitty commands.
+- Substantive work is design-first and anchored to its GitHub issue. One PR per work package; titles and bodies must be `#N`-traceable.
+- Use TDD: add the regression test first and run it to prove red before implementing.
+- Every PR adds an appropriate `CHANGELOG.md` `[Unreleased]` entry.
+- Acknowledge reviewed spec drift up front with `spec-reviewed:` commit trailers; the blocking CI spec-drift check reads commit trailers.
+- Respect package layers. Symfony imports use the existing checker allowlist convention; any exception belongs in the explicit allowlist with a one-line rationale.
+- `git stash` is forbidden for all agents and subagents. If a rebase needs a clean tree, commit on a temporary branch. Do not touch the dangling `da4d26758` stash.
+- Run the split Unit suite with `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit`; do not run the whole suite as one process.
+- Run local gates under `set -o pipefail`. Local results are advisory; GitHub CI is authoritative.
+- Never merge to `main` while a release split/fan-out is running.
+- Merge PRs only via the `auto-merge-when-green` label, which enables native auto-merge after all five required checks pass.
+- Keep changes paired with boundary-level tests; update specs only when architecture or enduring contracts change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Repository agent rules now pin the mandatory PR, TDD, changelog, spec-drift, worker-safe git, local-gate, release-fan-out, and auto-merge conventions.** `AGENTS.md` remains a terse entry point to the authoritative `CLAUDE.md` and workflow/spec documents while ensuring future agent sessions inherit the process guardrails up front.
+
 ## [0.1.0-alpha.260] - 2026-07-13
 
 ### Security


### PR DESCRIPTION
Part of #1971

## Summary
- distill the mandatory repository process rules into the root `AGENTS.md`
- preserve `CLAUDE.md` and workflow/spec documents as authoritative detail
- record the process bootstrap in `[Unreleased]`

## Verification
- `bash tools/drift-detector.sh origin/main`

spec-reviewed: all — process-only guidance; no runtime contract changed