### PR TITLE
docs(#2020): define North Cloud mapper trust boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **North Cloud mapper documentation now names its external-content trust boundary (#2020).** Consumer mappers must sanitize HTML according to each destination field's markup contract before returning values for persistence.
+
 ## [0.1.0-alpha.264] - 2026-07-14
 
 ### Fixed

--- a/packages/northcloud/README.md
+++ b/packages/northcloud/README.md
@@ -58,13 +58,23 @@ final class NcHitToKnowledgeItemMapper implements NcHitToEntityMapperInterface
     {
         return [
             'title' => (string) ($hit['title'] ?? ''),
-            'body' => (string) ($hit['snippet'] ?? $hit['body'] ?? ''),
+            // External HTML must be sanitized here against the destination
+            // field's allowlist before it is persisted.
+            'body' => $this->htmlSanitizer->sanitize(
+                (string) ($hit['snippet'] ?? $hit['body'] ?? ''),
+            ),
             'source_url' => (string) ($hit['url'] ?? ''),
             // ...app-specific fields
         ];
     }
 }
 ```
+
+`NcHitToEntityMapperInterface::map()` is the trust boundary for North Cloud
+content. The sync service cannot safely apply one generic sanitizer because each
+destination field owns a different markup contract. Mapper implementations must
+sanitize external HTML before returning rendered or rich-text field values; plain
+text and identifiers should be validated/coerced for their destination types.
 
 Register the mapper in your `AppServiceProvider`:
 

--- a/packages/northcloud/src/Sync/NcHitToEntityMapperInterface.php
+++ b/packages/northcloud/src/Sync/NcHitToEntityMapperInterface.php
@@ -14,6 +14,12 @@ namespace Waaseyaa\NorthCloud\Sync;
  * Multiple mappers may fire on the same hit — every mapper whose supports() returns
  * true will produce an entity. This lets a single NC article populate, say, both a
  * `teaching` and an `event`.
+ *
+ * Trust boundary: North Cloud hit values are external input. Implementations MUST
+ * sanitize any HTML-bearing value inside map() before returning it for persistence,
+ * according to the destination field's allowed markup. NcSyncService deliberately
+ * treats the returned field array as application-owned data and does not apply a
+ * generic sanitizer that could either miss a field or destroy permitted markup.
  */
 interface NcHitToEntityMapperInterface
 {
@@ -31,6 +37,10 @@ interface NcHitToEntityMapperInterface
 
     /**
      * Map an NC hit to a field array ready for EntityStorage::create().
+     *
+     * This method is the mapper-owned sanitization boundary. Never copy external
+     * HTML directly into a rendered or rich-text field; sanitize it against that
+     * field's allowlist before returning it.
      *
      * @param array<string, mixed> $hit
      * @return array<string, mixed>


### PR DESCRIPTION
## Summary
- document mapper-owned sanitization at the external North Cloud content boundary
- make the README example sanitize rendered HTML before persistence
- explain why the sync service cannot apply one field-agnostic sanitizer

## Testing
- `bin/git diff --check`

Part of #2020