### PR TITLE
fix(#1971): drop process-lifetime runtime caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Repository agent rules now pin the mandatory PR, TDD, changelog, spec-drift, worker-safe git, local-gate, release-fan-out, and auto-merge conventions.** `AGENTS.md` remains a terse entry point to the authoritative `CLAUDE.md` and workflow/spec documents while ensuring future agent sessions inherit the process guardrails up front.
 
+### Fixed
+
+- **Persistent workers no longer retain stale state reads or abandoned AI-run telemetry (#1971, R17).** `SqlState` now reads its authoritative database on every `get()`/`getMultiple()` call instead of serving a per-instance cache that could outlive the request, while `AgentRunTelemetryListener` replaces its one-active-run aggregation slot when the next Messenger job starts so a missing terminal event cannot grow memory for the worker lifetime. Two-request/one-process regressions cover both single and multiple state reads and interrupted telemetry aggregation.
+
 ## [0.1.0-alpha.260] - 2026-07-13
 
 ### Security

--- a/packages/ai-observability/src/Listener/AgentRunTelemetryListener.php
+++ b/packages/ai-observability/src/Listener/AgentRunTelemetryListener.php
@@ -91,7 +91,10 @@ final class AgentRunTelemetryListener implements EventSubscriberInterface
     public function onRunStarted(AgentRunStarted $event): void
     {
         $this->safely(__METHOD__, $event->runId, function () use ($event): void {
-            $this->runs[$event->runId] = [
+            // A Messenger worker executes one AgentRun at a time. Replacing the
+            // map here reclaims an interrupted run whose terminal event never
+            // arrived instead of retaining it for the worker's lifetime.
+            $this->runs = [$event->runId => [
                 'agent_definition_id' => $event->agentDefinitionId,
                 'account_id' => $event->accountId,
                 'tokens_in' => 0,
@@ -101,7 +104,7 @@ final class AgentRunTelemetryListener implements EventSubscriberInterface
                 'tool_call_count' => 0,
                 'iteration_durations_ms' => [],
                 'started_at' => $event->startedAt,
-            ];
+            ]];
         });
     }
 

--- a/packages/ai-observability/tests/Unit/Listener/AgentRunTelemetryListenerTest.php
+++ b/packages/ai-observability/tests/Unit/Listener/AgentRunTelemetryListenerTest.php
@@ -259,6 +259,60 @@ final class AgentRunTelemetryListenerTest extends TestCase
     }
 
     #[Test]
+    public function startingTheNextRunDropsInterruptedRunStateInTheSameWorker(): void
+    {
+        $this->saveQueuedRun('run-a', accountId: 1, agentDefinitionId: 'first-agent');
+        $this->saveQueuedRun('run-b', accountId: 2, agentDefinitionId: 'second-agent');
+        $telescope = new RecordingTelescopeRecorder();
+        $listener = new AgentRunTelemetryListener(
+            telescope: $telescope,
+            runRepository: $this->runRepository,
+        );
+
+        $listener->onRunStarted(new AgentRunStarted(
+            runId: 'run-a',
+            agentDefinitionId: 'first-agent',
+            accountId: 1,
+            startedAt: new \DateTimeImmutable('2026-05-18T12:00:00+00:00'),
+        ));
+        $listener->onProviderCallCompleted(new AgentRunProviderCallCompleted(
+            runId: 'run-a',
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-6',
+            tokensIn: 100,
+            tokensOut: 50,
+        ));
+
+        $listener->onRunStarted(new AgentRunStarted(
+            runId: 'run-b',
+            agentDefinitionId: 'second-agent',
+            accountId: 2,
+            startedAt: new \DateTimeImmutable('2026-05-18T12:01:00+00:00'),
+        ));
+        $listener->onRunTerminated(new AgentRunTerminated(
+            runId: 'run-b',
+            status: 'completed',
+            errorCode: null,
+            finishedAt: new \DateTimeImmutable('2026-05-18T12:01:01+00:00'),
+        ));
+
+        // A late terminal event for the interrupted request must not recover
+        // aggregates retained from before the next worker message started.
+        $listener->onRunTerminated(new AgentRunTerminated(
+            runId: 'run-a',
+            status: 'failed',
+            errorCode: 'worker_interrupted',
+            finishedAt: new \DateTimeImmutable('2026-05-18T12:02:00+00:00'),
+        ));
+
+        self::assertCount(2, $telescope->records);
+        self::assertSame('run-a', $telescope->records[1]['run_id']);
+        self::assertNull($telescope->records[1]['agent_definition_id']);
+        self::assertSame(0, $telescope->records[1]['tokens_in']);
+        self::assertSame(0, $telescope->records[1]['tokens_out']);
+    }
+
+    #[Test]
     public function getSubscribedEventsCoversFiveEvents(): void
     {
         $map = AgentRunTelemetryListener::getSubscribedEvents();

--- a/packages/state/src/SqlState.php
+++ b/packages/state/src/SqlState.php
@@ -12,9 +12,6 @@ use Waaseyaa\Database\DatabaseInterface;
  */
 final class SqlState implements StateInterface
 {
-    /** @var array<string, mixed> */
-    private array $cache = [];
-
     /** @var bool Whether the state table has been verified/created. */
     private bool $tableEnsured = false;
 
@@ -24,10 +21,6 @@ final class SqlState implements StateInterface
 
     public function get(string $key, mixed $default = null): mixed
     {
-        if (array_key_exists($key, $this->cache)) {
-            return $this->cache[$key];
-        }
-
         $this->ensureTable();
 
         $result = $this->database->select('state', 's')
@@ -42,9 +35,7 @@ final class SqlState implements StateInterface
             // `allowed_classes => false` cannot be used. Deferred hardening (HMAC
             // integrity signing) is tracked in docs/specs/infrastructure.md
             // "Stored-payload unserialize() trust boundary (D-12)".
-            $value = unserialize($row['value']);
-            $this->cache[$key] = $value;
-            return $value;
+            return unserialize($row['value']);
         }
 
         return $default;
@@ -52,33 +43,22 @@ final class SqlState implements StateInterface
 
     public function getMultiple(array $keys): array
     {
-        $values = [];
-        $keysToLoad = [];
-
-        // Check cache first.
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $this->cache)) {
-                $values[$key] = $this->cache[$key];
-            } else {
-                $keysToLoad[] = $key;
-            }
+        if ($keys === []) {
+            return [];
         }
 
-        if (!empty($keysToLoad)) {
-            $this->ensureTable();
+        $values = [];
+        $this->ensureTable();
 
-            $result = $this->database->select('state', 's')
-                ->fields('s', ['name', 'value'])
-                ->condition('s.name', $keysToLoad, 'IN')
-                ->execute();
+        $result = $this->database->select('state', 's')
+            ->fields('s', ['name', 'value'])
+            ->condition('s.name', $keys, 'IN')
+            ->execute();
 
-            foreach ($result as $row) {
-                // Trust boundary (D-12): see get() — server-controlled `mixed`
-                // state payload; `allowed_classes => false` is not viable.
-                $value = unserialize($row['value']);
-                $this->cache[$row['name']] = $value;
-                $values[$row['name']] = $value;
-            }
+        foreach ($result as $row) {
+            // Trust boundary (D-12): see get() — server-controlled `mixed`
+            // state payload; `allowed_classes => false` is not viable.
+            $values[$row['name']] = unserialize($row['value']);
         }
 
         return $values;
@@ -112,8 +92,6 @@ final class SqlState implements StateInterface
                     ->execute();
             }
         }
-
-        $this->cache[$key] = $value;
     }
 
     public function setMultiple(array $values): void
