### PR TITLE
fix(#1971): isolate HTTP presentation state per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Persistent HTTP workers no longer carry Inertia shared props or the active language into the next request (#1971, R17).** `InertiaMiddleware` clears request-shared props in `finally` on every response path, preventing account-shaped props from surviving in process statics, and SSR routing resets the shared `LanguageManager` before applying the current request's prefix. Two-request/one-process regressions pin both boundaries; companion coverage verifies that the dual static Twig environments are already replaced on every production-order provider boot and require no runtime change.
+
 ### Changed
 
 - **Repository agent rules now pin the mandatory PR, TDD, changelog, spec-drift, worker-safe git, local-gate, release-fan-out, and auto-merge conventions.** `AGENTS.md` remains a terse entry point to the authoritative `CLAUDE.md` and workflow/spec documents while ensuring future agent sessions inherit the process guardrails up front.

--- a/packages/inertia/src/Inertia.php
+++ b/packages/inertia/src/Inertia.php
@@ -41,6 +41,11 @@ final class Inertia
         self::$shared[$key] = $value;
     }
 
+    public static function clearShared(): void
+    {
+        self::$shared = [];
+    }
+
     /** @param array<string, mixed> $props */
     public static function render(
         string $component,
@@ -78,7 +83,7 @@ final class Inertia
 
     public static function reset(): void
     {
-        self::$shared = [];
+        self::clearShared();
         self::$version = '';
         self::$renderer = null;
     }

--- a/packages/inertia/src/InertiaMiddleware.php
+++ b/packages/inertia/src/InertiaMiddleware.php
@@ -19,17 +19,21 @@ final class InertiaMiddleware implements HttpMiddlewareInterface
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
-        if ($request->headers->get('X-Inertia') !== 'true') {
+        try {
+            if ($request->headers->get('X-Inertia') !== 'true') {
+                return $next->handle($request);
+            }
+
+            $clientVersion = $request->headers->get('X-Inertia-Version');
+            if ($clientVersion !== null && $clientVersion !== $this->version) {
+                return new Response('', 409, [
+                    'X-Inertia-Location' => $request->getRequestUri(),
+                ]);
+            }
+
             return $next->handle($request);
+        } finally {
+            Inertia::clearShared();
         }
-
-        $clientVersion = $request->headers->get('X-Inertia-Version');
-        if ($clientVersion !== null && $clientVersion !== $this->version) {
-            return new Response('', 409, [
-                'X-Inertia-Location' => $request->getRequestUri(),
-            ]);
-        }
-
-        return $next->handle($request);
     }
 }

--- a/packages/inertia/tests/Unit/InertiaMiddlewareTest.php
+++ b/packages/inertia/tests/Unit/InertiaMiddlewareTest.php
@@ -9,11 +9,22 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaMiddleware;
 
 #[CoversClass(InertiaMiddleware::class)]
 final class InertiaMiddlewareTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Inertia::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        Inertia::reset();
+    }
+
     public function testNonInertiaRequestPassesThrough(): void
     {
         $middleware = new InertiaMiddleware('v1');
@@ -64,6 +75,34 @@ final class InertiaMiddlewareTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testSharedPropsDoNotSurviveIntoTheNextRequestInTheSameProcess(): void
+    {
+        $middleware = new InertiaMiddleware('v1');
+        $handler = new class implements HttpHandlerInterface {
+            /** @var list<array<string, mixed>> */
+            public array $pages = [];
+
+            private int $requestCount = 0;
+
+            public function handle(Request $request): Response
+            {
+                if ($this->requestCount++ === 0) {
+                    Inertia::share('auth', ['user' => ['name' => 'Alice']]);
+                }
+
+                $this->pages[] = Inertia::render('Dashboard', [])->toPageObject();
+
+                return new Response('ok');
+            }
+        };
+
+        $middleware->process(Request::create('/first'), $handler);
+        $middleware->process(Request::create('/second'), $handler);
+
+        $this->assertSame(['user' => ['name' => 'Alice']], $handler->pages[0]['props']['auth']);
+        $this->assertArrayNotHasKey('auth', $handler->pages[1]['props']);
     }
 
     private function createMockHandler(Response $response): HttpHandlerInterface

--- a/packages/ssr/src/LanguageResolver.php
+++ b/packages/ssr/src/LanguageResolver.php
@@ -77,6 +77,7 @@ final class LanguageResolver
         if ($manager === null) {
             return $path;
         }
+        $manager->resetToDefault();
         $availableLanguages = array_keys($manager->getLanguages());
         $defaultLanguage = $manager->getDefaultLanguage();
 

--- a/packages/ssr/tests/Unit/SsrPageHandlerTest.php
+++ b/packages/ssr/tests/Unit/SsrPageHandlerTest.php
@@ -431,4 +431,16 @@ final class SsrPageHandlerTest extends TestCase
         $this->assertSame('/communities', $result);
         $this->assertSame('en', $manager->getCurrentLanguage()->id);
     }
