### PR TITLE
fix(#1999): guard admin credentials and repository stash use

### DIFF
--- a/.github/workflows/admin-dist.yml
+++ b/.github/workflows/admin-dist.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           # Default token: the push it makes won't trigger CI on the branch
           # (GITHUB_TOKEN trigger suppression), so CI is chain-dispatched
           # explicitly after the PR is created/updated below. RELEASE_PAT is
@@ -61,6 +62,8 @@ jobs:
 
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -70,6 +73,20 @@ jobs:
           Built from $(git rev-parse --short HEAD) by admin-dist workflow.
 
           Co-Authored-By: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          # Checkout credentials stay out of .git/config while npm runs. Supply
+          # the token only to this push through an ephemeral askpass helper;
+          # the helper contains no credential and is removed on step exit.
+          GIT_ASKPASS="$RUNNER_TEMP/admin-dist-git-askpass"
+          export GIT_ASKPASS GIT_TERMINAL_PROMPT=0
+          trap 'rm -f "$GIT_ASKPASS"' EXIT
+          cat > "$GIT_ASKPASS" <<'ASKPASS'
+          #!/usr/bin/env bash
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "$GH_TOKEN" ;;
+          esac
+          ASKPASS
+          chmod 700 "$GIT_ASKPASS"
           git push --force-with-lease origin admin-dist/update
 
       - name: Create or update PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,7 @@ jobs:
           run_gate check-admin-coercion-patterns
           run_gate check-admin-coercion-self-test
           run_gate check-admin-dist-fresh
+          run_gate check-field-guards
           run_gate check-openapi
           exit "$fail"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Every PR adds an appropriate `CHANGELOG.md` `[Unreleased]` entry.
 - Acknowledge reviewed spec drift up front with `spec-reviewed:` commit trailers; the blocking CI spec-drift check reads commit trailers.
 - Respect package layers. Symfony imports use the existing checker allowlist convention; any exception belongs in the explicit allowlist with a one-line rationale.
-- `git stash` is forbidden for all agents and subagents. If a rebase needs a clean tree, commit on a temporary branch. Do not touch the dangling `da4d26758` stash.
+- Run repository Git commands through `bin/git`; it mechanically refuses `git stash` for all agents and subagents. If a rebase needs a clean tree, commit on a temporary branch. Do not touch the dangling `da4d26758` stash.
 - Run the split Unit suite with `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit`; do not run the whole suite as one process.
 - Run local gates under `set -o pipefail`. Local results are advisory; GitHub CI is authoritative.
 - Never merge to `main` while a release split/fan-out is running.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Deleted five test-only or vestigial content/CLI subsystems (#1992, R19).** Genealogy's shadow field catalogue and stale vendored API copy, Bimaaji's unvalidated Task DSL, menu's callerless tree builder, path's superseded manager/processor trio, and the orphaned parallel ingest connector/normalization pipeline are removed without shims. Canonical genealogy registration, menu entities, path resolution/uniqueness, and `IngestionEnvelopeNormalizer` remain production paths.
 
+### Security
+
+- **R20 field guards reduce credential and hidden-work regressions (#1999).** The admin-dist checkout no longer persists its write token in the runner's Git config, and the documented repository `bin/git` entrypoint mechanically rejects every `git stash` form while preserving normal Git command arguments. A tooling regression gate pins both controls; the existing dangling `da4d26758` stash remains untouched.
+
 ## [0.1.0-alpha.261] - 2026-07-14
 
 ### Added

--- a/bin/git
+++ b/bin/git
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Repository Git entrypoint. Stashing is forbidden because it hides concurrent
+# agent work and previously left recoverable state outside normal branch review.
+set -euo pipefail
+
+args=("$@")
+command_name=""
+index=0
+
+while [ "${index}" -lt "${#args[@]}" ]; do
+    argument="${args[${index}]}"
+    case "${argument}" in
+        -C|-c|--git-dir|--work-tree|--namespace|--super-prefix|--config-env)
+            index=$((index + 2))
+            ;;
+        --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*|--config-env=*)
+            index=$((index + 1))
+            ;;
+        --)
+            index=$((index + 1))
+            if [ "${index}" -lt "${#args[@]}" ]; then
+                command_name="${args[${index}]}"
+            fi
+            break
+            ;;
+        -* )
+            index=$((index + 1))
+            ;;
+        *)
+            command_name="${argument}"
+            break
+            ;;
+    esac
+done
+
+if [ "${command_name}" = "stash" ]; then
+    echo "ERROR: git stash is forbidden in this repository." >&2
+    echo "Commit work on a temporary branch instead; leave dangling stash da4d26758 untouched." >&2
+    exit 64
+fi
+
+system_git="${WAASEYAA_SYSTEM_GIT:-}"
+if [ -z "${system_git}" ]; then
+    self_path="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+    while IFS= read -r candidate; do
+        candidate_path="$(cd "$(dirname "${candidate}")" && pwd -P)/$(basename "${candidate}")"
+        if [ "${candidate_path}" != "${self_path}" ]; then
+            system_git="${candidate}"
+            break
+        fi
+    done < <(type -aP git)
+fi
+
+if [ -z "${system_git}" ] || [ ! -x "${system_git}" ]; then
+    echo "ERROR: bin/git could not locate the system git executable." >&2
+    exit 127
+fi
+
+exec "${system_git}" "$@"

