### PR TITLE
fix: wire agent tool loop with per-agent allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Production agent runs now execute only tools explicitly allowlisted by their agent definition (#1975, R18 M2+M3).** `RunAgentHandler` advertises the allowlisted registry descriptors instead of hardcoding an empty tool list, while `AgentExecutor` independently rejects any model-emitted or direct tool invocation absent from that allowlist and rechecks the tool capability before execution. The tool loop and its security boundary land together so enabling tools can never expose the global catalogue to every agent.
+
+### Security
+
 - **Persistent HTTP workers no longer carry Inertia shared props or the active language into the next request (#1971, R17).** `InertiaMiddleware` clears request-shared props in `finally` on every response path, preventing account-shaped props from surviving in process statics, and SSR routing resets the shared `LanguageManager` before applying the current request's prefix. Two-request/one-process regressions pin both boundaries; companion coverage verifies that the dual static Twig environments are already replaced on every production-order provider boot and require no runtime change.
 
 ### Changed

--- a/docs/specs/agent-executor.md
+++ b/docs/specs/agent-executor.md
@@ -290,7 +290,7 @@ proxied to the remote at execution time.
 Agents run as the **initiator's account**. `AgentContext::account` is the
 user who triggered the run.
 
-Authorization happens at four gates:
+Authorization happens at five gates:
 
 1. **Route capability** — `_permission: 'agent.run'` on every
    `/api/ai/agent/run*` route, evaluated by `AccessChecker`.
@@ -307,10 +307,14 @@ Authorization happens at four gates:
    `AgentAuditLog` rows are written (audit A7 F2 / R10 WP2 — this gate was
    plumbed attribute → manifest → registry → definition but left unenforced
    until this fix).
-3. **Per-tool capability** — every tool the agent invokes requires the
+3. **Per-agent tool allowlist** — `RunAgentHandler` advertises only the tool
+   names in `AgentDefinition.tools`, and `AgentExecutor` independently rejects
+   any model-emitted or direct invocation whose name is absent from that list
+   before consulting the global registry. An empty list is fail-closed.
+4. **Per-tool capability** — every tool the agent invokes requires the
    initiator to hold `tool.<name>` (or `tool.mcp.<server>.<name>`). Enforced
    at request-validation time AND defensively at tool-execution time.
-4. **Entity-level access** — tools that touch entities go through
+5. **Entity-level access** — tools that touch entities go through
    `EntityAccessHandler` against the initiator's account. The previous
    `accessCheck(false)` bypass in `McpToolExecutor` is removed.
 

--- a/docs/specs/ai-integration.md
+++ b/docs/specs/ai-integration.md
@@ -1042,6 +1042,11 @@ the missing half is producer dispatch, tracked as a follow-up issue.
 
 ## Implementation gotchas
 
+- **Tool-loop wiring and allowlisting are inseparable (R18 M2+M3, #1975):**
+  `RunAgentHandler` resolves provider descriptors only for
+  `AgentDefinition::$tools`; `AgentExecutor` receives the same trusted name
+  list and checks membership again before global-registry lookup or execution.
+  Never wire provider tools without this second fail-closed gate.
 - **`RunAgentHandler` enforces `AgentDefinition::$requiresCapability`** (audit
   A7 F2 / R10 WP2, 2026-07-05): this field used to be plumbed end-to-end
   (attribute → manifest → registry → definition) but never checked before

--- a/packages/ai-agent/src/AgentExecutor.php
+++ b/packages/ai-agent/src/AgentExecutor.php
@@ -123,6 +123,7 @@ final class AgentExecutor
      * @param array<int, array<string, mixed>> $tools     Tool descriptors to advertise to the provider.
      * @param int $maxIterations Iteration budget (FR-026).
      * @param int $maxTokens Provider per-call token budget.
+     * @param list<string> $allowedToolNames Agent-definition tool names authorized for this run.
      */
     public function executeRun(
         AgentRun $run,
@@ -131,9 +132,9 @@ final class AgentExecutor
         array $messages,
         ?string $system = null,
         array $tools = [],
-        array $allowedToolNames = [],
         int $maxIterations = 10,
         int $maxTokens = 4096,
+        array $allowedToolNames = [],
     ): AgentResult {
         // Scope the acting-account context to the run initiator (research D1
         // writer 3, FR-002) so entity saves made *by agent tools* — including

--- a/packages/ai-agent/src/AgentExecutor.php
+++ b/packages/ai-agent/src/AgentExecutor.php
@@ -339,17 +339,6 @@ final class AgentExecutor
                     continue;
                 }
 
-                if (!$initiatorAccount->hasPermission($tool->capability)) {
-                    $message = \sprintf('Tool "%s" is not authorized.', $toolName);
-                    $this->appendError($runId, $iteration, 'tool_unauthorized', $message, $toolName, $toolArgs);
-                    $toolResults[] = new ToolResultBlock(
-                        toolUseId: $toolUseBlock->id,
-                        content: json_encode(['error' => $message], JSON_THROW_ON_ERROR),
-                        isError: true,
-                    )->toArray();
-                    continue;
-                }
-
                 // HITL gate for destructive tools (FR-020).
                 if ($tool->destructive) {
                     $gate = $this->applyHitlGate($run, $hitl, $tool, $toolUseBlock->id, $iteration);
@@ -521,10 +510,6 @@ final class AgentExecutor
             }
 
             return AgentToolResult::error($e->getMessage());
-        }
-
-        if (!$account->hasPermission($tool->capability)) {
-            return AgentToolResult::error(\sprintf('Tool "%s" is not authorized.', $toolName));
         }
 
         try {

--- a/packages/ai-agent/src/AgentExecutor.php
+++ b/packages/ai-agent/src/AgentExecutor.php
@@ -131,6 +131,7 @@ final class AgentExecutor
         array $messages,
         ?string $system = null,
         array $tools = [],
+        array $allowedToolNames = [],
         int $maxIterations = 10,
         int $maxTokens = 4096,
     ): AgentResult {
@@ -152,6 +153,7 @@ final class AgentExecutor
                 $messages,
                 $system,
                 $tools,
+                $allowedToolNames,
                 $maxIterations,
                 $maxTokens,
             );
@@ -183,6 +185,7 @@ final class AgentExecutor
         array $messages,
         ?string $system,
         array $tools,
+        array $allowedToolNames,
         int $maxIterations,
         int $maxTokens,
     ): AgentResult {
@@ -313,6 +316,17 @@ final class AgentExecutor
                 $toolName = $toolUseBlock->name;
                 $toolArgs = $toolUseBlock->input;
 
+                if (!\in_array($toolName, $allowedToolNames, true)) {
+                    $message = \sprintf('Tool "%s" is not available.', $toolName);
+                    $this->appendError($runId, $iteration, 'tool_not_found', $message, $toolName, $toolArgs);
+                    $toolResults[] = new ToolResultBlock(
+                        toolUseId: $toolUseBlock->id,
+                        content: json_encode(['error' => $message], JSON_THROW_ON_ERROR),
+                        isError: true,
+                    )->toArray();
+                    continue;
+                }
+
                 try {
                     $tool = $this->toolRegistry->get($toolName);
                 } catch (ToolNotFoundException $e) {
@@ -320,6 +334,17 @@ final class AgentExecutor
                     $toolResults[] = new ToolResultBlock(
                         toolUseId: $toolUseBlock->id,
                         content: json_encode(['error' => $e->getMessage()], JSON_THROW_ON_ERROR),
+                        isError: true,
+                    )->toArray();
+                    continue;
+                }
+
+                if (!$initiatorAccount->hasPermission($tool->capability)) {
+                    $message = \sprintf('Tool "%s" is not authorized.', $toolName);
+                    $this->appendError($runId, $iteration, 'tool_unauthorized', $message, $toolName, $toolArgs);
+                    $toolResults[] = new ToolResultBlock(
+                        toolUseId: $toolUseBlock->id,
+                        content: json_encode(['error' => $message], JSON_THROW_ON_ERROR),
                         isError: true,
                     )->toArray();
                     continue;
@@ -477,7 +502,17 @@ final class AgentExecutor
         AccountInterface $account,
         ?string $runId = null,
         int $iteration = 0,
+        array $allowedToolNames = [],
     ): AgentToolResult {
+        if (!\in_array($toolName, $allowedToolNames, true)) {
+            $message = \sprintf('Tool "%s" is not available.', $toolName);
+            if ($runId !== null) {
+                $this->appendError($runId, $iteration, 'tool_not_found', $message, $toolName, $arguments);
+            }
+
+            return AgentToolResult::error($message);
+        }
+
         try {
             $tool = $this->toolRegistry->get($toolName);
         } catch (ToolNotFoundException $e) {
@@ -486,6 +521,10 @@ final class AgentExecutor
             }
 
             return AgentToolResult::error($e->getMessage());
+        }
+
+        if (!$account->hasPermission($tool->capability)) {
+            return AgentToolResult::error(\sprintf('Tool "%s" is not authorized.', $toolName));
         }
 
         try {

--- a/packages/ai-agent/src/Message/RunAgentHandler.php
+++ b/packages/ai-agent/src/Message/RunAgentHandler.php
@@ -18,6 +18,8 @@ use Waaseyaa\AI\Agent\Enum\RunStatus;
 use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\AI\Agent\Repository\AgentRunRepository;
 use Waaseyaa\AI\Observability\Event\AgentRunTerminated;
+use Waaseyaa\AI\Tools\ToolNotFoundException;
+use Waaseyaa\AI\Tools\ToolRegistryInterface;
 use Waaseyaa\Foundation\Event\EventDispatcherInterface;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
@@ -62,6 +64,7 @@ final class RunAgentHandler
         private readonly AgentRunRepository $runRepository,
         private readonly AgentExecutor $executor,
         private readonly AgentDefinitionRegistry $definitionRegistry,
+        private readonly ToolRegistryInterface $toolRegistry,
         private readonly AgentRunBroadcasterInterface $broadcaster,
         private readonly ProviderInterface $provider,
         private readonly InitiatorAccountLoaderInterface $accountLoader,
@@ -122,6 +125,7 @@ final class RunAgentHandler
             $messages = [
                 ['role' => 'user', 'content' => (string) $run->get('prompt')],
             ];
+            $tools = $this->allowedToolDescriptors($definition);
 
             $result = $this->executor->executeRun(
                 run: $run,
@@ -129,7 +133,8 @@ final class RunAgentHandler
                 provider: $this->provider,
                 messages: $messages,
                 system: $definition->system !== '' ? $definition->system : null,
-                tools: [],
+                tools: $tools,
+                allowedToolNames: $definition->tools,
                 maxIterations: $definition->maxIterations,
             );
 
@@ -206,6 +211,30 @@ final class RunAgentHandler
                 'error_message' => $errorMessage,
             ]);
         }
