### PR TITLE
fix(#1999): wait through post-tag CI startup

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -23,7 +23,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SHA: ${{ github.sha }}
-        run: bash bin/wait-for-green-ci "${SHA}" 0
+        # A tag push starts a fresh CI run at the same SHA. Poll through that
+        # run instead of racing it in single-check mode.
+        run: bash bin/wait-for-green-ci "${SHA}" 2700
 
   split:
     needs: verify-ci-green

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Split fan-out waits through post-tag CI startup (#1999).** The exact-SHA release gate now polls through the CI run triggered by the tag push instead of failing single-check mode while that newer run is still in progress.
+
 ## [0.1.0-alpha.262] - 2026-07-14
 
 ### Changed

--- a/tests/Architecture/CiReleaseWorkflowParityTest.php
+++ b/tests/Architecture/CiReleaseWorkflowParityTest.php
@@ -74,7 +74,7 @@ final class CiReleaseWorkflowParityTest extends TestCase
 
         $gate = substr($split, $gateStart, $splitStart - $gateStart);
         self::assertStringContainsString('ref: ${{ github.sha }}', $gate);
-        self::assertStringContainsString('bash bin/wait-for-green-ci "${SHA}" 0', $gate);
+        self::assertStringContainsString('bash bin/wait-for-green-ci "${SHA}" 2700', $gate);
 
         $greenCiGate = $this->read('bin/wait-for-green-ci');
         self::assertStringContainsString('actions/workflows/ci.yml/runs?head_sha=${SHA}', $greenCiGate);


### PR DESCRIPTION
Follow-up to the alpha.262 fan-out recovery. The tag-triggered split gate used single-check mode, so it raced the newly started post-tag CI run even though the exact release SHA had already passed its release gate.

This changes split fan-out to poll the exact SHA for up to 45 minutes, preserving fail-closed behavior while removing the startup race.

Red: `CiReleaseWorkflowParityTest` observed timeout `0` instead of `2700`.

Green:
- CiReleaseWorkflowParityTest: 4 tests, 44 assertions
- Architecture: 48 tests, 362 assertions
- monorepo release-shape guard passed
- composer policy passed after fetching the alpha.262 tag
- diff check clean

Tracks #1999.