### PR TITLE
feat(#2043): require deliberate entity API exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Generic JSON:API entity routes now require an explicit exposure opt-in (#2043).** `#[ContentEntityType]` and imperative `EntityType` definitions default `api` to false; routing, discovery, workflow sub-routes, and OpenAPI share the same exposure predicate, while registered unexposed types return a diagnostic naming `api: true`. Compiled discovery now consumes canonical content-entity metadata, and the prior unused `#[AsEntityType]` static-factory path is deprecated. See `docs/upgrade-notes/entity-type-api-exposure.md` for the Minoo inventory and migration.
+
 ### Fixed
 
 - **Provider and framework HTTP middleware now unwind over the real dispatched response (#2039).** Response-side app effects, security headers, debug headers, and the HTML CSRF cookie reach final controller/domain-router responses instead of being applied to an empty pre-dispatch `200` sentinel.

--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -158,6 +158,7 @@ return [
     'Waaseyaa\Entity\EntityTypeInterface' => 'public',
     'Waaseyaa\Entity\EntityTypeManagerInterface' => 'public',
     'Waaseyaa\Entity\DefinesEntityType' => 'public',
+    'Waaseyaa\Entity\ApiExposableEntityTypeInterface' => 'public',
     'Waaseyaa\Entity\FieldableInterface' => 'public',
     'Waaseyaa\Entity\RevisionableInterface' => 'public',
     'Waaseyaa\Entity\TranslatableInterface' => 'public',

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1216,7 +1216,14 @@ final class JsonApiRouteProvider
 }
 ```
 
-Registers a single public discovery route plus five CRUD routes per entity type. The discovery route is always registered, even when no entity types are present.
+Registers a single public discovery route plus generic routes only for entity
+types that deliberately opt in through `ApiExposableEntityTypeInterface`.
+`EntityType` sources that value from `api: true` on `#[ContentEntityType]` or
+the imperative constructor. The default is false. Registered unexposed types
+receive diagnostic-only routes that return `entity_type_not_api_exposed` and
+name the required flag; they receive no CRUD, field auto-save, translation, or
+workflow routes. Discovery and OpenAPI apply the same predicate. The discovery
+route is always registered, even when no entity types are exposed.
 
 | Route Name | Method | Path | Controller Method | Access |
 |-----------|--------|------|-------------------|--------|

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -654,11 +654,21 @@ For multi-bundle entity types (those declaring `bundleEntityType`), fields may a
 
 Entity types are registered explicitly with `EntityTypeManager::registerEntityType()`. The manager throws `\InvalidArgumentException` if a type ID is already registered.
 
-### EntityTypeAttribute (future plugin discovery)
+### Compiled content-entity discovery
 
 File: `packages/entity/src/Attribute/EntityTypeAttribute.php`
 
-PHP attribute `#[EntityTypeAttribute(...)]` for class-level discovery. Extends `WaaseyaaPlugin`. Not currently used for registration (types are still registered manually via `EntityType::fromClass()` + `EntityTypeManager::registerEntityType()`); composer-classmap auto-discovery of `#[ContentEntityType]`-decorated classes is the **M2 mission** ([`attribute-entity-classmap-discovery`](../../kitty-specs/attribute-entity-classmap-discovery-01KQ6E2B/)). Once M2 lands, the explicit registration step disappears.
+`#[ContentEntityType]` is the canonical metadata and compiled-discovery marker.
+When `entity_auto_register` is enabled, `PackageManifestCompiler` records concrete
+content entities and `ProviderRegistry` hydrates the same `EntityType::fromClass()`
+definition used by explicit providers. Existing provider registration remains
+valid and wins before auto-registration. `#[AsEntityType]` plus
+`DefinesEntityType` is retained only as a deprecated compatibility path.
+
+The attribute's `api` flag defaults to `false`. `EntityType` implements
+`ApiExposableEntityTypeInterface`; generic API routing is enabled only when that
+capability returns true. Raw `new EntityType(..., api: true)` registration is the
+imperative escape hatch for dynamic or conditional definitions.
 
 ## Known Transitional Gaps (M1)
 

--- a/docs/specs/package-discovery.md
+++ b/docs/specs/package-discovery.md
@@ -268,7 +268,8 @@ The compiler scans `Waaseyaa\` classes (from either classmap or PSR-4 fallback).
 | `AsFieldType` | Field type plugins | `$instance->id` => class name |
 | `Listener` | Event listeners | Reads `__invoke()` parameter type to determine event class; `$instance->priority` for ordering |
 | `AsMiddleware` | Middleware | `$instance->pipeline` (http/event/job) + `$instance->priority` |
-| `AsEntityType` | Entity types | Currently tracked via providers (no-op in compiler) |
+| `ContentEntityType` | Content entity types | Compiled to `attributeEntityTypes`, hydrated through `EntityType::fromClass()` when auto-registration is enabled |
+| `AsEntityType` | Legacy entity factories | Deprecated compatibility path for `DefinesEntityType` implementations |
 | `PolicyAttribute` | Access policies | `$instance->entityType` => class name |
 
 **Cache output**: `storage/framework/packages.php`

--- a/docs/upgrade-notes/entity-type-api-exposure.md
+++ b/docs/upgrade-notes/entity-type-api-exposure.md
@@ -1,0 +1,50 @@
+# Entity-type JSON:API exposure
+
+Starting with `0.1.0-alpha.266`, registering an entity type no longer enables
+generic `/api/{entity_type}` CRUD routes by itself. Exposure is an explicit
+capability and defaults to `false`.
+
+Attributed content entities that intentionally use the generic JSON:API surface
+must opt in on their canonical metadata:
+
+```php
+#[ContentEntityType(id: 'event', label: 'Event', api: true)]
+final class Event extends ContentEntityBase
+{
+}
+```
+
+Imperatively registered types use the equivalent constructor flag:
+
+```php
+new EntityType(
+    id: 'event_type',
+    label: 'Event type',
+    class: EventType::class,
+    api: true,
+);
+```
+
+Requests to a registered type without the opt-in return a JSON:API `404` error
+with code `entity_type_not_api_exposed`; the detail names the missing `api: true`
+flag. Discovery links, workflow sub-routes, and generated OpenAPI paths use the
+same exposure decision.
+
+## In-house consumer migration
+
+The pre-flip inventory is recorded on framework issue #2043. Minoo currently
+registers 23 application-defined types:
+
+`dictionary_entry`, `example_sentence`, `word_part`, `speaker`, `ingest_log`,
+`featured_item`, `dialect_region`, `group`, `group_type`, `cultural_group`,
+`community`, `elder_support_request`, `contributor`, `event`, `event_type`,
+`game_session`, `daily_challenge`, `crossword_puzzle`, `post`, `saved_word`,
+`translation_memory`, `tm_gap_log`, and `tm_backlog`.
+
+Classify those types in the Minoo repository and add `api: true` only where its
+generic admin surface should continue constructing `/api/{entityType}` requests.
+Minoo's migration is a separate project follow-up; it is not part of the
+framework release.
+
+The `waaseyaa-feeds` types `feed_source`, `feed_item`, and `fetch_log` are
+internal persistence definitions and should remain at the default `api: false`.

--- a/packages/ai-agent/src/AiAgentEntityServiceProvider.php
+++ b/packages/ai-agent/src/AiAgentEntityServiceProvider.php
@@ -42,6 +42,7 @@ final class AiAgentEntityServiceProvider extends ServiceProvider
             keys: ['id' => 'id', 'uuid' => 'id', 'label' => 'id'],
             description: 'One executor invocation. Aggregate root for agent_audit_log.',
             group: 'ai',
+            api: true,
         ));
 
         $this->entityType(new EntityType(
@@ -51,6 +52,7 @@ final class AiAgentEntityServiceProvider extends ServiceProvider
             keys: ['id' => 'id', 'uuid' => 'id', 'label' => 'event_type'],
             description: 'One audit-log row per executor event. Append-only.',
             group: 'ai',
+            api: true,
         ));
 
         $this->singleton(AgentRunRepository::class, fn(): AgentRunRepository => new AgentRunRepository(

--- a/packages/ai-observability/src/ObservabilityServiceProvider.php
+++ b/packages/ai-observability/src/ObservabilityServiceProvider.php
@@ -26,6 +26,7 @@ final class ObservabilityServiceProvider extends ServiceProvider
             class: Trace::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'label'],
             group: 'ai',
+            api: true,
         ));
 
         $this->singleton(TraceContext::class, fn(): TraceContext => new TraceContext());

--- a/packages/ai-pipeline/src/AIPipelineServiceProvider.php
+++ b/packages/ai-pipeline/src/AIPipelineServiceProvider.php
@@ -18,6 +18,7 @@ final class AIPipelineServiceProvider extends ServiceProvider
             class: Pipeline::class,
             keys: ['id' => 'id', 'label' => 'label'],
             group: 'ai',
+            api: true,
         ));
     }
 }

--- a/packages/api/src/ApiDiscoveryController.php
+++ b/packages/api/src/ApiDiscoveryController.php
@@ -38,6 +38,9 @@ final class ApiDiscoveryController
 
         if ($this->account?->isAuthenticated() === true) {
             foreach ($this->entityTypeManager->getDefinitions() as $id => $definition) {
+                if (!EntityTypeApiExposure::isExposed($definition)) {
+                    continue;
+                }
                 if (method_exists($definition, 'isDiscoverable') && !$definition->isDiscoverable()) {
                     continue; // non-discoverable: absent for every caller (FR-002)
                 }

--- a/packages/api/src/EntityTypeApiExposure.php
+++ b/packages/api/src/EntityTypeApiExposure.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Api;
+
+use Waaseyaa\Entity\ApiExposableEntityTypeInterface;
+use Waaseyaa\Entity\EntityTypeInterface;
+
+final class EntityTypeApiExposure
+{
+    public static function isExposed(EntityTypeInterface $entityType): bool
+    {
+        return $entityType instanceof ApiExposableEntityTypeInterface
+            && $entityType->isApiExposed();
+    }
+}

--- a/packages/api/src/JsonApiRouteProvider.php
+++ b/packages/api/src/JsonApiRouteProvider.php
@@ -44,9 +44,46 @@ final class JsonApiRouteProvider
         );
 
         foreach ($this->entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+            if (!EntityTypeApiExposure::isExposed($definition)) {
+                $this->registerNotExposedRoutes($router, $entityTypeId);
+                continue;
+            }
             $this->registerEntityTypeRoutes($router, $entityTypeId);
             $this->registerFieldAutoSave($router, $entityTypeId);
             $this->registerTranslationRoutes($router, $entityTypeId);
+        }
+    }
+
+    private function registerNotExposedRoutes(WaaseyaaRouter $router, string $entityTypeId): void
+    {
+        $diagnostic = static fn(): array => [
+            'statusCode' => 404,
+            'body' => [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [[
+                    'status' => '404',
+                    'code' => 'entity_type_not_api_exposed',
+                    'title' => 'Entity type is not API-exposed',
+                    'detail' => sprintf(
+                        'Entity type "%s" is registered but not API-exposed. Set api: true on #[ContentEntityType] or the imperative EntityType definition.',
+                        $entityTypeId,
+                    ),
+                ]],
+            ],
+        ];
+
+        foreach ([
+            "api.{$entityTypeId}.not_exposed" => $this->basePath . '/' . $entityTypeId,
+            "api.{$entityTypeId}.not_exposed_path" => $this->basePath . '/' . $entityTypeId . '/{path}',
+        ] as $name => $path) {
+            $builder = RouteBuilder::create($path)
+                ->controller($diagnostic)
+                ->methods('GET', 'POST', 'PATCH', 'DELETE', 'PUT')
+                ->allowAll();
+            if (str_ends_with($name, '_path')) {
+                $builder->requirement('path', '.+');
+            }
+            $router->addRoute($name, $builder->build());
         }
     }
 
@@ -224,6 +261,9 @@ final class JsonApiRouteProvider
     public function registerWorkflowTransitionRoutes(WaaseyaaRouter $router): void
     {
         foreach ($this->entityTypeManager->getDefinitions() as $entityTypeId => $definition) {
+            if (!EntityTypeApiExposure::isExposed($definition)) {
+                continue;
+            }
             $this->registerWorkflowTransitionRoutesForType($router, $entityTypeId);
         }
     }

--- a/packages/api/src/OpenApi/OpenApiGenerator.php
+++ b/packages/api/src/OpenApi/OpenApiGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Api\OpenApi;
 
+use Waaseyaa\Api\EntityTypeApiExposure;
 use Waaseyaa\Entity\EntityTypeInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 
@@ -56,11 +57,16 @@ final class OpenApiGenerator
             $schemas = $spec['components']['schemas'];
 
             foreach ($definitions as $entityTypeId => $entityType) {
+                if (!EntityTypeApiExposure::isExposed($entityType)) {
+                    continue;
+                }
                 $paths = array_merge($paths, $this->buildPathsForEntityType($entityType));
                 $schemas = array_merge($schemas, $this->buildSchemasForEntityType($entityType));
             }
 
-            $spec['paths'] = $paths;
+            if ($paths !== []) {
+                $spec['paths'] = $paths;
+            }
             $spec['components']['schemas'] = $schemas;
         }
 

--- a/packages/api/tests/Unit/ApiDiscoveryControllerTest.php
+++ b/packages/api/tests/Unit/ApiDiscoveryControllerTest.php
@@ -44,6 +44,21 @@ final class ApiDiscoveryControllerTest extends TestCase
     }
 
     #[Test]
+    public function discoverOmitsRegisteredTypesWithoutApiOptIn(): void
+    {
+        $manager = new EntityTypeManager(new EventDispatcher());
+        $manager->registerEntityType(new EntityType(
+            id: 'internal_feed',
+            label: 'Internal feed',
+            class: \stdClass::class,
+        ));
+
+        $doc = (new ApiDiscoveryController($manager, '/api', $this->authenticatedAccount()))->discover();
+
+        self::assertSame(['self' => '/api'], $doc['links']);
+    }
+
+    #[Test]
     public function discover_returns_only_self_link_for_anonymous_account(): void
     {
         $manager = $this->createManagerWithArticleAndTag();
@@ -74,12 +89,14 @@ final class ApiDiscoveryControllerTest extends TestCase
             label: 'Article',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+        api: true,
         ));
         $manager->registerEntityType(new EntityType(
             id: 'internal_thing',
             label: 'Internal Thing',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+            api: true,
             discoverable: false,
         ));
 
@@ -122,12 +139,14 @@ final class ApiDiscoveryControllerTest extends TestCase
             label: 'Article',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+        api: true,
         ));
         $manager->registerEntityType(new EntityType(
             id: 'tag',
             label: 'Tag',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+        api: true,
         ));
 
         return $manager;

--- a/packages/api/tests/Unit/ApiServiceProviderTest.php
+++ b/packages/api/tests/Unit/ApiServiceProviderTest.php
@@ -26,6 +26,7 @@ final class ApiServiceProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $router = new WaaseyaaRouter();

--- a/packages/api/tests/Unit/Http/Router/DiscoveryRouterTest.php
+++ b/packages/api/tests/Unit/Http/Router/DiscoveryRouterTest.php
@@ -767,6 +767,7 @@ final class DiscoveryRouterTest extends TestCase
             label: 'Article',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+            api: true,
         ));
 
         return $etm;

--- a/packages/api/tests/Unit/JsonApiRouteProviderTest.php
+++ b/packages/api/tests/Unit/JsonApiRouteProviderTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Foundation\Http\ControllerDispatcher;
 
 #[CoversClass(JsonApiRouteProvider::class)]
 final class JsonApiRouteProviderTest extends TestCase
@@ -35,6 +37,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -52,6 +55,63 @@ final class JsonApiRouteProviderTest extends TestCase
     }
 
     #[Test]
+    public function unexposedFeedTypesReceiveOnlyLoudDiagnosticRoutesByDefault(): void
+    {
+        foreach (['feed_source', 'feed_item', 'fetch_log'] as $entityTypeId) {
+            $this->entityTypeManager->registerEntityType(new EntityType(
+                id: $entityTypeId,
+                label: $entityTypeId,
+                class: TestEntity::class,
+                keys: TestEntity::definitionKeys(),
+            ));
+        }
+
+        $provider = new JsonApiRouteProvider($this->entityTypeManager);
+        $provider->registerRoutes($this->router);
+        $provider->registerWorkflowTransitionRoutes($this->router);
+
+        $routes = $this->router->getRouteCollection();
+        foreach (['feed_source', 'feed_item', 'fetch_log'] as $entityTypeId) {
+            self::assertNull($routes->get("api.{$entityTypeId}.index"));
+            self::assertNull($routes->get("api.{$entityTypeId}.workflow_transitions"));
+            self::assertNull($routes->get("api.{$entityTypeId}.workflow_transition"));
+            $diagnostic = $routes->get("api.{$entityTypeId}.not_exposed");
+            self::assertNotNull($diagnostic);
+            self::assertSame('/api/' . $entityTypeId, $diagnostic->getPath());
+
+            $response = ($diagnostic->getDefault('_controller'))();
+            self::assertSame(404, $response['statusCode']);
+            self::assertSame('entity_type_not_api_exposed', $response['body']['errors'][0]['code']);
+            self::assertStringContainsString('api: true', $response['body']['errors'][0]['detail']);
+        }
+    }
+
+    #[Test]
+    public function unexposedTypeRequestReturnsNamedApiExposureDiagnostic(): void
+    {
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'feed_source',
+            label: 'Feed source',
+            class: TestEntity::class,
+            keys: TestEntity::definitionKeys(),
+        ));
+
+        $router = new WaaseyaaRouter(new \Symfony\Component\Routing\RequestContext('', 'GET'));
+        new JsonApiRouteProvider($this->entityTypeManager)->registerRoutes($router);
+        $match = $router->match('/api/feed_source');
+        $request = Request::create('/api/feed_source');
+        $request->attributes->add($match);
+
+        $response = new ControllerDispatcher([])->dispatch($request);
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('entity_type_not_api_exposed', $document['errors'][0]['code']);
+        self::assertStringContainsString('feed_source', $document['errors'][0]['detail']);
+        self::assertStringContainsString('api: true', $document['errors'][0]['detail']);
+    }
+
+    #[Test]
     public function indexRouteHasCorrectPathAndMethod(): void
     {
         $this->entityTypeManager->registerEntityType(new EntityType(
@@ -59,6 +119,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -79,6 +140,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -98,6 +160,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -117,6 +180,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -136,6 +200,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -155,6 +220,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -175,6 +241,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -194,12 +261,14 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
         $this->entityTypeManager->registerEntityType(new EntityType(
             id: 'user',
             label: 'User',
             class: UserNameContentTestEntity::class,
             keys: UserNameContentTestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -221,6 +290,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager, '/jsonapi');
@@ -252,6 +322,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -273,6 +344,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $provider = new JsonApiRouteProvider($this->entityTypeManager);
@@ -297,6 +369,7 @@ final class JsonApiRouteProviderTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+            api: true,
         ));
 
         $context = new \Symfony\Component\Routing\RequestContext('', 'GET');

--- a/packages/api/tests/Unit/OpenApi/OpenApiGeneratorTest.php
+++ b/packages/api/tests/Unit/OpenApi/OpenApiGeneratorTest.php
@@ -93,6 +93,22 @@ final class OpenApiGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function registeredTypesWithoutApiOptInAreAbsentFromTheSpecification(): void
+    {
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'fetch_log',
+            label: 'Fetch log',
+            class: TestEntity::class,
+            keys: TestEntity::definitionKeys(),
+        ));
+
+        $spec = (new OpenApiGenerator($this->entityTypeManager))->generate();
+
+        self::assertInstanceOf(\stdClass::class, $spec['paths']);
+        self::assertArrayNotHasKey('FetchLogResource', $spec['components']['schemas']);
+    }
+
+    #[Test]
     public function oneEntityTypeProducesFivePathOperations(): void
     {
         $this->entityTypeManager->registerEntityType(new EntityType(
@@ -100,6 +116,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -129,12 +146,14 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
         $this->entityTypeManager->registerEntityType(new EntityType(
             id: 'user',
             label: 'User',
             class: UserNameContentTestEntity::class,
             keys: UserNameContentTestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -157,6 +176,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -178,6 +198,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'User Role',
             class: UserRoleContentTestEntity::class,
             keys: UserRoleContentTestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -199,6 +220,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Content',
             class: NodeContentTestEntity::class,
             keys: NodeContentTestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -226,6 +248,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -266,6 +289,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -286,6 +310,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -321,6 +346,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -349,6 +375,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator(
@@ -370,6 +397,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -390,6 +418,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -410,6 +439,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -428,6 +458,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -490,12 +521,14 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
         $this->entityTypeManager->registerEntityType(new EntityType(
             id: 'user',
             label: 'User',
             class: UserNameContentTestEntity::class,
             keys: UserNameContentTestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -528,6 +561,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -563,6 +597,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);
@@ -580,6 +615,7 @@ final class OpenApiGeneratorTest extends TestCase
             label: 'Article',
             class: TestEntity::class,
             keys: TestEntity::definitionKeys(),
+        api: true,
         ));
 
         $generator = new OpenApiGenerator($this->entityTypeManager);

--- a/packages/attachment/src/Attachment.php
+++ b/packages/attachment/src/Attachment.php
@@ -30,7 +30,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * canonical-shape rationale. Other descriptive fields (filename, content_type,
  * size, storage_uri, checksum) live in the `_data` JSON blob.
  */
-#[ContentEntityType(id: 'attachment', label: 'Attachment', description: 'File attachment linked to a parent entity.')]
+#[ContentEntityType(id: 'attachment', label: 'Attachment', description: 'File attachment linked to a parent entity.', api: true)]
 #[ContentEntityKeys(id: 'id', uuid: 'uuid', label: 'filename')]
 final class Attachment extends ContentEntityBase
 {

--- a/packages/engagement/src/Comment.php
+++ b/packages/engagement/src/Comment.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'comment', label: 'Comment')]
+#[ContentEntityType(id: 'comment', label: 'Comment', api: true)]
 #[ContentEntityKeys(id: 'cid', uuid: 'uuid', label: 'body')]
 final class Comment extends ContentEntityBase
 {

--- a/packages/engagement/src/Follow.php
+++ b/packages/engagement/src/Follow.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'follow', label: 'Follow')]
+#[ContentEntityType(id: 'follow', label: 'Follow', api: true)]
 #[ContentEntityKeys(id: 'fid', uuid: 'uuid', label: 'target_type')]
 final class Follow extends ContentEntityBase
 {

--- a/packages/engagement/src/Reaction.php
+++ b/packages/engagement/src/Reaction.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'reaction', label: 'Reaction')]
+#[ContentEntityType(id: 'reaction', label: 'Reaction', api: true)]
 #[ContentEntityKeys(id: 'rid', uuid: 'uuid', label: 'reaction_type')]
 final class Reaction extends ContentEntityBase
 {

--- a/packages/entity/src/ApiExposableEntityTypeInterface.php
+++ b/packages/entity/src/ApiExposableEntityTypeInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity;
+
+/**
+ * Opt-in capability for entity types that deliberately expose generic JSON:API routes.
+ *
+ * @api
+ */
+interface ApiExposableEntityTypeInterface
+{
+    public function isApiExposed(): bool;
+}

--- a/packages/entity/src/Attribute/ContentEntityType.php
+++ b/packages/entity/src/Attribute/ContentEntityType.php
@@ -16,6 +16,7 @@ namespace Waaseyaa\Entity\Attribute;
  *                            single-argument call sites.
  * @param string $description Optional human prose describing the entity type. May
  *                            be surfaced in admin UIs and generated documentation.
+ * @param bool   $api         Whether generic JSON:API routes are deliberately exposed.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final readonly class ContentEntityType
@@ -24,5 +25,6 @@ final readonly class ContentEntityType
         public string $id,
         public string $label = '',
         public string $description = '',
+        public bool $api = false,
     ) {}
 }

--- a/packages/entity/src/Attribute/EntityClassMetadata.php
+++ b/packages/entity/src/Attribute/EntityClassMetadata.php
@@ -23,6 +23,7 @@ final readonly class EntityClassMetadata
         public array $keys,
         public string $label = '',
         public string $description = '',
+        public bool $api = false,
         public array $fields = [],
     ) {}
 }

--- a/packages/entity/src/Attribute/EntityMetadataReader.php
+++ b/packages/entity/src/Attribute/EntityMetadataReader.php
@@ -40,6 +40,7 @@ final class EntityMetadataReader
             keys: $keys,
             label: $labelDescription['label'],
             description: $labelDescription['description'],
+            api: $labelDescription['api'],
             fields: $fields,
         );
     }
@@ -152,7 +153,7 @@ final class EntityMetadataReader
      * hierarchy and surface its label/description fields.
      *
      * @param class-string $class
-     * @return array{label: string, description: string}
+     * @return array{label: string, description: string, api: bool}
      */
     private static function resolveLabelAndDescription(string $class): array
     {
@@ -164,6 +165,7 @@ final class EntityMetadataReader
                 return [
                     'label' => $instance->label,
                     'description' => $instance->description,
+                    'api' => $instance->api,
                 ];
             }
             $parent = $ref->getParentClass();
@@ -173,7 +175,7 @@ final class EntityMetadataReader
             $ref = $parent;
         }
 
-        return ['label' => '', 'description' => ''];
+        return ['label' => '', 'description' => '', 'api' => false];
     }
 
     /**

--- a/packages/entity/src/DefinesEntityType.php
+++ b/packages/entity/src/DefinesEntityType.php
@@ -9,6 +9,8 @@ namespace Waaseyaa\Entity;
  *
  * Used when {@see \Waaseyaa\Foundation\Attribute\AsEntityType} is present on the class and
  * {@see \Waaseyaa\Foundation\Kernel\Bootstrap\ProviderRegistry} auto-registration is enabled.
+ *
+ * @deprecated Use #[Attribute\ContentEntityType] and EntityType::fromClass().
  */
 interface DefinesEntityType
 {

--- a/packages/entity/src/EntityType.php
+++ b/packages/entity/src/EntityType.php
@@ -22,7 +22,7 @@ use Waaseyaa\Field\FieldStorage;
  * `#[Field]` attributes. The constructor's `$_fieldDefinitions` slot is
  * `@internal` and is reserved for that factory plus the test stub helper.
  */
-final readonly class EntityType implements EntityTypeInterface
+final readonly class EntityType implements EntityTypeInterface, ApiExposableEntityTypeInterface
 {
     /**
      * Canonical scope identifier for community-scoped tenancy.
@@ -52,6 +52,7 @@ final readonly class EntityType implements EntityTypeInterface
      *   legacy `HasCommunityInterface` marker (mission #1257 §C1).
      * @param bool $discoverable Whether this entity type appears in the GET /api discovery
      *   index. Visibility only — CRUD routes and access enforcement are unaffected.
+     * @param bool $api Whether generic JSON:API routes are deliberately exposed.
      * @param array<string, FieldDefinitionInterface|array<string, mixed>> $_fieldDefinitions
      *   @internal Field definitions keyed by field name. Populated only by
      *   {@see self::fromClass()} and {@see \Waaseyaa\Entity\Tests\Helper\TestEntityType::stub()}.
@@ -76,6 +77,7 @@ final readonly class EntityType implements EntityTypeInterface
         private ?string $primaryStorageBackend = null,
         private ?array $tenancy = null,
         private bool $discoverable = true,
+        private bool $api = false,
         private array $_fieldDefinitions = [],
     ) {
         // T036: revisionable entity types must declare a non-empty revision key.
@@ -248,6 +250,7 @@ final readonly class EntityType implements EntityTypeInterface
             description: $description,
             tenancy: $tenancy,
             discoverable: $discoverable,
+            api: $metadata->api,
             _fieldDefinitions: $metadata->fields,
         );
     }
@@ -424,5 +427,10 @@ final readonly class EntityType implements EntityTypeInterface
     public function isDiscoverable(): bool
     {
         return $this->discoverable;
+    }
+
+    public function isApiExposed(): bool
+    {
+        return $this->api;
     }
 }

--- a/packages/entity/tests/Fixtures/AttributeFirstEntities/FactoryTestFixtures.php
+++ b/packages/entity/tests/Fixtures/AttributeFirstEntities/FactoryTestFixtures.php
@@ -12,7 +12,7 @@ use Waaseyaa\Entity\ContentEntityBase;
 /**
  * Simple content entity used by EntityType::fromClass() happy-path tests.
  */
-#[ContentEntityType(id: 'simple', label: 'Simple', description: 'A simple test entity.')]
+#[ContentEntityType(id: 'simple', label: 'Simple', description: 'A simple test entity.', api: true)]
 final class SimpleFixture extends ContentEntityBase
 {
     #[Field(label: 'Title')]

--- a/packages/entity/tests/Unit/Attribute/ContentEntityTypeTest.php
+++ b/packages/entity/tests/Unit/Attribute/ContentEntityTypeTest.php
@@ -20,6 +20,7 @@ final class ContentEntityTypeTest extends TestCase
         self::assertSame('foo', $attr->id);
         self::assertSame('', $attr->label);
         self::assertSame('', $attr->description);
+        self::assertFalse($attr->api);
     }
 
     #[Test]
@@ -29,11 +30,13 @@ final class ContentEntityTypeTest extends TestCase
             id: 'todo',
             label: 'Todo Item',
             description: 'A unit of work.',
+            api: true,
         );
 
         self::assertSame('todo', $attr->id);
         self::assertSame('Todo Item', $attr->label);
         self::assertSame('A unit of work.', $attr->description);
+        self::assertTrue($attr->api);
     }
 
     #[Test]

--- a/packages/entity/tests/Unit/EntityTypeFromClassTest.php
+++ b/packages/entity/tests/Unit/EntityTypeFromClassTest.php
@@ -38,6 +38,7 @@ final class EntityTypeFromClassTest extends TestCase
         self::assertSame('Simple', $type->getLabel());
         self::assertSame(SimpleFixture::class, $type->getClass());
         self::assertSame('A simple test entity.', $type->getDescription());
+        self::assertTrue($type->isApiExposed());
 
         $fields = $type->getFieldDefinitions();
         self::assertArrayHasKey('title', $fields);
@@ -51,6 +52,7 @@ final class EntityTypeFromClassTest extends TestCase
 
         self::assertSame('empty_fields', $type->id());
         self::assertSame([], $type->getFieldDefinitions());
+        self::assertFalse($type->isApiExposed());
     }
 
     public function testTenancyOverrideIsForwardedOnFirstCall(): void

