### PR TITLE
feat(#2037): encrypt OIDC secrets at rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **OIDC secrets now use purpose-bound encrypted storage (#2037).** RSA private keys and opaque access/refresh tokens are stored in versioned sodium secretbox envelopes under distinct HKDF-derived keys; token lookup uses separate derived HMAC keys, runtime reads require authenticated envelopes, and `oidc:migrate-secrets --confirm` converts existing rows transactionally.
+
 - **Application key custody now has one fail-closed HKDF root (#2037).** Production-equivalent kernels require a canonical 32-byte `WAASEYAA_APP_SECRET`, derive distinct audit-checkpoint and cache-payload HMAC keys with HKDF-SHA-256, require every keyed audit checkpoint (including genesis) to carry a valid versioned signature, and treat legacy cache rows as cold misses. Existing audit chains upgrade only through the explicit transactional `audit:migrate-checkpoint-signatures --confirm` command, which refuses mixed or broken history; the skeleton generates the root secret and an upgrade note covers the trust and migration boundary.
 
 ## [0.1.0-alpha.265] - 2026-07-14

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -995,7 +995,7 @@ Per spec §15 Q9, `extra.waaseyaa.migrations` also accepts an **ordered list** o
 
 **SQLite / `down()`:** Additive column migrations may use a no-op `down()` when portable `DROP COLUMN` is not guaranteed; prefer compensating migrations for breaking changes.
 
-**Reference packages:** `waaseyaa/queue`, `waaseyaa/notification`, `waaseyaa/scheduler`, `waaseyaa/ai-observability` register `migrations`; `waaseyaa/oidc` registers `migrations/2026_04_26_000001_oidc_client_schema.php` for the `oidc_client` table and lookup columns (#1286).
+**Reference packages:** `waaseyaa/queue`, `waaseyaa/notification`, `waaseyaa/scheduler`, `waaseyaa/ai-observability` register `migrations`; `waaseyaa/oidc` registers its client, token, signing-key, consent, and secret-storage migrations. The secret-storage migration adds keyed lookup columns for access and refresh tokens; existing secret values are converted transactionally by the application-key-aware `oidc:migrate-secrets --confirm` command (#2037).
 
 ## HTTP Client
 

--- a/docs/upgrade-notes/oidc-secrets-at-rest.md
+++ b/docs/upgrade-notes/oidc-secrets-at-rest.md
@@ -1,0 +1,19 @@
+# OIDC secrets-at-rest migration
+
+Set the same canonical `WAASEYAA_APP_SECRET` on every issuer process before the
+upgrade. Take and verify a trusted database backup, stop issuer traffic and
+background work, apply migrations, and run:
+
+```sh
+bin/waaseyaa oidc:migrate-secrets --confirm
+```
+
+The command converts existing signing private keys, opaque access tokens, and
+opaque refresh tokens in one transaction. It is idempotent for already-converted
+rows and refuses unrecognized or inconsistent material. Resume issuer traffic
+only after the command succeeds.
+
+Runtime reads require versioned authenticated envelopes. Changing
+`WAASEYAA_APP_SECRET` invalidates persisted OIDC signing-key envelopes, access
+and refresh-token envelopes, and their keyed lookup values. This work package
+does not provide re-encryption or rotation tooling.

--- a/packages/cli/src/Command/Oidc/MigrateSecretsCommand.php
+++ b/packages/cli/src/Command/Oidc/MigrateSecretsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Command\Oidc;
+
+use Waaseyaa\CLI\Command\SymfonyCommandIO;
+use Waaseyaa\Oidc\Security\LegacyOidcSecretMigrator;
+
+/** @api */
+final class MigrateSecretsCommand
+{
+    public function __construct(private readonly LegacyOidcSecretMigrator $migrator) {}
+
+    public function execute(SymfonyCommandIO $io): int
+    {
+        if (!(bool) $io->option('confirm')) {
+            $io->error('oidc:migrate-secrets requires --confirm after verifying a trusted backup.');
+
+            return 1;
+        }
+
+        try {
+            $counts = $this->migrator->migrate();
+        } catch (\RuntimeException $e) {
+            $io->error($e->getMessage());
+
+            return 1;
+        }
+
+        $io->writeln(sprintf(
+            'Encrypted %d signing key(s), %d access token(s), and %d refresh token(s).',
+            $counts['signing_keys'],
+            $counts['access_tokens'],
+            $counts['refresh_tokens'],
+        ));
+
+        return 0;
+    }
+}

--- a/packages/cli/src/Provider/OidcServiceProvider.php
+++ b/packages/cli/src/Provider/OidcServiceProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Waaseyaa\CLI\Provider;
 
 use Waaseyaa\CLI\Command\HandlerCommand;
+use Waaseyaa\CLI\Command\HandlerOption;
+use Waaseyaa\CLI\Command\HandlerOptionMode;
+use Waaseyaa\CLI\Command\Oidc\MigrateSecretsCommand;
 use Waaseyaa\CLI\Command\Oidc\RotateSigningKeyCommand;
 use Waaseyaa\Foundation\ServiceProvider\Capability\ProvidesConsoleCommandsInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
@@ -32,6 +35,18 @@ final class OidcServiceProvider extends ServiceProvider implements ProvidesConso
             name: 'oidc:rotate-signing-key',
             description: 'Generate a new RS256 signing keypair and rotate out the current key (WP04).',
             handler: [RotateSigningKeyCommand::class, 'execute'],
+        );
+        yield new HandlerCommand(
+            name: 'oidc:migrate-secrets',
+            description: 'Encrypt existing OIDC signing keys and opaque tokens with application-derived keys.',
+            handler: [MigrateSecretsCommand::class, 'execute'],
+            options: [
+                new HandlerOption(
+                    name: 'confirm',
+                    mode: HandlerOptionMode::None,
+                    description: 'Confirm the bounded in-place custody migration.',
+                ),
+            ],
         );
     }
 }

--- a/packages/foundation/src/Security/ApplicationSecret.php
+++ b/packages/foundation/src/Security/ApplicationSecret.php
@@ -18,6 +18,11 @@ final class ApplicationSecret
     public const string HKDF_SALT = 'waaseyaa.app-secret.hkdf.v1';
     public const string PURPOSE_AUDIT_CHECKPOINT_HMAC = 'waaseyaa.audit.checkpoint-hmac.v1';
     public const string PURPOSE_CACHE_PAYLOAD_HMAC = 'waaseyaa.cache.payload-hmac.v1';
+    public const string PURPOSE_OIDC_SIGNING_KEY_ENCRYPTION = 'waaseyaa.oidc.signing-key-encryption.v1';
+    public const string PURPOSE_OIDC_ACCESS_TOKEN_ENCRYPTION = 'waaseyaa.oidc.access-token-encryption.v1';
+    public const string PURPOSE_OIDC_ACCESS_TOKEN_LOOKUP = 'waaseyaa.oidc.access-token-lookup.v1';
+    public const string PURPOSE_OIDC_REFRESH_TOKEN_ENCRYPTION = 'waaseyaa.oidc.refresh-token-encryption.v1';
+    public const string PURPOSE_OIDC_REFRESH_TOKEN_LOOKUP = 'waaseyaa.oidc.refresh-token-lookup.v1';
 
     /** @var \WeakMap<self, string>|null */
     private static ?\WeakMap $secrets = null;

--- a/packages/oidc/README.md
+++ b/packages/oidc/README.md
@@ -24,29 +24,25 @@ This package provides the authorization-server primitives used by a dedicated Id
 
 ## Security: secrets at rest
 
-Two categories of long-lived secrets are persisted by this package, and both are
-stored **unencrypted** at rest by design in v1:
+OIDC secret persistence is rooted in `WAASEYAA_APP_SECRET` through distinct,
+versioned HKDF-SHA-256 purposes:
 
-- **Opaque access tokens** (`oidc_access_token.token`, `AccessTokenIssuer`). The
-  value is a 256-bit random string and is looked up by exact value
-  (`findByOpaqueToken`), so the at-rest column must match the bearer string.
-  Tokens are short-lived (1h) and revocable.
-- **RSA signing private keys** (`oidc_signing_key.private_key_pem`,
-  `SigningKeyRepository`). The PEM must be available in plaintext at signing
-  time (`IdTokenMinter`), and keys rotate (current + one previous).
+- RSA private keys use sodium secretbox with a fresh nonce and a strict
+  `secretbox.hkdf-v1:` envelope. Public-key material remains directly readable.
+- Opaque access and refresh tokens use separate secretbox encryption keys and
+  separate HMAC-SHA-256 lookup keys. Exact lookup uses the keyed lookup column;
+  the bearer value is returned only after its encrypted envelope authenticates.
+- Issuer signing uses the encrypted database repository unless file keys are
+  explicitly configured. Database key configuration or decryption errors are
+  propagated and do not select another provider.
 
-**Threat model:** confidentiality of these secrets relies on confidentiality of
-the database file/connection (filesystem permissions, disk encryption, network
-TLS, and DB access control) — the same trust boundary as the rest of the entity
-store. A read of the DB discloses live bearer tokens and signing keys.
+Existing installations run `bin/waaseyaa oidc:migrate-secrets --confirm` in
+maintenance mode after taking a trusted backup. The command converts signing
+keys, access tokens, and refresh tokens in one transaction. Runtime readers
+accept only authenticated envelopes; there is no ongoing plaintext read mode.
+See `docs/upgrade-notes/oidc-secrets-at-rest.md` for the bounded procedure.
 
-Hashing tokens at rest and KMS/app-key-encrypting the signing keys are tracked
-hardening (audit D-13); they are deferred because token hashing must be applied
-consistently across the access- and refresh-token stores and key encryption
-requires app-key/KMS bootstrap and encryption-key rotation — out of scope for a
-single-IdP v1. Do not weaken the DB trust boundary in the meantime.
-
-See [ADR-006](../../docs/adr/006-cross-app-identity-via-oidc.md) for full context, invariants, and migration plan.
+See [ADR-006](../../docs/adr/006-cross-app-identity-via-oidc.md) for full context.
 
 ## Status
 

--- a/packages/oidc/migrations/2026_07_15_000005_oidc_secret_storage.php
+++ b/packages/oidc/migrations/2026_07_15_000005_oidc_secret_storage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+return new class extends Migration {
+    public function up(SchemaBuilder $schema): void
+    {
+        $connection = $schema->getConnection();
+
+        foreach (['oidc_access_token', 'oidc_refresh_token'] as $table) {
+            if (!$schema->hasTable($table) || $schema->hasColumn($table, 'token_lookup')) {
+                continue;
+            }
+
+            $connection->executeStatement(sprintf('ALTER TABLE %s ADD COLUMN token_lookup CHAR(64) NULL', $table));
+            $connection->executeStatement(sprintf('CREATE UNIQUE INDEX idx_%s_lookup ON %s (token_lookup)', $table, $table));
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // Forward-only custody migration.
+    }
+};

--- a/packages/oidc/src/Key/SigningKeyRepository.php
+++ b/packages/oidc/src/Key/SigningKeyRepository.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Oidc\Keys\OpenSslKeyFactory;
 use Waaseyaa\Oidc\Keys\SigningKey;
+use Waaseyaa\Oidc\Security\SecretBoxEnvelope;
 
 /**
  * DB-backed signing key repository.
@@ -16,12 +17,8 @@ use Waaseyaa\Oidc\Keys\SigningKey;
  * Older keys are pruned atomically on each rotate() call.
  * Auto-bootstraps a first key on empty table so cold-start auth requests succeed.
  *
- * Secrets at rest: the RSA private key PEM is stored unencrypted in
- * `private_key_pem` and must remain plaintext at signing time (IdTokenMinter),
- * so confidentiality relies on the database trust boundary. KMS/app-key
- * encryption is tracked hardening (audit D-13) deferred because it requires
- * encryption-key bootstrap and rotation; see packages/oidc/README.md
- * "Secrets at rest".
+ * Private-key PEM values are persisted only in versioned sodium secretbox
+ * envelopes under the application-derived OIDC signing-key purpose.
  *
  * @api
  */
@@ -31,10 +28,15 @@ final class SigningKeyRepository
     private const ALGORITHM = 'RS256';
 
     private bool $tableEnsured = false;
+    private readonly SecretBoxEnvelope $envelope;
 
     public function __construct(
         private readonly DatabaseInterface $database,
-    ) {}
+        #[\SensitiveParameter]
+        string $encryptionKey,
+    ) {
+        $this->envelope = new SecretBoxEnvelope($encryptionKey);
+    }
 
     /**
      * The current signing key (rotated_out_at IS NULL).
@@ -126,7 +128,7 @@ final class SigningKeyRepository
             ->values([
                 'kid' => $kid,
                 'algorithm' => self::ALGORITHM,
-                'private_key_pem' => $privateKeyPem,
+                'private_key_pem' => $this->envelope->seal($privateKeyPem),
                 'public_key_pem' => $publicKeyPem,
                 'created_at' => $nowTs,
                 'rotated_out_at' => null,
@@ -184,7 +186,7 @@ final class SigningKeyRepository
             kid: (string) $row['kid'],
             algorithm: (string) $row['algorithm'],
             publicKeyPem: (string) $row['public_key_pem'],
-            privateKeyPem: (string) $row['private_key_pem'],
+            privateKeyPem: $this->envelope->open((string) $row['private_key_pem']),
         );
     }
 

--- a/packages/oidc/src/OidcServiceProvider.php
+++ b/packages/oidc/src/OidcServiceProvider.php
@@ -9,6 +9,7 @@ use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Security\ApplicationSecret;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Oidc\Authorize\AuthorizationRequestValidator;
 use Waaseyaa\Oidc\Authorize\AuthorizeController;
@@ -29,6 +30,7 @@ use Waaseyaa\Oidc\Keys\PemFileKeyLoader;
 use Waaseyaa\Oidc\Repository\AuthorizationCodeRepositoryInterface;
 use Waaseyaa\Oidc\Repository\DatabaseAuthorizationCodeRepository;
 use Waaseyaa\Oidc\Revoke\RevocationController;
+use Waaseyaa\Oidc\Security\LegacyOidcSecretMigrator;
 use Waaseyaa\Oidc\Token\AccessTokenIssuer;
 use Waaseyaa\Oidc\Token\IdTokenMinter;
 use Waaseyaa\Oidc\Token\InMemoryKeyMaterialProvider;
@@ -57,8 +59,8 @@ final class OidcServiceProvider extends ServiceProvider
             fn(): OidcIssuerConfig => new OidcIssuerConfig(issuerUrl: $this->resolveIssuer()),
         );
 
-        // Key material — WP04 uses DB-backed RealKeyMaterialProvider when
-        // SigningKeyRepository is available; falls back to file-based for existing installs.
+        // File-backed loaders remain available for explicit callers. Issuer signing uses
+        // the encrypted DB repository and propagates configuration/decryption failures.
         $this->singleton(
             OidcKeyLoaderInterface::class,
             fn(): OidcKeyLoaderInterface => $this->resolveKeyLoader(),
@@ -69,23 +71,28 @@ final class OidcServiceProvider extends ServiceProvider
             function (): SigningKeyRepository {
                 $database = $this->resolveDatabase();
 
-                return new SigningKeyRepository(database: $database);
+                $applicationSecret = $this->resolve(ApplicationSecret::class);
+                assert($applicationSecret instanceof ApplicationSecret);
+
+                return new SigningKeyRepository(
+                    database: $database,
+                    encryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_SIGNING_KEY_ENCRYPTION),
+                );
             },
         );
 
         $this->singleton(
             KeyMaterialProviderInterface::class,
             function (): KeyMaterialProviderInterface {
-                // Use DB-backed provider if database is available; fall back to file-backed.
-                try {
-                    return new RealKeyMaterialProvider(
-                        repository: $this->resolve(SigningKeyRepository::class),
-                    );
-                } catch (\Throwable) {
+                if ($this->hasConfiguredFileKeys()) {
                     return new InMemoryKeyMaterialProvider(
                         keyLoader: $this->resolve(OidcKeyLoaderInterface::class),
                     );
                 }
+
+                return new RealKeyMaterialProvider(
+                    repository: $this->resolve(SigningKeyRepository::class),
+                );
             },
         );
 
@@ -127,16 +134,47 @@ final class OidcServiceProvider extends ServiceProvider
         // Token issuers
         $this->singleton(
             AccessTokenIssuer::class,
-            fn(): AccessTokenIssuer => new AccessTokenIssuer(
-                database: $this->resolveDatabase(),
-            ),
+            function (): AccessTokenIssuer {
+                $applicationSecret = $this->resolve(ApplicationSecret::class);
+                assert($applicationSecret instanceof ApplicationSecret);
+
+                return new AccessTokenIssuer(
+                    database: $this->resolveDatabase(),
+                    encryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_ACCESS_TOKEN_ENCRYPTION),
+                    lookupKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_ACCESS_TOKEN_LOOKUP),
+                );
+            },
         );
 
         $this->singleton(
             RefreshTokenIssuer::class,
-            fn(): RefreshTokenIssuer => new RefreshTokenIssuer(
-                database: $this->resolveDatabase(),
-            ),
+            function (): RefreshTokenIssuer {
+                $applicationSecret = $this->resolve(ApplicationSecret::class);
+                assert($applicationSecret instanceof ApplicationSecret);
+
+                return new RefreshTokenIssuer(
+                    database: $this->resolveDatabase(),
+                    encryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_REFRESH_TOKEN_ENCRYPTION),
+                    lookupKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_REFRESH_TOKEN_LOOKUP),
+                );
+            },
+        );
+
+        $this->singleton(
+            LegacyOidcSecretMigrator::class,
+            function (): LegacyOidcSecretMigrator {
+                $applicationSecret = $this->resolve(ApplicationSecret::class);
+                assert($applicationSecret instanceof ApplicationSecret);
+
+                return new LegacyOidcSecretMigrator(
+                    database: $this->resolveDatabase(),
+                    signingKeyEncryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_SIGNING_KEY_ENCRYPTION),
+                    accessTokenEncryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_ACCESS_TOKEN_ENCRYPTION),
+                    accessTokenLookupKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_ACCESS_TOKEN_LOOKUP),
+                    refreshTokenEncryptionKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_REFRESH_TOKEN_ENCRYPTION),
+                    refreshTokenLookupKey: $applicationSecret->derive(ApplicationSecret::PURPOSE_OIDC_REFRESH_TOKEN_LOOKUP),
+                );
+            },
         );
 
         $this->singleton(
@@ -325,5 +363,17 @@ final class OidcServiceProvider extends ServiceProvider
         }
 
         return PemFileKeyLoader::fromConfig([]);
+    }
+
+    private function hasConfiguredFileKeys(): bool
+    {
+        $configKeys = $this->config['oidc']['signing_keys'] ?? null;
+        if (is_array($configKeys) && $configKeys !== []) {
+            return true;
+        }
+
+        $envDir = getenv('OIDC_SIGNING_KEY_DIR');
+
+        return is_string($envDir) && $envDir !== '';
     }
 }

--- a/packages/oidc/src/Security/LegacyOidcSecretMigrator.php
+++ b/packages/oidc/src/Security/LegacyOidcSecretMigrator.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Security;
+
+use Waaseyaa\Database\DatabaseInterface;
+
+/** @api */
+final class LegacyOidcSecretMigrator
+{
+    private readonly SecretBoxEnvelope $signingKeys;
+    private readonly OpaqueTokenProtector $accessTokens;
+    private readonly OpaqueTokenProtector $refreshTokens;
+
+    public function __construct(
+        private readonly DatabaseInterface $database,
+        #[\SensitiveParameter]
+        string $signingKeyEncryptionKey,
+        #[\SensitiveParameter]
+        string $accessTokenEncryptionKey,
+        #[\SensitiveParameter]
+        string $accessTokenLookupKey,
+        #[\SensitiveParameter]
+        string $refreshTokenEncryptionKey,
+        #[\SensitiveParameter]
+        string $refreshTokenLookupKey,
+    ) {
+        $this->signingKeys = new SecretBoxEnvelope($signingKeyEncryptionKey);
+        $this->accessTokens = new OpaqueTokenProtector($accessTokenEncryptionKey, $accessTokenLookupKey);
+        $this->refreshTokens = new OpaqueTokenProtector($refreshTokenEncryptionKey, $refreshTokenLookupKey);
+    }
+
+    /** @return array{signing_keys: int, access_tokens: int, refresh_tokens: int} */
+    public function migrate(): array
+    {
+        $transaction = $this->database->transaction('oidc_secret_storage_migration');
+
+        try {
+            $counts = [
+                'signing_keys' => $this->migrateSigningKeys(),
+                'access_tokens' => $this->migrateTokens('oidc_access_token', $this->accessTokens),
+                'refresh_tokens' => $this->migrateTokens('oidc_refresh_token', $this->refreshTokens),
+            ];
+            $transaction->commit();
+
+            return $counts;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
+        }
+    }
+
+    private function migrateSigningKeys(): int
+    {
+        if (!$this->database->schema()->tableExists('oidc_signing_key')) {
+            return 0;
+        }
+
+        $count = 0;
+        foreach ($this->database->select('oidc_signing_key')->fields('oidc_signing_key', ['kid', 'private_key_pem'])->execute() as $row) {
+            $stored = (string) $row['private_key_pem'];
+            if (str_starts_with($stored, 'secretbox.hkdf-v1:')) {
+                $this->signingKeys->open($stored);
+                continue;
+            }
+            if (!str_starts_with($stored, '-----BEGIN ') || !str_contains($stored, 'PRIVATE KEY-----')) {
+                throw new \RuntimeException('OIDC secret migration refused unrecognized signing-key material.');
+            }
+
+            $updated = $this->database->update('oidc_signing_key')
+                ->fields(['private_key_pem' => $this->signingKeys->seal($stored)])
+                ->condition('kid', (string) $row['kid'])
+                ->condition('private_key_pem', $stored)
+                ->execute();
+            if ($updated !== 1) {
+                throw new \RuntimeException('OIDC secret migration refused a concurrent signing-key change.');
+            }
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    private function migrateTokens(string $table, OpaqueTokenProtector $protector): int
+    {
+        $schema = $this->database->schema();
+        if (!$schema->tableExists($table)) {
+            return 0;
+        }
+        if (!$schema->fieldExists($table, 'token_lookup')) {
+            $schema->addField($table, 'token_lookup', ['type' => 'varchar', 'length' => 64]);
+            $schema->addUniqueKey($table, 'idx_' . $table . '_lookup', ['token_lookup']);
+        }
+
+        $count = 0;
+        foreach ($this->database->select($table)->fields($table, ['jti', 'token', 'token_lookup'])->execute() as $row) {
+            $stored = (string) $row['token'];
+            $lookup = $row['token_lookup'] ?? null;
+            if (is_string($lookup) && $lookup !== '') {
+                $protector->open($stored);
+                continue;
+            }
+            if ($stored === '' || str_starts_with($stored, 'secretbox.hkdf-v1:')) {
+                throw new \RuntimeException('OIDC secret migration refused inconsistent token material.');
+            }
+
+            $updated = $this->database->update($table)
+                ->fields([
+                    'token' => $protector->seal($stored),
+                    'token_lookup' => $protector->lookup($stored),
+                ])
+                ->condition('jti', (string) $row['jti'])
+                ->condition('token', $stored)
+                ->execute();
+            if ($updated !== 1) {
+                throw new \RuntimeException('OIDC secret migration refused a concurrent token change.');
+            }
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    /** @return array{database: string, keys: string} */
+    public function __debugInfo(): array
+    {
+        return ['database' => $this->database::class, 'keys' => '[REDACTED]'];
+    }
+
+    /** @return never */
+    public function __serialize(): array
+    {
+        throw new \LogicException('OIDC secret migrators cannot be serialized.');
+    }
+}

--- a/packages/oidc/src/Security/OpaqueTokenProtector.php
+++ b/packages/oidc/src/Security/OpaqueTokenProtector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Security;
+
+use Waaseyaa\Foundation\Security\SensitiveKey;
+
+/** @api */
+final class OpaqueTokenProtector
+{
+    private readonly SecretBoxEnvelope $envelope;
+    private readonly SensitiveKey $lookupKey;
+
+    public function __construct(
+        #[\SensitiveParameter]
+        string $encryptionKey,
+        #[\SensitiveParameter]
+        string $lookupKey,
+    ) {
+        if (strlen($lookupKey) !== 32) {
+            throw new \InvalidArgumentException('OIDC token lookup keys must be 32 bytes.');
+        }
+
+        $this->envelope = new SecretBoxEnvelope($encryptionKey);
+        $this->lookupKey = new SensitiveKey($lookupKey);
+    }
+
+    public function seal(#[\SensitiveParameter] string $token): string
+    {
+        return $this->envelope->seal($token);
+    }
+
+    public function open(string $envelope): string
+    {
+        return $this->envelope->open($envelope);
+    }
+
+    public function lookup(#[\SensitiveParameter] string $token): string
+    {
+        return hash_hmac('sha256', $token, $this->lookupKey->bytes());
+    }
+
+    /** @return array{envelope: string, lookup_key: string} */
+    public function __debugInfo(): array
+    {
+        return ['envelope' => SecretBoxEnvelope::class, 'lookup_key' => '[REDACTED]'];
+    }
+
+    /** @return never */
+    public function __serialize(): array
+    {
+        throw new \LogicException('OIDC token protectors cannot be serialized.');
+    }
+}

--- a/packages/oidc/src/Security/SecretBoxEnvelope.php
+++ b/packages/oidc/src/Security/SecretBoxEnvelope.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Security;
+
+use Waaseyaa\Foundation\Security\SensitiveKey;
+
+/** @api */
+final class SecretBoxEnvelope
+{
+    private const PREFIX = 'secretbox.hkdf-v1:';
+
+    private readonly SensitiveKey $key;
+
+    public function __construct(#[\SensitiveParameter] string $key)
+    {
+        if (strlen($key) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+            throw new \InvalidArgumentException('OIDC encryption keys must be 32 bytes.');
+        }
+
+        $this->key = new SensitiveKey($key);
+    }
+
+    public function seal(#[\SensitiveParameter] string $plaintext): string
+    {
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $this->key->bytes());
+
+        return self::PREFIX . sodium_bin2base64($nonce . $ciphertext, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+
+    public function open(string $envelope): string
+    {
+        if (!str_starts_with($envelope, self::PREFIX)) {
+            throw self::invalidEnvelope();
+        }
+
+        $encoded = substr($envelope, strlen(self::PREFIX));
+        try {
+            $payload = sodium_base642bin($encoded, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING, '');
+        } catch (\SodiumException) {
+            throw self::invalidEnvelope();
+        }
+
+        if (strlen($payload) < SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + SODIUM_CRYPTO_SECRETBOX_MACBYTES) {
+            throw self::invalidEnvelope();
+        }
+
+        $nonce = substr($payload, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $ciphertext = substr($payload, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $this->key->bytes());
+        if ($plaintext === false) {
+            throw self::invalidEnvelope();
+        }
+
+        return $plaintext;
+    }
+
+    /** @return array{key: string} */
+    public function __debugInfo(): array
+    {
+        return ['key' => '[REDACTED]'];
+    }
+
+    /** @return never */
+    public function __serialize(): array
+    {
+        throw new \LogicException('OIDC secret envelopes cannot be serialized.');
+    }
+
+    private static function invalidEnvelope(): \RuntimeException
+    {
+        return new \RuntimeException('OIDC encrypted material could not be authenticated.');
+    }
+}

--- a/packages/oidc/src/Token/AccessTokenIssuer.php
+++ b/packages/oidc/src/Token/AccessTokenIssuer.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Oidc\Token;
 
 use DateTimeImmutable;
 use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Oidc\Security\OpaqueTokenProtector;
 
 /**
  * Issues and persists opaque OIDC access tokens.
@@ -14,11 +15,9 @@ use Waaseyaa\Database\DatabaseInterface;
  * verify them and detect revocation without round-tripping to the IdP JWK set.
  * The token value itself is a 32-byte URL-safe random string (opaque to clients).
  *
- * Secrets at rest: the opaque token is stored unencrypted in the `token` column
- * (lookup is by exact value, see findByOpaqueToken), so confidentiality relies on
- * the database trust boundary. Hashing tokens at rest is tracked hardening
- * (audit D-13) deferred because it must be applied consistently across the
- * access- and refresh-token stores; see packages/oidc/README.md "Secrets at rest".
+ * The bearer value is persisted in a versioned secretbox envelope. Exact lookup
+ * uses a separate application-derived HMAC key and authenticates the envelope
+ * before returning a record.
  *
  * @api
  */
@@ -28,10 +27,17 @@ final class AccessTokenIssuer
     private const EXPIRY_SECONDS = 3600;
 
     private bool $tableEnsured = false;
+    private readonly OpaqueTokenProtector $protector;
 
     public function __construct(
         private readonly DatabaseInterface $database,
-    ) {}
+        #[\SensitiveParameter]
+        string $encryptionKey,
+        #[\SensitiveParameter]
+        string $lookupKey,
+    ) {
+        $this->protector = new OpaqueTokenProtector($encryptionKey, $lookupKey);
+    }
 
     /**
      * Issues a new access token and persists it.
@@ -54,7 +60,8 @@ final class AccessTokenIssuer
         $this->database->insert(self::TABLE)
             ->values([
                 'jti' => $jti,
-                'token' => $token,
+                'token' => $this->protector->seal($token),
+                'token_lookup' => $this->protector->lookup($token),
                 'client_id' => $clientId,
                 'account_id' => $accountId,
                 'scope' => implode(' ', $scopes),
@@ -79,6 +86,8 @@ final class AccessTokenIssuer
         $this->ensureTable();
 
         foreach ($this->database->select(self::TABLE)->condition('jti', $jti)->execute() as $row) {
+            $row['token'] = $this->protector->open((string) $row['token']);
+
             return $row;
         }
 
@@ -86,7 +95,7 @@ final class AccessTokenIssuer
     }
 
     /**
-     * Find an access token by its opaque token value (stored in the `token` column).
+     * Find an access token through its purpose-bound keyed lookup value.
      *
      * @return array<string, mixed>|null
      */
@@ -94,8 +103,13 @@ final class AccessTokenIssuer
     {
         $this->ensureTable();
 
-        foreach ($this->database->select(self::TABLE)->condition('token', $token)->execute() as $row) {
-            return $row;
+        foreach ($this->database->select(self::TABLE)->condition('token_lookup', $this->protector->lookup($token))->execute() as $row) {
+            $storedToken = $this->protector->open((string) $row['token']);
+            if (hash_equals($storedToken, $token)) {
+                $row['token'] = $storedToken;
+
+                return $row;
+            }
         }
 
         return null;
@@ -152,7 +166,8 @@ final class AccessTokenIssuer
         $this->database->query(<<<'SQL'
                 CREATE TABLE IF NOT EXISTS oidc_access_token (
                     jti VARCHAR(128) PRIMARY KEY NOT NULL,
-                    token VARCHAR(128) NOT NULL UNIQUE,
+                    token TEXT NOT NULL UNIQUE,
+                    token_lookup CHAR(64) NOT NULL UNIQUE,
                     client_id VARCHAR(255) NOT NULL,
                     account_id VARCHAR(255) NOT NULL,
                     scope TEXT NOT NULL,
@@ -161,6 +176,15 @@ final class AccessTokenIssuer
                     revoked_at INTEGER
                 )
             SQL);
+
+        $schema = $this->database->schema();
+        if (!$schema->tableExists(self::TABLE)) {
+            throw new \RuntimeException('OIDC access-token schema is unavailable.');
+        }
+        if (!$schema->fieldExists(self::TABLE, 'token_lookup')) {
+            $schema->addField(self::TABLE, 'token_lookup', ['type' => 'varchar', 'length' => 64]);
+            $schema->addUniqueKey(self::TABLE, 'idx_oidc_access_token_lookup', ['token_lookup']);
+        }
 
         $this->tableEnsured = true;
     }

--- a/packages/oidc/src/Token/RefreshTokenIssuer.php
+++ b/packages/oidc/src/Token/RefreshTokenIssuer.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Oidc\Token;
 
 use DateTimeImmutable;
 use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Oidc\Security\OpaqueTokenProtector;
 
 /**
  * Issues and persists OIDC refresh tokens.
@@ -23,10 +24,17 @@ final class RefreshTokenIssuer
     private const EXPIRY_SECONDS = 7_776_000; // 90 days
 
     private bool $tableEnsured = false;
+    private readonly OpaqueTokenProtector $protector;
 
     public function __construct(
         private readonly DatabaseInterface $database,
-    ) {}
+        #[\SensitiveParameter]
+        string $encryptionKey,
+        #[\SensitiveParameter]
+        string $lookupKey,
+    ) {
+        $this->protector = new OpaqueTokenProtector($encryptionKey, $lookupKey);
+    }
 
     /**
      * Issue a new refresh token, optionally inheriting a chain from a prior token.
@@ -53,7 +61,8 @@ final class RefreshTokenIssuer
         $this->database->insert(self::TABLE)
             ->values([
                 'jti' => $jti,
-                'token' => $token,
+                'token' => $this->protector->seal($token),
+                'token_lookup' => $this->protector->lookup($token),
                 'access_token_jti' => $accessTokenJti,
                 'client_id' => $clientId,
                 'account_id' => $accountId,
@@ -88,8 +97,13 @@ final class RefreshTokenIssuer
     {
         $this->ensureTable();
 
-        foreach ($this->database->select(self::TABLE)->condition('token', $token)->execute() as $row) {
-            return $this->hydrate($row);
+        foreach ($this->database->select(self::TABLE)->condition('token_lookup', $this->protector->lookup($token))->execute() as $row) {
+            $storedToken = $this->protector->open((string) $row['token']);
+            if (hash_equals($storedToken, $token)) {
+                $row['token'] = $storedToken;
+
+                return $this->hydrate($row);
+            }
         }
 
         return null;
@@ -103,6 +117,8 @@ final class RefreshTokenIssuer
         $this->ensureTable();
 
         foreach ($this->database->select(self::TABLE)->condition('jti', $jti)->execute() as $row) {
+            $row['token'] = $this->protector->open((string) $row['token']);
+
             return $this->hydrate($row);
         }
 
@@ -173,7 +189,8 @@ final class RefreshTokenIssuer
         $this->database->query(<<<'SQL'
                 CREATE TABLE IF NOT EXISTS oidc_refresh_token (
                     jti VARCHAR(128) PRIMARY KEY NOT NULL,
-                    token VARCHAR(128) NOT NULL UNIQUE,
+                    token TEXT NOT NULL UNIQUE,
+                    token_lookup CHAR(64) NOT NULL UNIQUE,
                     access_token_jti VARCHAR(128) NOT NULL,
                     client_id VARCHAR(255) NOT NULL,
                     account_id VARCHAR(255) NOT NULL,
@@ -185,6 +202,15 @@ final class RefreshTokenIssuer
                     revoked_at INTEGER
                 )
             SQL);
+
+        $schema = $this->database->schema();
+        if (!$schema->tableExists(self::TABLE)) {
+            throw new \RuntimeException('OIDC refresh-token schema is unavailable.');
+        }
+        if (!$schema->fieldExists(self::TABLE, 'token_lookup')) {
+            $schema->addField(self::TABLE, 'token_lookup', ['type' => 'varchar', 'length' => 64]);
+            $schema->addUniqueKey(self::TABLE, 'idx_oidc_refresh_token_lookup', ['token_lookup']);
+        }
 
         $this->tableEnsured = true;
     }

--- a/packages/oidc/tests/Integration/Security/OidcSecretStorageTest.php
+++ b/packages/oidc/tests/Integration/Security/OidcSecretStorageTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Oidc\Tests\Integration\Security;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Oidc\Key\SigningKeyRepository;
+use Waaseyaa\Oidc\Security\LegacyOidcSecretMigrator;
+use Waaseyaa\Oidc\Security\SecretBoxEnvelope;
+use Waaseyaa\Oidc\Token\AccessTokenIssuer;
+use Waaseyaa\Oidc\Token\RefreshTokenIssuer;
+
+final class OidcSecretStorageTest extends TestCase
+{
+    #[Test]
+    public function signing_private_keys_are_stored_in_a_versioned_encrypted_envelope(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $repository = new SigningKeyRepository($db, random_bytes(32));
+
+        $key = $repository->rotate();
+        $stored = (string) $db->getConnection()->fetchOne('SELECT private_key_pem FROM oidc_signing_key');
+
+        self::assertStringStartsWith('secretbox.hkdf-v1:', $stored);
+        self::assertStringNotContainsString((string) $key->privateKeyPem, $stored);
+        self::assertSame($key->privateKeyPem, $repository->currentKey()->privateKeyPem);
+    }
+
+    #[Test]
+    public function opaque_tokens_use_encrypted_storage_and_purpose_bound_lookup_values(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $access = new AccessTokenIssuer($db, random_bytes(32), random_bytes(32));
+        $refresh = new RefreshTokenIssuer($db, random_bytes(32), random_bytes(32));
+        $now = new \DateTimeImmutable('@1700000000');
+
+        $accessPair = $access->issue('client', 'account', ['openid'], $now);
+        $refreshRecord = $refresh->issue(
+            $accessPair->jti,
+            'client',
+            'account',
+            ['openid'],
+            $now->getTimestamp(),
+            $now,
+        );
+
+        $accessRow = $db->getConnection()->fetchAssociative('SELECT token, token_lookup FROM oidc_access_token');
+        $refreshRow = $db->getConnection()->fetchAssociative('SELECT token, token_lookup FROM oidc_refresh_token');
+        self::assertIsArray($accessRow);
+        self::assertIsArray($refreshRow);
+        self::assertStringStartsWith('secretbox.hkdf-v1:', (string) $accessRow['token']);
+        self::assertStringStartsWith('secretbox.hkdf-v1:', (string) $refreshRow['token']);
+        self::assertStringNotContainsString($accessPair->token, (string) $accessRow['token']);
+        self::assertStringNotContainsString($refreshRecord->token, (string) $refreshRow['token']);
+        self::assertNotSame($accessRow['token_lookup'], $refreshRow['token_lookup']);
+        self::assertSame($accessPair->jti, $access->findByOpaqueToken($accessPair->token)['jti'] ?? null);
+        self::assertSame($refreshRecord->jti, $refresh->findByToken($refreshRecord->token)?->jti);
+    }
+
+    #[Test]
+    public function invalid_envelopes_fail_loudly(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $repository = new SigningKeyRepository($db, random_bytes(32));
+        $repository->rotate();
+        $db->getConnection()->executeStatement(
+            "UPDATE oidc_signing_key SET private_key_pem = 'secretbox.hkdf-v1:invalid'",
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $repository->currentKey();
+    }
+
+    #[Test]
+    public function explicit_migration_converts_existing_secret_rows_transactionally(): void
+    {
+        $db = DBALDatabase::createSqlite();
+        $connection = $db->getConnection();
+        $connection->executeStatement('CREATE TABLE oidc_signing_key (kid VARCHAR(36) PRIMARY KEY, algorithm VARCHAR(16), private_key_pem TEXT, public_key_pem TEXT, created_at INTEGER, rotated_out_at INTEGER)');
+        $connection->executeStatement('CREATE TABLE oidc_access_token (jti VARCHAR(128) PRIMARY KEY, token VARCHAR(128), client_id VARCHAR(255), account_id VARCHAR(255), scope TEXT, issued_at INTEGER, expires_at INTEGER, revoked_at INTEGER)');
+        $connection->executeStatement('CREATE TABLE oidc_refresh_token (jti VARCHAR(128) PRIMARY KEY, token VARCHAR(128), access_token_jti VARCHAR(128), client_id VARCHAR(255), account_id VARCHAR(255), scope TEXT, auth_time INTEGER, chain_root_jti VARCHAR(128), issued_at INTEGER, expires_at INTEGER, revoked_at INTEGER)');
+
+        $keyPair = new \Waaseyaa\Oidc\Keys\OpenSslKeyFactory()->generateRsaKeyPair();
+        $connection->insert('oidc_signing_key', ['kid' => 'legacy', 'algorithm' => 'RS256', 'private_key_pem' => $keyPair['private'], 'public_key_pem' => $keyPair['public'], 'created_at' => 1, 'rotated_out_at' => null]);
+        $connection->insert('oidc_access_token', ['jti' => 'access', 'token' => 'legacy-access', 'client_id' => 'client', 'account_id' => 'account', 'scope' => 'openid', 'issued_at' => 1, 'expires_at' => 2, 'revoked_at' => null]);
+        $connection->insert('oidc_refresh_token', ['jti' => 'refresh', 'token' => 'legacy-refresh', 'access_token_jti' => 'access', 'client_id' => 'client', 'account_id' => 'account', 'scope' => 'openid', 'auth_time' => 1, 'chain_root_jti' => 'refresh', 'issued_at' => 1, 'expires_at' => 2, 'revoked_at' => null]);
+
+        $keys = [random_bytes(32), random_bytes(32), random_bytes(32), random_bytes(32), random_bytes(32)];
+        $counts = new LegacyOidcSecretMigrator($db, ...$keys)->migrate();
+
+        self::assertSame(['signing_keys' => 1, 'access_tokens' => 1, 'refresh_tokens' => 1], $counts);
+        self::assertSame($keyPair['private'], (new SigningKeyRepository($db, $keys[0]))->currentKey()->privateKeyPem);
+        self::assertSame('access', (new AccessTokenIssuer($db, $keys[1], $keys[2]))->findByOpaqueToken('legacy-access')['jti'] ?? null);
+        self::assertSame('refresh', (new RefreshTokenIssuer($db, $keys[3], $keys[4]))->findByToken('legacy-refresh')?->jti);
+    }
+
+    #[Test]
+    public function key_and_plaintext_material_are_absent_from_object_and_failure_surfaces(): void
+    {
+        $key = random_bytes(32);
+        $plaintext = 'private-material-' . bin2hex(random_bytes(8));
+        $envelope = new SecretBoxEnvelope($key);
+        $sealed = $envelope->seal($plaintext);
+
+        ob_start();
+        var_dump($envelope);
+        $debug = (string) ob_get_clean() . var_export($envelope, true);
+        self::assertStringNotContainsString($key, $debug);
+        self::assertStringNotContainsString($plaintext, $sealed);
+
+        try {
+            $envelope->open('secretbox.hkdf-v1:invalid');
+            self::fail('Invalid encrypted material must be rejected.');
+        } catch (\RuntimeException $e) {
+            self::assertStringNotContainsString($key, $e->getMessage());
+            self::assertStringNotContainsString($plaintext, $e->getMessage());
+        }
+
+        $this->expectException(\LogicException::class);
+        serialize($envelope);
+    }
+}

--- a/packages/oidc/tests/Integration/Token/TokenControllerTest.php
+++ b/packages/oidc/tests/Integration/Token/TokenControllerTest.php
@@ -330,8 +330,8 @@ final class TokenControllerTest extends TestCase
         }
 
         $db = DBALDatabase::createSqlite();
-        $accessTokenIssuer = new AccessTokenIssuer($db);
-        $refreshTokenIssuer = new RefreshTokenIssuer($db);
+        $accessTokenIssuer = new AccessTokenIssuer($db, str_repeat('a', 32), str_repeat('b', 32));
+        $refreshTokenIssuer = new RefreshTokenIssuer($db, str_repeat('c', 32), str_repeat('d', 32));
 
         return new TokenController(
             clientLookup: new OidcClientLookup($this->repository),

--- a/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
+++ b/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
@@ -49,7 +49,7 @@ final class UserinfoControllerTest extends TestCase
         // Shared in-memory connection for the oidc_access_token table so the
         // issuer and the controller see the same rows.
         $this->tokenDb = DBALDatabase::createSqlite();
-        $this->accessTokenIssuer = new AccessTokenIssuer($this->tokenDb);
+        $this->accessTokenIssuer = new AccessTokenIssuer($this->tokenDb, str_repeat('a', 32), str_repeat('b', 32));
 
         // User entity storage (separate in-memory DB is fine; the controller
         // resolves it via the EntityTypeManager).

--- a/packages/oidc/tests/Unit/OidcAccessHandlerBusResolutionTest.php
+++ b/packages/oidc/tests/Unit/OidcAccessHandlerBusResolutionTest.php
@@ -14,6 +14,7 @@ use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistryKernelServices;
 use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Foundation\Security\ApplicationSecret;
 use Waaseyaa\Oidc\OidcServiceProvider;
 use Waaseyaa\Oidc\Userinfo\UserinfoController;
 
@@ -119,6 +120,7 @@ final class OidcAccessHandlerBusResolutionTest extends TestCase
             providersAccessor: static fn(): array => [],
             accountContext: null,
             accessHandlerAccessor: $accessHandlerAccessor,
+            applicationSecret: ApplicationSecret::fromEnvironmentValue(null, 'testing'),
         );
     }
 

--- a/packages/oidc/tests/Unit/OidcClientSchemaMigrationTest.php
+++ b/packages/oidc/tests/Unit/OidcClientSchemaMigrationTest.php
@@ -43,13 +43,15 @@ final class OidcClientSchemaMigrationTest extends TestCase
 
         $migrator = new Migrator($connection, $repository);
         $result = $migrator->run($all);
-        self::assertSame(4, $result->count);
+        self::assertSame(5, $result->count);
 
         $schema = new SchemaBuilder($connection);
         self::assertTrue($schema->hasTable('oidc_client'));
         self::assertTrue($schema->hasColumn('oidc_client', 'client_id'));
         self::assertTrue($schema->hasColumn('oidc_client', 'is_confidential'));
         self::assertTrue($schema->hasColumn('oidc_client', 'client_secret_hash'));
+        self::assertTrue($schema->hasColumn('oidc_access_token', 'token_lookup'));
+        self::assertTrue($schema->hasColumn('oidc_refresh_token', 'token_lookup'));
 
         $result2 = $migrator->run($all);
         self::assertSame(0, $result2->count);

--- a/packages/oidc/tests/Unit/Revoke/RevocationControllerTest.php
+++ b/packages/oidc/tests/Unit/Revoke/RevocationControllerTest.php
@@ -59,8 +59,8 @@ final class RevocationControllerTest extends TestCase
         );
 
         $this->tokenDb = DBALDatabase::createSqlite();
-        $this->accessTokenIssuer = new AccessTokenIssuer($this->tokenDb);
-        $this->refreshTokenIssuer = new RefreshTokenIssuer($this->tokenDb);
+        $this->accessTokenIssuer = new AccessTokenIssuer($this->tokenDb, str_repeat('a', 32), str_repeat('b', 32));
+        $this->refreshTokenIssuer = new RefreshTokenIssuer($this->tokenDb, str_repeat('c', 32), str_repeat('d', 32));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Part of #2037

## Summary

- stores OIDC signing private keys in strict versioned sodium secretbox envelopes
- stores opaque access and refresh tokens in separate encrypted envelopes
- uses distinct HKDF-derived HMAC lookup keys for access and refresh token lookup
- derives every OIDC custody key from `WAASEYAA_APP_SECRET` under a versioned purpose
- propagates database key configuration and envelope authentication failures
- adds a transactional, operator-confirmed conversion command for existing rows
- updates both migration and runtime schema paths and the package security contract

## TDD evidence

- regression proof before implementation: 3 tests, 1 error, 2 failures
- OIDC package: 201 tests, 495 assertions
- full split Unit suite: 9,597 tests, 223,598 assertions (`--no-coverage`)
- PHPStan: 1,636 files, no errors
- code style, composer policy, and spec drift: green

## Guarantees

- Persisted RSA private-key PEM is available only after its versioned envelope authenticates.
- Persisted opaque access and refresh tokens are encrypted and use distinct purpose-bound lookup values.
- Runtime readers do not accept plaintext secret rows.
- Existing OIDC secret rows convert in one explicit transaction.

## Checklist

- [x] `Part of #2037` references the anchor
- [x] Regression tests were written and run red before implementation
- [x] `[Unreleased]` changelog entry included
- [x] Reviewed contracts and upgrade procedure included
