### PR TITLE
fix(#2020): make AI telemetry boot failures observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AI telemetry boot failures are observable (#2020).** Best-effort agent telemetry wiring now warns through the framework logger when dispatcher or repository resolution fails instead of silently disabling the pipeline. The retired duplicate trace-pricing table remains removed, leaving the live `ModelPriceTable` as the sole pricing catalogue.
+
 ## [0.1.0-alpha.264] - 2026-07-14
 
 ### Fixed

--- a/packages/ai-observability/src/AgentTelemetryServiceProvider.php
+++ b/packages/ai-observability/src/AgentTelemetryServiceProvider.php
@@ -80,9 +80,15 @@ final class AgentTelemetryServiceProvider extends ServiceProvider
             }
             $listener = $this->resolve(AgentRunTelemetryListener::class);
             $dispatcher->addSubscriber($listener);
-        } catch (\Throwable) {
+        } catch (\Throwable $exception) {
             // Best-effort wiring: a missing EventDispatcher / AgentRunRepository
             // binding (e.g. minimal kernel without ai-agent) must not break boot.
+            $logger = $this->resolveOptional(LoggerInterface::class);
+            if ($logger instanceof LoggerInterface) {
+                $logger->warning('ai_observability.telemetry_wiring_failed', [
+                    'exception' => $exception,
+                ]);
+            }
         }
     }
 }

--- a/packages/ai-observability/tests/Unit/AgentTelemetryServiceProviderTest.php
+++ b/packages/ai-observability/tests/Unit/AgentTelemetryServiceProviderTest.php
@@ -14,6 +14,7 @@ use Waaseyaa\AI\Observability\Listener\AgentRunTelemetryListener;
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 use Waaseyaa\Foundation\Event\SymfonyEventDispatcherAdapter;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\ServiceProvider\KernelServicesInterface;
 
 /**
@@ -58,6 +59,42 @@ final class AgentTelemetryServiceProviderTest extends TestCase
 
         $provider->boot();
         $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function boot_logs_wiring_failures(): void
+    {
+        $failure = new \RuntimeException('dispatcher unavailable');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                'ai_observability.telemetry_wiring_failed',
+                $this->callback(static fn(array $context): bool => $context['exception'] === $failure),
+            );
+
+        $provider = new AgentTelemetryServiceProvider();
+        $provider->setKernelServices(new class ($logger, $failure) implements KernelServicesInterface {
+            public function __construct(
+                private readonly LoggerInterface $logger,
+                private readonly \Throwable $failure,
+            ) {}
+
+            public function get(string $abstract): ?object
+            {
+                if ($abstract === LoggerInterface::class) {
+                    return $this->logger;
+                }
+                if ($abstract === \Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class) {
+                    throw $this->failure;
+                }
+
+                return null;
+            }
+        });
+        $provider->register();
+
+        $provider->boot();
     }
 
     /**


### PR DESCRIPTION
## Summary
- warn through the framework logger when best-effort telemetry subscriber wiring fails
- pin the formerly silent failure with a provider boundary test
- record that the duplicate trace pricing table was already removed and the live ModelPriceTable is canonical

## Test plan
- `php -d memory_limit=1G ./vendor/bin/phpunit packages/ai-observability/tests --no-coverage`
- `bin/check-package-layers`
- changed-file PHP CS Fixer dry run

Part of #2020