### PR TITLE
test(#2020): pin fail-closed debug gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The debug provider's fail-closed production gate now has regression coverage (#2020).** Malformed `APP_DEBUG` values register neither debug middleware nor preview routes, while an absent environment value may still use explicit server-side configuration.
+
 ## [0.1.0-alpha.264] - 2026-07-14
 
 ### Fixed

--- a/packages/debug/tests/Unit/DebugServiceProviderTest.php
+++ b/packages/debug/tests/Unit/DebugServiceProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Debug\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Debug\DebugServiceProvider;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Routing\Exception\RouteNotFoundException;
+use Waaseyaa\Routing\WaaseyaaRouter;
+
+#[CoversClass(DebugServiceProvider::class)]
+final class DebugServiceProviderTest extends TestCase
+{
+    private string|false $originalAppDebug;
+
+    protected function setUp(): void
+    {
+        $this->originalAppDebug = getenv('APP_DEBUG');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalAppDebug === false) {
+            putenv('APP_DEBUG');
+        } else {
+            putenv('APP_DEBUG='.$this->originalAppDebug);
+        }
+    }
+
+    public function test_malformed_environment_value_fails_closed_even_when_config_enables_debug(): void
+    {
+        putenv('APP_DEBUG=definitely-not-a-boolean');
+        $provider = new DebugServiceProvider();
+        $provider->setKernelContext('', ['debug' => true], []);
+        $manager = new EntityTypeManager(new EventDispatcher());
+        $router = new WaaseyaaRouter();
+
+        $provider->routes($router, $manager);
+
+        self::assertSame([], $provider->middleware($manager));
+        $this->expectException(RouteNotFoundException::class);
+        $router->match('/_error/500');
+    }
+
+    public function test_absent_environment_value_uses_server_side_config(): void
+    {
+        putenv('APP_DEBUG');
+        $provider = new DebugServiceProvider();
+        $provider->setKernelContext('', ['debug' => true], []);
+        $manager = new EntityTypeManager(new EventDispatcher());
+        $router = new WaaseyaaRouter();
+
+        $provider->routes($router, $manager);
+
+        self::assertCount(1, $provider->middleware($manager));
+        self::assertSame('debug.error_preview', $router->match('/_error/500')['_route']);
+    }
+}


### PR DESCRIPTION
## Summary
- prove malformed `APP_DEBUG` values register neither debug middleware nor preview routes
- prove absent `APP_DEBUG` may use explicit server-side configuration
- preserve the existing fail-closed production behavior

## Testing
- `php -d memory_limit=1G ./vendor/bin/phpunit packages/debug/tests --no-coverage`

Part of #2020