### PR TITLE
fix(#2039): run HTTP middleware around final dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Provider and framework HTTP middleware now unwind over the real dispatched response (#2039).** Response-side app effects, security headers, debug headers, and the HTML CSRF cookie reach final controller/domain-router responses instead of being applied to an empty pre-dispatch `200` sentinel.
+
 ## [0.1.0-alpha.265] - 2026-07-14
 
 ### Added

--- a/docs/specs/access-control.md
+++ b/docs/specs/access-control.md
@@ -494,10 +494,10 @@ The `view`-operation symmetry between layers 2 and 3 is deliberate: a row's visi
 
 **Entry point:** `public/index.php`
 
-The authorization pipeline is a pair of HTTP middleware executed in order:
+Authorization participates in the shared HTTP middleware onion around real dispatch:
 
 ```
-Request -> SessionMiddleware -> AuthorizationMiddleware -> Final Handler -> Response
+Request -> SessionMiddleware -> AuthorizationMiddleware -> Controller/domain-router dispatch -> Response
 ```
 
 ### SessionMiddleware
@@ -676,7 +676,7 @@ the per-save `withActorUid()` override is the only knob.
 **File:** `packages/user/src/Middleware/CsrfMiddleware.php`
 **Namespace:** `Waaseyaa\User\Middleware`
 
-`CsrfMiddleware` runs in the HTTP authorization pipeline (priority 20) and enforces session-based CSRF protection for all state-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`).
+`CsrfMiddleware` runs in the HTTP pipeline (priority 20) and enforces session-based CSRF protection for all state-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`). On allowed requests it unwinds over the final dispatched response and attaches the readable token cookie to HTML.
 
 ### XSRF-TOKEN cookie
 

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1461,6 +1461,8 @@ After routing matches, `HttpKernel` builds an `HttpPipeline` of HTTP middleware 
 
 If any middleware short-circuits — for example `AuthorizationMiddleware` returning **302** to `/login` for unauthenticated `_authenticated` render routes, or **401** JSON:API for API routes — it does not call the terminal handler and its response is returned through the outer response-side middleware. Otherwise every middleware unwinds over the real dispatched response, including non-200 controller responses.
 
+Exceptions thrown by terminal dispatch setup (including provider router construction) bubble through the pipeline to the outer `HttpKernel::handle()` catch, preserving the established unhandled-exception JSON detail and log classification. The narrower local pipeline catch remains responsible only for exceptions originating in middleware.
+
 ### Response-side middleware contract
 
 `CsrfMiddleware` attaches `XSRF-TOKEN` while unwinding over a final `text/html` response. `SecurityHeadersMiddleware` applies framing and MIME-sniffing defaults in the same response phase. Provider middleware contributed through `HasMiddlewareInterface` gets the identical supported hook: code after `$next->handle($request)` receives the final response and may return a replacement or decorated response.

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -1453,27 +1453,25 @@ CORS origin resolution in `HttpKernel::handleCors()`:
 2. Checks `WAASEYAA_CORS_ORIGIN` env var — if set, overrides the config array with a single-origin list.
 3. Passes `allowDevLocalhostPorts: true` when the kernel is in development mode (env is `dev`, `development`, `local`, or `testing`), allowing any localhost port.
 
-### HTTP authorization pipeline (`HttpKernel::serveHttpRequest`)
+### HTTP middleware and dispatch pipeline (`HttpKernel::serveHttpRequest`)
 
-`serveHttpRequest()` orchestrates three focused private steps: `matchRoute()` (builds the `WaaseyaaRouter`, matches the path, populates `HttpRequest` attributes — returns `HttpResponse` on 404/405/500), `buildMiddlewareStack()` (assembles and sorts the auth pipeline, returns `HttpPipeline`), and `buildRouterChain()` (assembles domain routers + `BroadcastRouter`, returns `ControllerDispatcher`). Each is a pure code-movement extraction with no behavior change.
+`serveHttpRequest()` orchestrates three focused private steps: `matchRoute()` (builds the `WaaseyaaRouter`, matches the path, populates `HttpRequest` attributes — returns `HttpResponse` on 404/405/500), `buildMiddlewareStack()` (assembles and sorts the HTTP pipeline, returns `HttpPipeline`), and `buildRouterChain()` (assembles domain routers + `BroadcastRouter`, returns `ControllerDispatcher`).
 
-After routing matches, `HttpKernel` builds an `HttpPipeline` of HTTP middleware (Bearer auth, session, CSRF, `AuthorizationMiddleware`, provider middleware). The inner handler is a stub that returns **200** with an empty body when the entire chain allows the request through.
+After routing matches, `HttpKernel` builds an `HttpPipeline` of HTTP middleware (security headers, Bearer auth, session, CSRF, `AuthorizationMiddleware`, provider middleware). Its terminal handler performs request-body preparation and real controller/domain-router dispatch.
 