+    }
+
+    /** @return list<array{name: string, description: string, input_schema: array<string, mixed>}> */
+    private function allowedToolDescriptors(AgentDefinition $definition): array
+    {
+        $descriptors = [];
+        foreach ($definition->tools as $name) {
+            try {
+                $tool = $this->toolRegistry->get($name);
+            } catch (ToolNotFoundException $e) {
+                $this->logger->warning('RunAgentHandler: allowed tool is not registered.', [
+                    'tool' => $name,
+                    'exception' => $e->getMessage(),
+                ]);
+                continue;
+            }
+            $descriptors[] = [
+                'name' => $tool->name,
+                'description' => $tool->impl->description(),
+                'input_schema' => $tool->inputSchema,
+            ];
+        }
+
+        return $descriptors;
     }
 
     /**

--- a/packages/ai-agent/src/MessagingServiceProvider.php
+++ b/packages/ai-agent/src/MessagingServiceProvider.php
@@ -20,6 +20,7 @@ use Waaseyaa\AI\Agent\Reaper\StalledRunReaper;
 use Waaseyaa\AI\Agent\Repository\AgentAuditLogRepository;
 use Waaseyaa\AI\Agent\Repository\AgentRunRepository;
 use Waaseyaa\AI\Agent\Service\AgentRunService;
+use Waaseyaa\AI\Tools\ToolRegistryInterface;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -83,6 +84,7 @@ final class MessagingServiceProvider extends ServiceProvider
                 runRepository: $this->resolve(AgentRunRepository::class),
                 executor: $this->resolve(AgentExecutor::class),
                 definitionRegistry: $this->resolve(AgentDefinitionRegistry::class),
+                toolRegistry: $this->resolve(ToolRegistryInterface::class),
                 broadcaster: $this->resolve(AgentRunBroadcasterInterface::class),
                 provider: $this->resolve(ProviderInterface::class),
                 accountLoader: $this->resolve(InitiatorAccountLoaderInterface::class),

--- a/packages/ai-agent/tests/Unit/AgentExecutorEventDispatchTest.php
+++ b/packages/ai-agent/tests/Unit/AgentExecutorEventDispatchTest.php
@@ -129,6 +129,7 @@ final class AgentExecutorEventDispatchTest extends TestCase
             $this->fakeAccount(1),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: ['echo_tool'],
             maxIterations: 5,
         );
 
@@ -244,6 +245,7 @@ final class AgentExecutorEventDispatchTest extends TestCase
             $this->fakeAccount(1),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: ['noop'],
             maxIterations: 5,
         );
 
@@ -272,6 +274,7 @@ final class AgentExecutorEventDispatchTest extends TestCase
             $this->fakeAccount(42),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: ['ok_tool'],
             maxIterations: 5,
         );
 
@@ -300,6 +303,7 @@ final class AgentExecutorEventDispatchTest extends TestCase
             $this->fakeAccount(42),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: ['boom_tool'],
             maxIterations: 5,
         );
 
@@ -443,6 +447,7 @@ final class AgentExecutorEventDispatchTest extends TestCase
             $this->fakeAccount(1),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: ['list_arg_tool'],
             maxIterations: 5,
         );
 

--- a/packages/cli/tests/Unit/Command/Ai/AiRunCommandTest.php
+++ b/packages/cli/tests/Unit/Command/Ai/AiRunCommandTest.php
@@ -202,6 +202,7 @@ final class AiRunCommandTest extends TestCase
             runRepository: $runRepo,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: new InertBroadcasterForAiRunTest(),
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/packages/cli/tests/Unit/Command/Ai/AiRunCommandWatchTest.php
+++ b/packages/cli/tests/Unit/Command/Ai/AiRunCommandWatchTest.php
@@ -261,6 +261,7 @@ final class AiRunCommandWatchTest extends TestCase
             runRepository: $runRepo,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: new InertBroadcasterForWatchTest(),
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/tests/Integration/AgentRun/AgentRunObservabilityTest.php
+++ b/tests/Integration/AgentRun/AgentRunObservabilityTest.php
@@ -151,6 +151,7 @@ final class AgentRunObservabilityTest extends TestCase
             $this->fakeAccount(42),
             $provider,
             messages: [['role' => 'user', 'content' => 'observe']],
+            allowedToolNames: ['obs_tool'],
             maxIterations: 5,
         );
 

--- a/tests/Integration/PhaseN/AgentRuntime/AsyncHttpRunTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/AsyncHttpRunTest.php
@@ -257,6 +257,7 @@ final class AsyncHttpRunTest extends TestCase
             runRepository: $this->runRepository,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: $broadcaster,
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/tests/Integration/PhaseN/AgentRuntime/BimaajiAgentRunCapabilityTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/BimaajiAgentRunCapabilityTest.php
@@ -61,6 +61,7 @@ final class BimaajiAgentRunCapabilityTest extends TestCase
             $account,
             $provider,
             messages: [['role' => 'user', 'content' => 'demo']],
+            allowedToolNames: ['bimaaji_introspect_section', 'bimaaji_propose_mutation', 'bimaaji_generate_patch'],
             maxIterations: 6,
         );
 

--- a/tests/Integration/PhaseN/AgentRuntime/BimaajiAgentRunTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/BimaajiAgentRunTest.php
@@ -59,6 +59,7 @@ final class BimaajiAgentRunTest extends TestCase
             $account,
             $provider,
             messages: [['role' => 'user', 'content' => 'demo']],
+            allowedToolNames: ['bimaaji_introspect_section', 'bimaaji_propose_mutation', 'bimaaji_generate_patch'],
             maxIterations: 6,
         );
 

--- a/tests/Integration/PhaseN/AgentRuntime/CancellationTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/CancellationTest.php
@@ -269,6 +269,7 @@ final class CancellationTest extends TestCase
             runRepository: $this->runRepository,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: new AgentRunBroadcaster($this->broadcastStorage),
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/tests/Integration/PhaseN/AgentRuntime/CliInlineRunTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/CliInlineRunTest.php
@@ -171,6 +171,7 @@ final class CliInlineRunTest extends TestCase
             runRepository: $runRepo,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: $broadcaster,
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/tests/Integration/PhaseN/AgentRuntime/EnqueueAndConsumeTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/EnqueueAndConsumeTest.php
@@ -212,6 +212,7 @@ final class EnqueueAndConsumeTest extends TestCase
             runRepository: $this->runRepository,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: $this->broadcaster,
             provider: new NullLlmProvider(),
             accountLoader: new StubInitiatorAccountLoader(),

--- a/tests/Integration/PhaseN/AgentRuntime/ExecutorHitlTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/ExecutorHitlTest.php
@@ -97,6 +97,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 
@@ -121,6 +122,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 
@@ -207,6 +209,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 
@@ -257,6 +260,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 
@@ -304,6 +308,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 
@@ -349,6 +354,7 @@ final class ExecutorHitlTest extends TestCase
             $this->fakeAccount(99),
             $provider,
             messages: [['role' => 'user', 'content' => 'go']],
+            allowedToolNames: [$tool->name],
             maxIterations: 3,
         );
 

--- a/tests/Integration/PhaseN/AgentRuntime/RequiresCapabilityGateTest.php
+++ b/tests/Integration/PhaseN/AgentRuntime/RequiresCapabilityGateTest.php
@@ -22,12 +22,17 @@ use Waaseyaa\AI\Agent\Entity\AgentRun;
 use Waaseyaa\AI\Agent\Enum\RunStatus;
 use Waaseyaa\AI\Agent\Message\RunAgent;
 use Waaseyaa\AI\Agent\Message\RunAgentHandler;
+use Waaseyaa\AI\Agent\Provider\MessageRequest;
+use Waaseyaa\AI\Agent\Provider\MessageResponse;
 use Waaseyaa\AI\Agent\Provider\NullLlmProvider;
+use Waaseyaa\AI\Agent\Provider\ProviderInterface;
 use Waaseyaa\AI\Agent\Repository\AgentAuditLogRepository;
 use Waaseyaa\AI\Agent\Repository\AgentRunRepository;
 use Waaseyaa\AI\Agent\Service\AgentRunDraft;
 use Waaseyaa\AI\Agent\Service\AgentRunService;
+use Waaseyaa\AI\Tools\AbstractAgentTool;
 use Waaseyaa\AI\Tools\AgentTool;
+use Waaseyaa\AI\Tools\AgentToolResult;
 use Waaseyaa\AI\Tools\ToolNotFoundException;
 use Waaseyaa\AI\Tools\ToolRegistryInterface;
 use Waaseyaa\Database\DBALDatabase;
@@ -218,31 +223,87 @@ final class RequiresCapabilityGateTest extends TestCase
         );
     }
 
-    private function buildService(): AgentRunService
+    #[Test]
+    public function definitionAllowlistAdvertisesAndExecutesOnlyItsNamedTool(): void
+    {
+        $allowedImpl = new R18CountingTool();
+        $blockedImpl = new R18CountingTool();
+        $provider = new R18ToolUseProvider('allowed_tool');
+        $service = $this->buildService([
+            $this->tool('allowed_tool', $allowedImpl),
+            $this->tool('blocked_tool', $blockedImpl),
+        ], $provider);
+
+        $run = $service->runInline(new AgentRunDraft(
+            accountId: self::ACCOUNT_HAS_PERMISSION,
+            agentDefinitionId: null,
+            bundle: ['id' => 'tool-agent', 'label' => 'Tool agent', 'description' => '', 'prompt' => 'go', 'tools' => ['allowed_tool']],
+            prompt: 'go',
+        ));
+
+        self::assertSame(RunStatus::Completed, $run->getStatus());
+        self::assertSame(['allowed_tool'], array_column($provider->advertisedTools, 'name'));
+        self::assertSame(1, $allowedImpl->calls);
+        self::assertSame(0, $blockedImpl->calls);
+    }
+
+    #[Test]
+    public function adversarialProviderCannotInvokeGloballyRegisteredOffListTool(): void
+    {
+        $allowedImpl = new R18CountingTool();
+        $blockedImpl = new R18CountingTool();
+        $provider = new R18ToolUseProvider('blocked_tool');
+        $service = $this->buildService([
+            $this->tool('allowed_tool', $allowedImpl),
+            $this->tool('blocked_tool', $blockedImpl),
+        ], $provider);
+
+        $run = $service->runInline(new AgentRunDraft(
+            accountId: self::ACCOUNT_HAS_PERMISSION,
+            agentDefinitionId: null,
+            bundle: ['id' => 'tool-agent', 'label' => 'Tool agent', 'description' => '', 'prompt' => 'go', 'tools' => ['allowed_tool']],
+            prompt: 'go',
+        ));
+
+        self::assertSame(RunStatus::Completed, $run->getStatus());
+        self::assertSame(['allowed_tool'], array_column($provider->advertisedTools, 'name'));
+        self::assertSame(0, $blockedImpl->calls);
+    }
+
+    /** @param list<AgentTool> $tools */
+    private function buildService(array $tools = [], ?ProviderInterface $provider = null): AgentRunService
     {
         $manifest = new PackageManifest(agentDefinitions: []);
         $registry = new AgentDefinitionRegistry($manifest);
-        $toolRegistry = new class implements ToolRegistryInterface {
+        $toolRegistry = new class ($tools) implements ToolRegistryInterface {
+            /** @var array<string, AgentTool> */
+            private array $tools = [];
+
+            public function __construct(array $tools)
+            {
+                foreach ($tools as $tool) {
+                    $this->tools[$tool->name] = $tool;
+                }
+            }
+
             public function register(AgentTool $tool): void
             {
-                unset($tool);
+                $this->tools[$tool->name] = $tool;
             }
 
             public function get(string $name): AgentTool
             {
-                throw new ToolNotFoundException(\sprintf('No tools registered (%s).', $name));
+                return $this->tools[$name] ?? throw new ToolNotFoundException(\sprintf('No tool registered (%s).', $name));
             }
 
             public function has(string $name): bool
             {
-                unset($name);
-
-                return false;
+                return isset($this->tools[$name]);
             }
 
             public function all(): iterable
             {
-                return [];
+                return array_values($this->tools);
             }
         };
 
@@ -259,8 +320,9 @@ final class RequiresCapabilityGateTest extends TestCase
             runRepository: $this->runRepository,
             executor: $executor,
             definitionRegistry: $registry,
+            toolRegistry: $toolRegistry,
             broadcaster: $this->broadcaster,
-            provider: new NullLlmProvider(),
+            provider: $provider ?? new NullLlmProvider(),
             accountLoader: new CapabilityTestAccountLoader(),
         );
 
@@ -274,6 +336,19 @@ final class RequiresCapabilityGateTest extends TestCase
             messageBus: $bus,
             runRepository: $this->runRepository,
             inlineHandler: $handler,
+        );
+    }
+
+    private function tool(string $name, R18CountingTool $impl): AgentTool
+    {
+        return new AgentTool(
+            name: $name,
+            capability: self::CAPABILITY,
+            destructive: false,
+            dryRunSupported: false,
+            category: 'test',
+            inputSchema: ['type' => 'object', 'properties' => []],
+            impl: $impl,
         );
     }
 
