### PR TITLE
fix(#2020): make policy discovery optimization-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,22 @@ jobs:
             --no-interaction
           (cd "$work/skel-proj" && ./bin/maintenance/waaseyaa-audit-site)
 
+      - name: Fresh skeleton preserves the complete discovery set without classmap optimization
+        run: |
+          set -euo pipefail
+          git -C "$GITHUB_WORKSPACE" checkout -B main
+          work=$(mktemp -d)
+          cleanup() { rm -rf "$work"; }
+          trap cleanup EXIT
+          cp -R skeleton/. "$work/"
+          composer config --working-dir="$work" optimize-autoloader false
+          composer config --working-dir="$work" repositories.framework path "$GITHUB_WORKSPACE"
+          composer config --working-dir="$work" repositories.packages path "$GITHUB_WORKSPACE/packages/*"
+          composer require --working-dir="$work" waaseyaa/framework:dev-main --no-update --no-interaction
+          composer install --working-dir="$work" --no-interaction --no-scripts --no-plugins
+          test "$(php -r '$m=require $argv[1]; echo count(array_filter(array_keys($m), static fn(string $c): bool => str_starts_with($c, "Waaseyaa\\")));' "$work/vendor/composer/autoload_classmap.php")" = 0
+          php "$GITHUB_WORKSPACE/tools/policy-discovery-smoke.php" "$work"
+
   packaged-form:
     name: packaged-form
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Access-policy discovery no longer depends on Composer's optimized classmap (#2020).** Package discovery now unions classmap and PSR-4 candidates, validates every package's declared policy inventory, and aborts boot on missing or divergent policies instead of silently running with partial enforcement. The same scanner fix restores non-optimized discovery for agent tools and definitions, middleware, formatters, field/entity types, and schedule entries.
+
 ### Added
 
 - **Failed queue jobs can be removed individually with `queue:forget` (#2020).** The command returns failure for an unknown ID and deletes only the selected failed row.

--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -1,5 +1,6 @@
 # Access Control
 
+<!-- Spec reviewed 2026-07-14 - #2020 policy discovery security: packages declare their full access-policy inventory in extra.waaseyaa.policies. PackageManifestCompiler rejects missing/divergent discovery before boot, and AccessPolicyRegistry throws rather than warning-and-skipping if a manifested class disappears. -->
 <!-- Spec reviewed 2026-07-14 - R21 WP7 (#2010): bin/check-access-hardening is the recurring prevention gate for the audit's agent-tool guard, public access-vs-status, filter/sort field-access, and explicit route-posture failure classes. It runs fixture self-tests and the real repository scan through composer verify and the blocking verify-gates CI job. -->
 
 <!-- Spec reviewed 2026-07-02 - audit-remediation batch WP3: new Waaseyaa\Path\PathAliasUniquenessListener (BeforeSaveEvent hook enforcing path_alias (alias, langcode) uniqueness) queries via accessCheck(false), justified identically to PathAliasResolver above — a system-context uniqueness check, not a user-facing view. No change to the access pipeline, gate logic, or access-decision semantics; see CHANGELOG [Unreleased] Fixed for the full path-alias NFC-normalization + uniqueness fix. -->
@@ -229,6 +230,8 @@ For `checkFieldAccess()` and `filterFields()`, see `docs/specs/field-access.md`.
 ### Policy Registration
 
 Policies are passed to the constructor or added via `addPolicy()`. In the current post-M10 boot flow, `AccessPolicyRegistry` builds the handler from `PackageManifest::$policies`, while the kernel still exposes the resulting gate to `AccessChecker` during boot:
+
+Every installed package that owns a `#[PolicyAttribute]` class declares that class in `extra.waaseyaa.policies`. Discovery must contain every declared class independent of Composer autoload optimization; a count/content mismatch or a class that cannot be loaded aborts boot with `POLICY_MANIFEST_MISMATCH`. There is no warning-and-continue path for incomplete enforcement.
 
 ```php
 $accessHandler = new EntityAccessHandler([

--- a/docs/specs/package-discovery.md
+++ b/docs/specs/package-discovery.md
@@ -1,5 +1,6 @@
 # Package Discovery
 
+<!-- Spec reviewed 2026-07-14 - #2020 security: attribute discovery unions Composer's classmap with every eligible PSR-4 namespace, so optimization cannot change enforcement or catalogues. Installed packages declare their access-policy inventory in extra.waaseyaa.policies; a missing declared class or manifest entry is a hard boot failure. -->
 <!-- Spec reviewed 2026-05-01 - extra.waaseyaa is the authoritative registration path for providers, commands, and routes. waaseyaa/cli, waaseyaa/api, waaseyaa/graphql, waaseyaa/mcp, waaseyaa/telescope all declare their service providers via extra.waaseyaa.providers; root composer.json reserves extra.waaseyaa.providers as an extension point for app-level providers. ConsoleKernel must not introduce new string-literal command lists; commands belong in the owning package's HasCommandsInterface implementation (mission #824 WP08 surface A, closes #854) -->
 
 Specification for how Waaseyaa packages are discovered, registered, booted, and compiled into optimized artifacts.
@@ -9,9 +10,11 @@ Specification for how Waaseyaa packages are discovered, registered, booted, and 
 Waaseyaa uses a two-phase discovery system:
 
 1. **Coarse-grained**: Composer `extra.waaseyaa` in each package's `composer.json` declares providers, commands, routes, migrations, and permissions.
-2. **Fine-grained**: PHP 8 attributes on classes (`#[AsFieldType]`, `#[Listener]`, `#[AsMiddleware]`, `PolicyAttribute`) are scanned at compile time from Composer's autoload classmap, with PSR-4 directory scanning as fallback.
+2. **Fine-grained**: PHP 8 attributes on classes (`#[AsFieldType]`, `#[Listener]`, `#[AsMiddleware]`, `PolicyAttribute`) are scanned at compile time from the union of Composer's autoload classmap and all eligible PSR-4 directories. PSR-4 is never conditional on the classmap being empty: an ordinary non-optimized install has a valid partial classmap.
 
 Both are unified by `PackageManifestCompiler` into a single cached artifact at `storage/framework/packages.php`.
+
+The cache fingerprint includes `composer.json`, `installed.json`, `autoload_classmap.php`, and `autoload_psr4.php`. Changing autoload optimization therefore invalidates and recompiles the artifact; a cached policy set is also checked against the independent `extra.waaseyaa.policies` inventory before it can boot.
 
 ## ServiceProvider Lifecycle
 
@@ -102,6 +105,7 @@ Each package declares its registration metadata in `extra.waaseyaa`:
     "extra": {
         "waaseyaa": {
             "providers": ["Waaseyaa\\Node\\NodeServiceProvider"],
+            "policies": ["Waaseyaa\\Node\\NodeAccessPolicy"],
             "commands": ["Waaseyaa\\Node\\Command\\NodeCreateCommand"],
             "routes": ["Waaseyaa\\Node\\NodeRouteProvider"],
             "migrations": "migrations/",
@@ -121,6 +125,7 @@ Supported keys:
 | Key | Type | Purpose |
 |-----|------|---------|
 | `providers` | `string[]` | ServiceProvider FQCNs |
+| `policies` | `string[]` | Complete package-owned `#[PolicyAttribute]` class inventory; missing entries/classes fail boot |
 | `commands` | `string[]` | CLI command FQCNs |
 | `routes` | `string[]` | Route provider FQCNs |
 | `migrations` | `string` | Path to migrations directory (relative to package) |

--- a/packages/access/composer.json
+++ b/packages/access/composer.json
@@ -44,6 +44,11 @@
         "branch-alias": {
             "dev-main": "0.1.x-dev",
             "dev-develop/v1.1": "0.1.x-dev"
+        },
+        "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Access\\ConfigEntityAccessPolicy"
+            ]
         }
     },
     "config": {

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -101,6 +101,9 @@
             "dev-develop/v1.1": "0.1.x-dev"
         },
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\AI\\Agent\\Access\\AgentRunAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\AI\\Agent\\AiAgentEntityServiceProvider",
                 "Waaseyaa\\AI\\Agent\\AiAgentServiceProvider",

--- a/packages/attachment/composer.json
+++ b/packages/attachment/composer.json
@@ -50,6 +50,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Attachment\\Policy\\ParentDelegatedAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Attachment\\AttachmentServiceProvider"
             ]

--- a/packages/engagement/composer.json
+++ b/packages/engagement/composer.json
@@ -38,6 +38,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Engagement\\EngagementAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Engagement\\EngagementServiceProvider"
             ]

