### PR TITLE
chore(#1999): enforce server-side release governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **R20 server-side release governance (#1999).** The main-branch ruleset now requires every unconditional blocking CI context, and an idempotent repository operator applies or audits forward-only release-tag protection across every split mirror when organization-level rulesets are unavailable.
 - **R19 dead public surfaces (#1992).** The first-party MCP admin routes are attached to their existing read models; the consumerless search read surface is explicitly parked as `@internal` until an access-checked first-party endpoint adopts it; and the unused migration plugin registry, `SearchIndexJob`, duplicate embedding pipeline, zero-implementation pipeline step contract, and undrained AI pipeline dispatcher are deleted without shims.
 - **Media CAS/versioning is explicitly parked as internal (#1992, #1742; R19).** Version-namespace classes and their API/admin readers are no longer advertised as `@api`. Reactivation requires a boundary test proving real upload bytes survive the production request boundary and are durably persisted to CAS before version rows are exposed. The #1951 early-return guard remains unchanged; this does not finish or activate CAS.
 

--- a/bin/configure-split-tag-protection
+++ b/bin/configure-split-tag-protection
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply or audit the forward-only release-tag ruleset on every repository in
+# split.yml. Organization-level rulesets are not available on every GitHub
+# plan/token, so this is the idempotent mirror-side fallback.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SPLIT_YML="${SPLIT_YML:-${ROOT_DIR}/.github/workflows/split.yml}"
+REPO_OWNER="${REPO_OWNER:-waaseyaa}"
+RULESET_NAME="${RULESET_NAME:-split-tag-protection-forward-only}"
+MODE="${1:---check}"
+
+if [[ "${MODE}" != "--check" && "${MODE}" != "--apply" ]]; then
+  echo "Usage: $0 [--check|--apply]" >&2
+  exit 2
+fi
+if [[ ! -f "${SPLIT_YML}" ]]; then
+  echo "FAIL: split workflow not found: ${SPLIT_YML}" >&2
+  exit 1
+fi
+for command in gh jq python3; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "FAIL: required command not found: ${command}" >&2
+    exit 1
+  fi
+done
+
+mapfile -t repositories < <(python3 - "${SPLIT_YML}" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for repository in sorted(set(re.findall(r"remote:\s*'([^']+)'", text))):
+    print(repository)
+PY
+)
+
+if [[ "${#repositories[@]}" -eq 0 ]]; then
+  echo "FAIL: no split mirrors parsed from ${SPLIT_YML}" >&2
+  exit 1
+fi
+
+payload="$({
+  jq -cn \
+    --arg name "${RULESET_NAME}" \
+    '{
+      name: $name,
+      target: "tag",
+      enforcement: "active",
+      conditions: {ref_name: {include: ["refs/tags/**"], exclude: []}},
+      rules: [
+        {type: "deletion"},
+        {type: "non_fast_forward"},
+        {type: "update"}
+      ],
+      bypass_actors: []
+    }'
+})"
+
+failures=0
+for repository in "${repositories[@]}"; do
+  endpoint="repos/${REPO_OWNER}/${repository}/rulesets"
+  rulesets="$(gh api "${endpoint}")"
+  ruleset_id="$(jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id' <<<"${rulesets}" | head -n 1)"
+
+  state="missing"
+  if [[ -n "${ruleset_id}" ]]; then
+    detail="$(gh api "${endpoint}/${ruleset_id}")"
+    if jq -e \
+      --arg name "${RULESET_NAME}" \
+      '(.name == $name)
+       and (.target == "tag")
+       and (.enforcement == "active")
+       and (.conditions.ref_name.include == ["refs/tags/**"])
+       and (([.rules[].type] | sort) == (["deletion", "non_fast_forward", "update"] | sort))' \
+      >/dev/null <<<"${detail}"; then
+      state="protected"
+    else
+      state="drifted"
+    fi
+  fi
+
+  if [[ "${MODE}" == "--check" ]]; then
+    if [[ "${state}" == "protected" ]]; then
+      echo "${repository}: protected"
+    else
+      echo "${repository}: ${state}"
+      failures=$((failures + 1))
+    fi
+    continue
+  fi
+
+  case "${state}" in
+    protected)
+      echo "${repository}: already protected"
+      ;;
+    missing)
+      gh api --method POST "${endpoint}" --input - <<<"${payload}" >/dev/null
+      echo "${repository}: created"
+      ;;
+    drifted)
+      gh api --method PUT "${endpoint}/${ruleset_id}" --input - <<<"${payload}" >/dev/null
+      echo "${repository}: updated"
+      ;;
+  esac
+done
+
+if [[ "${failures}" -ne 0 ]]; then
+  echo "FAIL: ${failures} of ${#repositories[@]} split mirrors lack the exact forward-only tag ruleset." >&2
+  exit 1
+fi
+
+echo "OK: ${#repositories[@]} split mirrors have forward-only release-tag governance (${MODE#--})."