-If any middleware short-circuits — for example `AuthorizationMiddleware` returning **302** to `/login` for unauthenticated `_authenticated` render routes, or **401** JSON:API for API routes — that response **must** be returned to the client immediately. The kernel treats any pipeline response whose status is **not 200** as final and does not continue to `ControllerDispatcher`. Only **200** from the pipeline means proceed to dispatch.
+If any middleware short-circuits — for example `AuthorizationMiddleware` returning **302** to `/login` for unauthenticated `_authenticated` render routes, or **401** JSON:API for API routes — it does not call the terminal handler and its response is returned through the outer response-side middleware. Otherwise every middleware unwinds over the real dispatched response, including non-200 controller responses.
 
-### XSRF-TOKEN cookie hook (`HttpKernel::serveHttpRequest`)
+### Response-side middleware contract
 
-After `ControllerDispatcher` returns the final controller response, `serveHttpRequest` calls `CsrfMiddleware::attachCookieIfHtml($httpRequest, $finalResponse)` (around line 419). This pairs with the request-side CSRF middleware step earlier in the auth pipeline.
+`CsrfMiddleware` attaches `XSRF-TOKEN` while unwinding over a final `text/html` response. `SecurityHeadersMiddleware` applies framing and MIME-sniffing defaults in the same response phase. Provider middleware contributed through `HasMiddlewareInterface` gets the identical supported hook: code after `$next->handle($request)` receives the final response and may return a replacement or decorated response.
 
-The separation exists because the auth pipeline inner-handler stub returns a bare 200 with no Content-Type; `CsrfMiddleware::attachXsrfCookie` therefore sees no `text/html` response and cannot write the cookie. The kernel post-dispatch hook runs against the real controller response, which carries the correct Content-Type and headers.
-
-Behaviour of the hook:
+Behaviour of the CSRF response step:
 
 - **Restricted to `text/html`** — skips JSON, octet-stream, and any other primary Content-Type.
 - **Idempotent** — no-ops if an `XSRF-TOKEN` cookie is already present on the response (the middleware may have set it for non-validating GET requests that pass through without the 200-stub issue).
 - **Session guard** — returns immediately if no PHP session is active or the session token key is absent.
 
-This hook is the only post-dispatch mutation `serveHttpRequest` applies to the controller response; everything else (CORS, debug headers) is handled earlier in the pipeline.
+The kernel does not duplicate these mutations after dispatch; the middleware onion is the response phase.
 
 ### SlugGenerator (Unicode-preserving slugs)
 

--- a/docs/specs/middleware-pipeline.md
+++ b/docs/specs/middleware-pipeline.md
@@ -144,10 +144,10 @@ A middleware can short-circuit by returning a response without calling `$next->h
 
 ## HTTP Pipeline Chain
 
-The production HTTP pipeline in `HttpKernel::serveHttpRequest()` wires middleware in priority order:
+The production HTTP pipeline in `HttpKernel::serveHttpRequest()` wires middleware in priority order around the real dispatch handler:
 
 ```
-SessionMiddleware -> AuthorizationMiddleware -> final handler
+SecurityHeadersMiddleware -> SessionMiddleware -> CsrfMiddleware -> AuthorizationMiddleware -> provider middleware -> controller/domain-router dispatch
 ```
 
 ### Wiring code (from HttpKernel::serveHttpRequest())
@@ -158,15 +158,18 @@ foreach ($middlewares as $middleware) {
     $pipeline = $pipeline->withMiddleware($middleware);
 }
 
-$authResponse = $pipeline->handle(
+$response = $pipeline->handle(
     $httpRequest,
-    new class implements HttpHandlerInterface {
-        public function handle(HttpRequest $request): HttpResponse {
-            return new HttpResponse('', 200);
-        }
-    },
+    $dispatchHandler,
 );
 ```