--- a/packages/field/composer.json
+++ b/packages/field/composer.json
@@ -69,6 +69,9 @@
             "dev-develop/v1.1": "0.1.x-dev"
         },
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Field\\Classification\\Policy\\ClassificationFieldAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Field\\FieldServiceProvider"
             ]

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -131,6 +131,7 @@ final class PackageManifestCompiler
         // declared in the project's extra.waaseyaa.providers must be read separately.
         $this->mergeRootWaaseyaaIntoLists($providers, $permissions, onlyAppendMissingFromRoot: false);
 
+
         // Detect provider capability: ProvidesConsoleCommandsInterface
         // Uses string constant to avoid importing from Layer 6 (CLI package).
         foreach ($providers as $providerClass) {
@@ -223,6 +224,10 @@ final class PackageManifestCompiler
         }
 
         $attributeEntityTypes = array_values(array_unique($attributeEntityTypes));
+        $this->assertDeclaredPoliciesDiscovered(
+            $packages,
+            array_keys($policies),
+        );
 
         return new PackageManifest(
             providers: $providers,
@@ -354,11 +359,18 @@ final class PackageManifestCompiler
 
                     $manifest = PackageManifest::fromArray($data);
                     $manifest = $this->mergeRootWaaseyaaIntoManifest($manifest);
+                    $this->assertDeclaredPoliciesDiscovered(
+                        $this->installedPackages(),
+                        array_keys($manifest->policies),
+                    );
 
                     return $this->validateCachedProviders($manifest, $cachePath, $knownMissing);
                 }
             } catch (StaleManifestException) {
                 // New missing providers — fall through to compileAndCache()
+            } catch (PolicyManifestMismatchException $e) {
+                $this->logger->error($e->getMessage());
+                throw $e;
             } catch (\Throwable $e) {
                 // Corrupt cache (e.g. a cache file that throws on require()) — log
                 // before falling through to recompile, so an operator can see WHY
@@ -520,26 +532,151 @@ final class PackageManifestCompiler
             ));
         }
 