--- a/tests/Release/SplitMirrorTagProtectionTest.sh
+++ b/tests/Release/SplitMirrorTagProtectionTest.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+cat > "${TMP_DIR}/split.yml" <<'YAML'
+matrix:
+  package:
+    - { local: 'packages/zeta', remote: 'zeta' }
+    - { local: 'packages/alpha', remote: 'alpha' }
+    - { local: 'packages/alpha-copy', remote: 'alpha' }
+YAML
+
+cat > "${TMP_DIR}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
+endpoint=""
+method="GET"
+for arg in "$@"; do
+  case "${arg}" in
+    repos/*/rulesets*) endpoint="${arg}" ;;
+    POST|PUT) method="${arg}" ;;
+  esac
+done
+
+if [[ "${method}" == "GET" ]]; then
+  if [[ "${endpoint}" == */rulesets/42 ]]; then
+    printf '%s\n' '{"id":42,"name":"split-tag-protection-forward-only","target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/**"],"exclude":[]}},"rules":[{"type":"deletion"},{"type":"non_fast_forward"},{"type":"update"}]}'
+    exit 0
+  fi
+  if [[ "${FAKE_GH_MODE}" == "protected" ]]; then
+    printf '%s\n' '[{"id":42,"name":"split-tag-protection-forward-only","target":"tag","enforcement":"active"}]'
+  else
+    printf '%s\n' '[]'
+  fi
+  exit 0
+fi
+
+payload="$(cat)"
+printf '%s\n' "${payload}" >> "${FAKE_GH_PAYLOAD_LOG}"
+printf '%s\n' '{"id":42,"name":"split-tag-protection-forward-only","target":"tag","enforcement":"active"}'
+SH
+chmod +x "${TMP_DIR}/bin/gh"
+
+export PATH="${TMP_DIR}/bin:${PATH}"
+export FAKE_GH_LOG="${TMP_DIR}/gh.log"
+export FAKE_GH_PAYLOAD_LOG="${TMP_DIR}/payload.log"
+
+export FAKE_GH_MODE=unprotected
+if SPLIT_YML="${TMP_DIR}/split.yml" "${ROOT_DIR}/bin/configure-split-tag-protection" --check >"${TMP_DIR}/check.out" 2>&1; then
+  echo "FAIL: --check passed for unprotected mirrors"
+  exit 1
+fi
+grep -q 'alpha: missing' "${TMP_DIR}/check.out"
+grep -q 'zeta: missing' "${TMP_DIR}/check.out"
+
+: > "${FAKE_GH_LOG}"
+: > "${FAKE_GH_PAYLOAD_LOG}"
+SPLIT_YML="${TMP_DIR}/split.yml" "${ROOT_DIR}/bin/configure-split-tag-protection" --apply >"${TMP_DIR}/apply.out"
+
+[[ "$(grep -c -- '--method POST' "${FAKE_GH_LOG}")" -eq 2 ]]
+[[ "$(grep -c 'refs/tags/\\*\\*' "${FAKE_GH_PAYLOAD_LOG}")" -eq 2 ]]
+grep -q '"type":"deletion"' "${FAKE_GH_PAYLOAD_LOG}"
+grep -q '"type":"update"' "${FAKE_GH_PAYLOAD_LOG}"
+grep -q '"type":"non_fast_forward"' "${FAKE_GH_PAYLOAD_LOG}"
+
+: > "${FAKE_GH_LOG}"
+export FAKE_GH_MODE=protected
+SPLIT_YML="${TMP_DIR}/split.yml" "${ROOT_DIR}/bin/configure-split-tag-protection" --check >"${TMP_DIR}/protected.out"
+[[ "$(grep -c 'repos/waaseyaa/.*/rulesets' "${FAKE_GH_LOG}")" -eq 4 ]]
+! grep -q -- '--method' "${FAKE_GH_LOG}"
+grep -q 'OK: 2 split mirrors' "${TMP_DIR}/protected.out"
+
+echo "OK: split mirror tag-protection operator is idempotent and covers the matrix exactly once."


### PR DESCRIPTION
## Summary

- adds an idempotent check/apply operator for forward-only tag rules on every split-matrix repository
- records the completed live main-ruleset expansion and mirror rollout
- preserves mirror branch force-push behavior; only release-tag update/delete is blocked

Part of #1999.

## Live policy evidence

- `main-protection` now enforces all 14 unconditional audit contexts while preserving its existing PR, review, bypass, merge-method, and strictness settings
- pre-apply `--check`: 74/74 mirrors reported missing
- `--apply`: 74/74 rulesets created
- post-apply `--check`: 74/74 mirrors reported protected

## TDD

- Red: `bin/configure-split-tag-protection` absent (`exit 127`)
- Green: `bash tests/Release/SplitMirrorTagProtectionTest.sh`
- split Unit: 9,414 tests / 223,028 assertions
- PHPStan: 1,622 files, no errors
- composer policy and spec drift: pass
- `bash -n` and `git diff --check`: pass