### PR TITLE
fix(#2043): normalize boolean persistence shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Boolean entity fields now have one persistence shape (#2043).** Every repository save normalizes declared and inferred boolean fields to integer `0`/`1` before base, bundle, and revision writes, so authoring and migration destinations store identical values. Existing rows adopt the canonical shape on their next save; domain consumers should continue to use helpers such as `Node::isPublished()`.
+
 - **Groups JSON:API exposure is now deliberate and permission-gated (#1871, #2043).** The load-bearing `group` and `group_type` definitions opt in with `api: true`, appear in authenticated discovery, and require `administer groups` for entity CRUD through the package-owned `GroupAccessPolicy`.
 
 - **Generic JSON:API entity routes now require an explicit exposure opt-in (#2043).** `#[ContentEntityType]` and imperative `EntityType` definitions default `api` to false; routing, discovery, workflow sub-routes, and OpenAPI share the same exposure predicate, while registered unexposed types return a diagnostic naming `api: true`. Compiled discovery now consumes canonical content-entity metadata, and the prior unused `#[AsEntityType]` static-factory path is deprecated. See `docs/upgrade-notes/entity-type-api-exposure.md` for the Minoo inventory and migration.

--- a/docs/specs/entity-system.md
+++ b/docs/specs/entity-system.md
@@ -169,7 +169,7 @@ flowchart LR
 2. **`toArray()`:** Returns the internal `$values` array **without** `castIn`; callers MUST NOT treat it as domain-typed if the entity uses `$casts`.
 3. **`get($name)`:** If `$casts[$name]` exists, return `castIn($name, $raw, $spec)`; otherwise return raw (or `null` if key missing).
 4. **`set($name, $value)`:** If `$casts[$name]` exists, store `castOut(...)`; otherwise store the value as-is. After `set()`, `toArray()` must remain JSON- and SQL-driver-safe.
-5. **Save path:** `EntityRepository::doSave()` / `SqlEntityStorage::save()` use `toArray()` only — never `get()` — so the invariant in (4) must hold for all cast fields.
+5. **Save path:** `EntityRepository::doSave()` snapshots `toArray()` — never `get()` — then normalizes fields whose resolved definition is `boolean`/`bool` to integer `0`/`1` before any base, bundle, or revision write. All other cast fields retain the invariant in (4).
 6. **Load path:** `EntityInstantiator` does not invoke `ValueCaster`; casting is lazy on `get()` / presentation helpers.
 7. **Tests:** Override `protected function valueCaster(): ValueCaster` on an entity subclass to inject fakes; default is `new ValueCaster()`.
 
@@ -315,14 +315,14 @@ Non-backed enums and unknown class-strings (non-enum classes) are rejected (`Cas
 **Persistence (ST-4 / ST-5, #1181):**
 
 - `EntityRepository::hydrate()` and `SqlEntityStorage::mapRowToEntity()` merge `_data` and instantiate entities with **unchanged** storage-shaped rows; no casting at load boundary.
-- `EntityRepository::doSave()` and `SqlEntityStorage::save()` snapshot `$entity->toArray()`; values must remain JSON- and SQL-driver-safe. After `set()` on a cast field, `castOut` keeps scalars / JSON strings (e.g. backed enum value, `array` → JSON string) so `splitForStorage()` / driver `write()` do not see live objects in the blob.
-- `SqlEntityStorage::splitForStorage()` requires no change when the invariant holds.
+- `EntityRepository::doSave()` snapshots `$entity->toArray()`; values must remain JSON- and SQL-driver-safe. It then resolves class, registry-core, and bundle field definitions and converts each present, non-null `boolean`/`bool` value to integer `0`/`1`. The normalized snapshot is shared by base, bundle, and revision writes.
+- After `set()` on any other cast field, `castOut` keeps scalars / JSON strings (e.g. backed enum value, `array` → JSON string) so the driver does not see live objects in the blob.
 
 Integration coverage: `packages/entity-storage/tests/Unit/CastPersistenceIntegrationTest.php` (in-memory `EntityRepository` + SQLite `SqlEntityStorage`).
 
 **JSON:API serialization (ST-7, #1181):** `Waaseyaa\Api\ResourceSerializer` builds attributes from `EntityValues::toCastAwareMap($entity)` (same keys as `toArray()`, values from `get()`), excluding `id`/`uuid` storage keys, then applies field-definition boolean/timestamp coercions and JSON normalization (enums, `DateTimeInterface`, nested arrays). See `docs/specs/jsonapi.md`. Do not build attributes from `toArray()` alone — that bypasses `$casts`.
 
-**Presentation map (ST-8, #1181):** `Waaseyaa\Entity\EntityValues::toCastAwareMap()` returns all keys from `toArray()` with values from `get()` — use this (or `get()` per field) in GraphQL resolvers, discovery visibility, relationship policies, SSR field bags, MCP tool payloads, embedding text extraction, and workflow visibility helpers. `WorkflowVisibility::isNodePublicForEntity()` wraps the same idea for nodes. `EntityValues::statusToInt()` normalizes boolean/string/numeric status flags to `0|1` for strict published checks. Persistence, `SqlEntityStorage`, and `EntityRepository::doSave()` continue to use raw `toArray()` only.
+**Presentation map (ST-8, #1181):** `Waaseyaa\Entity\EntityValues::toCastAwareMap()` returns all keys from `toArray()` with values from `get()` — use this (or `get()` per field) in GraphQL resolvers, discovery visibility, relationship policies, SSR field bags, MCP tool payloads, embedding text extraction, and workflow visibility helpers. `WorkflowVisibility::isNodePublicForEntity()` wraps the same idea for nodes. `EntityValues::statusToInt()` normalizes boolean/string/numeric status flags to `0|1` for strict published checks. Persistence continues to take its snapshot from raw `toArray()`; the repository's definition-driven boolean normalization is the only type-specific storage adjustment at that boundary.
 
 ### Branching and snapshots (P3)
 

--- a/docs/upgrade-notes/boolean-field-storage-normalization.md
+++ b/docs/upgrade-notes/boolean-field-storage-normalization.md
@@ -1,0 +1,36 @@
+# Boolean field storage normalization
+
+Starting with `0.1.0-alpha.266`, the canonical entity repository stores every
+present, non-null field declared or inferred as `boolean`/`bool` as integer
+`0` or `1`. The normalization happens once after pre-save processing and before
+the same snapshot is sent to base, bundle, or revision storage. Interactive,
+batch, and migration-destination saves therefore share one stored shape.
+
+Existing rows are normalized when they are next saved. Read-side domain code
+should continue to use entity helpers such as `Node::isPublished()` rather
+than compare raw field values.
+
+## Framework field audit
+
+The field-definition audit found these boolean fields, all covered by the
+repository boundary:
+
+| Entity type | Boolean fields |
+|---|---|
+| `attachment` | `is_active` |
+| `comment` | `status` |
+| `node` | `status`, `promote`, `sticky` |
+| `genealogy_tree` | `status` |
+| `genealogy_family` | `status` |
+| `genealogy_person` | `is_living`, `status` |
+| `genealogy_event` | `status` |
+| `thread_message` | `status` |
+| `path_alias` | `status` |
+| `taxonomy_term` | `status` |
+| `user` | `email_verified`, `status` |
+| `oidc_client` | `is_confidential` |
+
+`user.email_verified` and `oidc_client.is_confidential` rely on typed-property
+inference; the other entries declare `boolean` explicitly. `group.status` is
+declared as an integer field and already uses the framework's integer `0`/`1`
+contract, so it remains outside boolean-field normalization.

--- a/docs/upgrade-notes/boolean-field-storage-normalization.md
+++ b/docs/upgrade-notes/boolean-field-storage-normalization.md
@@ -31,6 +31,15 @@ repository boundary:
 | `oidc_client` | `is_confidential` |
 
 `user.email_verified` and `oidc_client.is_confidential` rely on typed-property
-inference; the other entries declare `boolean` explicitly. `group.status` is
-declared as an integer field and already uses the framework's integer `0`/`1`
-contract, so it remains outside boolean-field normalization.
+inference; the other entries declare `boolean` explicitly.
+
+The broader boolean-like inventory was also reviewed. These representations
+remain unchanged because they are not declared content-entity boolean fields:
+
+| Surface | Existing contract |
+|---|---|
+| `group.status` | Declared integer field using integer `0`/`1` |
+| `relationship.status` | Relationship data value normalized to integer `0`/`1` |
+| Audit-checkpoint `is_genesis` / `pruned` | Raw audit-table integer columns |
+| `ConfigEntityBase.status` | Configuration/YAML state |
+| Media file `status` | String lifecycle state |

--- a/packages/admin-surface/tests/Integration/Host/GenericAdminSurfaceHostFieldAccessPaginationTest.php
+++ b/packages/admin-surface/tests/Integration/Host/GenericAdminSurfaceHostFieldAccessPaginationTest.php
@@ -129,7 +129,7 @@ final class GenericAdminSurfaceHostFieldAccessPaginationTest extends TestCase
 
             public function fieldAccess(EntityInterface $entity, string $fieldName, string $operation, AccountInterface $account): AccessResult
             {
-                if ($fieldName === 'description' && $entity->get('classified') === true) {
+                if ($fieldName === 'description' && (bool) $entity->get('classified')) {
                     return AccessResult::forbidden('Classified descriptions are hidden.');
                 }
 

--- a/packages/entity-storage/src/EntityRepository.php
+++ b/packages/entity-storage/src/EntityRepository.php
@@ -1301,6 +1301,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 unset($targetRow[$pointerKey]);
             }
         }
+        $targetRow = $this->normalizeBooleanStorageValues($targetRow, entityId: $entityId);
 
         // Wrap in transaction (invariant #4: atomic pointer update).
         $transaction = $this->database?->transaction();
@@ -1435,6 +1436,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 unset($row[$pointerKey]);
             }
         }
+        $row = $this->normalizeBooleanStorageValues($row, entityId: $entityId);
 
         $keys = $this->entityType->getKeys();
         $idKey = $keys['id'] ?? 'id';
@@ -1580,6 +1582,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 // fields are partitioned and upserted from this same target
                 // snapshot in the transaction; otherwise the subtable's old
                 // value would override the promoted `_data` value on read.
+                $targetRow = $this->normalizeBooleanStorageValues($targetRow, entityId: $entityId);
                 $outgoingRow = $targetRow;
                 $bundleValues = [];
                 $bundleName = null;
@@ -1622,6 +1625,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 }
                 $baseRow = $priorBaseRow;
                 $baseRow['published_revision_id'] = $revisionId;
+                $baseRow = $this->normalizeBooleanStorageValues($baseRow, entityId: $entityId);
                 $this->driver->write($this->entityType->id(), $entityId, $baseRow);
             }
             $transaction?->commit();
@@ -2211,7 +2215,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 continue; // already has revision history
             }
 
-            $values = $entity->toArray();
+            $values = $this->normalizeBooleanStorageValues($entity->toArray(), $entity);
             $transaction = $this->database?->transaction();
             try {
                 $revisionId = $this->revisionDriver->writeRevision($id, $values, $log, author: $actor);

--- a/packages/entity-storage/src/EntityRepository.php
+++ b/packages/entity-storage/src/EntityRepository.php
@@ -538,6 +538,84 @@ final class EntityRepository implements EntityRepositoryInterface
     }
 
     /**
+     * Normalize declared boolean fields to the storage-canonical 0/1 shape.
+     *
+     * This runs after pre-save listeners have finished mutating the entity and
+     * before the shared value snapshot reaches base, bundle, or revision
+     * storage. Null remains null for optional fields.
+     *
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>
+     */
+    private function normalizeBooleanStorageValues(
+        array $values,
+        ?EntityInterface $entity = null,
+        ?string $entityId = null,
+    ): array {
+        $definitions = $entity !== null
+            ? $this->resolveValidationFieldDefinitions($entity)
+            : $this->resolveArrayWriteFieldDefinitions($values, $entityId);
+
+        foreach ($definitions as $name => $definition) {
+            if (!\in_array(\strtolower($definition->getType()), ['bool', 'boolean'], true)
+                || !\array_key_exists($name, $values)
+                || $values[$name] === null
+            ) {
+                continue;
+            }
+
+            $value = $values[$name];
+            if ($value instanceof \BackedEnum) {
+                $value = $value->value;
+            }
+
+            $values[$name] = match (true) {
+                $value === true, $value === 1 => 1,
+                $value === false, $value === 0 => 0,
+                \is_string($value) && \in_array(\strtolower(\trim($value)), ['1', 'true', 'yes'], true) => 1,
+                default => 0,
+            };
+        }
+
+        return $values;
+    }
+
+    /**
+     * Resolve field definitions for repository entry points that accept value
+     * arrays instead of an entity object (the translation write APIs).
+     *
+     * @param array<string, mixed> $values
+     * @return array<string, \Waaseyaa\Field\FieldDefinitionInterface>
+     */
+    private function resolveArrayWriteFieldDefinitions(array $values, ?string $entityId): array
+    {
+        $fields = $this->entityType->getFieldDefinitions();
+        if ($this->fieldRegistry === null) {
+            return $fields;
+        }
+
+        $entityTypeId = $this->entityType->id();
+        foreach ($this->fieldRegistry->coreFieldsFor($entityTypeId) as $name => $definition) {
+            $fields[$name] = $definition;
+        }
+
+        $bundleKey = $this->entityType->getKeys()['bundle'] ?? null;
+        $bundle = $bundleKey !== null ? (string) ($values[$bundleKey] ?? '') : '';
+        if ($bundle === '' && $bundleKey !== null && $entityId !== null) {
+            $baseRow = $this->driver->read($entityTypeId, $entityId);
+            $bundle = (string) ($baseRow[$bundleKey] ?? '');
+        }
+
+        if ($bundle !== '') {
+            foreach ($this->fieldRegistry->bundleFieldsFor($entityTypeId, $bundle) as $name => $definition) {
+                $fields[$name] = $definition;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
      * Coordinates a single entity save: optimistic-locking preconditions,
      * validation, the in-transaction guarded pointer claim, base + bundle +
      * revision writes, and the lifecycle event sequence.
@@ -765,7 +843,7 @@ final class EntityRepository implements EntityRepositoryInterface
             BeforeSaveEvent::class,
         );
 
-        $values = $entity->toArray();
+        $values = $this->normalizeBooleanStorageValues($entity->toArray(), $entity);
         // C-22 WP4 fix: read the id key from the entity's raw value bag
         // (toArray()), not the $entity->id() accessor. Some entity classes
         // (e.g. Waaseyaa\User\User::id(), which implements AccountInterface's
@@ -1622,6 +1700,7 @@ final class EntityRepository implements EntityRepositoryInterface
             BeforeRevisionPointerMoveEvent::class,
         );
 
+        $values = $this->normalizeBooleanStorageValues($values, entityId: $entityId);
         $revisionId = $driver->writeRevision($entityId, $values, $log, $langcode, $actor);
 
         $entity = $this->loadTranslationRevision($entityId, $langcode, $revisionId);
@@ -1673,6 +1752,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     BeforeRevisionPointerMoveEvent::class,
                 );
 
+                $values = $this->normalizeBooleanStorageValues($values, entityId: $entityId);
                 $created[$langcode] = $driver->writeRevision($entityId, $values, $log, $langcode, $actor);
             }
             $transaction?->commit();
@@ -1803,6 +1883,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 BeforeRevisionPointerMoveEvent::class,
             );
 
+            $values = $this->normalizeBooleanStorageValues($values, entityId: $entityId);
             $this->upsertLangcodePeerRow($entityId, $langcode, $values);
             $revisionId = $driver->writeRevision($entityId, $values, $log, $langcode, $actor);
             $transaction->commit();

--- a/packages/entity-storage/tests/Unit/DefaultRevisionDisciplineTest.php
+++ b/packages/entity-storage/tests/Unit/DefaultRevisionDisciplineTest.php
@@ -22,6 +22,7 @@ use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\EntityStorage\Tests\Fixtures\TestRevisionableEntity;
 use Waaseyaa\Field\FieldDefinition;
 use Waaseyaa\Field\FieldDefinitionRegistry;
+use Waaseyaa\Field\FieldStorage;
 
 /**
  * CW-v1 option-1 forward-draft rebuild — storage mechanics (#1920 PR-1).
@@ -58,6 +59,9 @@ final class DefaultRevisionDisciplineTest extends TestCase
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'revision' => 'revision_id'],
             revisionable: true,
             revisionDefault: true,
+            _fieldDefinitions: [
+                'flag' => ['type' => 'boolean', 'stored' => FieldStorage::Data],
+            ],
         );
 
         $handler = new SqlSchemaHandler($entityType, $this->db);
@@ -299,6 +303,32 @@ final class DefaultRevisionDisciplineTest extends TestCase
         $this->assertSame(1, $row['published_revision_id'] ?? null, 'published pointer now equals the target');
         $this->assertSame('v1', $repo->find('1')?->label(), 'base row content was copied from the target revision');
         $this->assertSame('v1', $repo->loadPublishedRevision('1')?->label());
+    }
+
+    #[Test]
+    public function flagged_set_published_revision_normalizes_historical_boolean_values(): void
+    {
+        $repo = $this->buildRepo();
+
+        $entity = new TestRevisionableEntity(values: [
+            'title' => 'v1',
+            'id' => '1',
+            'uuid' => 'a',
+            'flag' => false,
+        ]);
+        $entity->enforceIsNew();
+        $repo->save($entity);
+
+        $this->db->getConnection()->update(
+            'test_revisionable_revision',
+            ['_data' => json_encode(['flag' => true], JSON_THROW_ON_ERROR)],
+            ['entity_id' => '1', 'revision_id' => 1],
+        );
+
+        $this->alwaysApplyDefaultRevisionSemantics();
+        $repo->setPublishedRevision('1', 1);
+
+        self::assertSame(1, $repo->find('1')?->toArray()['flag']);
     }
 
     #[Test]

--- a/packages/entity-storage/tests/Unit/EntityRepositoryRevisionSurfaceTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryRevisionSurfaceTest.php
@@ -17,6 +17,7 @@ use Waaseyaa\EntityStorage\EntityRepository;
 use Waaseyaa\EntityStorage\Revision\RevisionPruningPolicy;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
 use Waaseyaa\EntityStorage\Tests\Fixtures\TestRevisionableEntity;
+use Waaseyaa\Field\FieldStorage;
 
 /**
  * WP-revisions: repository-level surface added for the revision UX —
@@ -39,6 +40,9 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'revision' => 'revision_id'],
             revisionable: true,
             revisionDefault: true,
+            _fieldDefinitions: [
+                'flag' => ['type' => 'boolean', 'stored' => FieldStorage::Data],
+            ],
         );
 
         $handler = new SqlSchemaHandler($this->entityType, $this->db);
@@ -165,6 +169,32 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
         $this->assertSame('v1', $this->repo->find('1')->label());
         // ...and NO new revision was created (still exactly 3).
         $this->assertCount(3, $this->repo->listRevisions('1'));
+    }
+
+    #[Test]
+    public function revision_restore_paths_normalize_historical_boolean_values(): void
+    {
+        $entity = new TestRevisionableEntity(values: [
+            'title' => 'v1',
+            'id' => '1',
+            'uuid' => 'a',
+            'flag' => false,
+        ]);
+        $entity->enforceIsNew();
+        $this->repo->save($entity);
+
+        $this->db->getConnection()->update(
+            'test_revisionable_revision',
+            ['_data' => json_encode(['flag' => true], JSON_THROW_ON_ERROR)],
+            ['entity_id' => '1', 'revision_id' => 1],
+        );
+
+        $this->repo->setCurrentRevision('1', 1);
+        self::assertSame(1, $this->repo->find('1')?->toArray()['flag']);
+
+        $rolledBack = $this->repo->rollback('1', 1);
+        self::assertSame(1, $rolledBack->toArray()['flag']);
+        self::assertSame(1, $this->repo->find('1')?->toArray()['flag']);
     }
 
     #[Test]
@@ -415,5 +445,20 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
 
         // Idempotent: a second backfill does nothing.
         $this->assertSame(0, $this->repo->backfillInitialRevisions());
+    }
+
+    #[Test]
+    public function backfill_normalizes_historical_boolean_values(): void
+    {
+        $this->db->getConnection()->insert('test_revisionable', [
+            'id' => 8,
+            'uuid' => 'u8',
+            'title' => 'legacy boolean',
+            '_data' => json_encode(['flag' => true], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(1, $this->repo->backfillInitialRevisions());
+        self::assertSame(1, $this->repo->find('8')?->toArray()['flag']);
+        self::assertSame(1, $this->repo->loadRevision('8', 1)?->toArray()['flag']);
     }
 }

--- a/packages/entity-storage/tests/Unit/EntityRepositoryTranslationAxisTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryTranslationAxisTest.php
@@ -48,6 +48,9 @@ final class EntityRepositoryTranslationAxisTest extends TestCase
             revisionable: true,
             revisionDefault: true,
             translatable: true,
+            _fieldDefinitions: [
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'default' => 0],
+            ],
         );
 
         $handler = new SqlSchemaHandler($entityType, $this->db);
@@ -118,6 +121,26 @@ final class EntityRepositoryTranslationAxisTest extends TestCase
         $this->assertNotNull($oj);
         $this->assertSame('Hello', $en->label());
         $this->assertSame('Aanii', $oj->label());
+    }
+
+    #[Test]
+    public function every_translation_write_uses_canonical_boolean_storage(): void
+    {
+        $single = $this->repo->saveTranslationRevision('1', 'en', ['title' => 'Single', 'status' => true]);
+        self::assertSame(1, $this->repo->loadTranslationRevision('1', 'en', $single)?->toArray()['status']);
+
+        $batch = $this->repo->saveTranslationRevisions('2', [
+            'en' => ['title' => 'Batch', 'status' => true],
+        ]);
+        self::assertSame(1, $this->repo->loadTranslationRevision('2', 'en', $batch['en'])?->toArray()['status']);
+
+        $entity = new TestRevisionableEntity(values: ['title' => 'Default', 'uuid' => 'translation-bool']);
+        $entity->enforceIsNew();
+        $this->repo->save($entity);
+        $this->repo->saveTranslation((string) $entity->id(), 'oj', ['title' => 'Peer', 'status' => true]);
+
+        self::assertSame(1, $this->repo->loadTranslation((string) $entity->id(), 'oj')?->toArray()['status']);
+        self::assertSame(1, $this->repo->loadTranslationTip((string) $entity->id(), 'oj')?->toArray()['status']);
     }
 
     #[Test]

--- a/packages/migration/tests/Fixtures/MigrationTestWidgetType.php
+++ b/packages/migration/tests/Fixtures/MigrationTestWidgetType.php
@@ -34,6 +34,8 @@ final class MigrationTestWidgetType
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'widget_type'],
             _fieldDefinitions: [
                 'status' => ['type' => 'boolean', 'label' => 'Published', 'default' => 0],
+                'archived' => ['type' => 'boolean', 'label' => 'Archived', 'default' => 0],
+                'optional_flag' => ['type' => 'boolean', 'label' => 'Optional flag'],
             ],
         );
     }

--- a/packages/migration/tests/Fixtures/MigrationTestWidgetType.php
+++ b/packages/migration/tests/Fixtures/MigrationTestWidgetType.php
@@ -32,6 +32,9 @@ final class MigrationTestWidgetType
             label: 'Migration Test Widget',
             class: MigrationTestWidget::class,
             keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'widget_type'],
+            _fieldDefinitions: [
+                'status' => ['type' => 'boolean', 'label' => 'Published', 'default' => 0],
+            ],
         );
     }
 

--- a/packages/migration/tests/Integration/EntityDestinationTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationTest.php
@@ -151,6 +151,34 @@ final class EntityDestinationTest extends TestCase
     }
 
     #[Test]
+    public function authoring_and_import_writes_persist_the_same_boolean_shape(): void
+    {
+        $authored = $this->repository->create([
+            'title' => 'Authored',
+            'status' => true,
+        ]);
+        $this->repository->save($authored);
+
+        $destination = $this->makeDestination();
+        $imported = $destination->write(new DestinationRecord(
+            migrationId: self::MIGRATION_ID,
+            sourceId: new SourceId(sourceType: 'fake_source', keys: ['key' => 'boolean-parity']),
+            values: ['title' => 'Imported', 'status' => 1],
+        ));
+
+        $authoredRow = $this->repository->find((string) $authored->id());
+        $importedRows = $this->repository->findBy(['uuid' => $imported->destinationUuid]);
+
+        self::assertNotNull($authoredRow);
+        self::assertCount(1, $importedRows);
+        self::assertSame(1, $authoredRow->toArray()['status']);
+        self::assertSame(
+            $authoredRow->toArray()['status'],
+            $importedRows[0]->toArray()['status'],
+        );
+    }
+
+    #[Test]
     public function update_path_re_runs_with_different_hash_persist_new_values(): void
     {
         $destination = $this->makeDestination();

--- a/packages/migration/tests/Integration/EntityDestinationTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationTest.php
@@ -156,6 +156,8 @@ final class EntityDestinationTest extends TestCase
         $authored = $this->repository->create([
             'title' => 'Authored',
             'status' => true,
+            'archived' => false,
+            'optional_flag' => null,
         ]);
         $this->repository->save($authored);
 
@@ -163,7 +165,12 @@ final class EntityDestinationTest extends TestCase
         $imported = $destination->write(new DestinationRecord(
             migrationId: self::MIGRATION_ID,
             sourceId: new SourceId(sourceType: 'fake_source', keys: ['key' => 'boolean-parity']),
-            values: ['title' => 'Imported', 'status' => 1],
+            values: [
+                'title' => 'Imported',
+                'status' => 1,
+                'archived' => 0,
+                'optional_flag' => null,
+            ],
         ));
 
         $authoredRow = $this->repository->find((string) $authored->id());
@@ -176,6 +183,10 @@ final class EntityDestinationTest extends TestCase
             $authoredRow->toArray()['status'],
             $importedRows[0]->toArray()['status'],
         );
+        self::assertSame(0, $authoredRow->toArray()['archived']);
+        self::assertSame(0, $importedRows[0]->toArray()['archived']);
+        self::assertNull($authoredRow->toArray()['optional_flag']);
+        self::assertNull($importedRows[0]->toArray()['optional_flag']);
     }
 
     #[Test]

--- a/tests/Integration/EntityStorage/RepositoryUserRoundTripTest.php
+++ b/tests/Integration/EntityStorage/RepositoryUserRoundTripTest.php
@@ -61,7 +61,8 @@ final class RepositoryUserRoundTripTest extends TestCase
         $user = User::make([
             'name' => 'alice',
             'mail' => 'alice@example.com',
-            'status' => 1,
+            'email_verified' => true,
+            'status' => true,
         ]);
 
         $uid = $repository->save($user);
@@ -73,6 +74,7 @@ final class RepositoryUserRoundTripTest extends TestCase
         self::assertInstanceOf(User::class, $reloaded);
         self::assertSame('alice', $reloaded->getName());
         self::assertSame('alice@example.com', $reloaded->getEmail());
+        self::assertSame(1, $reloaded->toArray()['email_verified']);
         self::assertSame(1, $reloaded->get('status'));
     }
 }


### PR DESCRIPTION
Closes the R25 WP3 portion of #2043.

Guarantees:
- declared and inferred boolean fields persist as integer 0/1 across base, bundle, and revision storage
- authoring and EntityDestination writes persist the same status shape
- translation, revision restore/promotion, and initial-revision backfill writes use the same normalization boundary
- the framework boolean-field audit and upgrade guidance are recorded

TDD:
- authoring/import parity regression: red on bool true vs int 1, then green
- translation write regression: red on native bool revision shape, then green
- restore/promotion/backfill regressions: red on historical native bool shape, then green

Local verification:
- Unit: 9,612 tests, 223,660 assertions
- Integration: 1,489 tests, 6,019 assertions, 2 skipped
- focused WP3 matrix: 51 tests, 222 assertions
- phpstan: clean
- cs-check: clean
- package layers: clean