-        // App-namespace classes (e.g. Minoo\) typically aren't in the classmap
-        // without --optimize. Always scan PSR-4 directories for non-framework prefixes
-        // so app-level policies and middleware are discovered.
-        $appPrefixes = array_values(array_filter($prefixes, static fn(string $p) => $p !== 'Waaseyaa\\'));
-        if ($appPrefixes !== []) {
-            $appClasses = $this->scanPsr4Classes($appPrefixes);
-            $candidates = array_values(array_unique(array_merge($candidates, $appClasses)));
-        }
+        // A non-optimized Composer classmap is legitimately partial. Always union
+        // every discovery PSR-4 namespace with it; using PSR-4 only as an all-or-
+        // nothing fallback made four app policies suppress nineteen framework
+        // policies on a routine deployment.
+        $psr4Classes = $this->scanPsr4Classes($prefixes);
+        $candidates = array_values(array_unique(array_merge($candidates, $psr4Classes)));
 
         if ($candidates === []) {
-            // No classmap entries and no app classes — full PSR-4 fallback.
             $this->logger->warning(
                 'PackageManifestCompiler: no discoverable classes found. '
-                . 'Falling back to full PSR-4 directory scanning. '
-                . 'Run "composer dump-autoload --optimize" for faster, reliable discovery.',
+                . 'Composer classmap and PSR-4 scanning both returned no candidates.',
             );
-            $candidates = $this->scanPsr4Classes($prefixes);
         }
 
         return $this->scannedClasses = $this->filterDiscoveryClasses($candidates);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $packages
