### PR TITLE
fix(#1999): make spec-drift acknowledgements honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spec-drift acknowledgements now match the blocking CI contract (#1999, R20 WP5).** The detector reads revision-attached commit messages only, matching the repository's commit-trailer rule instead of advertising an unwired `PR_BODY` escape hatch, and accepts `spec-reviewed:` paths wrapped in Markdown backticks. Fixture-driven Architecture coverage pins both behaviours.
 - **Production runtime reachability now matches the advertised notification, SEO, and routing contracts (#1992, R19).** `sendAsync()` delivers directly when the default synchronous queue is active instead of executing an intentionally worker-only job; the SEO provider attaches its registered Twig extension during boot; and `HttpKernel` upcasts entity-typed route parameters before dispatch, returning 404 for a missing entity. The duplicate class-based notification migration was deleted in favor of the timestamped package migration.
 - **R19 production invariants and install boot (#1992).** Relationship saves now reach `RelationshipPreSaveListener` through the production lifecycle dispatcher, `config:import` rejects structurally invalid workflow assignments before active-store writes, and `ConfigManagerInterface` is bound for the supported `install` command outside the `db:init` path.
 

--- a/tests/Architecture/DriftDetectorAcknowledgementTest.php
+++ b/tests/Architecture/DriftDetectorAcknowledgementTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class DriftDetectorAcknowledgementTest extends TestCase
+{
+    private string $fixtureRoot;
+
+    protected function setUp(): void
+    {
+        $this->fixtureRoot = sys_get_temp_dir() . '/waaseyaa-drift-detector-' . bin2hex(random_bytes(6));
+        mkdir($this->fixtureRoot . '/tools', 0o777, true);
+        mkdir($this->fixtureRoot . '/packages/entity/src', 0o777, true);
+        mkdir($this->fixtureRoot . '/docs/specs', 0o777, true);
+
+        copy(dirname(__DIR__, 2) . '/tools/drift-detector.sh', $this->fixtureRoot . '/tools/drift-detector.sh');
+        file_put_contents($this->fixtureRoot . '/packages/entity/src/Example.php', "<?php\nfinal class Example {}\n");
+        file_put_contents($this->fixtureRoot . '/docs/specs/entity-system.md', "# Entity system\n");
+
+        $this->executeCommand('git init --quiet');
+        $this->executeCommand('git config user.email test@example.com');
+        $this->executeCommand('git config user.name "Drift Detector Test"');
+        $this->executeCommand('git add .');
+        $this->executeCommand('git commit --quiet -m baseline');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->fixtureRoot);
+    }
+
+    #[Test]
+    public function accepts_a_backtick_wrapped_commit_trailer(): void
+    {
+        file_put_contents(
+            $this->fixtureRoot . '/packages/entity/src/Example.php',
+            "<?php\nfinal class Example { public const CHANGED = true; }\n",
+        );
+        $this->executeCommand('git add packages/entity/src/Example.php');
+        $this->executeCommand("git commit --quiet -m 'fix: non-contract change' -m 'spec-reviewed: `docs/specs/entity-system.md` - no contract change'");
+
+        [$exitCode, $output] = $this->executeCommand('bash tools/drift-detector.sh HEAD~1', allowFailure: true);
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString("OK: docs/specs/entity-system.md (acknowledged via 'spec-reviewed:')", $output);
+    }
+
+    #[Test]
+    public function ignores_pr_body_acknowledgements_because_ci_enforces_commit_trailers(): void
+    {
+        file_put_contents(
+            $this->fixtureRoot . '/packages/entity/src/Example.php',
+            "<?php\nfinal class Example { public const CHANGED = true; }\n",
+        );
+        $this->executeCommand('git add packages/entity/src/Example.php');
+        $this->executeCommand("git commit --quiet -m 'fix: unacknowledged contract-bearing change'");
+
+        [$exitCode, $output] = $this->executeCommand(
+            "PR_BODY='spec-reviewed: docs/specs/entity-system.md - claimed only in PR body' bash tools/drift-detector.sh HEAD~1",
+            allowFailure: true,
+        );
+
+        self::assertSame(1, $exitCode, $output);
+        self::assertStringContainsString('STALE: docs/specs/entity-system.md', $output);
+    }
+
+    /** @return array{int, string} */
+    private function executeCommand(string $command, bool $allowFailure = false): array
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('cd ' . escapeshellarg($this->fixtureRoot) . ' && ' . $command . ' 2>&1', $output, $exitCode);
+        $joined = implode("\n", $output);
+
+        if (!$allowFailure) {
+            self::assertSame(0, $exitCode, "Command failed: {$command}\n{$joined}");
+        }
+
+        return [$exitCode, $joined];
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $child = $path . '/' . $item;
+            if (is_dir($child) && !is_link($child)) {
+                $this->removeTree($child);
+            } else {
+                unlink($child);
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -19,7 +19,9 @@
 # Override (acknowledge a flagged spec WITHOUT editing it — e.g. a comment-only
 # or otherwise non-contract source change): put a line
 #     spec-reviewed: <spec-path | spec-basename | all> [ — reason]
-# in any commit message in the range, or in the PR body via $PR_BODY.
+# in a commit message in the range. The blocking CI check intentionally reads
+# commit history only, so acknowledgements remain attached to the revision they
+# reviewed instead of depending on mutable PR metadata.
 #
 # Output modes:
 #   --output=json / WAASEYAA_OUTPUT=json → wrapped via DriftDetectorFormatter
@@ -225,12 +227,17 @@ if [ "${#AFFECTED_SPECS[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# --- collect spec-reviewed acknowledgements (commit messages in range + PR body) ---
+# --- collect spec-reviewed acknowledgements from commit messages in range ---
 declare -A ACK=()
 ACK_RAW="$(git log --format=%B "${BASE_REF}..HEAD" 2>/dev/null || true)"
-ACK_RAW="${ACK_RAW}"$'\n'"${PR_BODY:-}"
+ACK_BACKTICK_PATTERN='^[[:space:]]*spec-reviewed:[[:space:]]*`([^`[:space:]]+)`([[:space:]]|$)'
+ACK_PLAIN_PATTERN='^[[:space:]]*spec-reviewed:[[:space:]]*([^`[:space:]]+)'
 while IFS= read -r line; do
-  if [[ "$line" =~ ^[[:space:]]*spec-reviewed:[[:space:]]*([^[:space:]]+) ]]; then
+  if [[ "$line" =~ $ACK_BACKTICK_PATTERN ]]; then
+    tok="${BASH_REMATCH[1]}"
+    ACK["$tok"]=1
+    ACK["$(basename "$tok")"]=1
+  elif [[ "$line" =~ $ACK_PLAIN_PATTERN ]]; then
     tok="${BASH_REMATCH[1]}"
     ACK["$tok"]=1
     ACK["$(basename "$tok")"]=1
@@ -265,7 +272,7 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
   else
     echo "  STALE: $spec"
     echo "    Fix: update this spec in the same change set, or add"
-    echo "         'spec-reviewed: $spec — <reason>' to a commit message / the PR body"
+    echo "         'spec-reviewed: $spec — <reason>' to a commit message"
     STALE_COUNT=$((STALE_COUNT + 1))
   fi
   echo "    Changed source:"


### PR DESCRIPTION
Part of #1999

## Summary

- make commit trailers the single supported spec-drift acknowledgement surface, matching blocking CI and AGENTS.md
- accept Markdown-backtick-wrapped spec paths in spec-reviewed trailers
- add fixture-driven Architecture regressions for both the backtick parser and the deliberately ignored PR_BODY environment variable
- add the R20 WP5 Unreleased changelog entry

## TDD evidence

Red before implementation:
- DriftDetectorAcknowledgementTest: 2 failures
- backtick-wrapped commit trailer was reported STALE (expected exit 0, got 1)
- PR_BODY-only acknowledgement passed (expected exit 1, got 0)

Green after implementation:
- focused regression: 2 tests, 18 assertions
- Architecture suite: 26 tests, 150 assertions
- split Unit suite: 9414 tests, 223028 assertions
- PHPStan: no errors
- composer-policy: passed
- drift-detector against origin/main: no contract-bearing source changes
- git diff --check and bash syntax: passed

## Scope

This PR is fenced to R20 WP5. It does not alter CI job composition or the separate lefthook cleanup assigned to WP4.