### PR TITLE
fix(#2018): restore fresh-install node authoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh-install node authoring no longer fails validation with HTTP 500 (#2018).** Unix-backed node timestamps now derive constraints that accept both their integer storage representation and cast-aware `DateTimeInterface` domain values, restoring page, news, and event create/edit through the admin surface. JSON:API create and both update save paths map genuine entity-validation failures to 422, and the blocking cutover smoke now proves valid authoring plus invalid create/update rejection against synthetic `page`, `post`, and `tribe_events` bundles.
+
 ## [0.1.0-alpha.263] - 2026-07-14
 
 ### Changed

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,5 +1,6 @@
 # API Layer
 
+<!-- Spec reviewed 2026-07-14 - #2018 authoring spine: EntityValidationException is mapped to 422 on store(), plain update(), and expectation-stated update(); repository validation can no longer escape as an admin/API HTTP 500. -->
 <!-- Spec reviewed 2026-07-14 - R21 WP4 (#2010): GraphQlRouter propagates GraphQlEndpoint's statusCode instead of forcing HTTP 200, so parse/auth/method failures reach clients as 400/401/405. withMutationOverrides() remains supported, but a custom update/delete resolver replaces the generated EntityResolver path and therefore owns the enduring not-found/access-denied collapse obligation; delegating to EntityResolver is the preferred way to preserve it. -->
 <!-- Spec reviewed 2026-07-14 - R21 WP6 (#2010): POST /api/queue/jobs/{id}/retry validates the payload, atomically claims the failed row through FailedJobRepositoryInterface, and dispatches only for the claim winner. A competing retry returns JSON:API 409; corrupt payload remains 422, dispatch failure remains 502 and releases the claim, success remains 204 and forgets the row. -->
 
@@ -354,7 +355,8 @@ The `$accessHandler` and `$account` follow the **paired nullable** pattern: both
 3. Creates entity via `$storage->create($attributes)`.
 4. Checks create access via `$accessHandler->checkCreateAccess()`.
 5. Checks **field edit access** for each submitted attribute via `$accessHandler->checkFieldAccess($entity, $fieldName, 'edit', $account)`. Uses `isForbidden()` (field-level semantics).
-6. Saves entity and returns document with `statusCode: 201` and `meta.created = true`.
+6. Saves entity. `EntityValidationException` maps to 422; it never escapes as HTTP 500.
+7. Returns document with `statusCode: 201` and `meta.created = true`.
 
 **`update(string $entityTypeId, int|string $id, array $data): JsonApiDocument`**
 
@@ -367,6 +369,7 @@ The `$accessHandler` and `$account` follow the **paired nullable** pattern: both
 7. Applies updates via `$target->set($field, $value)` (requires `$target instanceof FieldableInterface`).
 8. Saves through `getRepository()->save($target)` in both cases (C-22 WP3 unified the two save paths onto the canonical repository) — **without** an expectation, the plain form; **with** an expectation, `getRepository()->save($target, context: SaveContext::default()->withExpectedRevisionId($n))` — and returns the resource serialized from `$target`. **A stated `expected_revision_id` against a DIVERGED working copy** (the tip has moved since the client's expectation was formed) hits the existing storage `\LogicException`/`RevisionConflictException` rejection matrix (`revision-system-unified.md` §3b) exactly as any other expectation mismatch does — no new machinery; the controller's `catch (\LogicException $e)` → 422 / `catch (RevisionConflictException $e)` → 409 mapping in `saveWithExpectation()` is unchanged.
 9. **Both save paths catch `Doctrine\DBAL\Exception\UniqueConstraintViolationException` → 409** (added 2026-07-02, audit-remediation WP2 review — previously only `store()` had this mapping and a PATCH tripping a uniqueness constraint, e.g. the attachment one-active-per-parent partial index under a race, surfaced a raw 500 with driver SQL). Same status/title shape as `store()`'s duplicate-ID 409, codeless (so `code: 'REVISION_CONFLICT'` stays the discriminator for the optimistic-locking 409), detail `"Updating entity of type '<type>' with ID '<id>' violated a uniqueness constraint."` — names the REAL entity id, not the request locator (locator honesty, contract §15). Pinned by `JsonApiControllerConflictTest::patchWithoutExpectationMapsUniqueConstraintViolationTo409` / `::patchWithExpectationMapsUniqueConstraintViolationTo409`.
+10. **Both save paths catch `EntityValidationException` → 422.** The plain and expectation-stated PATCH paths share the same validation-error factory, so invalid input is rejected without becoming an HTTP 500.
 
 **`destroy(string $entityTypeId, int|string $id): JsonApiDocument`**
 

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -1,5 +1,6 @@
 # Entity System
 
+<!-- Spec reviewed 2026-07-14 - #2018 authoring spine: integer fields with settings.subtype=timestamp now derive AtLeastOneOf(Type(int), Type(DateTimeInterface)) so unix-backed storage values and cast-aware domain values are both valid while unrelated scalar/container types remain rejected. This corrects the documented cast-aware validation contract; no validation path is disabled. -->
 <!-- Spec reviewed 2026-07-14 - R21 #2010: taxonomy hierarchy is guarded at EntityRepository's PRE_SAVE persistence boundary. TermHierarchyGuard rejects self-parenting, cycles, missing parents, and cross-vocabulary parent edges before any tree walk can consume persisted hierarchy. -->
 
 <!-- Spec reviewed 2026-07-13 - CW-v1 option-1 PR-4 (#1920, security): new `Waaseyaa\Entity\Write\EntityWritePayloadGuard` (`packages/entity/src/Write/EntityWritePayloadGuard.php`, `@api`) — the write-side field allowlist shared by JSON:API/admin-surface/GraphQL. No entity-system storage/save-load contract changes; it is a pure, stateless read of `EntityTypeInterface::getKeys()` + `EntityTypeManagerInterface::resolveFieldDefinitions()` (both pre-existing, unchanged read paths documented elsewhere in this spec). Full contract documented in `docs/specs/api-layer.md` "Write-side field allowlist (CW-v1 option-1 PR-4)", the surface that actually calls it. -->
@@ -1373,7 +1374,7 @@ Maps `EntityType::getFieldDefinitions()` metadata to per-field Symfony `Constrai
 | `type: email` | `Email` | In addition to string typing when applicable. |
 | `allowed_values` / `allowedValues` | `Choice` | Non-empty list only. |
 | `enum_class` / `enumClass` (`BackedEnum`) | `Choice` on backing values | PHP enum class name. |
-| `type` scalar | `Type` | `bool`, `int`, `float`, `string` (incl. `email`/`text`/`slug`), `array`/`json`. Omitted for `entity_reference` and `timestamp` (storage shape varies). |
+| `type` scalar | `Type` | `bool`, `int`, `float`, `string` (incl. `email`/`text`/`slug`), `array`/`json`. Omitted for `entity_reference` and `timestamp` (storage shape varies). Integer fields with `settings.subtype: timestamp` use `AtLeastOneOf(Type(int), Type(DateTimeInterface))`, accepting both unix storage and cast-aware domain representations. |
 | `min` / `max` settings on `integer` / `int` / `float` / `double` | `Range` | Derived when `min` and/or `max` is numeric — both, either, or neither may be present (mirrors the Length shape). (#1643) |
 
 Per-field declared constraints (`FieldDefinition::getConstraints()`, object-shaped definitions; array-shaped definitions carry `constraints` through `normalizeDefinition()`) are appended after the derived list for the same field.

--- a/packages/api/src/JsonApiController.php
+++ b/packages/api/src/JsonApiController.php
@@ -612,6 +612,8 @@ final class JsonApiController
                     sprintf("An entity of type '%s' with this ID already exists.", $entityTypeId),
                 ),
             );
+        } catch (EntityValidationException $e) {
+            return $this->validationError($entityTypeId, $e);
         } catch (TransitionDeniedException $e) {
             // WP2 rework (review finding #8): WorkflowStateGuard denies from
             // PRE_SAVE inside save() — never let it surface as an uncaught 500.
@@ -818,6 +820,8 @@ final class JsonApiController
                 // in the body. Names the REAL entity id, not the request
                 // locator (contract §15 locator honesty).
                 return $this->errorDocument($this->uniquenessConflictError($entityTypeId, (string) $target->id()));
+            } catch (EntityValidationException $e) {
+                return $this->validationError($entityTypeId, $e);
             } catch (TransitionDeniedException $e) {
                 // WP2 rework (review finding #8): same PRE_SAVE guard denial
                 // as create() and the expectation-stated PATCH path below.
@@ -881,9 +885,7 @@ final class JsonApiController
                 ],
             ));
         } catch (EntityValidationException $e) {
-            return $this->errorDocument(JsonApiError::unprocessable(
-                "Validation failed for entity of type '{$entityTypeId}': {$e->getMessage()}",
-            ));
+            return $this->validationError($entityTypeId, $e);
         } catch (TransitionDeniedException $e) {
             // WP2 rework (review finding #8): same PRE_SAVE guard denial as
             // create() and the plain PATCH path above.
@@ -896,6 +898,13 @@ final class JsonApiController
         }
 
         return null;
+    }
+
+    private function validationError(string $entityTypeId, EntityValidationException $exception): JsonApiDocument
+    {
+        return $this->errorDocument(JsonApiError::unprocessable(
+            "Validation failed for entity of type '{$entityTypeId}': {$exception->getMessage()}",
+        ));
     }
 
     /**

--- a/packages/api/tests/Unit/JsonApiControllerConflictTest.php
+++ b/packages/api/tests/Unit/JsonApiControllerConflictTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Validation;
 use Waaseyaa\Api\JsonApiController;
 use Waaseyaa\Api\ResourceSerializer;
@@ -103,7 +104,7 @@ final class JsonApiControllerConflictTest extends TestCase
             keys: self::REV_KEYS,
             revisionable: true,
             revisionDefault: true,
-            constraints: ['title' => [new NotBlank()]],
+            constraints: ['title' => [new NotBlank(), new Length(min: 3)]],
         );
         $this->entityTypeManager->registerEntityType($constrainedType);
         $constrainedHandler = new SqlSchemaHandler($constrainedType, $this->db);
@@ -346,6 +347,43 @@ final class JsonApiControllerConflictTest extends TestCase
             "Validation failed for entity of type 'test_constrained'",
             $array['errors'][0]['detail'],
         );
+    }
+
+    #[Test]
+    public function createValidationFailureMapsTo422(): void
+    {
+        $doc = $this->controller->store('test_constrained', [
+            'data' => [
+                'type' => 'test_constrained',
+                'attributes' => ['title' => 'x'],
+            ],
+        ]);
+        $array = $doc->toArray();
+
+        self::assertSame(422, $doc->statusCode);
+        self::assertSame('422', $array['errors'][0]['status']);
+        self::assertStringContainsString("Validation failed for entity of type 'test_constrained'", $array['errors'][0]['detail']);
+    }
+
+    #[Test]
+    public function patchWithoutExpectationValidationFailureMapsTo422(): void
+    {
+        $repo = $this->entityTypeManager->getRepository('test_constrained');
+        $entity = new TestRevisionableEntity(values: ['title' => 'valid', 'id' => '1', 'uuid' => 'c2']);
+        $entity->enforceIsNew();
+        $repo->save($entity);
+
+        $doc = $this->controller->update('test_constrained', '1', [
+            'data' => [
+                'type' => 'test_constrained',
+                'attributes' => ['title' => ''],
+            ],
+        ]);
+        $array = $doc->toArray();
+
+        self::assertSame(422, $doc->statusCode);
+        self::assertSame('422', $array['errors'][0]['status']);
+        self::assertStringContainsString("Validation failed for entity of type 'test_constrained'", $array['errors'][0]['detail']);
     }
 
     // -----------------------------------------------------------------------

--- a/packages/entity/src/Validation/FieldDefinitionConstraintBuilder.php
+++ b/packages/entity/src/Validation/FieldDefinitionConstraintBuilder.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Entity\Validation;
 
+use DateTimeInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -86,7 +88,7 @@ final class FieldDefinitionConstraintBuilder
             $constraints[] = new Choice(choices: $values);
         }
 
-        $typeConstraint = self::scalarTypeConstraint($type);
+        $typeConstraint = self::scalarTypeConstraint($def, $type);
         if ($typeConstraint !== null) {
             $constraints[] = $typeConstraint;
         }
@@ -227,8 +229,15 @@ final class FieldDefinitionConstraintBuilder
         };
     }
 
-    private static function scalarTypeConstraint(string $type): ?Constraint
+    private static function scalarTypeConstraint(FieldDefinitionInterface $def, string $type): ?Constraint
     {
+        if (in_array($type, ['integer', 'int'], true) && $def->getSetting('subtype') === 'timestamp') {
+            return new AtLeastOneOf([
+                new Type('int'),
+                new Type(DateTimeInterface::class),
+            ]);
+        }
+
         return match ($type) {
             // #1655: the framework's boolean convention keeps 0/1 through
             // get()/validate() with no cast (see User.php "status stays 0/1"

--- a/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
+++ b/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Entity\Tests\Unit\Validation;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,32 @@ use Waaseyaa\Field\Item\EnumFieldTypeException;
 #[CoversClass(FieldDefinitionConstraintBuilder::class)]
 final class FieldDefinitionConstraintBuilderTest extends TestCase
 {
+    #[Test]
+    public function integerTimestampAcceptsCastAwareDateTimeAndRejectsUnrelatedTypes(): void
+    {
+        $constraints = FieldDefinitionConstraintBuilder::build([
+            'created' => ['type' => 'integer', 'subtype' => 'timestamp'],
+        ]);
+
+        foreach ([0, new DateTimeImmutable('@0')] as $validValue) {
+            $valid = $this->stubEntity(['created' => $validValue]);
+            self::assertCount(
+                0,
+                (new EntityValidator(Validation::createValidator()))->validate($valid, $constraints),
+                'A timestamp must accept both its unix storage value and its cast-aware domain DateTime.',
+            );
+        }
+
+        foreach (['not-a-timestamp', 1.5, []] as $invalid) {
+            $entity = $this->stubEntity(['created' => $invalid]);
+            self::assertGreaterThan(
+                0,
+                (new EntityValidator(Validation::createValidator()))->validate($entity, $constraints)->count(),
+                sprintf('Timestamp subtype must reject %s.', get_debug_type($invalid)),
+            );
+        }
+    }
+
     #[Test]
     public function requiredStringRejectsBlank(): void
     {

--- a/tests/Integration/FreshInstall/CutoverFreshInstallSmokeTest.php
+++ b/tests/Integration/FreshInstall/CutoverFreshInstallSmokeTest.php
@@ -20,12 +20,15 @@ final class CutoverFreshInstallSmokeTest extends TestCase
 {
     private string $repoRoot;
     private string $projectRoot;
+    private ?Process $server = null;
+    private int $serverPort = 0;
 
     protected function setUp(): void
     {
         $this->repoRoot = (string) realpath(__DIR__ . '/../../..');
         $this->projectRoot = sys_get_temp_dir() . '/waaseyaa_cutover_' . bin2hex(random_bytes(6));
         mkdir($this->projectRoot . '/config', 0o755, true);
+        mkdir($this->projectRoot . '/public', 0o755, true);
         mkdir($this->projectRoot . '/storage', 0o755, true);
         mkdir($this->projectRoot . '/templates', 0o755, true);
         symlink($this->repoRoot . '/packages', $this->projectRoot . '/packages');
@@ -55,6 +58,8 @@ final class CutoverFreshInstallSmokeTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->server?->stop(1);
+
         if (!is_dir($this->projectRoot)) {
             return;
         }
@@ -120,6 +125,80 @@ final class CutoverFreshInstallSmokeTest extends TestCase
         );
     }
 
+    #[Test]
+    public function fresh_install_admin_authoring_creates_and_edits_page_and_bundled_content(): void
+    {
+        $install = $this->runPhase('db-init');
+        self::assertSame(0, $install->getExitCode(), $install->getErrorOutput() . $install->getOutput());
+        $import = $this->runPhase('import');
+        self::assertSame(0, $import->getExitCode(), $import->getErrorOutput() . $import->getOutput());
+
+        $this->startServer();
+
+        $createdIds = [];
+        foreach ([
+            'page' => ['body' => '<p>Page body.</p>'],
+            'post' => ['body' => '<p>News body.</p>'],
+            'tribe_events' => [
+                'body' => '<p>Event body.</p>',
+                'event_start' => '2026-08-01T10:00:00',
+                'event_end' => '2026-08-01T12:00:00',
+            ],
+        ] as $bundle => $bundleFields) {
+            $create = $this->adminAction('create', [
+                'attributes' => [
+                    'title' => "Synthetic {$bundle}",
+                    'slug' => "synthetic-{$bundle}",
+                    'type' => $bundle,
+                    ...$bundleFields,
+                ],
+            ]);
+
+            self::assertSame(200, $create['status'], "{$bundle} create returned HTTP {$create['status']}: {$create['body']}");
+            self::assertTrue($create['json']['ok'] ?? false, "{$bundle} create failed: {$create['body']}");
+
+            $id = (string) ($create['json']['data']['id'] ?? '');
+            self::assertNotSame('', $id, "{$bundle} create returned no id: {$create['body']}");
+            $createdIds[$bundle] = $id;
+
+            $update = $this->adminAction('update', [
+                'id' => $id,
+                'attributes' => ['title' => "Edited {$bundle}"],
+            ]);
+            self::assertSame(200, $update['status'], "{$bundle} update returned HTTP {$update['status']}: {$update['body']}");
+            self::assertTrue($update['json']['ok'] ?? false, "{$bundle} update failed: {$update['body']}");
+            self::assertSame("Edited {$bundle}", $update['json']['data']['attributes']['title'] ?? null);
+        }
+
+        $invalidCreate = $this->adminAction('create', [
+            'attributes' => [
+                'title' => 12345,
+                'slug' => 'invalid-page',
+                'type' => 'page',
+                'body' => '<p>Must not persist.</p>',
+            ],
+        ]);
+        self::assertNotSame(500, $invalidCreate['status'], $invalidCreate['body']);
+        self::assertFalse($invalidCreate['json']['ok'] ?? true, $invalidCreate['body']);
+        self::assertSame(422, $invalidCreate['json']['error']['status'] ?? null, $invalidCreate['body']);
+
+        $invalidUpdate = $this->adminAction('update', [
+            'id' => $createdIds['page'],
+            'attributes' => ['title' => 12345],
+        ]);
+        self::assertNotSame(500, $invalidUpdate['status'], $invalidUpdate['body']);
+        self::assertFalse($invalidUpdate['json']['ok'] ?? true, $invalidUpdate['body']);
+        self::assertSame(422, $invalidUpdate['json']['error']['status'] ?? null, $invalidUpdate['body']);
+
+        $connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => $this->projectRoot . '/storage/waaseyaa.sqlite',
+        ]);
+        self::assertSame(0, (int) $connection->fetchOne("SELECT COUNT(*) FROM node WHERE json_extract(_data, '$.slug') = 'invalid-page'"));
+        self::assertSame('Edited page', $connection->fetchOne("SELECT title FROM node WHERE json_extract(_data, '$.slug') = 'synthetic-page'"));
+        $connection->close();
+    }
+
     private function runPhase(string $phase, string $value = ''): Process
     {
         $command = [
@@ -151,6 +230,7 @@ final class CutoverFreshInstallSmokeTest extends TestCase
                 'database' => '{$databasePath}',
                 'environment' => 'local',
                 'app' => ['url' => 'http://localhost', 'name' => 'Fresh-install cutover smoke'],
+                'auth' => ['dev_fallback_account' => true],
                 'ssr' => ['theme' => '', 'cache_max_age' => 0],
                 'view_modes' => [
                     'node' => [
@@ -162,6 +242,72 @@ final class CutoverFreshInstallSmokeTest extends TestCase
                 ],
             ];
             PHP;
+    }
+
+    private function startServer(): void
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+        self::assertIsResource($socket, "Unable to reserve HTTP port: {$errorCode} {$errorMessage}");
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        self::assertIsString($address);
+        $this->serverPort = (int) substr(strrchr($address, ':'), 1);
+
+        $this->server = new Process([
+            PHP_BINARY,
+            '-S',
+            "127.0.0.1:{$this->serverPort}",
+            __DIR__ . '/Fixtures/authoring_http_router.php',
+        ], $this->projectRoot, [
+            'APP_ENV' => 'local',
+            'WAASEYAA_TEST_PROJECT_ROOT' => $this->projectRoot,
+        ]);
+        $this->server->setTimeout(null);
+        $this->server->start();
+
+        $deadline = microtime(true) + 10;
+        do {
+            $connection = @fsockopen('127.0.0.1', $this->serverPort, $errorCode, $errorMessage, 0.1);
+            if (is_resource($connection)) {
+                fclose($connection);
+
+                return;
+            }
+            usleep(20_000);
+        } while (microtime(true) < $deadline && $this->server->isRunning());
+
+        self::fail('Fresh-install HTTP server did not start: ' . $this->server->getErrorOutput());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array{status: int, body: string, json: array<string, mixed>}
+     */
+    private function adminAction(string $action, array $payload): array
+    {
+        $context = stream_context_create(['http' => [
+            'method' => 'POST',
+            'header' => "Content-Type: application/json\r\nAccept: application/json",
+            'content' => json_encode($payload, JSON_THROW_ON_ERROR),
+            'ignore_errors' => true,
+            'timeout' => 20,
+        ]]);
+        $body = file_get_contents(
+            "http://127.0.0.1:{$this->serverPort}/admin/_surface/node/action/{$action}",
+            false,
+            $context,
+        );
+        self::assertIsString($body);
+        $headers = function_exists('http_get_last_response_headers') ? http_get_last_response_headers() : ($http_response_header ?? []);
+        $statusLine = $headers[0] ?? '';
+        preg_match('/\s(\d{3})\s/', $statusLine, $matches);
+        $json = json_decode($body, true);
+
+        return [
+            'status' => isset($matches[1]) ? (int) $matches[1] : 0,
+            'body' => $body,
+            'json' => is_array($json) ? $json : [],
+        ];
     }
 
     private function writeAutoloadWrapper(): void

--- a/tests/Integration/FreshInstall/Fixtures/CutoverContentModelProvider.php
+++ b/tests/Integration/FreshInstall/Fixtures/CutoverContentModelProvider.php
@@ -31,6 +31,55 @@ final class CutoverContentModelProvider extends ServiceProvider implements Deriv
                     ),
                 ],
             ),
+            new ContentTypeModel(
+                entityTypeId: 'node',
+                bundle: 'page',
+                label: 'Page',
+                fields: $this->commonFields('page'),
+            ),
+            new ContentTypeModel(
+                entityTypeId: 'node',
+                bundle: 'post',
+                label: 'News',
+                fields: $this->commonFields('post'),
+            ),
+            new ContentTypeModel(
+                entityTypeId: 'node',
+                bundle: 'tribe_events',
+                label: 'Event',
+                fields: [
+                    ...$this->commonFields('tribe_events'),
+                    new FieldDefinition(
+                        name: 'event_start',
+                        type: 'string',
+                        settings: ['weight' => 10],
+                        targetEntityTypeId: 'node',
+                        targetBundle: 'tribe_events',
+                        label: 'Event start',
+                    ),
+                    new FieldDefinition(
+                        name: 'event_end',
+                        type: 'string',
+                        settings: ['weight' => 11],
+                        targetEntityTypeId: 'node',
+                        targetBundle: 'tribe_events',
+                        label: 'Event end',
+                    ),
+                ],
+            ),
         ]);
+    }
+
+    /** @return list<FieldDefinition> */
+    private function commonFields(string $bundle): array
+    {
+        return [
+            new FieldDefinition(
+                name: 'body',
+                type: 'text_long',
+                targetEntityTypeId: 'node',
+                targetBundle: $bundle,
+            ),
+        ];
     }
 }

--- a/tests/Integration/FreshInstall/Fixtures/authoring_http_router.php
+++ b/tests/Integration/FreshInstall/Fixtures/authoring_http_router.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+$projectRoot = getenv('WAASEYAA_TEST_PROJECT_ROOT');
+if (!is_string($projectRoot) || $projectRoot === '') {
+    throw new RuntimeException('Missing WAASEYAA_TEST_PROJECT_ROOT.');
+}
+
+require $projectRoot . '/vendor/autoload.php';
+
+new HttpKernel($projectRoot)->handle()->send();


### PR DESCRIPTION
Closes #2018

## Summary

- derive timestamp-subtype constraints that accept both unix integer storage values and cast-aware `DateTimeInterface` domain values
- map `EntityValidationException` to 422 for JSON:API create, plain update, and expectation-stated update
- extend the blocking fresh-install smoke through the real admin HTTP route for synthetic `page`, `post`, and `tribe_events` bundles, including invalid create/update rejection and non-persistence assertions
- document the corrected contracts and add the required `[Unreleased]` changelog entry

## Root cause

`Node::get()` cast `created` and `changed` to `DateTimeImmutable`, while their integer field definitions made `FieldDefinitionConstraintBuilder` derive `Type(int)`, so every validated node save failed before persistence and escaped the ordinary admin create/update paths as HTTP 500.

## Red proof

Before implementation, `CutoverFreshInstallSmokeTest::fresh_install_admin_authoring_creates_and_edits_page_and_bundled_content` returned HTTP 500 on the first valid `page` create through `/admin/_surface/node/action/create`. The focused builder regression also failed with one violation for `DateTimeImmutable`, and plain PATCH surfaced an uncaught `EntityValidationException`.

## Validation

- `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit --no-coverage` — 9,533 tests, 223,416 assertions (final pre-push run)
- `php -d memory_limit=1G ./vendor/bin/phpunit tests/Integration/FreshInstall/CutoverFreshInstallSmokeTest.php --no-coverage` — 2 tests, 46 assertions
- focused entity/API tests — 44 tests, 128 assertions
- PHPStan — no errors
- dead-code gate — no new unused members
- composer policy, package layers, Symfony import boundary, PHPUnit path coverage, formatting, and diff checks — green

## Checklist

- [x] **Traceability:** `Closes #2018` references the anchor issue
- [x] PR title includes `#2018`
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] `spec-reviewed:` commit trailers included for entity, API, and workflow contracts