### PR TITLE
fix(#2010): enforce SQLite foreign keys on connection open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Split fan-out waits through post-tag CI startup (#1999).** The exact-SHA release gate now polls through the CI run triggered by the tag push instead of failing single-check mode while that newer run is still in progress.
+- **SQLite connections now enforce declared foreign keys (#2010, R21 WP1).** `DBALDatabase::createSqlite()` issues `PRAGMA foreign_keys = ON` immediately after opening every in-memory or file-backed connection, before schema or data work can begin. A two-connection regression test proves each fresh connection rejects an orphaned child row instead of silently accepting referential corruption.
 
 ## [0.1.0-alpha.262] - 2026-07-14
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -499,7 +499,7 @@ final class DBALDatabase implements DatabaseInterface
 }
 ```
 
-`DBALDatabase` wraps a Doctrine DBAL `Connection`. The `createSqlite()` factory enables WAL mode for non-memory databases. Query results use `fetchAssociative()` (equivalent to FETCH_ASSOC — no duplicate numeric-indexed columns).
+`DBALDatabase` wraps a Doctrine DBAL `Connection`. The `createSqlite()` factory enables foreign-key enforcement on every new connection before any schema or data work, and enables WAL mode for non-memory databases. Query results use `fetchAssociative()` (equivalent to FETCH_ASSOC — no duplicate numeric-indexed columns).
 
 ### TransactionInterface
 

--- a/packages/database-legacy/src/DBALDatabase.php
+++ b/packages/database-legacy/src/DBALDatabase.php
@@ -26,6 +26,10 @@ final class DBALDatabase implements DatabaseInterface
             'memory' => $path === ':memory:',
         ]);
 
+        // SQLite scopes foreign-key enforcement to each connection and leaves
+        // it disabled by default. Set it before any schema or data work.
+        $connection->executeStatement('PRAGMA foreign_keys = ON');
+
         // Enable WAL mode for better concurrent read performance.
         if ($path !== ':memory:') {
             $connection->executeStatement('PRAGMA journal_mode = WAL');

--- a/packages/database-legacy/tests/Unit/DBALDatabaseTest.php
+++ b/packages/database-legacy/tests/Unit/DBALDatabaseTest.php
@@ -32,6 +32,27 @@ final class DBALDatabaseTest extends TestCase
         $this->assertInstanceOf(DBALDatabase::class, $db);
     }
 
+    public function testCreateSqliteEnforcesForeignKeysOnEveryNewConnection(): void
+    {
+        $first = DBALDatabase::createSqlite();
+        $second = DBALDatabase::createSqlite();
+
+        foreach ([$first, $second] as $database) {
+            $connection = $database->getConnection();
+            $connection->executeStatement('CREATE TABLE parent (id INTEGER PRIMARY KEY)');
+            $connection->executeStatement(
+                'CREATE TABLE child (parent_id INTEGER NOT NULL REFERENCES parent(id))',
+            );
+
+            try {
+                $connection->executeStatement('INSERT INTO child (parent_id) VALUES (404)');
+                $this->fail('A new SQLite connection accepted an orphaned foreign key.');
+            } catch (\Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
     public function testSelectReturnsSelectInterface(): void
     {
         $select = $this->db->select('users', 'u');


### PR DESCRIPTION
## What changed

- enable `PRAGMA foreign_keys = ON` immediately on every SQLite connection
- prove two independently opened connections reject orphaned child rows
- align the infrastructure contract and changelog

## Why

SQLite defaults foreign-key enforcement off per connection. Staging writes could therefore accept referential corruption even though schemas declared foreign keys.

## TDD evidence

- RED: focused regression failed because an orphaned child row was accepted (`1 test, 1 assertion, 1 failure`)
- GREEN: database package test file (`14 tests, 22 assertions`)
- GREEN: split Unit suite (`9510 tests, 223317 assertions`)

Part of #2010