+
+The terminal handler performs the real controller/domain-router dispatch. The
+same onion pass therefore supports both request-side checks and response-side
+work: middleware enters before dispatch, may short-circuit by returning its own
+response, and otherwise unwinds over the final response. Provider middleware
+contributed through `HasMiddlewareInterface::middleware()` has this same
+contract; no separate app response hook is required.
 
 `public/index.php` is a thin entry point that boots the kernel and sends the returned response. Production apps typically load `.env` **before** constructing `HttpKernel` via Symfony `Dotenv::loadEnv($projectRoot . '/.env', 'APP_ENV', 'production')` when the file exists — the third argument defaults missing `APP_ENV` to **`production`**, not Symfony's implicit **`dev`**. The monorepo entry wraps malformed `.env` in try/catch; skeleton / `make:public` stub match Minoo's optional-load + outer `Throwable` catch returning JSON:API 500. The file also contains a `cli-server` guard (see [cli-server static file guard](#cli-server-static-file-guard)) so static assets are served directly by the built-in server without passing through `HttpKernel`:
 
@@ -322,7 +325,7 @@ All HTTP middleware implement `HttpMiddlewareInterface` and use `#[AsMiddleware(
 
 | Priority | Class | Package | Purpose |
 |----------|-------|---------|---------|
-| 100 | `SecurityHeadersMiddleware` | foundation | CSP, X-Frame-Options, HSTS. Constructor: `(string $csp, bool $hstsEnabled, int $hstsMaxAge)`. **NOT wired into the runtime pipeline** — see note below; its `process()` decorates only the auth pipeline's stub `200`. The framing/sniffing defaults (`X-Frame-Options: SAMEORIGIN` + `nosniff`) are instead applied post-dispatch by `HttpKernel` via `SecurityHeadersMiddleware::applyResponseDefaults()` (#1651). |
+| 100 | `SecurityHeadersMiddleware` | foundation | Runtime-safe defaults (`X-Frame-Options: SAMEORIGIN` + `nosniff`) around the final response; CSP and HSTS remain opt-in. Constructor: `(?string $csp, bool $hstsEnabled, int $hstsMaxAge, string $frameOptions)`. Explicit construction retains the historical CSP/HSTS-on defaults; `HttpKernel` passes `null`/`false` for those deployment-sensitive headers. |
 | 90 | `CompressionMiddleware` | foundation | gzip compression for responses above minimum size. Constructor: `(int $minimumSize = 1024)` |
 | 80 | `RateLimitMiddleware` | foundation | IP-based rate limiting via `RateLimiterInterface`. Constructor: `(RateLimiterInterface, int $maxAttempts = 60, int $windowSeconds = 60)` |
 | 70 | `BodySizeLimitMiddleware` | foundation | Rejects payloads over max bytes (413). Constructor: `(int $maxBytes = 1_048_576)` |

--- a/docs/specs/security-defaults.md
+++ b/docs/specs/security-defaults.md
@@ -63,16 +63,16 @@ Access enforcement happens at the resolver level via `GraphQlAccessGuard`. Mutat
 
 ### HTTP response security headers
 
-`HttpKernel` applies framing / MIME-sniffing headers to **every dispatched response** via `SecurityHeadersMiddleware::applyResponseDefaults()`, called post-dispatch (#1651):
+`HttpKernel` wires `SecurityHeadersMiddleware` around real controller/domain-router dispatch, so framing / MIME-sniffing headers reach **every dispatched response** during the pipeline's response phase:
 
 | Header | Default | Notes |
 |--------|---------|-------|
 | `X-Frame-Options` | `SAMEORIGIN` | Blocks cross-origin framing (clickjacking) while preserving same-origin inline previews. Configurable via `security_headers.frame_options`. **Omitted** when the matched route set the `_frame_exempt` request attribute (`SecurityHeadersMiddleware::FRAME_EXEMPT_ATTRIBUTE`) — the per-route opt-out for content meant to be framed cross-origin. |
 | `X-Content-Type-Options` | `nosniff` | Always applied. |
 
-> **Why post-dispatch, not a pipeline middleware:** `SecurityHeadersMiddleware`'s `process()` carries `#[AsMiddleware(pipeline: http, priority: 100)]` but is **not** wired into the runtime authorization pipeline — that pipeline's inner handler returns a stub empty `200`, so a pipeline middleware would decorate the stub, never the controller's real response (the same reason `CsrfMiddleware::attachCookieIfHtml` runs post-dispatch). Before #1651 the middleware was compiled into the manifest but never instantiated, so every response was frameable. See [middleware-pipeline.md](middleware-pipeline.md).
+Provider-contributed HTTP middleware uses the same onion response phase: code after `$next->handle()` receives the final response. This is the supported app hook for response headers, cookies, compression, and equivalent response decoration. See [middleware-pipeline.md](middleware-pipeline.md).
 
-`Content-Security-Policy` and `Strict-Transport-Security` are **opt-in**, NOT applied by default: `default-src 'self'` would break consumer SPAs and same-origin inline previews, and HSTS needs HTTPS certainty. A deployment that wants them constructs `SecurityHeadersMiddleware($csp, $hstsEnabled, $hstsMaxAge)` and applies it deliberately (the constructor defaults remain `default-src 'self'` / `X-Frame-Options: DENY` / HSTS-on for that explicit path).
+`Content-Security-Policy` and `Strict-Transport-Security` are **opt-in**, NOT applied by the kernel defaults: `default-src 'self'` would break consumer SPAs and same-origin inline previews, and HSTS needs HTTPS certainty. A deployment that wants them contributes an explicitly configured `SecurityHeadersMiddleware($csp, $hstsEnabled, $hstsMaxAge)` from its provider (the constructor defaults remain `default-src 'self'` / `X-Frame-Options: DENY` / HSTS-on for that explicit path).
 
 ### Rate limiting
 

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -293,27 +293,44 @@ final class HttpKernel extends AbstractKernel
         $httpRequest = $matchResult;
 
         $pipeline = $this->buildMiddlewareStack();
+        $terminalFailure = new class {
+            public ?\Throwable $exception = null;
+        };
+        $terminalDispatch = function (HttpRequest $request) use ($broadcastStorage, $terminalFailure): HttpResponse {
+            try {
+                return $this->dispatchMatchedRequest($request, $broadcastStorage);
+            } catch (\Throwable $e) {
+                // Keep terminal dispatch on HttpKernel::handle()'s established
+                // unhandled-exception surface. The local catch below remains
+                // responsible only for middleware failures, as it was before
+                // dispatch became the pipeline's real terminal handler.
+                $terminalFailure->exception = $e;
+
+                throw $e;
+            }
+        };
 
         try {
             return $pipeline->handle(
                 $httpRequest,
-                new class ($this->dispatchMatchedRequest(...), $broadcastStorage) implements HttpHandlerInterface {
-                    /** @param \Closure(HttpRequest, BroadcastStorage): HttpResponse $dispatch */
-                    public function __construct(
-                        private readonly \Closure $dispatch,
-                        private readonly BroadcastStorage $broadcastStorage,
-                    ) {}
+                new class ($terminalDispatch) implements HttpHandlerInterface {
+                    /** @param \Closure(HttpRequest): HttpResponse $dispatch */
+                    public function __construct(private readonly \Closure $dispatch) {}
 
                     public function handle(HttpRequest $request): HttpResponse
                     {
-                        return ($this->dispatch)($request, $this->broadcastStorage);
+                        return ($this->dispatch)($request);
                     }
                 },
             );
         } catch (\Throwable $e) {
-            $this->logger->critical(sprintf("HTTP middleware/dispatch pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            if ($e === $terminalFailure->exception) {
+                throw $e;
+            }
 
-            return $this->jsonApiResponse(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An HTTP request processing error occurred.']]]);
+            $this->logger->critical(sprintf("Authorization pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+
+            return $this->jsonApiResponse(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An authorization error occurred.']]]);
         }
     }
 

--- a/packages/foundation/src/Kernel/HttpKernel.php
+++ b/packages/foundation/src/Kernel/HttpKernel.php
@@ -53,8 +53,9 @@ use Waaseyaa\User\Middleware\SessionMiddleware;
  * HTTP front controller kernel.
  *
  * Boots the application, handles CORS, matches routes, runs the
- * authorization pipeline (Session -> Authorization), and dispatches
- * to controllers. Returns a Symfony Response for the caller to send.
+ * HTTP middleware pipeline (Session -> Authorization -> dispatch), and returns
+ * a Symfony Response for the caller to send. Response-side middleware unwinds
+ * over the real controller/domain-router response.
  *
  * Error surface: JSON:API (`application/vnd.api+json`) for boot failures and
  * for unhandled exceptions after boot. See docs/specs/infrastructure.md
@@ -294,30 +295,39 @@ final class HttpKernel extends AbstractKernel
         $pipeline = $this->buildMiddlewareStack();
 
         try {
-            $authResponse = $pipeline->handle(
+            return $pipeline->handle(
                 $httpRequest,
-                new class implements HttpHandlerInterface {
+                new class ($this->dispatchMatchedRequest(...), $broadcastStorage) implements HttpHandlerInterface {
+                    /** @param \Closure(HttpRequest, BroadcastStorage): HttpResponse $dispatch */
+                    public function __construct(
+                        private readonly \Closure $dispatch,
+                        private readonly BroadcastStorage $broadcastStorage,
+                    ) {}
+
                     public function handle(HttpRequest $request): HttpResponse
                     {
-                        return new HttpResponse('', 200);
+                        return ($this->dispatch)($request, $this->broadcastStorage);
                     }
                 },
             );
         } catch (\Throwable $e) {
-            $this->logger->critical(sprintf("Authorization pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
+            $this->logger->critical(sprintf("HTTP middleware/dispatch pipeline error: %s in %s:%d\n%s", $e->getMessage(), $e->getFile(), $e->getLine(), $e->getTraceAsString()));
 
-            return $this->jsonApiResponse(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An authorization error occurred.']]]);
+            return $this->jsonApiResponse(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'An HTTP request processing error occurred.']]]);
         }
+    }
 
-        // The pipeline's inner handler returns 200 with an empty body on success.
-        // Short-circuit responses (302 login redirect, 401/403 JSON, etc.) must be returned as-is.
-        if ($authResponse->getStatusCode() !== 200) {
-            return $authResponse;
-        }
-
+    /**
+     * Dispatch the matched request as the middleware pipeline's terminal handler.
+     *
+     * Middleware can therefore short-circuit before dispatch and, on success,
+     * unwind over the real controller response for response-side work.
+     */
+    private function dispatchMatchedRequest(HttpRequest $httpRequest, BroadcastStorage $broadcastStorage): HttpResponse
+    {
         $account = $httpRequest->attributes->get('_account');
         if (!$account instanceof AccountInterface) {
-            $this->logger->error('_account attribute missing or invalid after authorization pipeline.');
+            $this->logger->error('_account attribute missing or invalid after HTTP middleware authentication.');
 
             return $this->jsonApiResponse(500, ['jsonapi' => ['version' => '1.1'], 'errors' => [['status' => '500', 'title' => 'Internal Server Error', 'detail' => 'Account resolution failed.']]]);
         }
@@ -341,32 +351,7 @@ final class HttpKernel extends AbstractKernel
 
         $dispatcher = $this->buildRouterChain();
 
-        $finalResponse = $dispatcher->dispatch($httpRequest);
-
-        // Attach the XSRF-TOKEN cookie to HTML responses after controller
-        // dispatch. CsrfMiddleware runs in the auth pipeline (before the
-        // controller), so it only sees the empty 200 pass-through response,
-        // not the real controller response. We call the middleware's static
-        // helper here to satisfy contract §1 (cookie on every text/html
-        // response) once the actual Content-Type is known.
-        CsrfMiddleware::attachCookieIfHtml($httpRequest, $finalResponse);
-
-        // Apply framing / MIME-sniffing security headers to the dispatched
-        // response (#1651). SecurityHeadersMiddleware never reaches the real
-        // response through the authorization pipeline (its inner handler is a
-        // stub 200), so — like the CSRF cookie above — the headers are applied
-        // here, post-dispatch. X-Frame-Options defaults to SAMEORIGIN (blocks
-        // cross-origin clickjacking, preserves same-origin previews) and is
-        // configurable via security_headers.frame_options; routes that must be
-        // embeddable cross-origin set the _frame_exempt request attribute to opt
-        // out. CSP/HSTS remain opt-in via the middleware constructor.
-        $frameOptions = is_array($this->config['security_headers'] ?? null)
-            && is_string($this->config['security_headers']['frame_options'] ?? null)
-            ? $this->config['security_headers']['frame_options']
-            : 'SAMEORIGIN';
-        SecurityHeadersMiddleware::applyResponseDefaults($httpRequest, $finalResponse, $frameOptions);
-
-        return $finalResponse;
+        return $dispatcher->dispatch($httpRequest);
     }
 
     /**
@@ -416,7 +401,7 @@ final class HttpKernel extends AbstractKernel
     }
 
     /**
-     * Build the ordered middleware pipeline for the authorization phase.
+     * Build the ordered middleware pipeline around real request dispatch.
      *
      * Collects built-in middleware (BearerAuth, Session, CSRF, Authorization),
      * optional debug header middleware, and any provider-contributed middleware,
@@ -432,6 +417,14 @@ final class HttpKernel extends AbstractKernel
         $errorPageRenderer = $this->resolveErrorPageRenderer();
 
         $middlewares = [
+            new SecurityHeadersMiddleware(
+                csp: null,
+                hstsEnabled: false,
+                frameOptions: is_array($this->config['security_headers'] ?? null)
+                    && is_string($this->config['security_headers']['frame_options'] ?? null)
+                    ? $this->config['security_headers']['frame_options']
+                    : 'SAMEORIGIN',
+            ),
             new BearerAuthMiddleware(
                 $userRepository,
                 (string) ($this->config['jwt_secret'] ?? ''),

--- a/packages/foundation/src/Middleware/SecurityHeadersMiddleware.php
+++ b/packages/foundation/src/Middleware/SecurityHeadersMiddleware.php
@@ -21,26 +21,21 @@ final class SecurityHeadersMiddleware implements HttpMiddlewareInterface
     public const string FRAME_EXEMPT_ATTRIBUTE = '_frame_exempt';
 
     public function __construct(
-        private readonly string $csp = "default-src 'self'",
+        private readonly ?string $csp = "default-src 'self'",
         private readonly bool $hstsEnabled = true,
         private readonly int $hstsMaxAge = 31_536_000,
+        private readonly string $frameOptions = 'DENY',
     ) {}
 
     public function process(Request $request, HttpHandlerInterface $next): Response
     {
         $response = $next->handle($request);
 
-        if (!$response->headers->has('Content-Security-Policy')) {
+        if ($this->csp !== null && !$response->headers->has('Content-Security-Policy')) {
             $response->headers->set('Content-Security-Policy', $this->csp);
         }
 
-        if (!$response->headers->has('X-Frame-Options')) {
-            $response->headers->set('X-Frame-Options', 'DENY');
-        }
-
-        if (!$response->headers->has('X-Content-Type-Options')) {
-            $response->headers->set('X-Content-Type-Options', 'nosniff');
-        }
+        self::applyResponseDefaults($request, $response, $this->frameOptions);
 
         if ($this->hstsEnabled && !$response->headers->has('Strict-Transport-Security')) {
             $response->headers->set(
@@ -56,14 +51,9 @@ final class SecurityHeadersMiddleware implements HttpMiddlewareInterface
      * Apply the framing / MIME-sniffing security headers to the FINAL,
      * post-dispatch response (#1651).
      *
-     * Why a static helper and not the pipeline: this middleware's `process()`
-     * runs inside the kernel's authorization pipeline, whose inner handler
-     * returns a stub empty `200` — so a pipeline middleware decorates the stub,
-     * never the controller's real response. (`CsrfMiddleware::attachCookieIfHtml`
-     * exists for the same reason.) `HttpKernel` therefore calls this on the
-     * dispatched response. Before this, `SecurityHeadersMiddleware` was compiled
-     * into the middleware manifest but never instantiated, so every response was
-     * frameable — the spec/kernel drift #1651 documented.
+     * The kernel wires this middleware around its real dispatch handler, so this
+     * helper is used by {@see process()} on the final response. It remains public
+     * for narrowly scoped response decorators and backwards compatibility.
      *
      * Scope — the two headers safe to apply to every response:
      *  - `X-Frame-Options` (`$frameOptions`, default `SAMEORIGIN`): blocks

--- a/packages/user/src/Middleware/CsrfMiddleware.php
+++ b/packages/user/src/Middleware/CsrfMiddleware.php
@@ -28,20 +28,19 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
     {
         $this->ensureToken();
 
-        if (!$this->requiresValidation($request)) {
-            return $next->handle($request);
-        }
-
-        if (!$this->hasValidToken($request)) {
+        if ($this->requiresValidation($request) && !$this->hasValidToken($request)) {
             $route = $request->attributes->get('_route_object');
             $isRenderRoute = $route instanceof Route && $route->getOption('_render') === true;
 
             if ($isRenderRoute) {
-                return new Response(
+                $response = new Response(
                     $this->renderHtmlError(),
                     403,
                     ['Content-Type' => 'text/html; charset=UTF-8'],
                 );
+                self::attachCookieIfHtml($request, $response);
+
+                return $response;
             }
 
             return new JsonResponse([
@@ -54,18 +53,18 @@ final class CsrfMiddleware implements HttpMiddlewareInterface
             ], 403, ['Content-Type' => 'application/vnd.api+json']);
         }
 
-        return $next->handle($request);
+        $response = $next->handle($request);
+        self::attachCookieIfHtml($request, $response);
+
+        return $response;
     }
 
     /**
      * Attach the XSRF-TOKEN cookie to a response if it is a text/html response.
      *
-     * Exposed as a public static helper so the HttpKernel can call it on the
-     * final controller response (which has the real Content-Type) after the
-     * auth pipeline has already run. The middleware itself attaches the cookie
-     * within its pipeline pass, but that runs against the auth-pipeline's empty
-     * 200 pass-through, not the controller response. The kernel calls this
-     * method on the controller response to satisfy contract §1.
+     * The kernel's middleware pipeline terminates in real controller dispatch,
+     * so {@see process()} calls this helper while unwinding over the final
+     * response. It stays public for backwards compatibility and focused tests.
      */
     public static function attachCookieIfHtml(Request $request, Response $response): void
     {

--- a/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
+++ b/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
@@ -7,6 +7,9 @@ namespace Waaseyaa\Tests\Integration\Phase13\Fixtures;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+use Waaseyaa\Foundation\ServiceProvider\Capability\HasMiddlewareInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
@@ -20,11 +23,19 @@ use Waaseyaa\Routing\WaaseyaaRouter;
  *   POST /test/protected     — CSRF-protected multipart endpoint (returns 200 OK)
  *   POST /test/api/json-route — JSON-exempt endpoint (returns 200 always)
  */
-final class CsrfTestServiceProvider extends ServiceProvider
+final class CsrfTestServiceProvider extends ServiceProvider implements HasMiddlewareInterface
 {
     public function register(): void
     {
         // No bindings needed for CSRF integration test routes.
+    }
+
+    /**
+     * @return list<HttpMiddlewareInterface>
+     */
+    public function middleware(EntityTypeManager $entityTypeManager): array
+    {
+        return [new FinalResponseProbeMiddleware()];
     }
 
     public function routes(WaaseyaaRouter $router, EntityTypeManager $entityTypeManager): void
@@ -73,5 +84,22 @@ final class CsrfTestServiceProvider extends ServiceProvider
                 ->methods('POST')
                 ->build(),
         );
+    }
+}
+
+/**
+ * Field-reproduction probe: an app/provider middleware response mutation must
+ * decorate the actual controller response, not the kernel's empty 200 sentinel.
+ */
+final class FinalResponseProbeMiddleware implements HttpMiddlewareInterface
+{
+    public function process(Request $request, HttpHandlerInterface $next): Response
+    {
+        $response = $next->handle($request);
+        $body = (string) $response->getContent();
+        $response->headers->set('X-App-Observed-Status', (string) $response->getStatusCode());
+        $response->headers->set('X-App-Observed-Body-Sha256', hash('sha256', $body));
+
+        return $response;
     }
 }

--- a/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
+++ b/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
@@ -7,9 +7,12 @@ namespace Waaseyaa\Tests\Integration\Phase13\Fixtures;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Http\Router\DomainRouterInterface;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
 use Waaseyaa\Foundation\Middleware\SecurityHeadersMiddleware;
+use Waaseyaa\Foundation\ServiceProvider\Capability\HasHttpDomainRoutersInterface;
 use Waaseyaa\Foundation\ServiceProvider\Capability\HasMiddlewareInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
@@ -24,7 +27,7 @@ use Waaseyaa\Routing\WaaseyaaRouter;
  *   POST /test/protected     — CSRF-protected multipart endpoint (returns 200 OK)
  *   POST /test/api/json-route — JSON-exempt endpoint (returns 200 always)
  */
-final class CsrfTestServiceProvider extends ServiceProvider implements HasMiddlewareInterface
+final class CsrfTestServiceProvider extends ServiceProvider implements HasHttpDomainRoutersInterface, HasMiddlewareInterface
 {
     public function register(): void
     {
@@ -45,6 +48,16 @@ final class CsrfTestServiceProvider extends ServiceProvider implements HasMiddle
             ),
             new FinalResponseProbeMiddleware(),
         ];
+    }
+
+    /** @return iterable<DomainRouterInterface> */
+    public function httpDomainRouters(HttpKernel $kernel): iterable
+    {
+        if (($_SERVER['REQUEST_URI'] ?? '') === '/test/throws') {
+            throw new \RuntimeException('fixture router construction exploded');
+        }
+
+        return [];
     }
 
     public function routes(WaaseyaaRouter $router, EntityTypeManager $entityTypeManager): void
@@ -91,6 +104,17 @@ final class CsrfTestServiceProvider extends ServiceProvider implements HasMiddle
                 ))
                 ->allowAll()
                 ->methods('POST')
+                ->build(),
+        );
+
+        $router->addRoute(
+            'test.controller.throws',
+            RouteBuilder::create('/test/throws')
+                ->controller(static function (): never {
+                    throw new \RuntimeException('fixture controller exploded');
+                })
+                ->allowAll()
+                ->methods('GET')
                 ->build(),
         );
     }

--- a/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
+++ b/tests/Integration/Phase13/Fixtures/CsrfTestServiceProvider.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
 use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+use Waaseyaa\Foundation\Middleware\SecurityHeadersMiddleware;
 use Waaseyaa\Foundation\ServiceProvider\Capability\HasMiddlewareInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\RouteBuilder;
@@ -35,7 +36,15 @@ final class CsrfTestServiceProvider extends ServiceProvider implements HasMiddle
      */
     public function middleware(EntityTypeManager $entityTypeManager): array
     {
-        return [new FinalResponseProbeMiddleware()];
+        return [
+            new SecurityHeadersMiddleware(
+                csp: "default-src 'none'",
+                hstsEnabled: true,
+                hstsMaxAge: 3600,
+                frameOptions: 'SAMEORIGIN',
+            ),
+            new FinalResponseProbeMiddleware(),
+        ];
     }
 
     public function routes(WaaseyaaRouter $router, EntityTypeManager $entityTypeManager): void

--- a/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
+++ b/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
@@ -156,6 +156,23 @@ final class InertiaMultipartCsrfIntegrationTest extends TestCase
         $this->assertNotNull($this->findSetCookieHeader('XSRF-TOKEN', $result['headers']));
     }
 
+    #[Test]
+    public function throwingTerminalDispatchSetupRetainsTheKernelUnhandledExceptionSurface(): void
+    {
+        $result = $this->dispatch([
+            'method' => 'GET',
+            'uri'    => '/test/throws',
+        ]);
+
+        $this->assertSame(500, $result['status']);
+        $payload = json_decode($result['body'], true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(
+            'An unexpected error occurred.',
+            $payload['errors'][0]['detail'] ?? null,
+            'Terminal dispatch exceptions must bubble to HttpKernel::handle(), not be reclassified as middleware failures.',
+        );
+    }
+
     // -----------------------------------------------------------------------
     // T010 — Multipart POST with X-XSRF-TOKEN succeeds (contract §2, §3 happy path)
     // -----------------------------------------------------------------------

--- a/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
+++ b/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
@@ -151,6 +151,8 @@ final class InertiaMultipartCsrfIntegrationTest extends TestCase
         );
         $this->assertSame('nosniff', $this->findHeader('X-Content-Type-Options', $result['headers']));
         $this->assertSame('SAMEORIGIN', $this->findHeader('X-Frame-Options', $result['headers']));
+        $this->assertSame("default-src 'none'", $this->findHeader('Content-Security-Policy', $result['headers']));
+        $this->assertSame('max-age=3600; includeSubDomains', $this->findHeader('Strict-Transport-Security', $result['headers']));
         $this->assertNotNull($this->findSetCookieHeader('XSRF-TOKEN', $result['headers']));
     }
 