--- a/packages/field/src/Entity/ClassificationLabelDefinition.php
+++ b/packages/field/src/Entity/ClassificationLabelDefinition.php
@@ -28,6 +28,7 @@ use Waaseyaa\Entity\ContentEntityBase;
     id: 'classification_label_definition',
     label: 'Classification Label Definition',
     description: 'Defines the vocabulary of classification labels available in the system',
+    api: true,
 )]
 final class ClassificationLabelDefinition extends ContentEntityBase
 {

--- a/packages/field/src/Entity/RetentionPolicy.php
+++ b/packages/field/src/Entity/RetentionPolicy.php
@@ -41,6 +41,7 @@ use Waaseyaa\Entity\ContentEntityBase;
     id: 'retention_policy',
     label: 'Retention Policy',
     description: 'Classification-driven retention rule (purge, redact, or hold-flag) keyed by label set.',
+    api: true,
 )]
 final class RetentionPolicy extends ContentEntityBase
 {

--- a/packages/field/src/FieldServiceProvider.php
+++ b/packages/field/src/FieldServiceProvider.php
@@ -82,6 +82,7 @@ final class FieldServiceProvider extends ServiceProvider
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'display_name'],
             description: 'Defines the vocabulary of classification labels available in the system',
             group: 'classification',
+            api: true,
         ));
 
         // Wire the inheritance resolver as a singleton so host applications