--- a/composer.json
+++ b/composer.json
@@ -500,6 +500,7 @@
         "check-getquery-bindings": "php bin/check-getquery-bindings",
         "check-dispatcher-keys": "php bin/check-dispatcher-keys",
         "check-admin-dist-fresh": "php bin/check-admin-dist-fresh",
+        "check-field-guards": "bash tests/Tooling/FieldGuardsTest.sh",
         "test": "php -d memory_limit=512M vendor/bin/phpunit --no-coverage",
         "verify": [
             "@cs-check",
@@ -519,6 +520,7 @@
             "@check-admin-coercion-patterns",
             "@check-admin-coercion-self-test",
             "@check-admin-dist-fresh",
+            "@check-field-guards",
             "@check-openapi",
             "@test"
         ],
@@ -532,6 +534,7 @@
         "check-getquery-bindings": "Fail-on-new gate for unbound getQuery()->execute() callsites. Baseline at tools/getquery-bindings-baseline.txt. New callsites fail CI; add to baseline with mandatory exemption comment if legitimately exempt. See CLAUDE.md § CI gates.",
         "check-dispatcher-keys": "Fail-on-new gate for provider register()/boot() methods that resolve an event dispatcher under an FQCN the production kernel-services bus does not serve (only Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface is served — see ProviderRegistryKernelServices::get()) and then addListener()/addSubscriber() with it, silently registering nothing. Baseline at tools/dispatcher-key-baseline.txt. Introduced in WP4 (framework-wide dead-subscriber sweep, audit-remediation batch 2026-07-01/02) after #1852 fixed the first live instance (relationship delete guard).",
         "check-admin-dist-fresh": "Admin dist freshness gate (D6). Fails when packages/admin/app source changes without rebuilding the committed packages/admin-surface/dist bundle, by comparing a line-ending-normalised content signature (packages/admin-surface/dist.signature) against a freshly computed one. Rebuild + refresh with bin/build-admin-dist. Prevents shipping a stale prebuilt admin SPA (e.g. the alpha.226 Edit-feedback feature that never reached the served bundle).",
+        "check-field-guards": "Regression gate for R20 field lessons: admin-dist checkout must not persist its write token, and the repository bin/git entrypoint must reject every git stash form while delegating allowed commands unchanged.",
         "check-openapi": "Spectral-lint the hand-maintained agent-run sub-spec packages/api/openapi.yaml (3 SSE endpoints + pending_approval shape) for YAML/OpenAPI structural validity. Syntax/shape lint of that one file only — does NOT check route parity against live routes. Requires Node.js + npx; exits 0 with SKIP notice when npx is unavailable (CI-safe). Wired as a hard gate in verify per NFR-004 (WP02, mission agent-executor-v1-1-audit-followups-01KS3S5M).",
         "check-symfony-imports": "Enforce the Path R-narrow Symfony-import boundary (mission #1107 C-005 (b)). Fails when `use Symfony\\…` appears outside the framework allowlist. Allowlist lives in .symfony-import-allowlist.json — see docs/specs/api-layer.md §Symfony Import Boundary.",
         "dev": "Start the PHP dev server (delegates to dev:php). For the admin SPA, run `composer dev:admin` in a second terminal — see docs/specs/operations-playbooks.md.",

