### PR TITLE
fix(#1982): hydrate derived bundle fields after fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fresh HTTP processes now hydrate import-derived bundle fields (#1982, G-034).** The migration provider replays derived field declarations only for bundle config entities already persisted by a completed import, restoring the process-local field registry before repository reads without moving full content-model registration back into first-install boot. Clean installs still register at import time, and repeated boots leave existing schema and rows unchanged.
+
 - **Agent cancellation and approval now use exact-status compare-and-swap updates (#1975, R18 M5).** Controller actions no longer save a stale hydrated run row that can regress a worker's terminal status or overwrite transcript and cost fields. Cancellation requires the status observed by the request; approve/deny additionally require the pending call id, and a lost race returns 409 without audit or broadcast side effects.
 
 ### Security

--- a/docs/specs/migration-platform.md
+++ b/docs/specs/migration-platform.md
@@ -1,5 +1,6 @@
 <!-- Spec reviewed 2026-05-13 - migration-platform-v1 mission landed -->
 <!-- Spec reviewed 2026-07-02 - R3 WP1 HtmlSanitizeProcessor nested-case + CDATA-content-model B-4 fix (§3.5, §16) -->
+<!-- Spec reviewed 2026-07-13 - #1982 restores import-derived field definitions on later process boots; full registration remains import-time only (§9.5). -->
 
 # Migration Platform
 
@@ -609,9 +610,10 @@ successfully and only fails when an operator runs `import:status` or
 
 `Waaseyaa\Migration\ContentModel\ContentModelRegistrar` is the **one
 supported path** for an application to declare per-bundle content types and
-fields derived from a migration source, at import time. It is bound as a
-singleton by `Waaseyaa\Migration\ServiceProvider` and invoked from
-`MigrationRunner`, never from a service provider's `boot()`.
+fields derived from a migration source. It is bound as a singleton by
+`Waaseyaa\Migration\ServiceProvider`. Full registration is invoked from
+`MigrationRunner` at import time; later process boots replay only field
+declarations for bundle config entities that a completed import persisted.
 
 **Contract:**
 
@@ -639,10 +641,20 @@ exactly like `HasMigrationsInterface` in §9 step 2:
 `ServiceProvider::withContentModelProviders()`
 (`Waaseyaa\Foundation\ServiceProvider\Capability\AcceptsContentModelProvidersInterface`).
 That step only collects object references — it never calls
-`deriveContentModel()`. Invocation happens later, in
+`deriveContentModel()`. Full registration happens later, in
 `MigrationRunner::ensureContentModelsRegistered()`, guarded to run exactly
 once per `MigrationRunner` instance (a container singleton, i.e. once per CLI
 process), immediately before the first migration of the invocation executes.
+
+**Read-process rehydration (#1982).** The field registry populated above is
+process-local. `Migration\ServiceProvider::boot()` therefore asks the collected
+providers for the same model and calls `ContentModelRegistrar::rehydrate()`.
+Rehydration declares fields only when the destination's bundle config entity
+already exists; it does not create config entities. A clean first-install boot
+before import is consequently still a no-op, while a later HTTP or worker
+process restores the definitions needed by `BundleSubtableGateway` to hydrate
+persisted columns. Replaying declarations is idempotent for upgraded installs
+and does not rewrite their entity rows.
 
 This split matters because of a real production failure. The Sheguiandah
 pass-1 build (`sheg-waaseyaa-pass1`, read-only reference) constructed
@@ -664,8 +676,8 @@ schema they import into exists.
 `ContentModelRegistrar` used to swallow every failure behind a
 `notice`/`error` log line and continue, because it was (on paper) invocable
 during kernel boot, where a hard failure would have crashed boot for reasons
-unrelated to the content model itself. Now that the only invocation point is
-import-time (§9.5 above), `register()` raises
+unrelated to the content model itself. Full `register()` remains an import-time
+operation (§9.5 above), and raises
 `Waaseyaa\Migration\Exception\ContentModelRegistrationException` on any
 structural failure — destination entity type not registered, bundle config
 entity cannot be built/saved, no field registry configured, or

--- a/packages/foundation/src/Kernel/AbstractKernel.php
+++ b/packages/foundation/src/Kernel/AbstractKernel.php
@@ -438,11 +438,11 @@ abstract class AbstractKernel
      * Foundation carries no compile-time edge to the Layer-3 migration
      * package, same collect-at-boot timing. The critical difference from the
      * pass-1 failure this fixes: this method only COLLECTS provider object
-     * references here; nothing here calls `deriveContentModel()`. Invocation
-     * happens later, in `Waaseyaa\Migration\Runner\MigrationRunner`, at the
-     * first `import:*` command that actually runs a migration — by which
-     * point the destination tables this collected provider's derived model
-     * describes are guaranteed to exist.
+     * references here; nothing here calls `deriveContentModel()`. Full
+     * registration happens later in `Waaseyaa\Migration\Runner\MigrationRunner`.
+     * The receiving provider may also replay field declarations during its
+     * boot, but only for bundle config entities already persisted by an import
+     * (#1982), so the first-install sequencing guarantee remains intact.
      */
     protected function injectContentModelProviders(): void
     {

--- a/packages/foundation/src/ServiceProvider/Capability/AcceptsContentModelProvidersInterface.php
+++ b/packages/foundation/src/ServiceProvider/Capability/AcceptsContentModelProvidersInterface.php
@@ -19,14 +19,12 @@ namespace Waaseyaa\Foundation\ServiceProvider\Capability;
  * abstract `Waaseyaa\Foundation\ServiceProvider\ServiceProvider` carries no
  * unused no-op default.
  *
- * Collection happens at boot (cheap — object references only); invocation of
- * `deriveContentModel()` and registration through the registrar happens at
- * import time (see `Waaseyaa\Migration\Runner\MigrationRunner`), not here.
- * This split is what fixes the pass-1 first-boot failure (G-026, #1940): a
- * provider constructed and invoked during `AbstractKernel::boot()`'s
- * schema-sync phase can find its destination tables not yet materialized;
- * a provider merely *collected* at boot and *invoked* at the first import
- * command never hits that window.
+ * Collection happens before provider boot. Full registration still happens at
+ * import time (see `Waaseyaa\Migration\Runner\MigrationRunner`). On later
+ * boots the migration provider may derive the same model to restore
+ * process-local field definitions, guarded by the bundle config entity that
+ * the completed import persisted (#1982). The guard preserves G-026's rule:
+ * first-install boot never creates an import-derived content type.
  *
  * The interface lives in Foundation (Layer 0) so the kernel can guard the
  * call site without a compile-time edge to the Layer-3 migration package,

--- a/packages/migration/src/ContentModel/ContentModelRegistrar.php
+++ b/packages/migration/src/ContentModel/ContentModelRegistrar.php
@@ -35,9 +35,11 @@ use Waaseyaa\Migration\Exception\ContentModelRegistrationException;
  * {@see \Waaseyaa\Migration\ServiceProvider} and invoked from
  * {@see \Waaseyaa\Migration\Runner\MigrationRunner} once per CLI invocation,
  * before the first migration runs — see that class's
- * `ensureContentModelsRegistered()`. This is deliberately NOT a boot-time
- * invocation: constructing and calling this class during
- * `AbstractKernel::boot()`'s schema-sync phase is the exact sequencing bug
+ * `ensureContentModelsRegistered()`. Later processes call
+ * {@see rehydrate()} during provider boot, but that path only restores fields
+ * for a bundle config entity already persisted by an import. It never creates
+ * a bundle config on first boot. Constructing and calling {@see register()}
+ * during `AbstractKernel::boot()`'s schema-sync phase is the sequencing bug
  * that left the pass-1 Sheguiandah build's `SfnWordPressMigrationProvider`
  * silently registering nothing on the first boot after `db:init` — the
  * destination tables did not exist yet. Invoking it at import time (after
@@ -68,8 +70,8 @@ use Waaseyaa\Migration\Exception\ContentModelRegistrationException;
  * is read. This replaced the earlier notice/error-log-and-continue
  * behaviour, which existed only because this class was (on paper) invocable
  * during kernel boot, where a hard failure would have crashed boot for
- * reasons unrelated to the content model. Now that the only invocation point
- * is import-time (post-boot), a loud failure is strictly better than
+ * reasons unrelated to the content model. Full registration now runs only at
+ * import time (post-boot), so a loud failure there is strictly better than
  * degrading to "some content silently landed in the `_data` blob instead of
  * a typed column."
  *
@@ -112,6 +114,49 @@ final readonly class ContentModelRegistrar
         foreach ($model->types as $type) {
             $this->ensureBundleConfigEntity($type);
             $this->declareFields($type);
+        }
+    }
+
+    /**
+     * Restore runtime field definitions for content types already persisted by
+     * a prior import.
+     *
+     * The field registry is process-local, while bundle config entities and
+     * their subtables survive process boundaries. The persisted bundle config
+     * is the guard: a first-install boot before import remains a no-op.
+     */
+    public function rehydrate(ContentModel $model): void
+    {
+        if ($model->isEmpty()) {
+            return;
+        }
+
+        foreach ($model->types as $type) {
+            if (!$this->bundleConfigExists($type)) {
+                continue;
+            }
+
+            $this->declareFields($type);
+        }
+    }
+
+    private function bundleConfigExists(ContentTypeModel $type): bool
+    {
+        try {
+            $entityType = $this->entityTypeManager->getDefinition($type->entityTypeId);
+            $bundleTypeId = $entityType->getBundleEntityType();
+            if ($bundleTypeId === null || $bundleTypeId === '') {
+                return false;
+            }
+
+            return $this->entityTypeManager->getRepository($bundleTypeId)->find($type->bundle) !== null;
+        } catch (\Throwable $e) {
+            throw new ContentModelRegistrationException(\sprintf(
+                '[content-model] could not rehydrate content type "%s" on %s: %s',
+                $type->bundle,
+                $type->entityTypeId,
+                $e->getMessage(),
+            ), previous: $e);
         }
     }
 

--- a/packages/migration/src/ContentModel/DerivesContentModelInterface.php
+++ b/packages/migration/src/ContentModel/DerivesContentModelInterface.php
@@ -21,9 +21,11 @@ namespace Waaseyaa\Migration\ContentModel;
  * `Waaseyaa\Migration\ServiceProvider` accepts the collected providers via
  * {@see \Waaseyaa\Foundation\ServiceProvider\Capability\AcceptsContentModelProvidersInterface}
  * and threads them into {@see \Waaseyaa\Migration\Runner\MigrationRunner},
- * which is where `deriveContentModel()` is actually called — once, before the
- * first migration of the CLI invocation, well after full kernel boot. See
- * docs/specs/migration-platform.md "Content model registration".
+ * where full registration runs once before the first migration of the CLI
+ * invocation. The migration provider also calls this method during later
+ * boots to restore process-local definitions for bundle configs already
+ * persisted by an import (#1982). See docs/specs/migration-platform.md
+ * "Content model registration".
  *
  * @api
  */

--- a/packages/migration/src/ServiceProvider.php
+++ b/packages/migration/src/ServiceProvider.php
@@ -64,10 +64,9 @@ final class ServiceProvider extends BaseServiceProvider implements AcceptsMigrat
     /**
      * @var list<DerivesContentModelInterface> Providers injected by the
      *      kernel's {@see \Waaseyaa\Foundation\Kernel\AbstractKernel::injectContentModelProviders()}
-     *      (G-026, #1940), or directly by tests. Only collected here — never
-     *      invoked here. See {@see ContentModelRegistrar} and
-     *      {@see \Waaseyaa\Migration\Runner\MigrationRunner} for the
-     *      import-time invocation point.
+     *      (G-026, #1940), or directly by tests. Import registration remains
+     *      owned by MigrationRunner; {@see boot()} only rehydrates definitions
+     *      for content types already persisted by an earlier import (#1982).
      */
     private array $contentModelProviders = [];
 
@@ -147,10 +146,9 @@ final class ServiceProvider extends BaseServiceProvider implements AcceptsMigrat
         // supported path for declaring import-derived per-bundle content
         // models (see that class's docblock for the full contract). Lazy
         // like EntityDestinationFactory above: EntityTypeManager is safe to
-        // resolve early, but the registrar itself is only ever INVOKED from
-        // MigrationRunner at the first import command — well after full
-        // kernel boot — so there is no boot-ordering hazard to guard against
-        // here the way there is for EntityDestinationFactory's GateInterface.
+        // resolve early. Full registration is invoked by MigrationRunner at
+        // the first import command; boot() uses only the persisted-config-
+        // guarded rehydration path (#1982).
         $this->singleton(ContentModelRegistrar::class, function () {
             $entityTypeManager = $this->resolve(EntityTypeManager::class);
             \assert($entityTypeManager instanceof EntityTypeManager);
@@ -229,6 +227,20 @@ final class ServiceProvider extends BaseServiceProvider implements AcceptsMigrat
         // fail fast at framework boot; they now surface at the first CLI
         // invocation that touches the registry instead. See
         // docs/specs/migration-platform.md §9 and CHANGELOG.md (G-024).
+
+        if ($this->contentModelProviders === []) {
+            return;
+        }
+
+        $registrar = $this->resolve(ContentModelRegistrar::class);
+        \assert($registrar instanceof ContentModelRegistrar);
+
+        foreach ($this->contentModelProviders as $provider) {
+            $model = $provider->deriveContentModel();
+            if ($model !== null) {
+                $registrar->rehydrate($model);
+            }
+        }
     }
 
     /**
@@ -256,11 +268,10 @@ final class ServiceProvider extends BaseServiceProvider implements AcceptsMigrat
      *
      * Implements {@see AcceptsContentModelProvidersInterface}: the kernel
      * discovers providers that expose an import-derived content model and
-     * hands them here (G-026, #1940). Same shape as
-     * {@see withMigrationProviders()} — collection only, no invocation. The
-     * providers are threaded into the {@see MigrationRunner} binding above
-     * and invoked from there, at the first import command, not from this
-     * provider's `boot()`.
+     * hands them here (G-026, #1940). The providers are threaded into the
+     * {@see MigrationRunner} for import-time registration and are also queried
+     * by {@see boot()} to restore process-local field definitions for already
+     * persisted content types (#1982).
      *
      * @param list<object> $providers
      */

--- a/packages/migration/tests/Fixtures/FreshInstallContentModelProvider.php
+++ b/packages/migration/tests/Fixtures/FreshInstallContentModelProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Fixtures;
+
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Migration\ContentModel\ContentModel;
+use Waaseyaa\Migration\ContentModel\ContentTypeModel;
+use Waaseyaa\Migration\ContentModel\DerivesContentModelInterface;
+
+/** @internal Fresh-install subprocess fixture for issue #1982. */
+final class FreshInstallContentModelProvider extends ServiceProvider implements DerivesContentModelInterface
+{
+    public const string ENTITY_TYPE = 'fresh_install_page';
+    public const string BUNDLE_TYPE = 'fresh_install_page_type';
+    public const string BUNDLE = 'page';
+
+    public function register(): void
+    {
+        $this->entityType(new EntityType(
+            id: self::ENTITY_TYPE,
+            label: 'Fresh-install page',
+            class: FreshInstallPage::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'page_type'],
+            bundleEntityType: self::BUNDLE_TYPE,
+        ));
+        $this->entityType(new EntityType(
+            id: self::BUNDLE_TYPE,
+            label: 'Fresh-install page type',
+            class: FreshInstallPageType::class,
+            keys: ['id' => 'id', 'label' => 'label'],
+        ));
+    }
+
+    public function deriveContentModel(): ContentModel
+    {
+        return new ContentModel(types: [
+            new ContentTypeModel(
+                entityTypeId: self::ENTITY_TYPE,
+                bundle: self::BUNDLE,
+                label: 'Page',
+                fields: [
+                    new FieldDefinition(
+                        name: 'body',
+                        type: 'text_long',
+                        targetEntityTypeId: self::ENTITY_TYPE,
+                        targetBundle: self::BUNDLE,
+                    ),
+                ],
+            ),
+        ]);
+    }
+}

--- a/packages/migration/tests/Fixtures/FreshInstallPage.php
+++ b/packages/migration/tests/Fixtures/FreshInstallPage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Fixtures;
+
+use Waaseyaa\Entity\Attribute\ContentEntityKeys;
+use Waaseyaa\Entity\Attribute\ContentEntityType;
+use Waaseyaa\Entity\ContentEntityBase;
+
+/** @internal */
+#[ContentEntityType(id: 'fresh_install_page')]
+#[ContentEntityKeys(id: 'id', uuid: 'uuid', label: 'title', bundle: 'page_type')]
+final class FreshInstallPage extends ContentEntityBase
+{
+}

--- a/packages/migration/tests/Fixtures/FreshInstallPageType.php
+++ b/packages/migration/tests/Fixtures/FreshInstallPageType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Fixtures;
+
+use Waaseyaa\Entity\Attribute\ContentEntityKeys;
+use Waaseyaa\Entity\Attribute\ContentEntityType;
+use Waaseyaa\Entity\ContentEntityBase;
+
+/** @internal */
+#[ContentEntityType(id: 'fresh_install_page_type')]
+#[ContentEntityKeys(id: 'id', label: 'label')]
+final class FreshInstallPageType extends ContentEntityBase
+{
+}

--- a/packages/migration/tests/Fixtures/fresh_install_content_model_runner.php
+++ b/packages/migration/tests/Fixtures/fresh_install_content_model_runner.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Kernel\ConsoleKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+use Waaseyaa\Migration\ContentModel\ContentModelRegistrar;
+use Waaseyaa\Migration\ServiceProvider as MigrationServiceProvider;
+use Waaseyaa\Migration\Tests\Fixtures\FreshInstallContentModelProvider;
+use Waaseyaa\Migration\Tests\Fixtures\FreshInstallPage;
+
+$projectRoot = $argv[1] ?? throw new RuntimeException('Missing project root.');
+$phase = $argv[2] ?? throw new RuntimeException('Missing phase.');
+
+require $projectRoot . '/vendor/autoload.php';
+
+if ($phase === 'db-init') {
+    $_SERVER['argv'] = [$argv[0], 'db:init'];
+    $GLOBALS['argv'] = $_SERVER['argv'];
+    exit((new ConsoleKernel($projectRoot))->handle());
+}
+
+if ($phase === 'import') {
+    $kernel = new ConsoleKernel($projectRoot);
+    $kernel->bootForCli();
+
+    $migrationProvider = null;
+    $modelProvider = null;
+    foreach ($kernel->getProviders() as $provider) {
+        $migrationProvider ??= $provider instanceof MigrationServiceProvider ? $provider : null;
+        $modelProvider ??= $provider instanceof FreshInstallContentModelProvider ? $provider : null;
+    }
+    if (!$migrationProvider instanceof MigrationServiceProvider || !$modelProvider instanceof FreshInstallContentModelProvider) {
+        throw new RuntimeException('Fresh-install providers were not discovered.');
+    }
+
+    $registrar = $migrationProvider->resolve(ContentModelRegistrar::class);
+    assert($registrar instanceof ContentModelRegistrar);
+    $registrar->register($modelProvider->deriveContentModel());
+
+    $entity = new FreshInstallPage([
+        'title' => 'Imported home',
+        'page_type' => FreshInstallContentModelProvider::BUNDLE,
+        'body' => '<p>Persisted bundle-field content.</p>',
+    ]);
+    $entity->enforceIsNew();
+    $kernel->getEntityTypeManager()->getRepository(FreshInstallContentModelProvider::ENTITY_TYPE)->save($entity);
+
+    echo (string) $entity->id();
+    exit(0);
+}
+
+if ($phase === 'http-read') {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['REQUEST_URI'] = '/';
+    $_SERVER['HTTP_HOST'] = 'localhost';
+
+    $kernel = new HttpKernel($projectRoot);
+    $kernel->handle(); // Real HTTP-kernel boot; the route result is immaterial to this storage read.
+    $entities = $kernel->getEntityTypeManager()
+        ->getRepository(FreshInstallContentModelProvider::ENTITY_TYPE)
+        ->findBy(['title' => 'Imported home']);
+
+    echo (string) ($entities[0]?->get('body') ?? '');
+    exit(0);
+}
+
+throw new RuntimeException('Unknown phase: ' . $phase);

--- a/packages/migration/tests/Integration/FreshInstallContentModelHydrationTest.php
+++ b/packages/migration/tests/Integration/FreshInstallContentModelHydrationTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Integration;
+
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use Waaseyaa\Migration\Tests\Fixtures\FreshInstallContentModelProvider;
+
+/** Fresh-install, cross-process regression for #1982. */
+#[CoversNothing]
+final class FreshInstallContentModelHydrationTest extends TestCase
+{
+    private string $projectRoot;
+    private string $repoRoot;
+    private string $vendorRoot;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = (string) realpath(__DIR__ . '/../../../..');
+        $processClass = (new \ReflectionClass(Process::class))->getFileName();
+        self::assertIsString($processClass);
+        $this->vendorRoot = dirname($processClass, 3);
+        $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_1982_' . bin2hex(random_bytes(6));
+        mkdir($this->projectRoot . '/config', 0755, true);
+        mkdir($this->projectRoot . '/storage', 0755, true);
+        mkdir($this->projectRoot . '/vendor/composer', 0755, true);
+
+        symlink($this->repoRoot . '/packages', $this->projectRoot . '/packages');
+        $this->writeAutoloadWrapper();
+
+        file_put_contents($this->projectRoot . '/composer.json', json_encode([
+            'name' => 'waaseyaa/fresh-install-1982-test',
+            'extra' => ['waaseyaa' => ['providers' => [FreshInstallContentModelProvider::class]]],
+        ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+        file_put_contents($this->projectRoot . '/config/entity-types.php', "<?php\nreturn [];\n");
+        file_put_contents($this->projectRoot . '/config/waaseyaa.php', sprintf(
+            "<?php\nreturn ['environment' => 'local', 'database' => %s, 'entity_schema_validation' => 'off'];\n",
+            var_export($this->projectRoot . '/storage/fresh.sqlite', true),
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectRoot)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectRoot, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isLink() || $item->isFile() ? unlink($item->getPathname()) : rmdir($item->getPathname());
+        }
+        rmdir($this->projectRoot);
+    }
+
+    #[Test]
+    public function fresh_install_import_is_hydrated_in_a_later_http_process(): void
+    {
+        $this->runPhase('db-init');
+        $entityId = trim($this->runPhase('import'));
+        self::assertNotSame('', $entityId);
+
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->projectRoot . '/storage/fresh.sqlite']);
+        self::assertSame(
+            '<p>Persisted bundle-field content.</p>',
+            $connection->fetchOne('SELECT body FROM fresh_install_page__page WHERE id = ?', [$entityId]),
+            'Precondition: the fresh import stored the field in the bundle subtable.',
+        );
+
+        self::assertSame(
+            '<p>Persisted bundle-field content.</p>',
+            trim($this->runPhase('http-read')),
+            'A fresh HTTP process must restore derived field definitions before repository hydration.',
+        );
+    }
+
+    #[Test]
+    public function boot_rehydration_is_idempotent_for_an_existing_install(): void
+    {
+        $this->runPhase('db-init');
+        $entityId = trim($this->runPhase('import'));
+        $before = $this->schemaAndRowSnapshot($entityId);
+
+        self::assertSame('<p>Persisted bundle-field content.</p>', trim($this->runPhase('http-read')));
+        self::assertSame($before, $this->schemaAndRowSnapshot($entityId));
+    }
+
+    private function runPhase(string $phase): string
+    {
+        $process = new Process([
+            PHP_BINARY,
+            __DIR__ . '/../Fixtures/fresh_install_content_model_runner.php',
+            $this->projectRoot,
+            $phase,
+        ], $this->projectRoot);
+        $process->setTimeout(60);
+        $process->mustRun();
+
+        return $process->getOutput();
+    }
+
+    /** @return array{columns: list<string>, row: array<string, mixed>} */
+    private function schemaAndRowSnapshot(string $entityId): array
+    {
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->projectRoot . '/storage/fresh.sqlite']);
+        $columns = array_column($connection->fetchAllAssociative('PRAGMA table_info(fresh_install_page__page)'), 'name');
+        $row = $connection->fetchAssociative('SELECT * FROM fresh_install_page__page WHERE id = ?', [$entityId]);
+        self::assertIsArray($row);
+
+        return ['columns' => $columns, 'row' => $row];
+    }
+
+    private function writeAutoloadWrapper(): void
+    {
+        foreach (['installed.json', 'installed.php'] as $file) {
+            copy($this->vendorRoot . '/composer/' . $file, $this->projectRoot . '/vendor/composer/' . $file);
+        }
+
+        $autoload = <<<'PHP'
+<?php
+require_once __VENDOR_AUTOLOAD__;
+
+$map = __REPO_MAP__;
+spl_autoload_register(static function (string $class) use ($map): void {
+    foreach ($map as $prefix => $baseDir) {
+        if (!str_starts_with($class, $prefix)) {
+            continue;
+        }
+        $candidate = $baseDir . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+        if (is_file($candidate)) {
+            require_once $candidate;
+        }
+        return;
+    }
+}, true, true);
+PHP;
+        $map = ['Waaseyaa\\Migration\\Tests\\' => $this->repoRoot . '/packages/migration/tests/'];
+        foreach (glob($this->repoRoot . '/packages/*/composer.json') as $composerFile) {
+            $data = json_decode((string) file_get_contents($composerFile), true, flags: JSON_THROW_ON_ERROR);
+            foreach (($data['autoload']['psr-4'] ?? []) as $prefix => $path) {
+                $map[$prefix] = dirname($composerFile) . '/' . rtrim((string) $path, '/');
+            }
+        }
+        uksort($map, static fn(string $a, string $b): int => strlen($b) <=> strlen($a));
+        file_put_contents(
+            $this->projectRoot . '/vendor/autoload.php',
+            str_replace(
+                ['__REPO_MAP__', '__VENDOR_AUTOLOAD__'],
+                [var_export($map, true), var_export($this->vendorRoot . '/autoload.php', true)],
+                $autoload,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Closes #1982

Part of #1985

## Summary

- rehydrate import-derived bundle field definitions during later process boots, guarded by the persisted bundle config entity
- keep full content-model registration in `MigrationRunner`, so a clean first-install boot before import remains a no-op
- add a clean consumer-database regression that runs the real `db:init`, writes through a separate import process, verifies the bundle-subtable value with raw SQL, and reads through a separate `HttpKernel` process
- snapshot an established install before/after rehydration to prove its subtable schema and stored row are unchanged

## TDD red proof

Before the fix, the fresh-install test failed in both cases after proving raw storage contained the value:

```text
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<p>Persisted bundle-field content.</p>'
+''

Tests: 2, Assertions: 5, Failures: 2
```

The test sequence is a new empty SQLite file → real `db:init` → separate import/write process → raw-SQL storage precondition → separate `HttpKernel` read process.

## Root cause

Import-time registration populated the process-local field registry only in the importing CLI process, so a later HTTP boot did not know to read the already-populated bundle subtable.

The default-revision read path is not involved: the raw bundle-subtable row is present before the failing HTTP read.

## Upgraded-install evidence

`boot_rehydration_is_idempotent_for_an_existing_install` snapshots the established subtable's columns and complete entity row, boots and reads through a new HTTP process, and asserts the snapshot is identical afterward. Existing/upgraded installs are unaffected beyond recovering the missing field declarations.

## Verification

- fresh-install regression: `OK (2 tests, 9 assertions)`
- migration Unit focus: `OK (201 tests, 573 assertions)`
- migration Integration suite: `OK (58 tests, 305 assertions)`
- split Unit suite with 1G limit: `OK (9756 tests, 223877 assertions)`
- `bin/check-package-layers`: passed (existing accepted cycle warnings only)
- `bin/check-composer-policy`: passed
- `tools/drift-detector.sh`: all affected specs acknowledged/up to date
- PHP syntax checks and `git diff --check`: passed

spec-reviewed: migration-platform.md — documents persisted-config-guarded read-process rehydration while preserving import-time registration
spec-reviewed: infrastructure.md — kernel boot ordering is unchanged; the receiving migration provider guards rehydration on persisted bundle config
spec-reviewed: package-discovery.md — provider discovery is unchanged; the existing capability handoff now supports guarded rehydration

## Checklist

- [x] **Traceability:** `Closes #1982` and `Part of #1985` reference the delivered issue and anchor
- [x] PR title includes `#1982`