@@ -130,8 +108,6 @@ final class SqlState implements StateInterface
         $this->database->delete('state')
             ->condition('name', $key)
             ->execute();
-
-        unset($this->cache[$key]);
     }
 
     public function deleteMultiple(array $keys): void
@@ -142,10 +118,6 @@ final class SqlState implements StateInterface
             $this->database->delete('state')
                 ->condition('name', $key)
                 ->execute();
-        }
-
-        foreach ($keys as $key) {
-            unset($this->cache[$key]);
         }
     }
 

--- a/packages/state/tests/Unit/SqlStateTest.php
+++ b/packages/state/tests/Unit/SqlStateTest.php
@@ -140,7 +140,6 @@ final class SqlStateTest extends TestCase
         $array = ['nested' => ['data' => [1, 2, 3]], 'key' => 'value'];
         $this->state->set('array_key', $array);
 
-        // Clear the in-memory cache by creating a fresh SqlState on the same database.
         $freshState = new SqlState($this->database);
         $result = $freshState->get('array_key');
 
@@ -155,7 +154,6 @@ final class SqlStateTest extends TestCase
 
         $this->state->set('object_key', $obj);
 
-        // Clear the in-memory cache by creating a fresh SqlState on the same database.
         $freshState = new SqlState($this->database);
         $retrieved = $freshState->get('object_key');
 