--- a/tests/Tooling/FieldGuardsTest.sh
+++ b/tests/Tooling/FieldGuardsTest.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+ADMIN_WORKFLOW="${ROOT_DIR}/.github/workflows/admin-dist.yml"
+CI_WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+GIT_WRAPPER="${ROOT_DIR}/bin/git"
+FAIL=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAIL=1
+}
+
+checkout_line="$(grep -n -m1 'uses: actions/checkout@' "${ADMIN_WORKFLOW}" | cut -d: -f1)"
+checkout_end=$((checkout_line + 12))
+if ! sed -n "${checkout_line},${checkout_end}p" "${ADMIN_WORKFLOW}" \
+    | grep -Eq '^[[:space:]]+persist-credentials:[[:space:]]+false[[:space:]]*$'; then
+    fail "admin-dist checkout must set persist-credentials: false"
+fi
+if ! grep -Fq 'GIT_ASKPASS=' "${ADMIN_WORKFLOW}" \
+    || ! grep -Eq '^[[:space:]]+GH_TOKEN:[[:space:]]+\$\{\{ secrets\.GITHUB_TOKEN \}\}[[:space:]]*$' "${ADMIN_WORKFLOW}"; then
+    fail "admin-dist push must authenticate from the step environment after checkout credentials are disabled"
+fi
+if ! grep -Eq '^[[:space:]]+run_gate check-field-guards[[:space:]]*$' "${CI_WORKFLOW}"; then
+    fail "ci/verify-gates must run the field-guards regression"
+fi
+
+if [ ! -x "${GIT_WRAPPER}" ]; then
+    fail "bin/git must exist and be executable"
+else
+    TMP_DIR="$(mktemp -d)"
+    trap 'rm -rf "${TMP_DIR}"' EXIT
+    FAKE_GIT="${TMP_DIR}/git-real"
+    CALLS="${TMP_DIR}/calls"
+
+    cat > "${FAKE_GIT}" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "${WAASEYAA_GIT_WRAPPER_CALLS}"
+FAKE
+    chmod +x "${FAKE_GIT}"
+
+    for invocation in \
+        "stash" \
+        "stash push" \
+        "-C ${ROOT_DIR} stash list" \
+        "-c color.ui=false stash pop"; do
+        : > "${CALLS}"
+        # shellcheck disable=SC2086 # Intentional word splitting exercises argv parsing.
+        if WAASEYAA_SYSTEM_GIT="${FAKE_GIT}" WAASEYAA_GIT_WRAPPER_CALLS="${CALLS}" \
+            "${GIT_WRAPPER}" ${invocation} >"${TMP_DIR}/stdout" 2>"${TMP_DIR}/stderr"; then
+            fail "bin/git accepted forbidden invocation: git ${invocation}"
+        fi
+        if ! grep -Fq 'git stash is forbidden' "${TMP_DIR}/stderr"; then
+            fail "bin/git did not explain the stash refusal: git ${invocation}"
+        fi
+        if [ -s "${CALLS}" ]; then
+            fail "bin/git delegated forbidden invocation: git ${invocation}"
+        fi
+    done
+
+    : > "${CALLS}"
+    if ! WAASEYAA_SYSTEM_GIT="${FAKE_GIT}" WAASEYAA_GIT_WRAPPER_CALLS="${CALLS}" \
+        "${GIT_WRAPPER}" -C "${ROOT_DIR}" status --short; then
+        fail "bin/git did not delegate an allowed command"
+    fi
+    if ! diff -u <(printf '%s\n' -C "${ROOT_DIR}" status --short) "${CALLS}"; then
+        fail "bin/git changed allowed-command arguments"
+    fi
+fi
+
+if [ "${FAIL}" -ne 0 ]; then
+    exit 1
+fi
+
+echo "PASS: admin checkout credentials and repository git wrapper are guarded"


### PR DESCRIPTION
Part of #1999

## Summary

- set `persist-credentials: false` on the admin-dist checkout so its write token is absent from `.git/config` while `npm ci` / the build executes
- preserve the later authenticated push with an environment-only `GIT_ASKPASS` helper that contains no credential and is deleted at step exit
- add the canonical `bin/git` repository entrypoint, which rejects direct and globally-optioned `stash` commands with exit 64 while delegating all allowed argv unchanged
- make `AGENTS.md` require that entrypoint, and run its boundary regression from both `composer verify` and blocking `ci/verify-gates`
- leave the existing `da4d26758` stash untouched
- file #2000 for the separately scoped recurring worker-mode mutable-statics gate generalized from R12/R17

## Design note

Native Git has no `pre-stash` hook, and aliases cannot override a built-in command. The repository wrapper is therefore the practical mechanical boundary: governed agents use `bin/git`, its parser handles `-C` / `-c` / long-form global options, and the regression proves forbidden commands never reach the underlying Git executable.

## Red / green evidence

Red, before implementation:

```text
FAIL: admin-dist checkout must set persist-credentials: false
FAIL: bin/git must exist and be executable
```

A second red regression caught the push-auth consequence of disabling checkout persistence:

```text
FAIL: admin-dist push must authenticate from the step environment after checkout credentials are disabled
```

A third red regression pinned blocking CI wiring:

```text
FAIL: ci/verify-gates must run the field-guards regression
```

Green:

- `composer check-field-guards` — PASS
- `php bin/check-composer-policy` — PASS
- `shellcheck bin/git tests/Tooling/FieldGuardsTest.sh` — PASS
- changed workflow YAML parse — PASS
- `composer phpstan` — no errors (1,622 files)
- `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit` — 9,414 tests, 223,028 assertions
- pre-push hook repeated spec-drift, composer-policy, phpstan, and Unit — PASS

## Follow-up issue

- #2000 — recurring prevention gate for new mutable process statics on request-path classes

## Checklist

- [x] **Traceability:** `Part of #1999` references the R20 anchor issue
- [x] PR title includes `#1999`
- [x] Regression was proven red before implementation
- [x] `[Unreleased]` changelog entry added
- [x] `spec-reviewed:` commit trailer included
