### PR TITLE
feat(#1981): compose split migration partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Fixed-bundle migrations now compose split source and id-map partitions without site adapter classes (#1981, G-032).** The migration package adds the format-neutral `FilteredSource` decorator, `PartitionedLookupProcessor` for mixed reference lists, and ordered `MigrationIdMap::lookupDestinationAcross()` for non-process consumers such as media URL resolvers. A fresh-install boundary test applies the real package migrations and runs category/tag plus image/document definitions through `MigrationRunner`, `EntityDestination`, the real access gate, and least-privilege per-bundle system accounts.
+
 ### Fixed
 
 - **Fresh HTTP processes now hydrate import-derived bundle fields (#1982, G-034).** The migration provider replays derived field declarations only for bundle config entities already persisted by a completed import, restoring the process-local field registry before repository reads without moving full content-model registration back into first-install boot. Clean installs still register at import time, and repeated boots leave existing schema and rows unchanged.

--- a/docs/extension-authoring/migration-process-plugins.md
+++ b/docs/extension-authoring/migration-process-plugins.md
@@ -19,9 +19,10 @@ value into one destination value during a migration run. Each entry in a
 `MigrationDefinition::$process` map names a destination field; the value names
 the plugin (or chain of plugins) that produces the destination value.
 
-The framework ships six built-in process plugins
+The framework ships seven built-in process plugins
 (`PassThroughProcessor`, `HtmlSanitizeProcessor`, `LookupProcessor`,
-`ConcatProcessor`, `TypeCoerceProcessor`, `DefaultValueProcessor`). Custom
+`ConcatProcessor`, `TypeCoerceProcessor`, `DefaultValueProcessor`,
+`PartitionedLookupProcessor`). Custom
 process plugins extend this set — examples: `WordPressShortcodeStrip`,
 `MarkdownToHtml`, `SlugifyTitle`, `ResolveAuthorByEmail`.
 
@@ -45,7 +46,7 @@ interface ProcessPluginInterface
 `id()` returns a stable identifier for the plugin. Format:
 `/^[a-z][a-z0-9_]*$/`.
 
-The framework **reserves** six ids — see
+The framework **reserves** seven ids — see
 `Waaseyaa\Migration\Plugin\ReservedPluginIds`:
 
 | Reserved id | Concrete class |
@@ -56,6 +57,7 @@ The framework **reserves** six ids — see
 | `concat` | `ConcatProcessor` |
 | `type_coerce` | `TypeCoerceProcessor` |
 | `default_value` | `DefaultValueProcessor` |
+| `partitioned_lookup` | `PartitionedLookupProcessor` |
 
 App-defined process plugins MUST use a non-reserved id. Recommended naming
 convention: `<vendor>_<purpose>` (e.g. `wordpress_shortcode_strip`,

--- a/docs/specs/migration-platform.md
+++ b/docs/specs/migration-platform.md
@@ -1,6 +1,7 @@
 <!-- Spec reviewed 2026-05-13 - migration-platform-v1 mission landed -->
 <!-- Spec reviewed 2026-07-02 - R3 WP1 HtmlSanitizeProcessor nested-case + CDATA-content-model B-4 fix (§3.5, §16) -->
 <!-- Spec reviewed 2026-07-13 - #1982 restores import-derived field definitions on later process boots; full registration remains import-time only (§9.5). -->
+<!-- Spec reviewed 2026-07-13 - #1981 fixed-bundle source and split id-map composition (§3.1, §3.5, §6.1, §16) -->
 
 # Migration Platform
 
@@ -28,7 +29,8 @@ APIs) into the framework's entity storage layer. It ships:
    (ADR 011) and revisions (ADR 016).
 4. **A small library of essential process plugins** (`PassThroughProcessor`,
    `HtmlSanitizeProcessor`, `LookupProcessor`, `ConcatProcessor`,
-   `TypeCoerceProcessor`, `DefaultValueProcessor`).
+   `TypeCoerceProcessor`, `DefaultValueProcessor`,
+   `PartitionedLookupProcessor`).
 5. **A CLI runner** with six commands: `import:run`, `import:run-all`,
    `import:status`, `import:resume`, `import:rollback`, `import:reset`.
 6. **An idempotency primitive** — the `migration_id_map` table, keyed by a
@@ -85,6 +87,12 @@ charter's deprecation cycle. FQCN root: `Waaseyaa\Migration\`.
 | `Waaseyaa\Migration\Plugin\ProcessPluginInterface` | Interface | Transforms a single source value into a destination value. |
 | `Waaseyaa\Migration\Plugin\DestinationPluginInterface` | Interface | Writes a `DestinationRecord` to its target system and supports rollback + lookup. |
 
+`Waaseyaa\Migration\Plugin\Source\FilteredSource` is the stable source
+decorator for fixed-bundle definitions backed by a mixed external stream. It
+filters lazily, delegates `SourceId` construction and stability to the wrapped
+source, exposes an application-selected plugin id, and reports an unknown
+count because evaluating the predicate is the only honest way to count.
+
 ### 3.2 Provider capabilities
 
 | FQCN | Kind | Purpose |
@@ -112,7 +120,7 @@ charter's deprecation cycle. FQCN root: `Waaseyaa\Migration\`.
 
 ### 3.5 Process plugin concretes
 
