### PR TITLE
fix: CAS agent cancellation and approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent cancellation and approval now use exact-status compare-and-swap updates (#1975, R18 M5).** Controller actions no longer save a stale hydrated run row that can regress a worker's terminal status or overwrite transcript and cost fields. Cancellation requires the status observed by the request; approve/deny additionally require the pending call id, and a lost race returns 409 without audit or broadcast side effects.
+
 ### Security
 
 - **Persistent HTTP workers no longer carry Inertia shared props or the active language into the next request (#1971, R17).** `InertiaMiddleware` clears request-shared props in `finally` on every response path, preventing account-shaped props from surviving in process statics, and SSR routing resets the shared `LanguageManager` before applying the current request's prefix. Two-request/one-process regressions pin both boundaries; companion coverage verifies that the dual static Twig environments are already replaced on every production-order provider boot and require no runtime change.

--- a/packages/ai-agent/src/Controller/AgentRunController.php
+++ b/packages/ai-agent/src/Controller/AgentRunController.php
@@ -282,7 +282,7 @@ final class AgentRunController
         $flipped = $this->runRepository->denyApproval($id, $callId, $now);
 
         if (!$flipped) {
-            return $this->error(409, 'already_terminal', "Run {$id} is already in a terminal state.");
+            return $this->error(409, 'run_status_changed', "Run {$id} changed state; denial was not applied.");
         }
 
         $this->auditRepository->append(AgentAuditLog::for(

--- a/packages/ai-agent/src/Controller/AgentRunController.php
+++ b/packages/ai-agent/src/Controller/AgentRunController.php
@@ -189,28 +189,22 @@ final class AgentRunController
             return $this->error(409, 'already_terminal', "Run {$id} is already in a terminal state.");
         }
 
-        if ($status === RunStatus::Queued) {
-            $flipped = $this->runRepository->markTerminal(
-                id: $id,
-                status: RunStatus::Cancelled,
-                finishedAt: $now,
-                errorCode: 'cancelled_by_user',
-                errorMessage: 'Run cancelled before worker pickup.',
-            );
-
-            if ($flipped) {
-                $this->broadcaster->push($id, 'run_cancelled', [
-                    'cancelled_at' => $now->format(\DATE_ATOM),
-                ]);
-            }
-
+        if ($status === RunStatus::Cancelling) {
             return new Response('', status: 204);
         }
 
-        // Worker has picked the row up — mark it as cancelling so the
-        // loop transitions to cancelled at the next boundary.
-        $run->set('status', RunStatus::Cancelling->value);
-        $this->runRepository->save($run);
+        $flipped = $this->runRepository->requestCancellation($id, $status, $now);
+        if (!$flipped) {
+            return $this->error(409, 'run_status_changed', "Run {$id} changed state; retry against the current status.");
+        }
+
+        if ($status === RunStatus::Queued) {
+            $this->broadcaster->push($id, 'run_cancelled', [
+                'cancelled_at' => $now->format(\DATE_ATOM),
+            ]);
+
+            return new Response('', status: 204);
+        }
 
         return new Response('', status: 204);
     }
@@ -262,9 +256,9 @@ final class AgentRunController
         $now = new \DateTimeImmutable('now');
 
         if ($decision === 'approve') {
-            $run->set('status', RunStatus::Running->value);
-            $run->set('pending_approval_call_id', null);
-            $this->runRepository->save($run);
+            if (!$this->runRepository->grantApproval($id, $callId)) {
+                return $this->error(409, 'run_status_changed', "Run {$id} changed state; approval was not applied.");
+            }
 
             $this->auditRepository->append(AgentAuditLog::for(
                 id: Uuid::v4()->toRfc4122(),
@@ -285,13 +279,7 @@ final class AgentRunController
         }
 
         // Deny: terminal failure with approval_denied.
-        $flipped = $this->runRepository->markTerminal(
-            id: $id,
-            status: RunStatus::Failed,
-            finishedAt: $now,
-            errorCode: 'approval_denied',
-            errorMessage: 'Approval denied by user.',
-        );
+        $flipped = $this->runRepository->denyApproval($id, $callId, $now);
 
         if (!$flipped) {
             return $this->error(409, 'already_terminal', "Run {$id} is already in a terminal state.");

--- a/packages/ai-agent/src/Repository/AgentRunRepository.php
+++ b/packages/ai-agent/src/Repository/AgentRunRepository.php
@@ -132,6 +132,58 @@ final class AgentRunRepository
         return $affected === 1;
     }
 
+    public function requestCancellation(string $id, RunStatus $expectedStatus, \DateTimeImmutable $now): bool
+    {
+        if ($expectedStatus === RunStatus::Queued) {
+            $fields = [
+                'status' => RunStatus::Cancelled->value,
+                'finished_at' => $this->formatDateTime($now),
+                'error_code' => 'cancelled_by_user',
+                'error_message' => 'Run cancelled before worker pickup.',
+            ];
+        } elseif ($expectedStatus === RunStatus::Running || $expectedStatus === RunStatus::AwaitingApproval) {
+            $fields = ['status' => RunStatus::Cancelling->value];
+        } else {
+            return false;
+        }
+
+        return $this->database->update(self::TABLE)
+            ->fields($fields)
+            ->condition('id', $id)
+            ->condition('status', $expectedStatus->value)
+            ->execute() === 1;
+    }
+
+    public function grantApproval(string $id, string $callId): bool
+    {
+        return $this->approvalTransition($id, $callId, [
+            'status' => RunStatus::Running->value,
+            'pending_approval_call_id' => null,
+        ]);
+    }
+
+    public function denyApproval(string $id, string $callId, \DateTimeImmutable $now): bool
+    {
+        return $this->approvalTransition($id, $callId, [
+            'status' => RunStatus::Failed->value,
+            'pending_approval_call_id' => null,
+            'finished_at' => $this->formatDateTime($now),
+            'error_code' => 'approval_denied',
+            'error_message' => 'Approval denied by user.',
+        ]);
+    }
+
+    /** @param array<string, mixed> $fields */
+    private function approvalTransition(string $id, string $callId, array $fields): bool
+    {
+        return $this->database->update(self::TABLE)
+            ->fields($fields)
+            ->condition('id', $id)
+            ->condition('status', RunStatus::AwaitingApproval->value)
+            ->condition('pending_approval_call_id', $callId)
+            ->execute() === 1;
+    }
+
     /**
      * Find runs whose `status='running'` and `started_at < $threshold`.
      *

--- a/packages/ai-agent/tests/Unit/Repository/AgentRunRepositoryTest.php
+++ b/packages/ai-agent/tests/Unit/Repository/AgentRunRepositoryTest.php
@@ -153,6 +153,30 @@ final class AgentRunRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function cancellationAndApprovalTransitionsRequireExactObservedState(): void
+    {
+        $run = $this->makeQueuedRun('cas-run', 1, 'work');
+        $this->repository->save($run);
+        self::assertTrue($this->repository->markRunning('cas-run', new \DateTimeImmutable()));
+
+        self::assertFalse($this->repository->requestCancellation('cas-run', RunStatus::Queued, new \DateTimeImmutable()));
+        self::assertTrue($this->repository->requestCancellation('cas-run', RunStatus::Running, new \DateTimeImmutable()));
+        self::assertSame(RunStatus::Cancelling, $this->repository->find('cas-run')?->getStatus());
+
+        $approval = $this->makeQueuedRun('approval-run', 1, 'work');
+        $this->repository->save($approval);
+        $this->database->update('agent_run')->fields([
+            'status' => RunStatus::AwaitingApproval->value,
+            'pending_approval_call_id' => 'call-1',
+        ])->condition('id', 'approval-run')->execute();
+
+        self::assertFalse($this->repository->grantApproval('approval-run', 'wrong-call'));
+        self::assertTrue($this->repository->grantApproval('approval-run', 'call-1'));
+        self::assertSame(RunStatus::Running, $this->repository->find('approval-run')?->getStatus());
+        self::assertFalse($this->repository->denyApproval('approval-run', 'call-1', new \DateTimeImmutable()));
+    }
+
+    #[Test]
     public function findStuckRunningReturnsRunsStartedBeforeThreshold(): void
     {
         $oldStart = new \DateTimeImmutable('2026-05-18T10:00:00+00:00');

--- a/tests/Integration/PhaseN/AgentRuntime/InteractiveHitlTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/InteractiveHitlTest.php
@@ -152,6 +152,65 @@ final class InteractiveHitlTest extends TestCase
         self::assertSame($expected, $run->get('pending_approval_call_id'));
     }
 
+    #[Test]
+    public function denyCasLossReturnsStateChangedWithoutAuditOrBroadcast(): void
+    {
+        $callId = 'call_' . Uuid::v4()->toRfc4122();
+        $replacementCallId = 'call_' . Uuid::v4()->toRfc4122();
+        $runId = $this->seedAwaitingApprovalRun(callerId: 42, callId: $callId);
+        $request = $this->buildRequest('POST', "/api/ai/agent/run/{$runId}/approve", \json_encode([
+            'call_id' => $callId,
+            'decision' => 'deny',
+        ], \JSON_THROW_ON_ERROR));
+
+        $database = $this->database;
+        $request->attributes->set('_account', new class ($database, $runId, $replacementCallId) implements AccountInterface {
+            private bool $raced = false;
+
+            public function __construct(
+                private readonly DBALDatabase $database,
+                private readonly string $runId,
+                private readonly string $replacementCallId,
+            ) {}
+
+            public function id(): int|string
+            {
+                return 42;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                if (!$this->raced) {
+                    $this->raced = true;
+                    $this->database->update('agent_run')
+                        ->fields(['pending_approval_call_id' => $this->replacementCallId])
+                        ->condition('id', $this->runId)
+                        ->execute();
+                }
+
+                return false;
+            }
+
+            public function getRoles(): array
+            {
+                return ['authenticated'];
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+        });
+
+        $response = $this->controller->approve($request, $runId);
+
+        self::assertSame(409, $response->getStatusCode());
+        self::assertSame('run_status_changed', \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['error_code']);
+        self::assertSame($replacementCallId, $this->runRepository->find($runId)?->get('pending_approval_call_id'));
+        self::assertSame([], $this->auditRepository->findByRunId($runId));
+        self::assertNotContains('approval_resolved', $this->channelEvents('agent.run.' . $runId));
+    }
+
     private function seedAwaitingApprovalRun(int $callerId, string $callId): string
     {
         $id = Uuid::v4()->toRfc4122();


### PR DESCRIPTION
Closes part of #1975.

Makes cancellation and approval/denial transitions conditional on the exact observed run status (and pending tool-call ID for HITL), preventing stale controller saves from winning lost-update races.

Tests prove failed stale transitions cannot mutate the run.

Changelog: Fixed.