@@ -317,6 +392,58 @@ final class RequiresCapabilityGateTest extends TestCase
         );
 
         return new AgentAuditLogRepository($entityRepo, $this->database);
+    }
+}
+
+final class R18CountingTool extends AbstractAgentTool
+{
+    public int $calls = 0;
+
+    public function execute(array $arguments, AccountInterface $account): AgentToolResult
+    {
+        ++$this->calls;
+
+        return AgentToolResult::text('ok');
+    }
+
+    public function inputSchema(): array
+    {
+        return ['type' => 'object', 'properties' => []];
+    }
+
+    public function description(): string
+    {
+        return 'R18 test tool';
+    }
+}
+
+final class R18ToolUseProvider implements ProviderInterface
+{
+    /** @var list<array<string, mixed>> */
+    public array $advertisedTools = [];
+
+    private int $calls = 0;
+
+    public function __construct(private readonly string $requestedTool) {}
+
+    public function sendMessage(MessageRequest $request): MessageResponse
+    {
+        ++$this->calls;
+        if ($this->calls === 1) {
+            $this->advertisedTools = $request->tools;
+
+            return new MessageResponse(
+                content: [['type' => 'tool_use', 'id' => 'call-1', 'name' => $this->requestedTool, 'input' => []]],
+                stopReason: 'tool_use',
+                usage: ['input_tokens' => 1, 'output_tokens' => 1],
+            );
+        }
+
+        return new MessageResponse(
+            content: [['type' => 'text', 'text' => 'done']],
+            stopReason: 'end_turn',
+            usage: ['input_tokens' => 1, 'output_tokens' => 1],
+        );
     }
 }
 


### PR DESCRIPTION
Closes part of #1975.

Wires AgentDefinition tools into production execution while enforcing the same per-agent allowlist before every registry lookup or invocation. M2 and M3 are intentionally inseparable.

Adversarial coverage proves a provider cannot invoke a globally registered tool omitted from its agent definition.

Changelog: Security.