--- a/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
+++ b/tests/Integration/Phase13/InertiaMultipartCsrfIntegrationTest.php
@@ -133,6 +133,27 @@ final class InertiaMultipartCsrfIntegrationTest extends TestCase
         $this->assertCookieAttributeAbsent($cookieHeader, 'Expires=', 'Cookie must be session-lifetime (no Expires)');
     }
 
+    #[Test]
+    public function providerMiddlewareAndFrameworkSecurityDecorateTheRealRenderedResponse(): void
+    {
+        $result = $this->dispatch([
+            'method' => 'GET',
+            'uri'    => '/test/protected',
+        ]);
+
+        $this->assertSame(200, $result['status']);
+        $this->assertStringContainsString('<p>CSRF test page</p>', $result['body']);
+        $this->assertSame('200', $this->findHeader('X-App-Observed-Status', $result['headers']));
+        $this->assertSame(
+            hash('sha256', $result['body']),
+            $this->findHeader('X-App-Observed-Body-Sha256', $result['headers']),
+            'Provider middleware must unwind over the final rendered response body.',
+        );
+        $this->assertSame('nosniff', $this->findHeader('X-Content-Type-Options', $result['headers']));
+        $this->assertSame('SAMEORIGIN', $this->findHeader('X-Frame-Options', $result['headers']));
+        $this->assertNotNull($this->findSetCookieHeader('XSRF-TOKEN', $result['headers']));
+    }
+
     // -----------------------------------------------------------------------
     // T010 — Multipart POST with X-XSRF-TOKEN succeeds (contract §2, §3 happy path)
     // -----------------------------------------------------------------------