@@ -109,6 +110,7 @@ final class FieldServiceProvider extends ServiceProvider
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'],
             description: 'Classification-driven retention rule (purge, redact, or hold-flag) keyed by label set.',
             group: 'classification',
+            api: true,
         ));
 
         // Bind the classification label registry (consumed by

--- a/packages/foundation/src/Attribute/AsEntityType.php
+++ b/packages/foundation/src/Attribute/AsEntityType.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Foundation\Attribute;
 
+/**
+ * @deprecated Use #[Waaseyaa\Entity\Attribute\ContentEntityType] on content
+ * entities. Compiled discovery now consumes that canonical metadata directly.
+ */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsEntityType
 {

--- a/packages/foundation/src/Discovery/PackageManifest.php
+++ b/packages/foundation/src/Discovery/PackageManifest.php
@@ -38,7 +38,7 @@ final class PackageManifest
         public readonly array $policies = [],
         /** @var array<string, array{surface: 'aggregate'|'implementation'|'tooling', activation: 'discovery'|'none'|'provider'}> */
         public readonly array $packageDeclarations = [],
-        /** @var list<class-string> Classes carrying #[AsEntityType] that also implement DefinesEntityType */
+        /** @var list<class-string> Canonical ContentEntityType classes and legacy AsEntityType factories */
         public readonly array $attributeEntityTypes = [],
         /** @var list<class-string> Provider classes that implement ProvidesConsoleCommandsInterface */
         public readonly array $consoleCommandProviders = [],

--- a/packages/foundation/src/Discovery/PackageManifestCompiler.php
+++ b/packages/foundation/src/Discovery/PackageManifestCompiler.php
@@ -48,6 +48,10 @@ final class PackageManifestCompiler
      */
     private const ENTITY_TYPE_DEFINITION_INTERFACE = 'Waaseyaa\\Entity\\DefinesEntityType';
 
+    /** @internal Layer-1 names stay strings to preserve Foundation's layer boundary. */
+    private const CONTENT_ENTITY_TYPE_ATTRIBUTE = 'Waaseyaa\\Entity\\Attribute\\ContentEntityType';
+    private const CONTENT_ENTITY_BASE = 'Waaseyaa\\Entity\\ContentEntityBase';
+
     private readonly LoggerInterface $logger;
 
     /**
@@ -174,6 +178,13 @@ final class PackageManifestCompiler
                 ) {
                     $attributeEntityTypes[] = $class;
                 }
+            }
+
+            if ($ref->getAttributes(self::CONTENT_ENTITY_TYPE_ATTRIBUTE) !== []
+                && class_exists(self::CONTENT_ENTITY_BASE)
+                && is_subclass_of($class, self::CONTENT_ENTITY_BASE, true)
+            ) {
+                $attributeEntityTypes[] = $class;
             }
 
             foreach ($ref->getAttributes(self::POLICY_ATTRIBUTE) as $attr) {
@@ -940,6 +951,7 @@ final class PackageManifestCompiler
                 $hasDiscoveryAttribute = !empty($ref->getAttributes(AsFieldType::class))
                     || !empty($ref->getAttributes(AsMiddleware::class))
                     || !empty($ref->getAttributes(AsEntityType::class))
+                    || $ref->getAttributes(self::CONTENT_ENTITY_TYPE_ATTRIBUTE) !== []
                     || !empty($ref->getAttributes(self::POLICY_ATTRIBUTE))
                     || !empty($ref->getAttributes(self::FORMATTER_ATTRIBUTE))
                     || $ref->getAttributes(self::AGENT_TOOL_ATTRIBUTE) !== []

--- a/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
+++ b/packages/foundation/src/Kernel/Bootstrap/ProviderRegistry.php
@@ -114,17 +114,29 @@ final class ProviderRegistry
         }
 
         $autoRegister = filter_var($config['entity_auto_register'] ?? false, FILTER_VALIDATE_BOOLEAN);
-        if ($autoRegister && $manifest->attributeEntityTypes !== [] && interface_exists(\Waaseyaa\Entity\DefinesEntityType::class)) {
+        if ($autoRegister && $manifest->attributeEntityTypes !== []) {
             foreach ($manifest->attributeEntityTypes as $entityClass) {
                 if (!class_exists($entityClass)) {
                     continue;
                 }
-                if (!is_subclass_of($entityClass, \Waaseyaa\Entity\DefinesEntityType::class, true)) {
+                $usesCanonicalMetadata = is_subclass_of($entityClass, \Waaseyaa\Entity\ContentEntityBase::class, true)
+                    && new \ReflectionClass($entityClass)->getAttributes(\Waaseyaa\Entity\Attribute\ContentEntityType::class) !== [];
+                if ($usesCanonicalMetadata) {
+                    $entityType = \Waaseyaa\Entity\EntityType::fromClass($entityClass);
+                } elseif (interface_exists(\Waaseyaa\Entity\DefinesEntityType::class)
+                    && is_subclass_of($entityClass, \Waaseyaa\Entity\DefinesEntityType::class, true)
+                ) {
+                    $entityType = $entityClass::entityType();
+                } elseif (is_subclass_of($entityClass, \Waaseyaa\Entity\ContentEntityBase::class, true)) {
+                    $entityType = \Waaseyaa\Entity\EntityType::fromClass($entityClass);
+                } else {
                     continue;
                 }
-                $entityType = $entityClass::entityType();
                 if ($entityTypeManager->hasDefinition($entityType->id())) {
-                    continue;
+                    $registered = $entityTypeManager->getDefinition($entityType->id());
+                    if ($registered->getClass() === $entityType->getClass()) {
+                        continue;
+                    }
                 }
                 try {
                     $entityTypeManager->registerEntityType($entityType, $entityClass);

--- a/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
+++ b/packages/foundation/tests/Unit/Discovery/PackageManifestCompilerTest.php
@@ -11,6 +11,9 @@ use Waaseyaa\Foundation\Log\LogLevel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\Attribute\ContentEntityKeys;
+use Waaseyaa\Entity\Attribute\ContentEntityType;
+use Waaseyaa\Entity\ContentEntityBase;
 
 #[CoversClass(PackageManifestCompiler::class)]
 final class PackageManifestCompilerTest extends TestCase
@@ -71,6 +74,24 @@ final class PackageManifestCompilerTest extends TestCase
             static fn(string $m): bool => str_contains($m, 'extra.waaseyaa.commands'),
         );
         $this->assertNotEmpty($warned, 'legacy extra.waaseyaa.commands should log a deprecation warning');
+    }
+
+    #[Test]
+    public function compileDiscoversCanonicalContentEntityAttribute(): void
+    {
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/autoload_classmap.php',
+            '<?php return [' . var_export(CompilerContentEntityFixture::class, true)
+            . ' => ' . var_export(__FILE__, true) . '];',
+        );
+        file_put_contents(
+            $this->tempDir . '/vendor/composer/installed.json',
+            json_encode(['packages' => []], JSON_THROW_ON_ERROR),
+        );
+
+        $manifest = (new PackageManifestCompiler($this->tempDir, $this->tempDir . '/storage'))->compile();
+
+        self::assertContains(CompilerContentEntityFixture::class, $manifest->attributeEntityTypes);
     }
 
     #[Test]
@@ -1563,4 +1584,10 @@ final class PackageManifestCompilerTest extends TestCase
         }
         rmdir($dir);
     }
+}
+
+#[ContentEntityType(id: 'compiler_content_fixture')]
+#[ContentEntityKeys(id: 'id', uuid: 'uuid', label: 'label')]
+final class CompilerContentEntityFixture extends ContentEntityBase
+{
 }

--- a/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
+++ b/packages/foundation/tests/Unit/Kernel/Bootstrap/ProviderRegistryTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\DefinesEntityType;
+use Waaseyaa\Entity\Attribute\ContentEntityKeys;
+use Waaseyaa\Entity\Attribute\ContentEntityType;
+use Waaseyaa\Entity\ContentEntityBase;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\Exception\EntityTypeRegistrationCollisionException;
@@ -186,6 +189,57 @@ final class ProviderRegistryTest extends TestCase
     }
 
     #[Test]
+    public function entityAutoRegisterUsesCanonicalContentEntityMetadata(): void
+    {
+        $registry = new ProviderRegistry(new NullLogger());
+        $database = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+        $entityTypeManager = new EntityTypeManager($dispatcher);
+
+        $registry->discoverAndRegister(
+            manifest: new PackageManifest(
+                providers: [],
+                attributeEntityTypes: [ContentAttributeAutoEntityFixture::class],
+            ),
+            projectRoot: sys_get_temp_dir(),
+            config: ['entity_auto_register' => true],
+            entityTypeManager: $entityTypeManager,
+            database: $database,
+            dispatcher: $dispatcher,
+        );
+
+        $definition = $entityTypeManager->getDefinition('content_attr_auto_fixture');
+        self::assertSame(ContentAttributeAutoEntityFixture::class, $definition->getClass());
+        self::assertSame('Content attribute fixture', $definition->getLabel());
+        self::assertFalse($definition->isApiExposed());
+    }
+
+    #[Test]
+    public function canonicalContentEntityMetadataTakesPrecedenceOverLegacyFactoryInterface(): void
+    {
+        CanonicalAndLegacyEntityFixture::$legacyFactoryCalls = 0;
+        $entityTypeManager = new EntityTypeManager(new EventDispatcher());
+
+        new ProviderRegistry(new NullLogger())->discoverAndRegister(
+            manifest: new PackageManifest(
+                providers: [],
+                attributeEntityTypes: [CanonicalAndLegacyEntityFixture::class],
+            ),
+            projectRoot: sys_get_temp_dir(),
+            config: ['entity_auto_register' => true],
+            entityTypeManager: $entityTypeManager,
+            database: DBALDatabase::createSqlite(':memory:'),
+            dispatcher: new EventDispatcher(),
+        );
+
+        $definition = $entityTypeManager->getDefinition('canonical_metadata_fixture');
+        self::assertSame(0, CanonicalAndLegacyEntityFixture::$legacyFactoryCalls);
+        self::assertSame(CanonicalAndLegacyEntityFixture::class, $definition->getClass());
+        self::assertTrue($definition->isApiExposed());
+        self::assertFalse($entityTypeManager->hasDefinition('legacy_factory_fixture'));
+    }
+
+    #[Test]
     public function entity_auto_register_off_skips_attribute_manifest_classes(): void
     {
         $registry = new ProviderRegistry(new NullLogger());
@@ -284,6 +338,31 @@ final class AttributeAutoEntityFixture implements DefinesEntityType
             id: 'attr_auto_fixture',
             label: 'Attr fixture',
             class: self::class,
+        );
+    }
+}
+
+#[ContentEntityType(id: 'content_attr_auto_fixture', label: 'Content attribute fixture')]
+#[ContentEntityKeys(id: 'id', uuid: 'uuid', label: 'label')]
+final class ContentAttributeAutoEntityFixture extends ContentEntityBase
+{
+}
+
+#[ContentEntityType(id: 'canonical_metadata_fixture', label: 'Canonical metadata fixture', api: true)]
+#[ContentEntityKeys(id: 'id', uuid: 'uuid', label: 'label')]
+final class CanonicalAndLegacyEntityFixture extends ContentEntityBase implements DefinesEntityType
+{
+    public static int $legacyFactoryCalls = 0;
+
+    public static function entityType(): EntityType
+    {
+        ++self::$legacyFactoryCalls;
+
+        return new EntityType(
+            id: 'legacy_factory_fixture',
+            label: 'Legacy factory fixture',
+            class: self::class,
+            api: false,
         );
     }
 }

--- a/packages/genealogy/src/Entity/GenealogyEvent.php
+++ b/packages/genealogy/src/Entity/GenealogyEvent.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'genealogy_event', label: 'Genealogy event', description: 'A vital or narrative event')]
+#[ContentEntityType(id: 'genealogy_event', label: 'Genealogy event', description: 'A vital or narrative event', api: true)]
 #[ContentEntityKeys(label: 'display_name')]
 final class GenealogyEvent extends ContentEntityBase
 {

--- a/packages/genealogy/src/Entity/GenealogyFamily.php
+++ b/packages/genealogy/src/Entity/GenealogyFamily.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'genealogy_family', label: 'Genealogy family', description: 'A family or household group')]
+#[ContentEntityType(id: 'genealogy_family', label: 'Genealogy family', description: 'A family or household group', api: true)]
 #[ContentEntityKeys(label: 'display_name')]
 final class GenealogyFamily extends ContentEntityBase
 {

--- a/packages/genealogy/src/Entity/GenealogyPerson.php
+++ b/packages/genealogy/src/Entity/GenealogyPerson.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'genealogy_person', label: 'Genealogy person', description: 'An individual in a genealogy dataset')]
+#[ContentEntityType(id: 'genealogy_person', label: 'Genealogy person', description: 'An individual in a genealogy dataset', api: true)]
 #[ContentEntityKeys(label: 'display_name')]
 final class GenealogyPerson extends ContentEntityBase
 {

--- a/packages/genealogy/src/Entity/GenealogyTree.php
+++ b/packages/genealogy/src/Entity/GenealogyTree.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'genealogy_tree', label: 'Genealogy tree', description: 'Tenancy root for genealogy workspace (owner, grants, community overlays).')]
+#[ContentEntityType(id: 'genealogy_tree', label: 'Genealogy tree', description: 'Tenancy root for genealogy workspace (owner, grants, community overlays).', api: true)]
 #[ContentEntityKeys(label: 'display_name')]
 final class GenealogyTree extends ContentEntityBase
 {

--- a/packages/groups/src/Group.php
+++ b/packages/groups/src/Group.php
@@ -18,7 +18,7 @@ use Waaseyaa\Field\FieldStorage;
  * stored in per-bundle subtables (`group__{bundle}`); core keys live on the
  * base `group` table. See docs/specs/bundle-scoped-storage.md.
  */
-#[ContentEntityType(id: 'group', label: 'Group', description: 'Multi-bundle group of members, actors, or subjects.')]
+#[ContentEntityType(id: 'group', label: 'Group', description: 'Multi-bundle group of members, actors, or subjects.', api: false)]
 #[ContentEntityKeys(id: 'gid', uuid: 'uuid', bundle: 'type', label: 'name', langcode: 'langcode')]
 final class Group extends ContentEntityBase
 {

--- a/packages/groups/src/GroupsServiceProvider.php
+++ b/packages/groups/src/GroupsServiceProvider.php
@@ -70,6 +70,7 @@ final class GroupsServiceProvider extends ServiceProvider
             ],
             group: 'groups',
             discoverable: false,
+            api: false,
             _fieldDefinitions: [
                 'description' => new FieldDefinition(
                     name: 'description',

--- a/packages/media/src/Media.php
+++ b/packages/media/src/Media.php
@@ -16,7 +16,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * that can be reused across the site. Each media entity belongs to a media type
  * (bundle) which determines the source plugin and field configuration.
  */
-#[ContentEntityType(id: 'media')]
+#[ContentEntityType(id: 'media', api: true)]
 #[ContentEntityKeys(id: 'mid', uuid: 'uuid', label: 'name', bundle: 'bundle')]
 final class Media extends ContentEntityBase
 {

--- a/packages/media/src/MediaServiceProvider.php
+++ b/packages/media/src/MediaServiceProvider.php
@@ -50,6 +50,7 @@ final class MediaServiceProvider extends ServiceProvider implements HasHttpDomai
             class: Media::class,
             keys: ['id' => 'mid', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'bundle'],
             group: 'media',
+            api: true,
         ));
 
         $this->entityType(new EntityType(
@@ -59,6 +60,7 @@ final class MediaServiceProvider extends ServiceProvider implements HasHttpDomai
             class: MediaType::class,
             keys: ['id' => 'id', 'label' => 'label'],
             group: 'media',
+            api: true,
         ));
 
         // WP01 (versioned-blob-media-abstraction-01KSEFTJ): content-addressed version entity.

--- a/packages/media/src/Version/MediaVersionType.php
+++ b/packages/media/src/Version/MediaVersionType.php
@@ -21,6 +21,7 @@ final class MediaVersionType
             class: MediaVersion::class,
             keys: ['id' => 'id', 'uuid' => 'uuid'],
             description: 'Content-addressed blob version record for a media entity.',
+            api: true,
         );
     }
 }