+
+    #[Test]
+    public function routing_language_is_reset_between_requests_in_the_same_process(): void
+    {
+        [$resolver, $manager] = $this->createResolverWithManager();
+
+        $this->assertSame('/about', $resolver->stripLanguagePrefixForRouting('/oj/about'));
+        $this->assertSame('oj', $manager->getCurrentLanguage()->id);
+
+        $this->assertSame('/about', $resolver->stripLanguagePrefixForRouting('/about'));
+        $this->assertSame('en', $manager->getCurrentLanguage()->id);
+    }
 }

--- a/packages/ssr/tests/Unit/SsrServiceProviderTest.php
+++ b/packages/ssr/tests/Unit/SsrServiceProviderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\SSR\SsrServiceProvider;
+use Waaseyaa\SSR\ThemeServiceProvider;
 
 #[CoversClass(SsrServiceProvider::class)]
 final class SsrServiceProviderTest extends TestCase
@@ -57,6 +58,9 @@ final class SsrServiceProviderTest extends TestCase
         mkdir($projectRoot . '/templates', 0755, true);
         file_put_contents($projectRoot . '/templates/page.html.twig', '<h1>Booted</h1>');
 
+        $themeProvider = new ThemeServiceProvider();
+        $themeProvider->setKernelContext($projectRoot, [], []);
+        $themeProvider->boot();
         $provider = new SsrServiceProvider();
         $provider->setKernelContext($projectRoot, [], ['string' => \Waaseyaa\SSR\Formatter\PlainTextFormatter::class]);
         $provider->register();
@@ -70,6 +74,47 @@ final class SsrServiceProviderTest extends TestCase
         $this->assertSame('&lt;b&gt;x&lt;/b&gt;', $registry->format('string', '<b>x</b>'));
 
         $this->removeDirectory($projectRoot);
+    }
+
+    #[Test]
+    public function consecutiveRequestBootsReplaceBothStaticTwigEnvironments(): void
+    {
+        $firstRoot = sys_get_temp_dir() . '/waaseyaa_ssr_worker_first_' . uniqid();
+        $secondRoot = sys_get_temp_dir() . '/waaseyaa_ssr_worker_second_' . uniqid();
+        mkdir($firstRoot . '/templates', 0755, true);
+        mkdir($secondRoot . '/templates', 0755, true);
+        file_put_contents($firstRoot . '/templates/page.html.twig', 'first request');
+        file_put_contents($secondRoot . '/templates/page.html.twig', 'second request');
+
+        $firstThemeProvider = new ThemeServiceProvider();
+        $firstThemeProvider->setKernelContext($firstRoot, [], []);
+        $firstThemeProvider->boot();
+        $firstSsrProvider = new SsrServiceProvider();
+        $firstSsrProvider->setKernelContext($firstRoot, [], []);
+        $firstSsrProvider->boot();
+        $firstThemeEnvironment = ThemeServiceProvider::getTwigEnvironment();
+        $firstSsrEnvironment = SsrServiceProvider::getTwigEnvironment();
+
+        $secondThemeProvider = new ThemeServiceProvider();
+        $secondThemeProvider->setKernelContext($secondRoot, [], []);
+        $secondThemeProvider->boot();
+        $secondSsrProvider = new SsrServiceProvider();
+        $secondSsrProvider->setKernelContext($secondRoot, [], []);
+        $secondSsrProvider->boot();
+        $secondThemeEnvironment = ThemeServiceProvider::getTwigEnvironment();
+        $secondSsrEnvironment = SsrServiceProvider::getTwigEnvironment();
+
+        $this->assertNotNull($firstThemeEnvironment);
+        $this->assertNotNull($firstSsrEnvironment);
+        $this->assertNotNull($secondThemeEnvironment);
+        $this->assertNotNull($secondSsrEnvironment);
+        $this->assertNotSame($firstThemeEnvironment, $secondThemeEnvironment);
+        $this->assertNotSame($firstSsrEnvironment, $secondSsrEnvironment);
+        $this->assertSame($secondThemeEnvironment, $secondSsrEnvironment);
+        $this->assertSame('second request', $secondSsrEnvironment->render('page.html.twig'));
+
+        $this->removeDirectory($firstRoot);
+        $this->removeDirectory($secondRoot);
     }
 
     private function removeDirectory(string $directory): void


### PR DESCRIPTION
Part of #1971

## Summary
- clear Inertia shared props in `finally` at the HTTP middleware boundary
- reset the shared language manager before each routing-prefix resolution
- prove both SSR Twig statics are replaced by consecutive production-order provider boots; no SSR runtime change needed
- add `[Unreleased]` security notes

## TDD evidence
- red: Inertia second request retained `auth`; i18n second unprefixed request retained `oj`
- green: `php -d memory_limit=1G ./vendor/bin/phpunit packages/inertia/tests/ packages/ssr/tests/ packages/i18n/tests/ --no-coverage` — 414 tests, 945 assertions

spec-reviewed: infrastructure.md — request-boundary isolation preserves the documented language and worker lifecycle contracts
spec-reviewed: all — Inertia and SSR package docs remain accurate