+     * @param list<string> $discoveredPolicies
+     */
+    private function assertDeclaredPoliciesDiscovered(array $packages, array $discoveredPolicies): void
+    {
+        $expected = $this->collectDeclaredPolicies($packages);
+        $sourceDirectories = $this->collectInstalledSourceDirectories($packages);
+        $actual = [];
+        foreach ($discoveredPolicies as $policyClass) {
+            if (!class_exists($policyClass)) {
+                continue;
+            }
+            $file = new \ReflectionClass($policyClass)->getFileName();
+            $realFile = is_string($file) ? realpath($file) : false;
+            if ($realFile === false) {
+                continue;
+            }
+            foreach ($sourceDirectories as $sourceDirectory) {
+                if (str_starts_with($realFile, $sourceDirectory . DIRECTORY_SEPARATOR)) {
+                    $actual[] = $policyClass;
+                    break;
+                }
+            }
+        }
+
+        // Root application policies remain source-discovered for backwards
+        // compatibility. If an app opts into declarations, validate them too.
+        foreach ($expected as $policyClass) {
+            if (in_array($policyClass, $discoveredPolicies, true) && class_exists($policyClass)) {
+                $actual[] = $policyClass;
+            }
+        }
+
+        $actual = array_values(array_unique($actual));
+        sort($expected);
+        sort($actual);
+
+        if ($actual !== $expected) {
+            throw new PolicyManifestMismatchException($expected, $actual);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $packages
+     * @return list<string>
+     */
+    private function collectDeclaredPolicies(array $packages): array
+    {
+        $declared = [];
+        foreach ($packages as $package) {
+            $policies = $package['extra']['waaseyaa']['policies'] ?? [];
+            if (!is_array($policies)) {
+                continue;
+            }
+            foreach ($policies as $policyClass) {
+                if (is_string($policyClass) && $policyClass !== '') {
+                    $declared[] = $policyClass;
+                }
+            }
+        }
+
+        $rootExtra = $this->readRootWaaseyaaExtra();
+        if (is_array($rootExtra['policies'] ?? null)) {
+            foreach ($rootExtra['policies'] as $policyClass) {
+                if (is_string($policyClass) && $policyClass !== '') {
+                    $declared[] = $policyClass;
+                }
+            }
+        }
+
+        return array_values(array_unique($declared));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $packages
+     * @return list<string>
+     */
+    private function collectInstalledSourceDirectories(array $packages): array
+    {
+        $directories = [];
+        $installedMetadataDir = $this->basePath . '/vendor/composer';
+        foreach ($packages as $package) {
+            $installPath = $package['install-path'] ?? null;
+            if (!is_string($installPath) || $installPath === '') {
+                continue;
+            }
+            $composerPath = $this->resolveInstalledPackageComposerPath($installPath, $installedMetadataDir);
+            if ($composerPath === null) {
+                continue;
+            }
+            $packageRoot = dirname($composerPath);
+            $psr4 = $package['autoload']['psr-4'] ?? [];
+            if (!is_array($psr4)) {
+                continue;
+            }
+            foreach ($psr4 as $relativeDirectories) {
+                foreach (is_array($relativeDirectories) ? $relativeDirectories : [$relativeDirectories] as $relativeDirectory) {
+                    if (!is_string($relativeDirectory)) {
+                        continue;
+                    }
+                    $directory = realpath($packageRoot . '/' . $relativeDirectory);
+                    if ($directory !== false) {
+                        $directories[] = rtrim($directory, DIRECTORY_SEPARATOR);
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($directories));
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function installedPackages(): array
+    {
+        $installedPath = $this->basePath . '/vendor/composer/installed.json';
+        if (!is_file($installedPath)) {
+            return [];
+        }
+        $installed = json_decode(file_get_contents($installedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        return array_map(
+            fn(array $package): array => $this->hydrateInstalledPackageMetadata(
+                package: $package,
+                installedMetadataDir: dirname($installedPath),
+            ),
+            $installed['packages'] ?? $installed,
+        );
     }
 
     private function assertProvidersExist(PackageManifest $manifest, string $cachePath): void
@@ -562,8 +699,10 @@ final class PackageManifestCompiler
     {
         $composerRaw = $this->readFileRaw($this->basePath . '/composer.json');
         $installedRaw = $this->readFileRaw($this->basePath . '/vendor/composer/installed.json');
+        $classmapRaw = $this->readFileRaw($this->basePath . '/vendor/composer/autoload_classmap.php');
+        $psr4Raw = $this->readFileRaw($this->basePath . '/vendor/composer/autoload_psr4.php');
 
-        return hash('xxh128', $composerRaw . "\0" . $installedRaw);
+        return hash('xxh128', implode("\0", [$composerRaw, $installedRaw, $classmapRaw, $psr4Raw]));
     }
 
     private function readFileRaw(string $path): string

--- a/packages/foundation/src/Discovery/PolicyManifestMismatchException.php
+++ b/packages/foundation/src/Discovery/PolicyManifestMismatchException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Foundation\Discovery;
+
+/** @internal Boot-integrity diagnostic for the package discovery compiler. */
+final class PolicyManifestMismatchException extends \RuntimeException
+{
+    /**
+     * @param list<string> $expected
+     * @param list<string> $discovered
+     */
+    public function __construct(
+        array $expected,
+        array $discovered,
+    ) {
+        $missing = array_values(array_diff($expected, $discovered));
+        $unexpected = array_values(array_diff($discovered, $expected));
+
+        parent::__construct(sprintf(
+            'POLICY_MANIFEST_MISMATCH: discovered %d package access policies, manifest declares %d; refusing to boot. Missing: %s; unexpected: %s',
+            count($discovered),
+            count($expected),
+            $missing === [] ? '(none)' : implode(', ', $missing),
+            $unexpected === [] ? '(none)' : implode(', ', $unexpected),
+        ));
+    }
+}

--- a/packages/foundation/src/Kernel/Bootstrap/AccessPolicyRegistry.php
+++ b/packages/foundation/src/Kernel/Bootstrap/AccessPolicyRegistry.php
@@ -14,9 +14,11 @@ final class AccessPolicyRegistry
     private readonly PolicyDependencyResolverInterface $resolver;
 
     public function __construct(
-        private readonly LoggerInterface $logger,
+        LoggerInterface $logger,
         ?PolicyDependencyResolverInterface $resolver = null,
     ) {
+        // Retained for constructor compatibility; missing policies now throw.
+        unset($logger);
         $this->resolver = $resolver ?? new NullPolicyDependencyResolver();
     }
 
@@ -45,13 +47,12 @@ final class AccessPolicyRegistry
         // Phase 1: instantiate policies that do not require EntityAccessHandler.
         foreach ($manifest->policies as $class => $entityTypes) {
             if (!class_exists($class)) {
-                $this->logger->warning(sprintf(
+                throw new PolicyInstantiationException(sprintf(
                     'Access policy class not found: %s (covering entity types: %s). '
-                    . 'Run "composer dump-autoload --optimize" to update the classmap.',
+                    . 'Refusing to boot with incomplete access enforcement.',
                     $class,
                     implode(', ', $entityTypes),
                 ));
-                continue;
             }
 
             $ref = new \ReflectionClass($class);

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -4,6 +4,7 @@ namespace Waaseyaa\Foundation\Tests\Unit\Discovery;
 
 use Waaseyaa\Foundation\Discovery\PackageManifest;
 use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+use Waaseyaa\Foundation\Discovery\PolicyManifestMismatchException;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\LoggerTrait;
 use Waaseyaa\Foundation\Log\LogLevel;
@@ -472,7 +473,7 @@ final class PackageManifestCompilerTest extends TestCase
     {
         // No vendor/composer/autoload_classmap.php and no app-level PSR-4 prefixes
         // (no root composer.json psr-4 entries) — scanClasses() takes the
-        // "no discoverable classes" fallback path and logs exactly one warning
+        // "no discoverable classes" path and logs exactly one warning
         // EACH TIME IT RUNS. compile() invokes scanClasses() directly (the
         // attribute-scan loop) and indirectly via scanScheduleEntryClasses() (the
         // schedule-entries pass) — before memoization this logged the fallback
@@ -499,7 +500,7 @@ final class PackageManifestCompilerTest extends TestCase
 
         $fallbackWarnings = array_values(array_filter(
             $logger->messages,
-            static fn(string $m): bool => str_contains($m, 'Falling back to full PSR-4 directory scanning'),
+            static fn(string $m): bool => str_contains($m, 'classmap and PSR-4 scanning both returned no candidates'),
         ));
 
         $this->assertCount(
@@ -588,6 +589,28 @@ final class PackageManifestCompilerTest extends TestCase
     }
 
     #[Test]
+    public function load_recompiles_when_composer_rewrites_the_autoload_classmap(): void
+    {
+        file_put_contents($this->tempDir . '/composer.json', '{"name":"test/root"}');
+        file_put_contents($this->tempDir . '/vendor/composer/installed.json', '{"packages":[]}');
+        file_put_contents($this->tempDir . '/vendor/composer/autoload_classmap.php', '<?php return [];');
+        file_put_contents($this->tempDir . '/vendor/composer/autoload_psr4.php', '<?php return [];');
+
+        $storagePath = $this->tempDir . '/storage';
+        (new PackageManifestCompiler($this->tempDir, $storagePath))->compileAndCache();
+        $before = require $storagePath . '/framework/packages.php';
+
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_classmap.php',
+            '<?php return ["Composer\\\\InstalledVersions" => "/tmp/InstalledVersions.php"];',
+        );
+        (new PackageManifestCompiler($this->tempDir, $storagePath))->load();
+        $after = require $storagePath . '/framework/packages.php';
+
+        $this->assertNotSame($before['_manifest_inputs_fp'], $after['_manifest_inputs_fp']);
+    }
+
+    #[Test]
     public function load_merges_root_providers_when_cache_incomplete_but_fingerprint_matches(): void
     {
         $composer = [
@@ -608,9 +631,12 @@ final class PackageManifestCompilerTest extends TestCase
 
         $fingerprint = hash(
             'xxh128',
-            (string) file_get_contents($this->tempDir . '/composer.json')
-            . "\0"
-            . (string) file_get_contents($this->tempDir . '/vendor/composer/installed.json'),
+            implode("\0", [
+                (string) file_get_contents($this->tempDir . '/composer.json'),
+                (string) file_get_contents($this->tempDir . '/vendor/composer/installed.json'),
+                '',
+                '',
+            ]),
         );
 
         $storagePath = $this->tempDir . '/storage';
@@ -659,9 +685,12 @@ final class PackageManifestCompilerTest extends TestCase
 
         $fingerprint = hash(
             'xxh128',
-            (string) file_get_contents($this->tempDir . '/composer.json')
-            . "\0"
-            . (string) file_get_contents($this->tempDir . '/vendor/composer/installed.json'),
+            implode("\0", [
+                (string) file_get_contents($this->tempDir . '/composer.json'),
+                (string) file_get_contents($this->tempDir . '/vendor/composer/installed.json'),
+                '',
+                '',
+            ]),
         );
 
         $storagePath = $this->tempDir . '/storage';
@@ -775,6 +804,178 @@ final class PackageManifestCompilerTest extends TestCase
             ['taxonomy_term'],
             $manifest->policies['Waaseyaa\\TestFixturesPsr4\\Gate\\Psr4Policy'] ?? null,
         );
+    }
+
+    #[Test]
+    public function partial_classmap_does_not_hide_framework_policies_behind_app_policies(): void
+    {
+        $appDir = $this->tempDir . '/app';
+        mkdir($appDir, 0o755, true);
+
+        for ($i = 1; $i <= 4; ++$i) {
+            $class = sprintf('AppPolicy%d', $i);
+            $path = $appDir . '/' . $class . '.php';
+            file_put_contents($path, sprintf(<<<'PHP'
+                <?php
+                declare(strict_types=1);
+                namespace App;
+                use Waaseyaa\Access\Gate\PolicyAttribute;
+                #[PolicyAttribute(entityType: 'app_fixture_%1$d')]
+                final class %2$s {}
+                PHP, $i, $class));
+            require_once $path;
+        }
+
+        file_put_contents(
+            $this->tempDir . '/composer.json',
+            json_encode([
+                'name' => 'app/field-reproduction',
+                'autoload' => ['psr-4' => ['App\\' => 'app/']],
+            ], JSON_THROW_ON_ERROR),
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => []], JSON_THROW_ON_ERROR),
+        );
+
+        $repoRoot = dirname(__DIR__, 5);
+        $psr4 = require $repoRoot . '/vendor/composer/autoload_psr4.php';
+        $psr4['App\\'] = [$appDir];
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_psr4.php',
+            '<?php return ' . var_export($psr4, true) . ';',
+        );
+
+        // A routine non-optimized install can contain a partial classmap. The four
+        // app policies are found by the app-prefix scan, but that non-empty result
+        // must not suppress the framework PSR-4 namespaces.
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_classmap.php',
+            '<?php return [\Composer\InstalledVersions::class => ' . var_export($repoRoot . '/vendor/composer/InstalledVersions.php', true) . '];',
+        );
+
+        $manifest = (new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage'))->compile();
+
+        $this->assertCount(23, $manifest->policies);
+        $this->assertArrayHasKey('Waaseyaa\\Node\\NodeAccessPolicy', $manifest->policies);
+        for ($i = 1; $i <= 4; ++$i) {
+            $this->assertArrayHasKey(sprintf('App\\AppPolicy%d', $i), $manifest->policies);
+        }
+        $this->assertContains(
+            'Waaseyaa\\AI\\Tools\\Entity\\EntityReadTool',
+            array_column($manifest->agentTools, 'class'),
+            'The MCP/agent tool catalogue must survive a non-optimized classmap.',
+        );
+        $this->assertSame(
+            'Waaseyaa\\SSR\\Formatter\\PlainTextFormatter',
+            $manifest->formatters['string'] ?? null,
+        );
+        $this->assertContains(
+            'Waaseyaa\\Access\\Middleware\\AuthorizationMiddleware',
+            array_column($manifest->middleware['http'] ?? [], 'class'),
+        );
+    }
+
+    #[Test]
+    public function compile_refuses_to_boot_when_declared_policy_manifest_is_incomplete(): void
+    {
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => [[
+                'name' => 'waaseyaa/security-fixture',
+                'extra' => ['waaseyaa' => ['policies' => [
+                    'Waaseyaa\\SecurityFixture\\MissingPolicy',
+                ]]],
+            ]]], JSON_THROW_ON_ERROR),
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_classmap.php',
+            '<?php return [];',
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_psr4.php',
+            '<?php return [];',
+        );
+
+        $this->expectException(PolicyManifestMismatchException::class);
+        $this->expectExceptionMessage(
+            'POLICY_MANIFEST_MISMATCH: discovered 0 package access policies, manifest declares 1; refusing to boot. Missing: Waaseyaa\\SecurityFixture\\MissingPolicy; unexpected: (none)',
+        );
+
+        (new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage'))->load();
+    }
+
+    #[Test]
+    public function load_rejects_a_cached_manifest_missing_a_declared_policy(): void
+    {
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => [[
+                'name' => 'waaseyaa/node',
+                'extra' => ['waaseyaa' => ['policies' => [
+                    'Waaseyaa\\Node\\NodeAccessPolicy',
+                ]]],
+            ]]], JSON_THROW_ON_ERROR),
+        );
+        $cacheDir = $this->tempDir . '/storage/framework';
+        mkdir($cacheDir, 0o755, true);
+        file_put_contents(
+            $cacheDir . '/packages.php',
+            '<?php return ' . var_export((new PackageManifest())->toArray(), true) . ';',
+        );
+
+        $this->expectException(PolicyManifestMismatchException::class);
+        $this->expectExceptionMessage('discovered 0 package access policies, manifest declares 1');
+
+        (new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage'))->load();
+    }
+
+    #[Test]
+    public function compile_refuses_an_installed_package_policy_omitted_from_the_inventory(): void
+    {
+        $packageRoot = $this->tempDir . '/vendor/waaseyaa/security-fixture';
+        $sourceDir = $packageRoot . '/src';
+        mkdir($sourceDir, 0o755, true);
+        $policyPath = $sourceDir . '/UndeclaredPolicy.php';
+        file_put_contents($policyPath, <<<'PHP'
+            <?php
+            declare(strict_types=1);
+            namespace Waaseyaa\SecurityFixture;
+            use Waaseyaa\Access\Gate\PolicyAttribute;
+            #[PolicyAttribute(entityType: 'security_fixture')]
+            final class UndeclaredPolicy {}
+            PHP);
+        require_once $policyPath;
+        $packageComposer = [
+            'name' => 'waaseyaa/security-fixture',
+            'autoload' => ['psr-4' => ['Waaseyaa\\SecurityFixture\\' => 'src/']],
+        ];
+        file_put_contents(
+            $packageRoot . '/composer.json',
+            json_encode($packageComposer, JSON_THROW_ON_ERROR),
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => [[
+                ...$packageComposer,
+                'install-path' => '../waaseyaa/security-fixture',
+            ]]], JSON_THROW_ON_ERROR),
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_classmap.php',
+            '<?php return [];',
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_psr4.php',
+            '<?php return ["Waaseyaa\\\\SecurityFixture\\\\" => [' . var_export($sourceDir, true) . ']];',
+        );
+
+        $this->expectException(PolicyManifestMismatchException::class);
+        $this->expectExceptionMessage(
+            'Missing: (none); unexpected: Waaseyaa\\SecurityFixture\\UndeclaredPolicy',
+        );
+
+        (new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage'))->compile();
     }
 
     #[Test]

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/AccessPolicyRegistryTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/AccessPolicyRegistryTest.php
@@ -108,7 +108,7 @@ final class AccessPolicyRegistryTest extends TestCase
     }
 
     #[Test]
-    public function missing_policy_class_is_skipped_with_warning(): void
+    public function missing_policy_class_fails_boot_loudly(): void
     {
         $resolver = new class implements PolicyDependencyResolverInterface {
             public function resolveParameter(string $policyClass, \ReflectionParameter $param, array $entityTypes): mixed
@@ -118,17 +118,17 @@ final class AccessPolicyRegistryTest extends TestCase
         };
 
         // Use a class-string for a non-existent class (never loaded) to verify
-        // the registry skips it with a warning rather than throwing.
+        // the registry cannot silently weaken the access-policy set.
         $nonExistentClass = self::nonExistentPolicyClass();
         $manifest = new PackageManifest(
             policies: [$nonExistentClass => ['test_entity']],
         );
 
         $registry = new AccessPolicyRegistry(new NullLogger(), $resolver);
-        // Missing class must not throw — just warn and skip.
-        $handler = $registry->discover($manifest);
+        $this->expectException(PolicyInstantiationException::class);
+        $this->expectExceptionMessage('Access policy class not found');
 
-        self::assertInstanceOf(EntityAccessHandler::class, $handler);
+        $registry->discover($manifest);
     }
 
     /**
@@ -232,7 +232,7 @@ final class AccessPolicyRegistryTest extends TestCase
 
     /**
      * Returns a class-string FQCN for a class that does not exist in the autoloader.
-     * Used to verify the registry skips missing classes with a warning.
+     * Used to verify the registry rejects missing classes.
      *
      * @return class-string
      */

--- a/packages/genealogy/composer.json
+++ b/packages/genealogy/composer.json
@@ -84,6 +84,9 @@
     "extra": {
         "waaseyaa": {
             "distributionExtension": true,
+            "policies": [
+                "Waaseyaa\\Genealogy\\Access\\GenealogyContentAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Genealogy\\GenealogyServiceProvider"
             ]

--- a/packages/media/composer.json
+++ b/packages/media/composer.json
@@ -55,6 +55,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Media\\MediaAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Media\\MediaServiceProvider"
             ],

--- a/packages/menu/composer.json
+++ b/packages/menu/composer.json
@@ -38,6 +38,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Menu\\MenuAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Menu\\MenuServiceProvider"
             ]

--- a/packages/messaging/composer.json
+++ b/packages/messaging/composer.json
@@ -43,6 +43,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Messaging\\MessagingAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Messaging\\MessagingServiceProvider"
             ]

--- a/packages/node/composer.json
+++ b/packages/node/composer.json
@@ -53,6 +53,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Node\\NodeAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Node\\NodeServiceProvider"
             ],

--- a/packages/note/composer.json
+++ b/packages/note/composer.json
@@ -38,6 +38,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Note\\NoteAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Note\\NoteServiceProvider"
             ]