--- a/packages/menu/src/MenuLink.php
+++ b/packages/menu/src/MenuLink.php
@@ -14,7 +14,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * Menu links are individual navigation items that belong to a menu.
  * They can be organized hierarchically via parent/child relationships.
  */
-#[ContentEntityType(id: 'menu_link')]
+#[ContentEntityType(id: 'menu_link', api: true)]
 #[ContentEntityKeys(label: 'title', bundle: 'menu_name')]
 final class MenuLink extends ContentEntityBase
 {

--- a/packages/menu/src/MenuServiceProvider.php
+++ b/packages/menu/src/MenuServiceProvider.php
@@ -18,6 +18,7 @@ final class MenuServiceProvider extends ServiceProvider
             class: Menu::class,
             keys: ['id' => 'id', 'label' => 'label'],
             group: 'structure',
+            api: true,
         ));
 
         $this->entityType(new EntityType(
@@ -27,6 +28,7 @@ final class MenuServiceProvider extends ServiceProvider
             class: MenuLink::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'menu_name'],
             group: 'structure',
+            api: true,
         ));
     }
 }

--- a/packages/messaging/src/MessageThread.php
+++ b/packages/messaging/src/MessageThread.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'message_thread', label: 'Message Thread')]
+#[ContentEntityType(id: 'message_thread', label: 'Message Thread', api: true)]
 #[ContentEntityKeys(id: 'mtid', uuid: 'uuid', label: 'title')]
 final class MessageThread extends ContentEntityBase
 {

--- a/packages/messaging/src/ThreadMessage.php
+++ b/packages/messaging/src/ThreadMessage.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'thread_message', label: 'Thread Message')]
+#[ContentEntityType(id: 'thread_message', label: 'Thread Message', api: true)]
 #[ContentEntityKeys(id: 'tmid', uuid: 'uuid', label: 'body')]
 final class ThreadMessage extends ContentEntityBase
 {

--- a/packages/messaging/src/ThreadParticipant.php
+++ b/packages/messaging/src/ThreadParticipant.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'thread_participant', label: 'Thread Participant')]
+#[ContentEntityType(id: 'thread_participant', label: 'Thread Participant', api: true)]
 #[ContentEntityKeys(id: 'tpid', uuid: 'uuid', label: 'role')]
 final class ThreadParticipant extends ContentEntityBase
 {

--- a/packages/node/src/Node.php
+++ b/packages/node/src/Node.php
@@ -39,7 +39,7 @@ use Waaseyaa\Field\FieldStorage;
  * listener that actually calls `setNewRevision()` from the bundle's
  * `NodeType::isNewRevision()` when nothing else has decided first.
  */
-#[ContentEntityType(id: 'node', label: 'Content', description: 'Published content items')]
+#[ContentEntityType(id: 'node', label: 'Content', description: 'Published content items', api: true)]
 #[ContentEntityKeys(id: 'nid', uuid: 'uuid', label: 'title', bundle: 'type', revision: 'revision_id')]
 final class Node extends ContentEntityBase implements HydratableFromStorageInterface, RevisionableInterface
 {

--- a/packages/node/src/NodeServiceProvider.php
+++ b/packages/node/src/NodeServiceProvider.php
@@ -33,6 +33,7 @@ final class NodeServiceProvider extends ServiceProvider
             class: NodeType::class,
             keys: ['id' => 'type', 'label' => 'name'],
             group: 'content',
+            api: true,
         ));
     }
 