@@ -301,6 +322,19 @@ final class InertiaMultipartCsrfIntegrationTest extends TestCase
             'body'       => (string) ($payload['body'] ?? ''),
             'session_id' => (string) ($payload['session_id'] ?? ''),
         ];
+    }
+
+    /** @param list<string> $headers */
+    private function findHeader(string $name, array $headers): ?string
+    {
+        $prefix = strtolower($name) . ':';
+        foreach ($headers as $header) {
+            if (str_starts_with(strtolower($header), $prefix)) {
+                return trim(substr($header, strlen($prefix)));
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Closes #2039.

## Finding

A real `HttpKernel` subprocess dispatch confirmed provider middleware received the empty pre-dispatch `200` sentinel, not the rendered response. Framework framing/sniffing headers and the CSRF cookie happened to survive only because `HttpKernel` duplicated those two effects with private/static post-dispatch calls; response-side app middleware had no live hook.

## Change

- Make real controller/domain-router dispatch the `HttpPipeline` terminal handler.
- Wire the framework's safe `SecurityHeadersMiddleware` defaults into that response phase; CSP/HSTS remain opt-in.
- Attach the HTML CSRF cookie while `CsrfMiddleware` unwinds over the final response.
- Remove the kernel's duplicate post-dispatch compensations.
- Document provider `HasMiddlewareInterface` middleware after-`next` code as the supported response hook.

## TDD evidence

Red on alpha.265:

```text
InertiaMultipartCsrfIntegrationTest::providerMiddlewareAndFrameworkSecurityDecorateTheRealRenderedResponse
Failed asserting that null is identical to '200'.
Tests: 5, Assertions: 38, Failures: 1.
```

Green:

```text
Focused real-kernel + middleware: OK (55 tests, 116 assertions)
Foundation + user Unit: OK (1388 tests, 2822 assertions)
Split Unit suite: OK (9578 tests, 223543 assertions)
Targeted PHPStan: No errors
CS, package layers, Symfony import boundary: clean
```

## Security behavior pinned

The real rendered HTML response carries provider-observed final body/status, configured CSP/HSTS, default `X-Frame-Options`/`X-Content-Type-Options`, and `XSRF-TOKEN`.
