### PR TITLE
fix(#2020): make new nodes fail closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **New nodes now default to unpublished and node-type identifiers expose their real domain type (#2020).** Omitted publication state fails closed to draft, while `NodeType::getType()` narrows the generic config-entity id to `?string`.
+
 ## [0.1.0-alpha.264] - 2026-07-14
 
 ### Fixed

--- a/packages/node/src/Node.php
+++ b/packages/node/src/Node.php
@@ -60,8 +60,8 @@ final class Node extends ContentEntityBase implements HydratableFromStorageInter
     #[Field(label: 'Slug', description: 'The URL-friendly identifier for this content.', required: true, settings: ['weight' => 2])]
     public string $slug = '';
 
-    #[Field(type: 'boolean', label: 'Published', description: 'Whether the content is published.', default: 1, settings: ['weight' => 10])]
-    public bool $status = true;
+    #[Field(type: 'boolean', label: 'Published', description: 'Whether the content is published.', default: 0, settings: ['weight' => 10])]
+    public bool $status = false;
 
     #[Field(type: 'boolean', label: 'Promoted to front page', description: 'Whether the content is promoted to the front page.', default: 0, settings: ['weight' => 11])]
     public bool $promote = false;
@@ -102,7 +102,8 @@ final class Node extends ContentEntityBase implements HydratableFromStorageInter
     ) {
         // Ensure defaults for optional properties.
         if (!array_key_exists('status', $values)) {
-            $values['status'] = 1;
+            // New content is private until an explicit publication decision.
+            $values['status'] = 0;
         }
         if (!array_key_exists('promote', $values)) {
             $values['promote'] = 0;

--- a/packages/node/src/NodeType.php
+++ b/packages/node/src/NodeType.php
@@ -54,9 +54,11 @@ final class NodeType extends ConfigEntityBase
     /**
      * Returns the machine name (type) of this node type.
      */
-    public function getType(): int|string|null
+    public function getType(): ?string
     {
-        return $this->id();
+        $id = $this->id();
+
+        return $id === null ? null : (string) $id;
     }
 
     /**

--- a/packages/node/tests/Unit/NodeTest.php
+++ b/packages/node/tests/Unit/NodeTest.php
@@ -160,10 +160,10 @@ final class NodeTest extends TestCase
     // Published status
     // -----------------------------------------------------------------
 
-    public function testIsPublishedDefaultTrue(): void
+    public function testNewNodeDefaultsToUnpublished(): void
     {
         $node = new Node();
-        $this->assertTrue($node->isPublished());
+        $this->assertFalse($node->isPublished());
     }
 
     public function testIsPublishedViaConstructor(): void

--- a/packages/node/tests/Unit/NodeTypeTest.php
+++ b/packages/node/tests/Unit/NodeTypeTest.php
@@ -76,6 +76,15 @@ final class NodeTypeTest extends TestCase
         $this->assertNull($type->getType());
     }
 
+    public function testGetTypeNarrowsTheConfigEntityIdToNullableString(): void
+    {
+        $returnType = new \ReflectionMethod(NodeType::class, 'getType')->getReturnType();
+
+        self::assertInstanceOf(\ReflectionNamedType::class, $returnType);
+        self::assertSame('string', $returnType->getName());
+        self::assertTrue($returnType->allowsNull());
+    }
+
     // -----------------------------------------------------------------
     // Name (human-readable label)
     // -----------------------------------------------------------------

--- a/tests/Integration/Phase7/JsonApiAccessIntegrationTest.php
+++ b/tests/Integration/Phase7/JsonApiAccessIntegrationTest.php
@@ -221,7 +221,7 @@ final class JsonApiAccessIntegrationTest extends TestCase
     }
 
     #[Test]
-    public function createWithoutStatusStaysPublishedForPublishers(): void
+    public function createWithoutStatusDefaultsToDraftEvenForPublishers(): void
     {
         $publisher = new User([
             'uid' => 6,
@@ -235,7 +235,7 @@ final class JsonApiAccessIntegrationTest extends TestCase
             'data' => [
                 'type' => 'node',
                 'attributes' => [
-                    'title' => 'Published by editor',
+                    'title' => 'Draft by editor',
                     'type' => 'article',
                     'uid' => 6,
                     // No 'status' attribute supplied.
@@ -246,7 +246,7 @@ final class JsonApiAccessIntegrationTest extends TestCase
         $this->assertSame(201, $doc->statusCode);
         $uuid = $doc->toArray()['data']['id'];
         $stored = $this->storage->load($this->findNodeIdByUuid($uuid));
-        $this->assertSame(1, (int) $stored->get('status'));
+        $this->assertSame(0, (int) $stored->get('status'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- default omitted node publication state to unpublished for every author, including publishers
- keep explicit publication values unchanged
- narrow `NodeType::getType()` to the domain-accurate `?string`

## Red proof
- `NodeTest::testNewNodeDefaultsToUnpublished` returned true
- `NodeTypeTest::testGetTypeNarrowsTheConfigEntityIdToNullableString` found a union return type

## Testing
- `php -d memory_limit=1G ./vendor/bin/phpunit tests/Integration/Phase7/JsonApiAccessIntegrationTest.php packages/node/tests --no-coverage` (171 tests, 292 assertions)
- first CI pass caught the stale publisher omission expectation and missing `revision-system-unified.md` drift acknowledgement; follow-up commit corrects both

Part of #2020