--- a/packages/note/src/Note.php
+++ b/packages/note/src/Note.php
@@ -15,7 +15,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * A Note is the minimal default content type shipped with Waaseyaa.
  * It is non-deletable via API — use NoteAccessPolicy to enforce that.
  */
-#[ContentEntityType(id: 'note', label: 'Note', description: 'Quick-entry content items with minimal structure')]
+#[ContentEntityType(id: 'note', label: 'Note', description: 'Quick-entry content items with minimal structure', api: true)]
 #[ContentEntityKeys(label: 'title')]
 final class Note extends ContentEntityBase
 {

--- a/packages/oidc/src/Entity/OidcClient.php
+++ b/packages/oidc/src/Entity/OidcClient.php
@@ -19,7 +19,7 @@ use Waaseyaa\Entity\Hydration\HydrationContext;
  * user-defined at creation time and never rewritten. The `id` column is an internal
  * auto-increment primary key for entity-system consistency.
  */
-#[ContentEntityType(id: 'oidc_client', label: 'OIDC Client', description: 'Relying-party clients registered with the OIDC issuer.')]
+#[ContentEntityType(id: 'oidc_client', label: 'OIDC Client', description: 'Relying-party clients registered with the OIDC issuer.', api: true)]
 #[ContentEntityKeys(label: 'name')]
 final class OidcClient extends ContentEntityBase implements HydratableFromStorageInterface
 {

--- a/packages/path/src/PathAlias.php
+++ b/packages/path/src/PathAlias.php
@@ -16,7 +16,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * (e.g. '/about-us'). Supports language-specific aliases and a published
  * status to control alias visibility.
  */
-#[ContentEntityType(id: 'path_alias', label: 'Path Alias', description: 'URL aliases for human-readable paths')]
+#[ContentEntityType(id: 'path_alias', label: 'Path Alias', description: 'URL aliases for human-readable paths', api: true)]
 #[ContentEntityKeys(label: 'alias', langcode: 'langcode')]
 final class PathAlias extends ContentEntityBase
 {

--- a/packages/relationship/src/Relationship.php
+++ b/packages/relationship/src/Relationship.php
@@ -8,7 +8,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityKeys;
 use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'relationship')]
+#[ContentEntityType(id: 'relationship', api: true)]
 #[ContentEntityKeys(id: 'rid', uuid: 'uuid', label: 'relationship_type', bundle: 'relationship_type')]
 final class Relationship extends ContentEntityBase
 {

--- a/packages/relationship/src/RelationshipServiceProvider.php
+++ b/packages/relationship/src/RelationshipServiceProvider.php
@@ -27,6 +27,7 @@ final class RelationshipServiceProvider extends ServiceProvider
                 'bundle' => 'relationship_type',
             ],
             group: 'content',
+            api: true,
         ));
     }
 

