### PR TITLE
fix(#2064): scope the packaged User smoke read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The published-skeleton entity round-trip smoke now establishes an explicit immutable profile-view principal before reading the Protected User name (#2064).** The smoke still persists an Internal email value, but does not bypass the entity boundary to inspect it; the alpha.268 missing-context throw remains unchanged.
+
 ## [0.1.0-alpha.268] - 2026-07-19
 
 - **The accepted User status-projection edge is now an explicit contract (#2064).** A physically absent stored `status` remains `null` in the closed query projection and denies ordinary profile visibility instead of inheriting User's active constructor default; the canonical boundary spec, policy rationale, and regression test pin both paths against a permissive fallback. Only administrators differ: their independent permission admits the exact null-bearing projection while the incomplete hydrated subject remains denied, and the private projection releases no field value.

--- a/tools/skeleton-smoke/smoke.php
+++ b/tools/skeleton-smoke/smoke.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
  * Exit codes: 0 success; non-zero failure.
  */
 
+use Waaseyaa\Access\AccountPrincipalFactoryInterface;
+use Waaseyaa\Access\Context\AccountFieldReadScopeInterface;
 use Waaseyaa\Foundation\Kernel\HttpKernel;
 use Waaseyaa\User\User;
 
@@ -67,6 +69,7 @@ $email = $marker . '@example.test';
 $user = User::make([
     'name' => $marker,
     'mail' => $email,
+    'permissions' => ['access user profiles'],
     'status' => 1,
     'created' => time(),
 ]);
@@ -85,10 +88,26 @@ if (!$reloaded instanceof User) {
     exit(1);
 }
 
-if ($reloaded->getName() !== $marker || $reloaded->getEmail() !== $email) {
+$resolver = $kernel->getHttpServiceResolver();
+$scope = $resolver->resolve(AccountFieldReadScopeInterface::class);
+if (!$scope instanceof AccountFieldReadScopeInterface) {
+    fwrite(STDERR, "skeleton-smoke: account field-read scope is not available\n");
+    exit(1);
+}
+
+$principalFactory = $resolver->resolve(AccountPrincipalFactoryInterface::class);
+if (!$principalFactory instanceof AccountPrincipalFactoryInterface) {
+    fwrite(STDERR, "skeleton-smoke: account principal factory is not available\n");
+    exit(1);
+}
+
+$profileViewer = $principalFactory->fromAccount($reloaded);
+$reloadedName = $scope->run($profileViewer, static fn(): string => $reloaded->getName());
+
+if ($reloadedName !== $marker) {
     fwrite(STDERR, "skeleton-smoke: round-trip mismatch\n");
-    fwrite(STDERR, "  expected name={$marker} mail={$email}\n");
-    fwrite(STDERR, "  got      name={$reloaded->getName()} mail={$reloaded->getEmail()}\n");
+    fwrite(STDERR, "  expected name={$marker}\n");
+    fwrite(STDERR, "  got      name={$reloadedName}\n");
     exit(1);
 }
 


### PR DESCRIPTION
Part of #2064

## Summary

Repairs the alert-only published-skeleton smoke after the alpha.268 field-read activation. The harness now derives an immutable profile-view principal through the kernel's audited principal factory and establishes the shared account read scope before reading the Protected User name.

The smoke continues to persist an Internal email value as part of the repository round trip, but does not read it through an ordinary accessor. Field classifications and the missing-context exception are unchanged.

## Evidence

- RED: release run 29671214054 failed at `User::getName()` with `MissingFieldReadContext`
- GREEN: fresh `composer create-project` from Packagist, exact `waaseyaa/framework:0.1.0-alpha.268`, migrations, and the corrected entity round-trip smoke
- Unit: 9,869 tests / 224,672 assertions
- PHPStan: 1,843 files, no errors
- Code style and composer policy: green

## Changelog

Adds an `[Unreleased]` Fixed entry.