@@ -169,7 +167,6 @@ final class SqlStateTest extends TestCase
         $this->state->set('flag_true', true);
         $this->state->set('flag_false', false);
 
-        // Fresh state to bypass cache.
         $freshState = new SqlState($this->database);
 
         $this->assertTrue($freshState->get('flag_true'));
@@ -180,52 +177,43 @@ final class SqlStateTest extends TestCase
     {
         $this->state->set('nullable', null);
 
-        // Fresh state to bypass cache.
         $freshState = new SqlState($this->database);
 
         // Should return null (the stored value), NOT the default.
         $this->assertNull($freshState->get('nullable', 'default'));
     }
 
-    public function testCachingPreventsRedundantQueries(): void
+    public function testGetReadsFreshStateOnTheNextRequestInTheSameProcess(): void
     {
-        $this->state->set('cached_key', 'cached_value');
+        $this->state->set('worker_key', 'first request');
+        $this->assertSame('first request', $this->state->get('worker_key'));
 
-        // First get populates the cache (value was already cached from set).
-        $value1 = $this->state->get('cached_key');
+        $concurrentRequest = new SqlState($this->database);
+        $concurrentRequest->set('worker_key', 'second request');
 
-        // Drop the table entirely to prove second read comes from cache.
-        $this->database->schema()->dropTable('state');
-
-        // This should still work because of the in-memory cache.
-        $value2 = $this->state->get('cached_key');
-
-        $this->assertSame('cached_value', $value1);
-        $this->assertSame('cached_value', $value2);
+        $this->assertSame('second request', $this->state->get('worker_key'));
     }
 
-    public function testDeleteClearsCache(): void
+    public function testDeleteRemovesStoredValue(): void
     {
         $this->state->set('key', 'value');
         $this->assertSame('value', $this->state->get('key'));
 
         $this->state->delete('key');
 
-        // After delete, get should return default, not cached value.
         $this->assertNull($this->state->get('key'));
     }
 
-    public function testGetMultipleUsesCacheForKnownKeys(): void
+    public function testGetMultipleReadsFreshStateOnTheNextRequestInTheSameProcess(): void
     {
         $this->state->set('x', 10);
         $this->state->set('y', 20);
+        $this->assertSame(['x' => 10, 'y' => 20], $this->state->getMultiple(['x', 'y']));
 
-        // Values are now cached. Get multiple for a mix of cached and uncached.
-        $result = $this->state->getMultiple(['x', 'y', 'z']);
+        $concurrentRequest = new SqlState($this->database);
+        $concurrentRequest->setMultiple(['x' => 11, 'y' => 21]);
 
-        $this->assertSame(10, $result['x']);
-        $this->assertSame(20, $result['y']);
-        $this->assertArrayNotHasKey('z', $result);
+        $this->assertSame(['x' => 11, 'y' => 21], $this->state->getMultiple(['x', 'y']));
     }
 
     public function testTableAutoCreatedOnFirstOperation(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1165,12 +1165,6 @@ parameters:
 			path: packages/ssr/src/ThemeServiceProvider.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: packages/state/src/SqlState.php
-
-		-
 			message: '#^Cannot call method bindValue\(\) on PDOStatement\|false\.$#'
 			identifier: method.nonObject
 			count: 15


### PR DESCRIPTION
Part of #1971

## Summary
- remove `SqlState`'s per-instance read cache so a long-lived instance observes authoritative writes
- replace abandoned AI telemetry aggregation when the next one-run-per-worker job starts
- add two-request/one-process regressions and an `[Unreleased]` entry

## TDD evidence
- red: 3 failures (stale `get`, stale `getMultiple`, retained interrupted-run telemetry)
- green: `php -d memory_limit=1G ./vendor/bin/phpunit packages/state/tests/ packages/ai-observability/tests/ --no-coverage` — 88 tests, 196 assertions

spec-reviewed: infrastructure.md — authoritative state reads preserve the documented storage contract
spec-reviewed: ai-integration.md — one-run-per-worker telemetry lifecycle is unchanged