--- a/packages/taxonomy/src/TaxonomyServiceProvider.php
+++ b/packages/taxonomy/src/TaxonomyServiceProvider.php
@@ -32,6 +32,7 @@ final class TaxonomyServiceProvider extends ServiceProvider
             class: Vocabulary::class,
             keys: ['id' => 'vid', 'label' => 'name'],
             group: 'taxonomy',
+            api: true,
             _fieldDefinitions: [
                 'description' => new FieldDefinition(
                     name: 'description',

--- a/packages/taxonomy/src/Term.php
+++ b/packages/taxonomy/src/Term.php
@@ -16,7 +16,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  * They support hierarchical relationships through parent term IDs,
  * and can be published or unpublished.
  */
-#[ContentEntityType(id: 'taxonomy_term', label: 'Taxonomy Term', description: 'Categorization terms for organizing content')]
+#[ContentEntityType(id: 'taxonomy_term', label: 'Taxonomy Term', description: 'Categorization terms for organizing content', api: true)]
 #[ContentEntityKeys(id: 'tid', uuid: 'uuid', label: 'name', bundle: 'vid')]
 final class Term extends ContentEntityBase
 {

--- a/packages/user/src/User.php
+++ b/packages/user/src/User.php
@@ -24,7 +24,7 @@ use Waaseyaa\Entity\Hydration\HydrationContext;
  * service) is responsible for populating the permissions from role
  * definitions.
  */
-#[ContentEntityType(id: 'user', label: 'User', description: 'Manage user accounts, roles, and authentication')]
+#[ContentEntityType(id: 'user', label: 'User', description: 'Manage user accounts, roles, and authentication', api: true)]
 #[ContentEntityKeys(id: 'uid', uuid: 'uuid', label: 'name')]
 final class User extends ContentEntityBase implements AccountInterface, HydratableFromStorageInterface
 {

--- a/packages/user/src/UserBlock.php
+++ b/packages/user/src/UserBlock.php
@@ -9,7 +9,7 @@ use Waaseyaa\Entity\Attribute\ContentEntityType;
 use Waaseyaa\Entity\Attribute\Field;
 use Waaseyaa\Entity\ContentEntityBase;
 
-#[ContentEntityType(id: 'user_block', label: 'User Block', description: 'Block rules for restricting user access')]
+#[ContentEntityType(id: 'user_block', label: 'User Block', description: 'Block rules for restricting user access', api: true)]
 #[ContentEntityKeys(id: 'ubid', uuid: 'uuid', label: 'blocker_id')]
 final class UserBlock extends ContentEntityBase
 {

--- a/packages/wayfinding/src/Entity/Trail.php
+++ b/packages/wayfinding/src/Entity/Trail.php
@@ -28,7 +28,7 @@ use Waaseyaa\Entity\ContentEntityBase;
  *
  * @api
  */
-#[ContentEntityType(id: 'wayfinding_trail', label: 'Wayfinding Trail', description: 'A saved, versioned, translatable guided trail of beacons.')]
+#[ContentEntityType(id: 'wayfinding_trail', label: 'Wayfinding Trail', description: 'A saved, versioned, translatable guided trail of beacons.', api: true)]
 #[ContentEntityKeys(
     id: 'tid',
     uuid: 'uuid',

--- a/packages/workflows/src/WorkflowServiceProvider.php
+++ b/packages/workflows/src/WorkflowServiceProvider.php
@@ -38,6 +38,7 @@ final class WorkflowServiceProvider extends ServiceProvider
             class: Workflow::class,
             keys: ['id' => 'id', 'label' => 'label'],
             group: 'workflows',
+            api: true,
         ));
 
         // CW-v1 WP-1 (#1920, docs/specs/content-workflow.md): engine core

--- a/tests/Integration/Phase7/ApiDiscoveryIntegrationTest.php
+++ b/tests/Integration/Phase7/ApiDiscoveryIntegrationTest.php
@@ -40,12 +40,14 @@ final class ApiDiscoveryIntegrationTest extends TestCase
             label: 'Article',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+            api: true,
         ));
         $this->entityTypeManager->registerEntityType(new EntityType(
             id: 'tag',
             label: 'Tag',
             class: \stdClass::class,
             keys: ['id' => 'id'],
+            api: true,
         ));
 
         $this->router = new WaaseyaaRouter(new RequestContext('', 'GET'));

