### PR TITLE
fix(#2020): log skipped OIDC route controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OIDC route wiring no longer turns controller construction failures into silent 404s (#2020).** Routing logs each skipped OIDC controller and its resolution exception while preserving the optional-route fail-open behavior.
+
 ## [0.1.0-alpha.264] - 2026-07-14
 
 ### Fixed

--- a/packages/routing/src/AuthOidcRouteServiceProvider.php
+++ b/packages/routing/src/AuthOidcRouteServiceProvider.php
@@ -21,6 +21,7 @@ use Waaseyaa\Auth\RateLimiterInterface;
 use Waaseyaa\Auth\Token\AuthTokenRepositoryInterface;
 use Waaseyaa\Auth\TwoFactorService;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Oidc\Authorize\AuthorizeController;
 use Waaseyaa\Oidc\Consent\ConsentScreenController;
@@ -197,31 +198,36 @@ final class AuthOidcRouteServiceProvider extends ServiceProvider
         $authorizeController = null;
         try {
             $authorizeController = $this->resolve(AuthorizeController::class);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logOidcResolutionFailure(AuthorizeController::class, $exception);
         }
 
         $tokenController = null;
         try {
             $tokenController = $this->resolve(TokenController::class);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logOidcResolutionFailure(TokenController::class, $exception);
         }
 
         $revocationController = null;
         try {
             $revocationController = $this->resolve(RevocationController::class);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logOidcResolutionFailure(RevocationController::class, $exception);
         }
 
         $userinfoController = null;
         try {
             $userinfoController = $this->resolve(UserinfoController::class);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logOidcResolutionFailure(UserinfoController::class, $exception);
         }
 
         $consentScreenController = null;
         try {
             $consentScreenController = $this->resolve(ConsentScreenController::class);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
+            $this->logOidcResolutionFailure(ConsentScreenController::class, $exception);
         }
 
         new OidcHttpRoutes(
@@ -231,5 +237,19 @@ final class AuthOidcRouteServiceProvider extends ServiceProvider
             userinfoController: $userinfoController,
             consentScreenController: $consentScreenController,
         )->registerRoutes($router);
+    }
+
+    /** @param class-string $controller */
+    private function logOidcResolutionFailure(string $controller, \Throwable $exception): void
+    {
+        $logger = $this->resolveOptional(LoggerInterface::class);
+        if (!$logger instanceof LoggerInterface) {
+            return;
+        }
+
+        $logger->warning('OIDC route controller could not be resolved; route registration skipped.', [
+            'controller' => $controller,
+            'exception' => $exception,
+        ]);
     }
 }

--- a/packages/routing/tests/Unit/AuthOidcRouteServiceProviderTest.php
+++ b/packages/routing/tests/Unit/AuthOidcRouteServiceProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Routing\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\LoggerTrait;
+use Waaseyaa\Foundation\Log\LogLevel;
+use Waaseyaa\Foundation\ServiceProvider\KernelServicesInterface;
+use Waaseyaa\Routing\AuthOidcRouteServiceProvider;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(AuthOidcRouteServiceProvider::class)]
+final class AuthOidcRouteServiceProviderTest extends TestCase
+{
+    public function test_oidc_controller_resolution_failures_are_logged(): void
+    {
+        $logger = new class implements LoggerInterface {
+            use LoggerTrait;
+
+            /** @var list<array{level: LogLevel, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log(LogLevel $level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+
+        $services = new class ($logger) implements KernelServicesInterface {
+            public function __construct(private readonly LoggerInterface $logger) {}
+
+            public function get(string $abstract): ?object
+            {
+                if ($abstract === LoggerInterface::class) {
+                    return $this->logger;
+                }
+
+                throw new \RuntimeException("Deliberate resolution failure for {$abstract}.");
+            }
+        };
+
+        $provider = new AuthOidcRouteServiceProvider();
+        $provider->setKernelServices($services);
+        $method = new \ReflectionMethod($provider, 'registerOidcRoutes');
+        $method->invoke($provider, new WaaseyaaRouter());
+
+        self::assertCount(5, $logger->records);
+        foreach ($logger->records as $record) {
+            self::assertSame(LogLevel::WARNING, $record['level']);
+            self::assertSame('OIDC route controller could not be resolved; route registration skipped.', $record['message']);
+            self::assertArrayHasKey('controller', $record['context']);
+            self::assertInstanceOf(\RuntimeException::class, $record['context']['exception']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- log each OIDC controller resolution failure before its route is skipped
- preserve optional OIDC route registration behavior
- add regression coverage for all five controller failures

## Testing
- `php -d memory_limit=1G ./vendor/bin/phpunit packages/routing/tests --no-coverage`
- `php -d memory_limit=1G ./vendor/bin/phpstan analyse packages/routing/src packages/routing/tests/Unit/AuthOidcRouteServiceProviderTest.php --no-progress`

Part of #2020