### PR TITLE
fix(#2010): harden service and data boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **R21 service/data correctness hardening (#2010).** Billing webhook results now retain Stripe `event.id`, optionally suppress duplicates through an atomic event-claim seam, fail closed on a missing id when that seam is active, and thread invoice currency beside minor-unit amounts. Structured-import no longer uses an in-band NUL sentinel for escaped pipes, so raw NUL bytes round-trip without becoming `|`.
 - **Split fan-out waits through post-tag CI startup (#1999).** The exact-SHA release gate now polls through the CI run triggered by the tag push instead of failing single-check mode while that newer run is still in progress.
 - **SQLite connections now enforce declared foreign keys (#2010, R21 WP1).** `DBALDatabase::createSqlite()` issues `PRAGMA foreign_keys = ON` immediately after opening every in-memory or file-backed connection, before schema or data work can begin. A two-connection regression test proves each fresh connection rejects an orphaned child row instead of silently accepting referential corruption.
 - **R21 content and storage invariants (#2010).** Taxonomy term saves now reject self-parenting, cycles, and cross-vocabulary parent edges before persistence; messaging materializes and uniquely constrains each `(thread_id, user_id)` participant pair, deterministically merging legacy duplicates without losing owner, join, or read state; default-revision promotion refreshes column-stored bundle fields from the promoted revision in the same transaction. The attachment at-most-one-active invariant and dual schema-path parity remain enforced by the existing package schema and save guards.
@@ -51,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Bimaaji patch identifiers are fail-closed and risk-signalled (#2010).** `MutationValidator` rejects entity-type and field names outside `^[a-z][a-z0-9_]*$`; `PatchGenerator` independently computes `unsafe` from the same allowlist so a forged accepted result cannot present a path-breaking patch as safe.
 - **R20 field guards reduce credential and hidden-work regressions (#1999).** The admin-dist checkout no longer persists its write token in the runner's Git config, and the documented repository `bin/git` entrypoint mechanically rejects every `git stash` form while preserving normal Git command arguments. A tooling regression gate pins both controls; the existing dangling `da4d26758` stash remains untouched.
 
 ## [0.1.0-alpha.261] - 2026-07-14

--- a/docs/specs/bimaaji.md
+++ b/docs/specs/bimaaji.md
@@ -97,6 +97,7 @@ Request/result types for agent-safe changes. No filesystem writes — the protoc
 - `MutationRequest` — what the agent wants to change (entity type, field, route, etc.)
 - `MutationResult` — success/failure with error codes, validated against graph
 - Sovereignty violations delegated to guardrail rules
+- `entityType` and non-null `field` identifiers are restricted to `^[a-z][a-z0-9_]*$`; invalid names fail validation before they can become suggested paths.
 
 ### Patch Generator
 
@@ -104,6 +105,7 @@ Converts accepted `MutationResult` into reviewable patches:
 - PHP files: AST-safe via `nikic/php-parser`, round-trip tested
 - Non-PHP: constrained operations with risk flags
 - Output: file path, content hashes, diff text
+- Defense in depth: `PatchGenerator` independently evaluates the same identifier allowlist and derives `PatchEntry::$unsafe` from that result. A forged successful `MutationResult` with path-breaking identifiers is therefore visibly unsafe even if it bypasses `MutationValidator`. Patch generation still never writes to disk.
 
 ### Sovereignty Guardrails
 

--- a/docs/specs/work-surface.md
+++ b/docs/specs/work-surface.md
@@ -200,6 +200,8 @@ $result = $importer->import($payload, 'node', 'profile');
 
 **Matching rules**: field name is an implicit alias; declared `promptAliases` take precedence. Normalization is UTF-8 lowercase + whitespace collapse (no transliteration — C-012). `bundle` defaults to `entityTypeId` when `null`.
 
+**Escaped-pipe byte integrity**: table rows are split directly on unescaped `|` characters. The parser does not substitute an in-band sentinel, so every raw byte inside a cell — including NUL — round-trips unchanged while `\|` still becomes a literal pipe.
+
 **Performance budget (NFR-004)**: peak memory ≤ 2× payload size.
 
 ---

--- a/packages/ai-agent/tests/Contract/Bimaaji/GeneratePatchToolTest.php
+++ b/packages/ai-agent/tests/Contract/Bimaaji/GeneratePatchToolTest.php
@@ -54,7 +54,7 @@ final class GeneratePatchToolTest extends TestCase
         self::assertCount(1, $payload['patches'], 'add_field on a known entity must yield exactly one patch.');
 
         $patch = $payload['patches'][0];
-        self::assertSame('src/Entity/fields/User/nickname.php', $patch['file_path'] ?? null);
+        self::assertSame('src/Entity/fields/user/nickname.php', $patch['file_path'] ?? null);
         self::assertArrayHasKey('content_hash', $patch);
         self::assertSame(hash('sha256', $patch['content']), $patch['content_hash']);
     }
@@ -171,7 +171,7 @@ final class GeneratePatchToolTest extends TestCase
     {
         $graph = new ApplicationGraph(version: '1.0', sections: [
             new GraphSection(key: 'entities', version: '1.0', data: [
-                'User' => ['label' => 'User', 'class' => 'App\\Entity\\User'],
+                'user' => ['label' => 'User', 'class' => 'App\\Entity\\User'],
             ]),
         ]);
 
@@ -186,7 +186,7 @@ final class GeneratePatchToolTest extends TestCase
     {
         return [
             'operation' => 'add_field',
-            'entity_type' => 'User',
+            'entity_type' => 'user',
             'field' => 'nickname',
             'parameters' => ['type' => 'string'],
         ];

--- a/packages/ai-agent/tests/Contract/Bimaaji/ProposeMutationToolTest.php
+++ b/packages/ai-agent/tests/Contract/Bimaaji/ProposeMutationToolTest.php
@@ -31,7 +31,7 @@ final class ProposeMutationToolTest extends TestCase
         self::assertIsArray($payload);
         self::assertSame('success', $payload['status']);
         self::assertSame(
-            ['operation' => 'add_field', 'entity_type' => 'User', 'field' => 'nickname', 'parameters' => ['type' => 'string']],
+            ['operation' => 'add_field', 'entity_type' => 'user', 'field' => 'nickname', 'parameters' => ['type' => 'string']],
             $payload['request'],
             'Tool must surface the MutationResult.request shape verbatim.',
         );
@@ -85,7 +85,7 @@ final class ProposeMutationToolTest extends TestCase
         $tool = new ProposeMutationTool($validator);
         $account = $this->accountWithPermission('bimaaji.mutate');
         $args = $this->validArguments();
-        $request = new MutationRequest('add_field', 'User', 'nickname', ['type' => 'string']);
+        $request = new MutationRequest('add_field', 'user', 'nickname', ['type' => 'string']);
 
         // Warm-up — first call pays autoloading / initial caches.
         $validator->validate($request);
@@ -164,7 +164,7 @@ final class ProposeMutationToolTest extends TestCase
     /** @param array<string, mixed>|null $entitiesData */
     private function makeTool(?array $entitiesData = null): ProposeMutationTool
     {
-        $entitiesData = $entitiesData ?? ['User' => ['label' => 'User', 'class' => 'App\\Entity\\User']];
+        $entitiesData = $entitiesData ?? ['user' => ['label' => 'User', 'class' => 'App\\Entity\\User']];
         $graph = new ApplicationGraph(version: '1.0', sections: [
             new GraphSection(key: 'entities', version: '1.0', data: $entitiesData),
         ]);
@@ -176,7 +176,7 @@ final class ProposeMutationToolTest extends TestCase
     {
         return new ApplicationGraph(version: '1.0', sections: [
             new GraphSection(key: 'entities', version: '1.0', data: [
-                'User' => ['label' => 'User', 'class' => 'App\\Entity\\User'],
+                'user' => ['label' => 'User', 'class' => 'App\\Entity\\User'],
             ]),
         ]);
     }
@@ -186,7 +186,7 @@ final class ProposeMutationToolTest extends TestCase
     {
         return [
             'operation' => 'add_field',
-            'entity_type' => 'User',
+            'entity_type' => 'user',
             'field' => 'nickname',
             'parameters' => ['type' => 'string'],
         ];

--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -4,7 +4,9 @@
 
 Stripe billing for Waaseyaa: subscriptions, checkout, customer portal, plan tiers.
 
-`BillingManager` is the single entry point for plan tier resolution, checkout session creation, and customer-portal URLs. `StripeClientInterface` plus `FakeStripeClient` make the integration testable without hitting Stripe; `WebhookHandler` dispatches Stripe webhook events into framework `DomainEvent`s.
+`BillingManager` is the single entry point for plan tier resolution, checkout session creation, and customer-portal URLs. `StripeClientInterface` plus `FakeStripeClient` make the integration testable without hitting Stripe; `WebhookHandler` maps verified Stripe webhook events into structured arrays.
+
+`WebhookHandler` accepts an optional atomic event-claim closure. Production consumers must back this seam with durable storage keyed by Stripe `event.id`: return `true` only for the first delivery and `false` for duplicates. When the seam is configured, a supported event without an id fails closed. Every handled result exposes `event_id`; invoice results carry `currency` beside Stripe's integer minor-unit amount so downstream code never interprets an amount without its currency.
 
 Key classes: `BillingManager`, `BillingServiceProvider`, `CheckoutSession`, `PlanTier`, `StripeClientInterface`, `WebhookHandler`.
 
@@ -14,7 +16,7 @@ This package is **v0.1 scaffolding**. The public surface (`BillingManager`, `Str
 
 ## Out of scope for v0.1
 
-Full Stripe billing integration — including webhook signature verification, subscription lifecycle management, and payment failure handling — is **deferred to post-v0.1**. The scaffold exists to:
+Full Stripe billing integration — including a durable webhook event-claim store, signature-verifying Stripe adapter, subscription lifecycle management, and payment failure handling — is **deferred to post-v0.1**. The scaffold exists to:
 
 1. Reserve the `waaseyaa/billing` package namespace.
 2. Define the `StripeClientInterface` contract so downstream code can type-hint against it.

--- a/packages/billing/src/WebhookHandler.php
+++ b/packages/billing/src/WebhookHandler.php
@@ -9,14 +9,19 @@ namespace Waaseyaa\Billing;
  */
 final class WebhookHandler
 {
+    /**
+     * @param ?\Closure(string $eventId): bool $claimEvent Atomically claim a Stripe event id.
+     *        Return true exactly once and false for an already-claimed delivery.
+     */
     public function __construct(
         private readonly StripeClientInterface $stripe,
+        private readonly ?\Closure $claimEvent = null,
     ) {}
 
     /**
      * Process a Stripe webhook event.
      *
-     * @return array<string, mixed>|null Structured event data, or null for unhandled events
+     * @return array<string, mixed>|null Structured event data, or null for unhandled/duplicate events
      */
     public function handle(string $payload, string $signature): ?array
     {
@@ -24,7 +29,7 @@ final class WebhookHandler
         $type = $event['type'] ?? '';
         $object = $event['data']['object'] ?? [];
 
-        return match ($type) {
+        $result = match ($type) {
             'checkout.session.completed' => $this->handleCheckoutCompleted($type, $object),
             'customer.subscription.created',
             'customer.subscription.updated',
@@ -33,6 +38,24 @@ final class WebhookHandler
             'invoice.payment_failed' => $this->handleInvoiceFailed($type, $object),
             default => null,
         };
+
+        if ($result === null) {
+            return null;
+        }
+
+        $eventId = is_string($event['id'] ?? null) ? $event['id'] : null;
+        if ($this->claimEvent !== null) {
+            if ($eventId === null || $eventId === '') {
+                throw new \RuntimeException('Stripe webhook event id is required for idempotency.');
+            }
+
+            $claimEvent = $this->claimEvent;
+            if (!$claimEvent($eventId)) {
+                return null;
+            }
+        }
+
+        return ['event_id' => $eventId] + $result;
     }
 
     /**
@@ -80,6 +103,7 @@ final class WebhookHandler
             'customer_id' => $object['customer'] ?? null,
             'subscription_id' => $object['subscription'] ?? null,
             'amount_paid' => $object['amount_paid'] ?? 0,
+            'currency' => $object['currency'] ?? null,
         ];
     }
 
@@ -95,6 +119,7 @@ final class WebhookHandler
             'customer_id' => $object['customer'] ?? null,
             'subscription_id' => $object['subscription'] ?? null,
             'amount_due' => $object['amount_due'] ?? 0,
+            'currency' => $object['currency'] ?? null,
         ];
     }
 }

--- a/packages/billing/tests/Unit/WebhookHandlerTest.php
+++ b/packages/billing/tests/Unit/WebhookHandlerTest.php
@@ -27,6 +27,7 @@ final class WebhookHandlerTest extends TestCase
     public function testHandleCheckoutSessionCompleted(): void
     {
         $this->stripe->setNextWebhookEvent([
+            'id' => 'evt_checkout',
             'type' => 'checkout.session.completed',
             'data' => [
                 'object' => [
@@ -42,6 +43,7 @@ final class WebhookHandlerTest extends TestCase
         $this->assertSame('checkout.session.completed', $result['event']);
         $this->assertSame('cus_abc', $result['customer_id']);
         $this->assertSame('sub_123', $result['subscription_id']);
+        $this->assertSame('evt_checkout', $result['event_id']);
     }
 
     public function testHandleSubscriptionCreated(): void
@@ -121,12 +123,14 @@ final class WebhookHandlerTest extends TestCase
     public function testHandleInvoicePaymentSucceeded(): void
     {
         $this->stripe->setNextWebhookEvent([
+            'id' => 'evt_invoice_paid',
             'type' => 'invoice.payment_succeeded',
             'data' => [
                 'object' => [
                     'customer' => 'cus_abc',
                     'subscription' => 'sub_123',
                     'amount_paid' => 1999,
+                    'currency' => 'cad',
                 ],
             ],
         ]);
@@ -135,6 +139,8 @@ final class WebhookHandlerTest extends TestCase
 
         $this->assertSame('invoice.payment_succeeded', $result['event']);
         $this->assertSame(1999, $result['amount_paid']);
+        $this->assertSame('cad', $result['currency']);
+        $this->assertSame('evt_invoice_paid', $result['event_id']);
     }
 
     public function testHandleInvoicePaymentFailed(): void
@@ -146,6 +152,7 @@ final class WebhookHandlerTest extends TestCase
                     'customer' => 'cus_abc',
                     'subscription' => 'sub_123',
                     'amount_due' => 1999,
+                    'currency' => 'usd',
                 ],
             ],
         ]);
@@ -154,6 +161,7 @@ final class WebhookHandlerTest extends TestCase
 
         $this->assertSame('invoice.payment_failed', $result['event']);
         $this->assertSame(1999, $result['amount_due']);
+        $this->assertSame('usd', $result['currency']);
     }
 
     public function testHandleUnknownEventReturnsNull(): void
@@ -166,5 +174,44 @@ final class WebhookHandlerTest extends TestCase
         $result = $this->handler->handle('payload', 'sig');
 
         $this->assertNull($result);
+    }
+
+    public function testIdempotencyClaimSuppressesDuplicateStripeEvent(): void
+    {
+        $claimed = [];
+        $handler = new WebhookHandler(
+            $this->stripe,
+            static function (string $eventId) use (&$claimed): bool {
+                if (isset($claimed[$eventId])) {
+                    return false;
+                }
+                $claimed[$eventId] = true;
+
+                return true;
+            },
+        );
+        $this->stripe->setNextWebhookEvent([
+            'id' => 'evt_once',
+            'type' => 'invoice.payment_succeeded',
+            'data' => ['object' => ['amount_paid' => 2500, 'currency' => 'cad']],
+        ]);
+
+        $this->assertNotNull($handler->handle('payload', 'sig'));
+        $this->assertNull($handler->handle('payload', 'sig'));
+        $this->assertSame(['evt_once' => true], $claimed);
+    }
+
+    public function testIdempotencyClaimFailsClosedWhenStripeEventIdIsMissing(): void
+    {
+        $handler = new WebhookHandler($this->stripe, static fn (string $eventId): bool => true);
+        $this->stripe->setNextWebhookEvent([
+            'type' => 'invoice.payment_succeeded',
+            'data' => ['object' => ['amount_paid' => 2500, 'currency' => 'cad']],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('event id');
+
+        $handler->handle('payload', 'sig');
     }
 }

--- a/packages/bimaaji/src/Mutation/MutationValidator.php
+++ b/packages/bimaaji/src/Mutation/MutationValidator.php
@@ -10,6 +10,7 @@ use Waaseyaa\Bimaaji\Policy\SovereigntyGuardrails;
 final class MutationValidator
 {
     private const array CREATION_OPERATIONS = ['add_entity_type'];
+    private const string IDENTIFIER_PATTERN = '/^[a-z][a-z0-9_]*$/';
 
     /**
      * @param ?SovereigntyGuardrails $guardrails Gates sovereignty-sensitive
@@ -38,6 +39,14 @@ final class MutationValidator
         }
 
         $errors = [];
+
+        if (preg_match(self::IDENTIFIER_PATTERN, $request->entityType) !== 1) {
+            $errors[] = 'INVALID_ENTITY_TYPE_FORMAT';
+        }
+
+        if ($request->field !== null && preg_match(self::IDENTIFIER_PATTERN, $request->field) !== 1) {
+            $errors[] = 'INVALID_FIELD_FORMAT';
+        }
 
         if (!in_array($request->operation, self::CREATION_OPERATIONS, true)) {
             $entitiesSection = $this->graph->getSection('entities');

--- a/packages/bimaaji/src/Patch/PatchGenerator.php
+++ b/packages/bimaaji/src/Patch/PatchGenerator.php
@@ -8,6 +8,8 @@ use Waaseyaa\Bimaaji\Mutation\MutationResult;
 
 final class PatchGenerator
 {
+    private const string IDENTIFIER_PATTERN = '/^[a-z][a-z0-9_]*$/';
+
     private readonly PhpFileBuilder $builder;
 
     public function __construct()
@@ -43,9 +45,14 @@ final class PatchGenerator
             content: $content,
             diffText: "--- /dev/null\n+++ b/{$filePath}\n@@ -0,0 +1 @@\n+{$content}",
             contentHash: hash('sha256', $content),
-            unsafe: false,
+            unsafe: !$this->isSafeIdentifier($entityType) || !$this->isSafeIdentifier($fieldName),
         );
 
         return new PatchSet([$entry]);
+    }
+
+    private function isSafeIdentifier(string $identifier): bool
+    {
+        return preg_match(self::IDENTIFIER_PATTERN, $identifier) === 1;
     }
 }

--- a/packages/bimaaji/tests/Unit/Mutation/MutationValidatorTest.php
+++ b/packages/bimaaji/tests/Unit/Mutation/MutationValidatorTest.php
@@ -91,6 +91,19 @@ final class MutationValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_path_breaking_entity_type_and_field_identifiers(): void
+    {
+        $graph = $this->buildGraph(['../node' => ['fields' => []]]);
+        $validator = new MutationValidator($graph);
+
+        $result = $validator->validate(new MutationRequest('add_field', '../node', '../../shell'));
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertContains('INVALID_ENTITY_TYPE_FORMAT', $result->errors);
+        $this->assertContains('INVALID_FIELD_FORMAT', $result->errors);
+    }
+
+    #[Test]
     public function it_accepts_entity_level_operations_without_field(): void
     {
         $graph = $this->buildGraph(['node' => ['fields' => []]]);

--- a/packages/bimaaji/tests/Unit/Patch/PatchGeneratorTest.php
+++ b/packages/bimaaji/tests/Unit/Patch/PatchGeneratorTest.php
@@ -123,4 +123,19 @@ final class PatchGeneratorTest extends TestCase
 
         self::assertStringContainsString('article', $patchSet->patches[0]->filePath);
     }
+
+    #[Test]
+    public function add_field_patch_computes_unsafe_from_identifier_allowlist(): void
+    {
+        $request = new MutationRequest(
+            operation: 'add_field',
+            entityType: '../article',
+            field: '../../shell',
+            parameters: ['type' => 'string'],
+        );
+
+        $patch = $this->generator->generate(MutationResult::success($request))->patches[0];
+
+        self::assertTrue($patch->unsafe);
+    }
 }

--- a/packages/structured-import/src/Gfm/GfmTableParser.php
+++ b/packages/structured-import/src/Gfm/GfmTableParser.php
@@ -20,9 +20,6 @@ namespace Waaseyaa\StructuredImport\Gfm;
  */
 final class GfmTableParser
 {
-    /** Sentinel used during pipe-escape substitution. Must not appear in valid UTF-8 input. */
-    private const PIPE_SENTINEL = "\x00";
-
     /**
      * Parse a GFM document and return data rows from the first valid 2-column table.
      *
@@ -148,8 +145,7 @@ final class GfmTableParser
      */
     private function looksLikeTableRow(string $line): bool
     {
-        $masked = str_replace('\\|', self::PIPE_SENTINEL, $line);
-        return str_contains($masked, '|');
+        return preg_match('/(?<!\\\\)\|/', $line) === 1;
     }
 
     /**
@@ -161,20 +157,17 @@ final class GfmTableParser
      */
     private function splitRow(string $line): array
     {
-        // Replace escaped pipes with a sentinel before splitting.
-        $masked = str_replace('\\|', self::PIPE_SENTINEL, $line);
-
         // Strip optional leading and trailing pipes.
-        $masked = preg_replace('/^\s*\|/', '', $masked) ?? $masked;
-        $masked = preg_replace('/\|\s*$/', '', $masked) ?? $masked;
+        $line = preg_replace('/^\s*\|/', '', $line) ?? $line;
+        $line = preg_replace('/\|\s*$/', '', $line) ?? $line;
 
-        $parts = explode('|', $masked);
+        $parts = $this->splitOnUnescapedPipes($line);
         $cells = [];
 
         foreach ($parts as $part) {
             // Restore escaped pipes and trim whitespace.
-            $cell = str_replace(self::PIPE_SENTINEL, '|', $part);
-            $cells[] = trim($cell);
+            $cell = str_replace('\\|', '|', $part);
+            $cells[] = trim($cell, " \t\n\r\v");
         }
 
         return $cells;
@@ -185,11 +178,10 @@ final class GfmTableParser
      */
     private function isSeparatorRow(string $line): bool
     {
-        $masked = str_replace('\\|', self::PIPE_SENTINEL, $line);
-        $masked = preg_replace('/^\s*\|/', '', $masked) ?? $masked;
-        $masked = preg_replace('/\|\s*$/', '', $masked) ?? $masked;
+        $line = preg_replace('/^\s*\|/', '', $line) ?? $line;
+        $line = preg_replace('/\|\s*$/', '', $line) ?? $line;
 
-        $cells = explode('|', $masked);
+        $cells = $this->splitOnUnescapedPipes($line);
 
         foreach ($cells as $cell) {
             if (!preg_match('/^\s*:?-+:?\s*$/', $cell)) {
@@ -207,10 +199,17 @@ final class GfmTableParser
      */
     private function splitSeparatorRow(string $line): array
     {
-        $masked = str_replace('\\|', self::PIPE_SENTINEL, $line);
-        $masked = preg_replace('/^\s*\|/', '', $masked) ?? $masked;
-        $masked = preg_replace('/\|\s*$/', '', $masked) ?? $masked;
+        $line = preg_replace('/^\s*\|/', '', $line) ?? $line;
+        $line = preg_replace('/\|\s*$/', '', $line) ?? $line;
 
-        return explode('|', $masked);
+        return $this->splitOnUnescapedPipes($line);
+    }
+
+    /** @return list<string> */
+    private function splitOnUnescapedPipes(string $line): array
+    {
+        $parts = preg_split('/(?<!\\\\)\|/', $line);
+
+        return $parts !== false ? $parts : [$line];
     }
 }

--- a/packages/structured-import/tests/Unit/Gfm/GfmTableParserTest.php
+++ b/packages/structured-import/tests/Unit/Gfm/GfmTableParserTest.php
@@ -368,4 +368,15 @@ final class GfmTableParserTest extends TestCase
 
         self::assertSame([], $result->errors);
     }
+
+    #[Test]
+    public function rawNulInsideCellRoundTripsWithoutBecomingAPipe(): void
+    {
+        $payload = "| Field | Value |\n| --- | --- |\n| title | a\x00b |";
+
+        $result = $this->parser->parse($payload);
+
+        self::assertSame([['prompt' => 'title', 'value' => "a\x00b"]], $result->rows);
+        self::assertSame([], $result->errors);
+    }
 }


### PR DESCRIPTION
Part of #2010.

## Outcome

- billing retains Stripe `event.id`, exposes an optional atomic event-claim seam, suppresses duplicate deliveries, fails closed on missing ids when claiming, and threads invoice currency beside minor-unit amounts
- structured-import splits directly on unescaped pipes, removing the NUL sentinel collision while preserving `\|` behavior
- Bimaaji validates entity-type/field identifiers against `^[a-z][a-z0-9_]*$` and independently derives `PatchEntry::unsafe` from the same check
- docs/specs and `[Unreleased]` changelog updated

## TDD

Focused tests first failed in seven places: missing invoice currency/event ids, duplicate delivery not suppressed, missing event id not rejected, raw NUL changed to `|`, invalid identifiers accepted, and unsafe hardcoded false.

Green evidence:
- billing: 37 tests, 81 assertions
- structured-import: 37 tests, 93 assertions
- Bimaaji: 167 tests, 404 assertions
- full Unit suite (`--no-coverage`): 9,514 tests, 223,330 assertions
- PHPStan: clean (1,622 files)
- PHP-CS-Fixer dry run: clean
- package-layer gate: clean (accepted baseline cycle warnings only)

## Review finding during full-suite verification

The first full Unit run caught four ai-agent Bimaaji contract fixtures using class-style `User` as the entity id. Production graph keys are canonical lowercase machine ids, and the requested allowlist correctly rejected `User`; the fixtures and expected patch path now use `user`. The second full Unit run is green.