-The framework reserves six process-plugin ids. App-defined process plugins MUST
+The framework reserves seven process-plugin ids. App-defined process plugins MUST
 use a non-reserved id; convention is `<vendor>_<purpose>` (e.g.
 `wordpress_shortcode_strip`).
 
@@ -124,6 +132,7 @@ use a non-reserved id; convention is `<vendor>_<purpose>` (e.g.
 | `Waaseyaa\Migration\Plugin\Process\ConcatProcessor` | `concat` |
 | `Waaseyaa\Migration\Plugin\Process\TypeCoerceProcessor` | `type_coerce` |
 | `Waaseyaa\Migration\Plugin\Process\DefaultValueProcessor` | `default_value` |
+| `Waaseyaa\Migration\Plugin\Process\PartitionedLookupProcessor` | `partitioned_lookup` |
 
 Reserved ids are owned by the framework. The complete list lives in
 `Waaseyaa\Migration\Plugin\ReservedPluginIds`.
@@ -165,6 +174,12 @@ of the same B-4 class:
 The `migration_id_map` table layout is **frozen stable surface**. Future
 column changes require a charter amendment and a data migration of every
 existing row.
+
+`MigrationIdMap::lookupDestinationAcross(list<string> $migrationIds,
+SourceId $sourceId)` is the stable ordered lookup for consumers outside a
+process chain. It returns the first matching `WriteResult`, or `null`. This is
+the composition seam for one logical source split into bundle-specific id-map
+partitions, such as image/document media migrations.
 
 ### 3.7 Exception types
 
@@ -809,6 +824,13 @@ lives at `docs/cookbook/migration-first-cut.md`.
 
 ## 16. History
 
+- 2026-07-13 — #1981 closes the fixed-bundle composition gap exposed by the
+  Sheguiandah pass-2 rehearsal. `FilteredSource` replaces app-defined source
+  wrappers, `PartitionedLookupProcessor` resolves mixed reference lists across
+  bundle-specific migrations, and `MigrationIdMap::lookupDestinationAcross()`
+  gives non-process consumers an ordered view of split id maps. Fresh-install
+  coverage pins real migrations, runner writes, fixed bundles, and
+  least-privilege create grants.
 - 2026-07-02 — Audit-remediation batch, R3 WP1 (M1). Closed two sibling
   stored-XSS bypasses in `HtmlSanitizeProcessor`'s DOMDocument fallback path,
   both reopening B-4: (1) a **nested-wrapper** bypass —

--- a/docs/specs/stability-charter.md
+++ b/docs/specs/stability-charter.md
@@ -561,6 +561,9 @@ Per [ADR 012a](../adr/012a-migration-substrate-in-core.md). Delivered by mission
 - `Waaseyaa\Migration\Plugin\Destination\EntityDestination` — default destination; writes through the entity-storage coordinator (ADR 010).
 - `Waaseyaa\Migration\Plugin\Destination\EntityDestinationFactory` — factory binding entity type + bundle.
 
+*Source composition:*
+- `Waaseyaa\Migration\Plugin\Source\FilteredSource` — lazy fixed-bundle source decorator that preserves wrapped-source identity semantics.
+
 *Reserved process plugins (framework-owned ids):*
 - `Waaseyaa\Migration\Plugin\Process\PassThroughProcessor` (`pass_through`).
 - `Waaseyaa\Migration\Plugin\Process\HtmlSanitizeProcessor` (`html_sanitize`).
@@ -568,11 +571,13 @@ Per [ADR 012a](../adr/012a-migration-substrate-in-core.md). Delivered by mission
 - `Waaseyaa\Migration\Plugin\Process\ConcatProcessor` (`concat`).
 - `Waaseyaa\Migration\Plugin\Process\TypeCoerceProcessor` (`type_coerce`).
 - `Waaseyaa\Migration\Plugin\Process\DefaultValueProcessor` (`default_value`).
+- `Waaseyaa\Migration\Plugin\Process\PartitionedLookupProcessor` (`partitioned_lookup`).
 
 Reserved-id list canonicalised in `Waaseyaa\Migration\Plugin\ReservedPluginIds`. App-defined process plugins MUST use a non-reserved id; convention `<vendor>_<purpose>`.
 
 *Schema:*
 - `migration_id_map` table layout — frozen stable surface. Future column changes require a charter amendment and a data migration of every existing row. Source-of-truth descriptor: `Waaseyaa\Migration\Schema\MigrationIdMapSchema`.
+- `Waaseyaa\Migration\MigrationIdMap::lookupDestination()` and `lookupDestinationAcross()` — read-only id-map access for source-reader composition; all mutation and traversal methods remain mission-internal.
 
 *Exception types:*
 - `Waaseyaa\Migration\Exception\MigrationCycleException`
@@ -610,7 +615,7 @@ Exit codes: `0` success, `1` generic failure, `2` lock held by another process.
 - `Waaseyaa\Migration\Runner\MigrationRunner` and all classes under `Waaseyaa\Migration\Runner\` (`MigrationLock`, `ProcessChainExecutor`, `RollbackWalker`, `RecordError`, `RollbackError`, `RollbackReport`, `RunOptions`, `RunReport`).
 - `storage/migration-locks/<id>.lock` file format (flock-based; lock-file presence is operator-visible but the format is not a published contract).
 - `Waaseyaa\Migration\Discovery\PluginRegistry`, `MigrationRegistry`, `CycleDetector`, `DependencyGraph`, `FilesystemManifestLoader` (boot-time discovery internals).
-- `Waaseyaa\Migration\MigrationIdMap` PHP gateway class (the **table** is stable; the PHP accessor is mission-internal — apps consult the table through `DestinationPluginInterface::lookup()`).
+- `Waaseyaa\Migration\MigrationIdMap` mutation, deletion, transaction, count, and reverse-walk methods. Only the two read-only lookup methods named above are stable source-reader composition seams.
 - `Waaseyaa\Migration\Canonical\CanonicalForm` (helper backing `SourceId::hash()`; behaviour is stable transitively, but the class is not a public extension point).
 
 **Operator-visible but not contractual:**

--- a/packages/migration/src/MigrationIdMap.php
+++ b/packages/migration/src/MigrationIdMap.php
@@ -123,6 +123,34 @@ final class MigrationIdMap
     }
 
     /**
+     * Look up one source identity across ordered migration partitions.
+     *
+     * Fixed-bundle imports write one id-map partition per bundle. Consumers
+     * that do not run inside a process chain (for example media URL resolvers)
+     * can use this method to address the split as one logical source. The
+     * first matching partition wins; a miss across all partitions is null.
+     *
+     * @param list<string> $migrationIds Ordered migration ids to consult.
+     *
+     * @api
+     */
+    public function lookupDestinationAcross(array $migrationIds, SourceId $sourceId): ?WriteResult
+    {
+        foreach ($migrationIds as $migrationId) {
+            if ($migrationId === '') {
+                throw new \InvalidArgumentException('MigrationIdMap::lookupDestinationAcross(): every migration id must be a non-empty string.');
+            }
+
+            $result = $this->lookupDestination($migrationId, $sourceId);
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Insert-or-update the id-map row keyed by `(migration_id, source_id_hash)`.
      *
      * Returns the {@see WriteResult} reflecting the new row state. Whether

--- a/packages/migration/src/Plugin/Process/DefaultValueProcessor.php
+++ b/packages/migration/src/Plugin/Process/DefaultValueProcessor.php
@@ -12,7 +12,7 @@ use Waaseyaa\Migration\Plugin\ReservedPluginIds;
  * Substitute a fallback when the chained value is null (and optionally when
  * it is the empty string).
  *
- * The cheapest of the six framework-reserved process plugins. Usually the
+ * A small framework-reserved process plugin. Usually the
  * last link in a chain, so a downstream destination can rely on a
  * non-null value.
  *

--- a/packages/migration/src/Plugin/Process/PartitionedLookupProcessor.php
+++ b/packages/migration/src/Plugin/Process/PartitionedLookupProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Plugin\Process;
+
+use Waaseyaa\Migration\Exception\ProcessException;
+use Waaseyaa\Migration\Plugin\ProcessContext;
+use Waaseyaa\Migration\Plugin\ProcessPluginInterface;
+use Waaseyaa\Migration\Plugin\ReservedPluginIds;
+use Waaseyaa\Migration\Plugin\WriteResult;
+use Waaseyaa\Migration\SourceId;
+
+/**
+ * Resolve a list whose items belong to different migration id-map partitions.
+ *
+ * Source-format wiring supplies callbacks that route each item to a migration
+ * id and construct its SourceId. This keeps taxonomy names, MIME types, and
+ * other external-system concepts outside the framework while allowing a
+ * fixed-bundle import to resolve one mixed reference field without a custom
+ * process-plugin class.
+ *
+ * @api
+ */
+final readonly class PartitionedLookupProcessor implements ProcessPluginInterface
+{
+    public const string ON_MISS_NULL = 'null';
+    public const string ON_MISS_FAIL = 'fail';
+
+    /**
+     * @param \Closure(mixed): ?string $migrationFor
+     * @param \Closure(mixed): ?SourceId $sourceIdFor
+     * @param (\Closure(WriteResult): mixed)|null $resultFor Defaults to the destination UUID.
+     */
+    public function __construct(
+        public string $sourceField,
+        private \Closure $migrationFor,
+        private \Closure $sourceIdFor,
+        private ?\Closure $resultFor = null,
+        public string $onMiss = self::ON_MISS_NULL,
+    ) {
+        if ($sourceField === '') {
+            throw new \InvalidArgumentException('PartitionedLookupProcessor::$sourceField must be a non-empty string.');
+        }
+        if ($onMiss !== self::ON_MISS_NULL && $onMiss !== self::ON_MISS_FAIL) {
+            throw new \InvalidArgumentException(\sprintf(
+                'PartitionedLookupProcessor::$onMiss must be %s or %s, got %s.',
+                var_export(self::ON_MISS_NULL, true),
+                var_export(self::ON_MISS_FAIL, true),
+                var_export($onMiss, true),
+            ));
+        }
+    }
+
+    public function id(): string
+    {
+        return ReservedPluginIds::PARTITIONED_LOOKUP;
+    }
+
+    public function stability(): string
+    {
+        return 'stable';
+    }
+
+    /** @return list<mixed> */
+    public function transform(mixed $value, ProcessContext $context): array
+    {
+        $items = $value ?? $context->sourceRecord->field($this->sourceField, []);
+        if (!is_array($items)) {
+            return $this->miss($context, 'Partitioned lookup requires a list source value.');
+        }
+
+        $resolved = [];
+        foreach ($items as $item) {
+            $migrationId = ($this->migrationFor)($item);
+            $sourceId = ($this->sourceIdFor)($item);
+            if (!is_string($migrationId) || $migrationId === '' || !$sourceId instanceof SourceId) {
+                $this->miss($context, 'No migration partition or source identity was provided for a list item.');
+                continue;
+            }
+
+            $result = ($context->lookup)($migrationId, $sourceId);
+            if (!$result instanceof WriteResult) {
+                $this->miss($context, \sprintf('No id-map row in migration %s for a list item.', var_export($migrationId, true)));
+                continue;
+            }
+
+            $mapped = $this->resultFor === null
+                ? $result->destinationUuid
+                : ($this->resultFor)($result);
+            if ($mapped === null) {
+                $this->miss($context, \sprintf('The destination reference mapper missed for migration %s.', var_export($migrationId, true)));
+                continue;
+            }
+
+            $resolved[] = $mapped;
+        }
+
+        return $resolved;
+    }
+
+    /** @return list<never> */
+    private function miss(ProcessContext $context, string $message): array
+    {
+        if ($this->onMiss === self::ON_MISS_FAIL) {
+            throw new ProcessException(
+                processCode: ProcessException::CODE_LOOKUP_MISS,
+                sourceField: $this->sourceField,
+                migrationId: $context->migrationId,
+                message: 'PartitionedLookupProcessor: ' . $message,
+            );
+        }
+
+        return [];
+    }
+}

--- a/packages/migration/src/Plugin/ReservedPluginIds.php
+++ b/packages/migration/src/Plugin/ReservedPluginIds.php
@@ -25,6 +25,7 @@ final class ReservedPluginIds
     public const string CONCAT = 'concat';
     public const string TYPE_COERCE = 'type_coerce';
     public const string DEFAULT_VALUE = 'default_value';
+    public const string PARTITIONED_LOOKUP = 'partitioned_lookup';
 
     /**
      * Every reserved id, in source order.
@@ -38,6 +39,7 @@ final class ReservedPluginIds
         self::CONCAT,
         self::TYPE_COERCE,
         self::DEFAULT_VALUE,
+        self::PARTITIONED_LOOKUP,
     ];
 
     /**

--- a/packages/migration/src/Plugin/Source/FilteredSource.php
+++ b/packages/migration/src/Plugin/Source/FilteredSource.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Plugin\Source;
+
+use Waaseyaa\Migration\Plugin\SourcePluginInterface;
+use Waaseyaa\Migration\Plugin\SourceRecord;
+use Waaseyaa\Migration\SourceId;
+
+/**
+ * Lazily narrow a source stream while preserving its identity semantics.
+ *
+ * Fixed-bundle migration definitions use this decorator when one external
+ * source contains records for several destination bundles. The wrapped
+ * source remains authoritative for stability and SourceId construction;
+ * only record selection and the discovery-facing plugin id are changed.
+ *
+ * @api
+ */
+final readonly class FilteredSource implements SourcePluginInterface
+{
+    /**
+     * @param \Closure(SourceRecord): bool $accept
+     */
+    public function __construct(
+        private SourcePluginInterface $source,
+        private \Closure $accept,
+        private string $pluginId,
+    ) {
+        if ($pluginId === '') {
+            throw new \InvalidArgumentException('FilteredSource::$pluginId must be a non-empty string.');
+        }
+    }
+
+    public function id(): string
+    {
+        return $this->pluginId;
+    }
+
+    public function stability(): string
+    {
+        return $this->source->stability();
+    }
+
+    public function records(): iterable
+    {
+        foreach ($this->source->records() as $record) {
+            if (($this->accept)($record)) {
+                yield $record;
+            }
+        }
+    }
+
+    public function sourceIdFor(SourceRecord $record): SourceId
+    {
+        return $this->source->sourceIdFor($record);
+    }
+
+    public function count(): ?int
+    {
+        return null;
+    }
+}

--- a/packages/migration/tests/Integration/SplitBundleCompositionFreshInstallTest.php
+++ b/packages/migration/tests/Integration/SplitBundleCompositionFreshInstallTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Access\Gate\EntityAccessGate;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+use Waaseyaa\Migration\Account\MigrationSystemAccount;
+use Waaseyaa\Migration\Discovery\HasMigrationsInterface;
+use Waaseyaa\Migration\Discovery\MigrationRegistry;
+use Waaseyaa\Migration\MigrationDefinition;
+use Waaseyaa\Migration\MigrationIdMap;
+use Waaseyaa\Migration\Plugin\Destination\EntityDestination;
+use Waaseyaa\Migration\Plugin\Process\PartitionedLookupProcessor;
+use Waaseyaa\Migration\Plugin\Source\FilteredSource;
+use Waaseyaa\Migration\Plugin\SourceRecord;
+use Waaseyaa\Migration\Plugin\WriteResult;
+use Waaseyaa\Migration\PluginFixtures\InMemorySource;
+use Waaseyaa\Migration\Runner\MigrationRunner;
+use Waaseyaa\Migration\Runner\ProcessChainExecutor;
+use Waaseyaa\Migration\Runner\RunOptions;
+use Waaseyaa\Migration\SourceId;
+use Waaseyaa\Node\Node;
+use Waaseyaa\Node\NodeAccessPolicy;
+
+/**
+ * Fresh-install reproduction for #1981.
+ *
+ * The database begins empty, installs the migration package through its real
+ * package migration files, then runs fixed-bundle definitions through the
+ * real runner, access gate, entity destination, and id-map. Alpha.260 cannot
+ * express the source filtering, mixed-partition term lookup, or media
+ * partition lookup below without application-defined adapter classes.
+ */
+#[CoversNothing]
+final class SplitBundleCompositionFreshInstallTest extends TestCase
+{
+    private DBALDatabase $db;
+    private EntityTypeManager $typeManager;
+    private EntityRepository $repository;
+    private MigrationIdMap $idMap;
+    private EventDispatcher $dispatcher;
+    private EntityAccessGate $gate;
+
+    protected function setUp(): void
+    {
+        EntityType::clearFromClassCache();
+        $this->db = DBALDatabase::createSqlite();
+        $connection = $this->db->getConnection();
+        $schema = new SchemaBuilder($connection);
+
+        foreach ([
+            '2026_05_13_000001_create_migration_id_map.php',
+            '2026_05_13_000002_create_migration_run_state.php',
+        ] as $file) {
+            $migration = require dirname(__DIR__, 2) . '/migrations/' . $file;
+            $migration->up($schema);
+        }
+
+        $connection->executeStatement(
+            'CREATE TABLE "node" ('
+            . '"nid" INTEGER PRIMARY KEY AUTOINCREMENT, '
+            . '"uuid" TEXT, "title" TEXT, "type" TEXT, '
+            . '"_data" TEXT DEFAULT \'{}\''
+            . ')',
+        );
+
+        $entityType = EntityType::fromClass(Node::class);
+        $this->typeManager = new EntityTypeManager(new EventDispatcher());
+        $this->typeManager->registerEntityType($entityType);
+        $this->dispatcher = new EventDispatcher();
+        $this->repository = new EntityRepository(
+            entityType: $entityType,
+            driver: new SqlStorageDriver(new SingleConnectionResolver($this->db), 'nid'),
+            eventDispatcher: $this->dispatcher,
+        );
+        $this->idMap = new MigrationIdMap($this->db);
+        $this->gate = new EntityAccessGate(new EntityAccessHandler([new NodeAccessPolicy()]));
+    }
+
+    protected function tearDown(): void
+    {
+        EntityType::clearFromClassCache();
+    }
+
+    #[Test]
+    public function split_bundle_sources_and_id_maps_compose_without_site_adapters(): void
+    {
+        $termSource = new InMemorySource('legacy_terms', [
+            new SourceRecord('legacy_term', ['id' => '1', 'partition' => 'category', 'title' => 'News']),
+            new SourceRecord('legacy_term', ['id' => '2', 'partition' => 'tag', 'title' => 'Community']),
+        ], sourceType: 'legacy_term');
+        $mediaSource = new InMemorySource('legacy_media', [
+            new SourceRecord('legacy_media', ['id' => '10', 'partition' => 'image', 'title' => 'Header']),
+            new SourceRecord('legacy_media', ['id' => '11', 'partition' => 'document', 'title' => 'Agenda']),
+        ], sourceType: 'legacy_media');
+
+        $definitions = [
+            $this->splitDefinition('terms_category', $termSource, 'category'),
+            $this->splitDefinition('terms_tag', $termSource, 'tag'),
+            $this->splitDefinition('media_image', $mediaSource, 'image'),
+            $this->splitDefinition('media_document', $mediaSource, 'document'),
+        ];
+
+        $contentSource = new InMemorySource('legacy_content', [
+            new SourceRecord('legacy_content', [
+                'id' => '100',
+                'title' => 'Mixed references',
+                'terms' => [
+                    ['partition' => 'category', 'id' => '1'],
+                    ['partition' => 'tag', 'id' => '2'],
+                ],
+            ]),
+        ], sourceType: 'legacy_content');
+        $definitions[] = new MigrationDefinition(
+            id: 'content_article',
+            source: $contentSource,
+            process: [
+                'title' => 'title',
+                'term_refs' => ['terms', new PartitionedLookupProcessor(
+                    sourceField: 'terms',
+                    migrationFor: static fn (mixed $item): ?string => is_array($item)
+                        ? match ($item['partition'] ?? null) {
+                            'category' => 'terms_category',
+                            'tag' => 'terms_tag',
+                            default => null,
+                        }
+                        : null,
+                    sourceIdFor: static fn (mixed $item): ?SourceId => is_array($item) && isset($item['id'])
+                        ? new SourceId('legacy_term', ['id' => (string) $item['id']])
+                        : null,
+                    resultFor: static fn (WriteResult $result): string => $result->destinationUuid,
+                    onMiss: PartitionedLookupProcessor::ON_MISS_FAIL,
+                )],
+            ],
+            destination: $this->destination('content_article', 'article'),
+            dependencies: ['terms_category', 'terms_tag'],
+            bundle: 'article',
+        );
+
+        $runner = $this->runner($definitions);
+        foreach (['terms_category', 'terms_tag', 'media_image', 'media_document', 'content_article'] as $id) {
+            $report = $runner->run($id, new RunOptions());
+            self::assertSame(1, $report->imported, $id);
+            self::assertSame(0, $report->failed, $id);
+        }
+
+        $content = $this->repository->findBy(['title' => 'Mixed references']);
+        self::assertCount(1, $content);
+        $termRefs = $content[0]->get('term_refs');
+        self::assertIsArray($termRefs);
+        self::assertCount(2, $termRefs);
+        self::assertNotSame($termRefs[0], $termRefs[1]);
+
+        foreach (['10' => 'image', '11' => 'document'] as $sourceId => $bundle) {
+            $result = $this->idMap->lookupDestinationAcross(
+                ['media_image', 'media_document'],
+                new SourceId('legacy_media', ['id' => (string) $sourceId]),
+            );
+            self::assertInstanceOf(WriteResult::class, $result);
+            $entity = $this->repository->findBy(['uuid' => $result->destinationUuid]);
+            self::assertCount(1, $entity);
+            self::assertSame($bundle, $entity[0]->get('type'));
+        }
+
+        self::assertCount(1, $this->repository->findBy(['type' => 'category']));
+        self::assertCount(1, $this->repository->findBy(['type' => 'tag']));
+        self::assertCount(1, $this->repository->findBy(['type' => 'image']));
+        self::assertCount(1, $this->repository->findBy(['type' => 'document']));
+    }
+
+    private function splitDefinition(
+        string $migrationId,
+        InMemorySource $source,
+        string $bundle,
+    ): MigrationDefinition {
+        return new MigrationDefinition(
+            id: $migrationId,
+            source: new FilteredSource(
+                source: $source,
+                accept: static fn (SourceRecord $record): bool => $record->field('partition') === $bundle,
+                pluginId: $migrationId,
+            ),
+            process: ['title' => 'title'],
+            destination: $this->destination($migrationId, $bundle),
+            bundle: $bundle,
+        );
+    }
+
+    private function destination(string $migrationId, string $bundle): EntityDestination
+    {
+        return new EntityDestination(
+            destinationEntityTypeId: 'node',
+            entityTypeManager: $this->typeManager,
+            entityRepository: $this->repository,
+            idMap: $this->idMap,
+            gate: $this->gate,
+            eventDispatcher: $this->dispatcher,
+            migrationId: $migrationId,
+            account: new MigrationSystemAccount(["create {$bundle} content"]),
+        );
+    }
+
+    /** @param list<MigrationDefinition> $definitions */
+    private function runner(array $definitions): MigrationRunner
+    {
+        $provider = new class($definitions) implements HasMigrationsInterface {
+            /** @param list<MigrationDefinition> $definitions */
+            public function __construct(private readonly array $definitions) {}
+
+            public function migrations(): iterable
+            {
+                yield from $this->definitions;
+            }
+        };
+        $registry = new MigrationRegistry([$provider]);
+        $registry->boot();
+
+        return new MigrationRunner($registry, new ProcessChainExecutor(), $this->idMap);
+    }
+}

--- a/packages/migration/tests/Unit/MigrationIdMapTest.php
+++ b/packages/migration/tests/Unit/MigrationIdMapTest.php
@@ -222,6 +222,27 @@ final class MigrationIdMapTest extends TestCase
     }
 
     #[Test]
+    public function lookup_destination_across_returns_first_matching_partition(): void
+    {
+        $sourceId = new SourceId('media', ['id' => '10']);
+        $this->idMap->upsert('media_document', $sourceId, 'media', 'document-uuid', 'hash', 'run');
+        $this->idMap->upsert('media_image', $sourceId, 'media', 'image-uuid', 'hash', 'run');
+
+        $result = $this->idMap->lookupDestinationAcross(['media_image', 'media_document'], $sourceId);
+
+        self::assertNotNull($result);
+        self::assertSame('image-uuid', $result->destinationUuid);
+        self::assertNull($this->idMap->lookupDestinationAcross(['missing'], $sourceId));
+    }
+
+    #[Test]
+    public function lookup_destination_across_rejects_empty_partition_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->idMap->lookupDestinationAcross([''], new SourceId('media', ['id' => '10']));
+    }
+
+    #[Test]
     public function transactional_commits_on_success(): void
     {
         $sourceId = new SourceId('wp', ['id' => 1]);

--- a/packages/migration/tests/Unit/Plugin/Process/PartitionedLookupProcessorTest.php
+++ b/packages/migration/tests/Unit/Plugin/Process/PartitionedLookupProcessorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Unit\Plugin\Process;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Migration\Exception\ProcessException;
+use Waaseyaa\Migration\Plugin\Process\PartitionedLookupProcessor;
+use Waaseyaa\Migration\Plugin\ProcessContext;
+use Waaseyaa\Migration\Plugin\ReservedPluginIds;
+use Waaseyaa\Migration\Plugin\SourceRecord;
+use Waaseyaa\Migration\Plugin\WriteResult;
+use Waaseyaa\Migration\SourceId;
+
+#[CoversClass(PartitionedLookupProcessor::class)]
+final class PartitionedLookupProcessorTest extends TestCase
+{
+    #[Test]
+    public function routes_each_item_and_maps_each_write_result(): void
+    {
+        $lookups = [];
+        $context = new ProcessContext(
+            new SourceRecord('mixed', ['items' => [
+                ['partition' => 'a', 'id' => '1'],
+                ['partition' => 'b', 'id' => '2'],
+            ]]),
+            'content',
+            'references',
+            function (string $migrationId, SourceId $sourceId) use (&$lookups): WriteResult {
+                $lookups[] = [$migrationId, $sourceId->keys];
+                return new WriteResult('entity', 'uuid-' . $sourceId->keys['id'], 'hash', 'run', '2026-01-01T00:00:00Z');
+            },
+        );
+        $processor = $this->processor(static fn (WriteResult $result): string => 'ref:' . $result->destinationUuid);
+
+        self::assertSame(['ref:uuid-1', 'ref:uuid-2'], $processor->transform(null, $context));
+        self::assertSame([['terms_a', ['id' => '1']], ['terms_b', ['id' => '2']]], $lookups);
+        self::assertSame(ReservedPluginIds::PARTITIONED_LOOKUP, $processor->id());
+        self::assertSame('stable', $processor->stability());
+    }
+
+    #[Test]
+    public function null_miss_skips_only_the_unresolved_item(): void
+    {
+        $context = new ProcessContext(
+            new SourceRecord('mixed', []),
+            'content',
+            'references',
+            static fn (string $migrationId, SourceId $sourceId): ?WriteResult => $sourceId->keys['id'] === '2'
+                ? new WriteResult('entity', 'uuid-2', 'hash', 'run', '2026-01-01T00:00:00Z')
+                : null,
+        );
+
+        self::assertSame(['uuid-2'], $this->processor()->transform([
+            ['partition' => 'a', 'id' => '1'],
+            ['partition' => 'b', 'id' => '2'],
+        ], $context));
+    }
+
+    #[Test]
+    public function fail_miss_raises_typed_process_exception(): void
+    {
+        $context = new ProcessContext(
+            new SourceRecord('mixed', ['items' => [['partition' => 'a', 'id' => '1']]]),
+            'content',
+            'references',
+            static fn (): null => null,
+        );
+        $processor = new PartitionedLookupProcessor(
+            'items',
+            static fn (): string => 'terms_a',
+            static fn (): SourceId => new SourceId('term', ['id' => '1']),
+            onMiss: PartitionedLookupProcessor::ON_MISS_FAIL,
+        );
+
+        $this->expectException(ProcessException::class);
+        $this->expectExceptionMessage('No id-map row');
+        $processor->transform(null, $context);
+    }
+
+    private function processor(?\Closure $resultFor = null): PartitionedLookupProcessor
+    {
+        return new PartitionedLookupProcessor(
+            'items',
+            static fn (mixed $item): ?string => is_array($item) && isset($item['partition'])
+                ? 'terms_' . $item['partition']
+                : null,
+            static fn (mixed $item): ?SourceId => is_array($item) && isset($item['id'])
+                ? new SourceId('term', ['id' => $item['id']])
+                : null,
+            $resultFor,
+        );
+    }
+}

--- a/packages/migration/tests/Unit/Plugin/Process/ProcessChainCompositionTest.php
+++ b/packages/migration/tests/Unit/Plugin/Process/ProcessChainCompositionTest.php
@@ -20,7 +20,7 @@ use Waaseyaa\Migration\Plugin\WriteResult;
 use Waaseyaa\Migration\SourceId;
 
 /**
- * Verifies chain semantics for the six framework-reserved process plugins.
+ * Verifies chain semantics for the original scalar framework process plugins.
  *
  * The migration runner (landing in WP06) threads the output of plugin N into
  * the `$value` argument of plugin N+1, reusing the same {@see ProcessContext}.

--- a/packages/migration/tests/Unit/Plugin/Process/ReservedPluginIdsParityTest.php
+++ b/packages/migration/tests/Unit/Plugin/Process/ReservedPluginIdsParityTest.php
@@ -12,11 +12,12 @@ use Waaseyaa\Migration\Plugin\Process\DefaultValueProcessor;
 use Waaseyaa\Migration\Plugin\Process\HtmlSanitizeProcessor;
 use Waaseyaa\Migration\Plugin\Process\LookupProcessor;
 use Waaseyaa\Migration\Plugin\Process\PassThroughProcessor;
+use Waaseyaa\Migration\Plugin\Process\PartitionedLookupProcessor;
 use Waaseyaa\Migration\Plugin\Process\TypeCoerceProcessor;
 use Waaseyaa\Migration\Plugin\ReservedPluginIds;
 
 /**
- * Drift guard: asserts that the set of ids returned by the six shipped
+ * Drift guard: asserts that the set of ids returned by the shipped
  * framework-reserved processors equals {@see ReservedPluginIds::ALL}.
  *
  * If a future WP adds a seventh processor, or renames one, this test breaks
@@ -38,6 +39,7 @@ final class ReservedPluginIdsParityTest extends TestCase
             (new ConcatProcessor([]))->id(),
             (new TypeCoerceProcessor('string'))->id(),
             (new DefaultValueProcessor(null))->id(),
+            $this->partitionedLookup()->id(),
         ];
 
         $shippedSorted = $shipped;
@@ -63,6 +65,7 @@ final class ReservedPluginIdsParityTest extends TestCase
             (new ConcatProcessor([]))->id(),
             (new TypeCoerceProcessor('string'))->id(),
             (new DefaultValueProcessor(null))->id(),
+            $this->partitionedLookup()->id(),
         ];
 
         foreach ($ids as $id) {
@@ -82,5 +85,15 @@ final class ReservedPluginIdsParityTest extends TestCase
         self::assertSame('stable', (new ConcatProcessor([]))->stability());
         self::assertSame('stable', (new TypeCoerceProcessor('string'))->stability());
         self::assertSame('stable', (new DefaultValueProcessor(null))->stability());
+        self::assertSame('stable', $this->partitionedLookup()->stability());
+    }
+
+    private function partitionedLookup(): PartitionedLookupProcessor
+    {
+        return new PartitionedLookupProcessor(
+            'items',
+            static fn (): string => 'partition',
+            static fn (): \Waaseyaa\Migration\SourceId => new \Waaseyaa\Migration\SourceId('source', ['id' => '1']),
+        );
     }
 }

--- a/packages/migration/tests/Unit/Plugin/ReservedPluginIdsTest.php
+++ b/packages/migration/tests/Unit/Plugin/ReservedPluginIdsTest.php
@@ -13,7 +13,7 @@ use Waaseyaa\Migration\Plugin\ReservedPluginIds;
 final class ReservedPluginIdsTest extends TestCase
 {
     #[Test]
-    public function exposes_six_reserved_ids_in_canonical_order(): void
+    public function exposes_reserved_ids_in_canonical_order(): void
     {
         self::assertSame([
             'pass_through',
@@ -22,6 +22,7 @@ final class ReservedPluginIdsTest extends TestCase
             'concat',
             'type_coerce',
             'default_value',
+            'partitioned_lookup',
         ], ReservedPluginIds::ALL);
     }
 
@@ -34,6 +35,7 @@ final class ReservedPluginIdsTest extends TestCase
         self::assertSame('concat', ReservedPluginIds::CONCAT);
         self::assertSame('type_coerce', ReservedPluginIds::TYPE_COERCE);
         self::assertSame('default_value', ReservedPluginIds::DEFAULT_VALUE);
+        self::assertSame('partitioned_lookup', ReservedPluginIds::PARTITIONED_LOOKUP);
     }
 
     #[Test]

--- a/packages/migration/tests/Unit/Plugin/Source/FilteredSourceTest.php
+++ b/packages/migration/tests/Unit/Plugin/Source/FilteredSourceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Migration\Tests\Unit\Plugin\Source;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Migration\Plugin\Source\FilteredSource;
+use Waaseyaa\Migration\Plugin\SourceRecord;
+use Waaseyaa\Migration\PluginFixtures\InMemorySource;
+
+#[CoversClass(FilteredSource::class)]
+final class FilteredSourceTest extends TestCase
+{
+    #[Test]
+    public function filters_lazily_and_delegates_identity_and_stability(): void
+    {
+        $source = new InMemorySource('mixed', [
+            new SourceRecord('row', ['id' => '1', 'bundle' => 'one']),
+            new SourceRecord('row', ['id' => '2', 'bundle' => 'two']),
+        ], sourceType: 'external');
+        $filtered = new FilteredSource(
+            $source,
+            static fn (SourceRecord $record): bool => $record->field('bundle') === 'two',
+            'mixed_two',
+        );
+
+        $records = iterator_to_array($filtered->records(), false);
+
+        self::assertSame('mixed_two', $filtered->id());
+        self::assertSame('stable', $filtered->stability());
+        self::assertNull($filtered->count());
+        self::assertCount(1, $records);
+        self::assertSame('2', $records[0]->field('id'));
+        self::assertSame($source->sourceIdFor($records[0])->hash(), $filtered->sourceIdFor($records[0])->hash());
+    }
+
+    #[Test]
+    public function rejects_empty_plugin_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new FilteredSource(new InMemorySource('mixed', []), static fn (): bool => true, '');
+    }
+}


### PR DESCRIPTION
Closes #1981
Part of #1985

## Summary

- add a lazy, format-neutral `FilteredSource` for fixed-bundle definitions
- add `PartitionedLookupProcessor` for mixed reference lists spanning several migration id maps
- add ordered `MigrationIdMap::lookupDestinationAcross()` for non-process consumers such as split media URL resolution
- pin the full clean-install path with real package migrations, `MigrationRunner`, `EntityDestination`, access checks, mixed taxonomy routing, split media lookup, and per-bundle least-privilege grants
- update the stable migration contract, extension guide, stability charter, and `[Unreleased]` changelog

## TDD evidence

Red on the unfixed path:

```text
Error: Class "Waaseyaa\Migration\Plugin\Source\FilteredSource" not found
Tests: 1, Assertions: 0, Errors: 1.
```

Green after implementation:

```text
Focused: 32 tests, 112 assertions
Migration package: 437 tests, 202197 assertions
Unit suite: 9763 tests, 223899 assertions
PHPStan: 1698 files, no errors
```

Additional local gates: PHP CS Fixer, package-layer check, Symfony-import boundary, Composer policy, no-secrets, syntax, and `git diff --check` green. GitHub CI is authoritative.

No WordPress-specific code or connector change is included.

## Checklist

- [x] **Traceability:** `Closes #1981` and `Part of #1985`
- [x] PR title includes `#1981`
- [x] Fresh-install red proof precedes implementation
- [x] `[Unreleased]` changelog entry included
- [x] `spec-reviewed:` trailers included on every commit