--- a/tests/Integration/Phase7/ApiRoutingIntegrationTest.php
+++ b/tests/Integration/Phase7/ApiRoutingIntegrationTest.php
@@ -61,6 +61,7 @@ final class ApiRoutingIntegrationTest extends TestCase
             _fieldDefinitions: [
                 'status' => new FieldDefinition(name: 'status', type: 'boolean'),
             ],
+            api: true,
         ));
 
         // Set up router with API routes through the package-owned provider surface.
@@ -290,6 +291,7 @@ final class ApiRoutingIntegrationTest extends TestCase
             label: 'Node',
             class: \Waaseyaa\Api\Tests\Fixtures\NodeContentTestEntity::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            api: true,
         ));
 
         $entityTypeManager->registerEntityType(new EntityType(
@@ -297,6 +299,7 @@ final class ApiRoutingIntegrationTest extends TestCase
             label: 'Taxonomy Term',
             class: \Waaseyaa\Api\Tests\Fixtures\TaxonomyTermContentTestEntity::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'vid'],
+            api: true,
         ));
 
         $router = new WaaseyaaRouter(new RequestContext('', 'GET'));

--- a/tests/Integration/Phase7/OpenApiIntegrationTest.php
+++ b/tests/Integration/Phase7/OpenApiIntegrationTest.php
@@ -45,6 +45,7 @@ final class OpenApiIntegrationTest extends TestCase
                 'label' => 'title',
                 'bundle' => 'type',
             ],
+            api: true,
         ));
     }
 
@@ -60,6 +61,7 @@ final class OpenApiIntegrationTest extends TestCase
                 'label' => 'name',
                 'bundle' => 'vid',
             ],
+            api: true,
         ));
     }
 


### PR DESCRIPTION
## Outcome

- defaults generic entity API exposure to false
- consolidates compiled canonical entity discovery while retaining the imperative and legacy compatibility paths
- applies one exposure decision to routing, discovery, workflow routes, and OpenAPI
- documents the 23-type Minoo migration inventory and follow-up

## Verification

- Unit: 9,608 tests, 223,648 assertions
- Integration: 1,489 tests, 5,992 assertions, 2 skipped
- PHPStan, formatting, package layers, and Composer policy green
- fresh-context verifier clean after one canonical-precedence regression was added

Part of #2043