--- a/packages/oidc/composer.json
+++ b/packages/oidc/composer.json
@@ -57,6 +57,9 @@
     "extra": {
         "waaseyaa": {
             "migrations": "migrations",
+            "policies": [
+                "Waaseyaa\\Oidc\\Access\\OidcClientAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Oidc\\OidcServiceProvider"
             ]

--- a/packages/path/composer.json
+++ b/packages/path/composer.json
@@ -43,6 +43,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Path\\PathAliasAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Path\\PathServiceProvider"
             ]

--- a/packages/relationship/composer.json
+++ b/packages/relationship/composer.json
@@ -22,6 +22,10 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Relationship\\RelationshipAccessPolicy",
+                "Waaseyaa\\Relationship\\RelationshipEndpointVisibilityPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Relationship\\RelationshipServiceProvider"
             ]

--- a/packages/taxonomy/composer.json
+++ b/packages/taxonomy/composer.json
@@ -43,6 +43,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Taxonomy\\TermAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Taxonomy\\TaxonomyServiceProvider"
             ]

--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -45,6 +45,10 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\User\\UserAccessPolicy",
+                "Waaseyaa\\User\\UserBlockAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\User\\UserServiceProvider"
             ]

--- a/packages/wayfinding/composer.json
+++ b/packages/wayfinding/composer.json
@@ -53,6 +53,9 @@
     },
     "extra": {
         "waaseyaa": {
+            "policies": [
+                "Waaseyaa\\Wayfinding\\Access\\TrailAccessPolicy"
+            ],
             "providers": [
                 "Waaseyaa\\Wayfinding\\WayfindingServiceProvider"
             ]

--- a/tools/policy-discovery-smoke.php
+++ b/tools/policy-discovery-smoke.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Discovery\PackageManifestCompiler;
+
+$projectRoot = $argv[1] ?? null;
+if (!is_string($projectRoot) || !is_file($projectRoot . '/vendor/autoload.php')) {
+    fwrite(STDERR, "Usage: php tools/policy-discovery-smoke.php <installed-project-root>\n");
+    exit(2);
+}
+
+require $projectRoot . '/vendor/autoload.php';
+
+$manifest = (new PackageManifestCompiler(
+    $projectRoot,
+    $projectRoot . '/storage',
+))->compile();
+
+$actual = [
+    'policies' => count($manifest->policies),
+    'agent_tools' => count($manifest->agentTools),
+    'formatters' => count($manifest->formatters),
+    'middleware' => array_sum(array_map('count', $manifest->middleware)),
+    'schedule_entries' => count($manifest->scheduleEntries),
+];
+$expected = [
+    'policies' => 18,
+    'agent_tools' => 21,
+    'formatters' => 6,
+    'middleware' => 15,
+    'schedule_entries' => 4,
+];
+
+if ($actual !== $expected) {
+    fwrite(STDERR, sprintf(
+        "DISCOVERY_PARITY_FAILURE: expected %s, got %s\n",
+        json_encode($expected, JSON_THROW_ON_ERROR),
+        json_encode($actual, JSON_THROW_ON_ERROR),
+    ));
+    exit(1);
+}
+
+printf("Discovery parity OK: %s\n", json_encode($actual, JSON_THROW_ON_ERROR));


### PR DESCRIPTION
Part of #2020

## Summary

- union Composer classmap and every eligible PSR-4 source tree so non-optimized installs discover the same classes as optimized installs
- declare and validate the exact package-owned access-policy inventory, including cached-manifest validation and hard boot failure on missing/unexpected policies
- make `AccessPolicyRegistry` fail closed if a manifested class cannot load
- extend the blocking fresh-skeleton CI job with an explicitly unoptimized install and exact discovery parity assertions
- document the discovery/security contract and add the required changelog entry

## Root cause

`PackageManifestCompiler::scanClasses()` only scanned Waaseyaa PSR-4 directories when the aggregate candidate set was empty, so the skeleton's app classes made a routine partial classmap look complete and suppressed framework policy discovery.

## Red / green evidence

- Red: field-shape fixture discovered 4 app policies instead of 23 total (`/tmp/2020-policy-discovery-red.log`): 1 test, 1 failure.
- Focused green: 43 tests, 87 assertions.
- Fresh skeleton, `optimize-autoloader=false`, zero Waaseyaa classmap entries: 18 policies, 21 agent tools, 6 formatters, 15 middleware, 4 schedule entries (`/tmp/2020-policy-fresh-skeleton-green.log`).
- Full Unit `--no-coverage`: 9,551 tests, 223,478 assertions.
- Full repository PHPStan pre-push: 1,628 files, no errors.
- Composer policy, package layers, CS, and spec drift: green.

## Discovery audit

Affected and fixed by the shared scanner: policies, agent tools, the MCP catalogue transitively, formatters, middleware, and schedule entries. Composer-metadata providers and provider-registered entity types/routes were immune. Agent-definition discovery shares the corrected scanner but currently has no production attributed definitions.

## Checklist

- [x] **Traceability:** `Part of #2020` references the anchor issue
- [x] PR title includes `#2020`
