### PR TITLE
refactor: break optional domain dependency edges (#2091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Framework and curated metapackage defaults no longer select site-specific domains (#2091).** Genealogy, AI-agent execution, OIDC, MCP, Wayfinding, messaging, and social engagement are explicit Composer opt-ins; the expanded `full` metapackage advertises agent and MCP support without installing them, and the monorepo's AI-observability companion no longer re-selects the agent runtime.
+- **Reusable package edges no longer force unrelated optional domains (#2091).** CLI, API, and routing advertise their AI-agent and OIDC integrations through Composer suggestions, while AI-agent advertises its Wayfinding trail tools; installing any reusable package alone therefore leaves those domains absent.
+- **Framework and curated metapackage defaults no longer select site-specific domains (#2091).** Genealogy, AI-agent execution, OIDC, MCP, Wayfinding, messaging, and social engagement are explicit Composer opt-ins; the expanded `full` metapackage advertises agent and MCP support without installing them, while the monorepo root retains optional packages only as development dependencies for their own test suites.
 
 ### Fixed
 

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -54,10 +54,6 @@
         },
         {
             "type": "path",
-            "url": "../wayfinding"
-        },
-        {
-            "type": "path",
             "url": "../config"
         },
         {
@@ -81,9 +77,11 @@
         "waaseyaa/entity-storage": "^0.1.0-alpha.271",
         "waaseyaa/foundation": "^0.1.0-alpha.271",
         "waaseyaa/http-client": "^0.1.0-alpha.271",
-        "waaseyaa/wayfinding": "^0.1.0-alpha.271",
         "waaseyaa/config": "^0.1.0-alpha.271",
         "waaseyaa/routing": "^0.1.0-alpha.271"
+    },
+    "suggest": {
+        "waaseyaa/wayfinding": "Provides optional trail tools for AI agents"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -50,10 +50,6 @@
         },
         {
             "type": "path",
-            "url": "../oidc"
-        },
-        {
-            "type": "path",
             "url": "../queue"
         },
         {
@@ -91,12 +87,14 @@
         "waaseyaa/mail": "^0.1.0-alpha.271",
         "waaseyaa/media": "^0.1.0-alpha.271",
         "waaseyaa/notification": "^0.1.0-alpha.271",
-        "waaseyaa/oidc": "^0.1.0-alpha.271",
         "waaseyaa/queue": "^0.1.0-alpha.271",
         "waaseyaa/relationship": "^0.1.0-alpha.271",
         "waaseyaa/routing": "^0.1.0-alpha.271",
         "waaseyaa/scheduler": "^0.1.0-alpha.271",
         "waaseyaa/workflows": "^0.1.0-alpha.271"
+    },
+    "suggest": {
+        "waaseyaa/oidc": "Provides optional OIDC client administration routes"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -10,10 +10,6 @@
         },
         {
             "type": "path",
-            "url": "../ai-agent"
-        },
-        {
-            "type": "path",
             "url": "../audit"
         },
         {
@@ -78,10 +74,6 @@
         },
         {
             "type": "path",
-            "url": "../oidc"
-        },
-        {
-            "type": "path",
             "url": "../plugin"
         },
         {
@@ -101,7 +93,6 @@
         "php": ">=8.5",
         "symfony/console": "^8.0",
         "waaseyaa/access": "^0.1.0-alpha.271",
-        "waaseyaa/ai-agent": "^0.1.0-alpha.271",
         "waaseyaa/audit": "^0.1.0-alpha.271",
         "waaseyaa/cache": "^0.1.0-alpha.271",
         "waaseyaa/config": "^0.1.0-alpha.271",
@@ -118,7 +109,6 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.271",
         "waaseyaa/field": "^0.1.0-alpha.271",
         "waaseyaa/foundation": "^0.1.0-alpha.271",
-        "waaseyaa/oidc": "^0.1.0-alpha.271",
         "waaseyaa/plugin": "^0.1.0-alpha.271",
         "waaseyaa/routing": "^0.1.0-alpha.271",
         "waaseyaa/search": "^0.1.0-alpha.271",
@@ -126,7 +116,9 @@
     },
     "suggest": {
         "ext-intl": "For ICU transliteration of diacritic titles to readable Latin ingest keys; a deterministic hash key is used otherwise",
-        "ext-pcntl": "Required for clean SIGINT handling in --watch mode"
+        "ext-pcntl": "Required for clean SIGINT handling in --watch mode",
+        "waaseyaa/ai-agent": "Provides the optional ai:* operator commands",
+        "waaseyaa/oidc": "Provides the optional oidc:* operator commands"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/packages/routing/composer.json
+++ b/packages/routing/composer.json
@@ -22,10 +22,6 @@
         },
         {
             "type": "path",
-            "url": "../oidc"
-        },
-        {
-            "type": "path",
             "url": "../foundation"
         },
         {
@@ -39,10 +35,12 @@
         "waaseyaa/access": "^0.1.0-alpha.271",
         "waaseyaa/i18n": "^0.1.0-alpha.271",
         "waaseyaa/auth": "^0.1.0-alpha.271",
-        "waaseyaa/oidc": "^0.1.0-alpha.271",
         "symfony/routing": "^7.0",
         "waaseyaa/foundation": "^0.1.0-alpha.271",
         "waaseyaa/user": "^0.1.0-alpha.271"
+    },
+    "suggest": {
+        "waaseyaa/oidc": "Provides optional OpenID Connect issuer routes"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/tests/Architecture/OptionalDomainDefaultsTest.php
+++ b/tests/Architecture/OptionalDomainDefaultsTest.php
@@ -46,4 +46,41 @@ final class OptionalDomainDefaultsTest extends TestCase
             }
         }
     }
+
+    #[Test]
+    public function reusable_packages_do_not_force_unrelated_optional_domains(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $forbiddenEdges = [
+            'waaseyaa/cli' => [
+                'manifest' => $root . '/packages/cli/composer.json',
+                'domains' => ['waaseyaa/ai-agent', 'waaseyaa/oidc'],
+            ],
+            'waaseyaa/api' => [
+                'manifest' => $root . '/packages/api/composer.json',
+                'domains' => ['waaseyaa/oidc'],
+            ],
+            'waaseyaa/routing' => [
+                'manifest' => $root . '/packages/routing/composer.json',
+                'domains' => ['waaseyaa/oidc'],
+            ],
+            'waaseyaa/ai-agent' => [
+                'manifest' => $root . '/packages/ai-agent/composer.json',
+                'domains' => ['waaseyaa/wayfinding'],
+            ],
+        ];
+
+        foreach ($forbiddenEdges as $package => $expectation) {
+            $manifest = json_decode((string) file_get_contents($expectation['manifest']), true, 512, JSON_THROW_ON_ERROR);
+            $requires = array_keys((array) ($manifest['require'] ?? []));
+
+            foreach ($expectation['domains'] as $optionalDomain) {
+                self::assertNotContains(
+                    $optionalDomain,
+                    $requires,
+                    sprintf('%s must not force optional domain %s.', $package, $optionalDomain),
+                );
+            }
+        }
+    }
 }

--- a/tests/Architecture/RequireParityTest.php
+++ b/tests/Architecture/RequireParityTest.php
@@ -20,7 +20,8 @@ use PHPUnit\Framework\TestCase;
  *
  * This test asserts require-parity for the packages remediated in this work
  * package. Each imported sibling package that sits at the same layer or below
- * (i.e. a legal, declarable dependency) MUST appear in `require`. Higher-layer
+ * (i.e. a legal, declarable dependency) MUST appear in `require` unless the
+ * shared PL007 baseline records a reviewed optional integration. Higher-layer
  * imports are layer violations owned by `check-package-layers` and are out of
  * scope here.
  */
@@ -84,10 +85,11 @@ final class RequireParityTest extends TestCase
 
         $selfLayer = $layerByPackage[$package] ?? null;
         self::assertNotNull($selfLayer, "Package {$package} has no known layer.");
+        $allowedOptionalEdges = self::optionalEdges($root);
 
         $undeclared = [];
         foreach (self::importsForPackage($packagesDir, $package, $namespaceToPackage) as $dep => $exampleFile) {
-            if ($dep === $package || isset($declared[$dep])) {
+            if ($dep === $package || isset($declared[$dep]) || isset($allowedOptionalEdges[$package][$dep])) {
                 continue;
             }
             $depLayer = $layerByPackage[$dep] ?? null;
@@ -108,6 +110,21 @@ final class RequireParityTest extends TestCase
                 json_encode($undeclared, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
             ),
         );
+    }
+
+    /** @return array<string, array<string, true>> */
+    private static function optionalEdges(string $root): array
+    {
+        $edges = [];
+        $lines = file($root . '/tools/package-layers-undeclared-baseline.txt', FILE_IGNORE_NEW_LINES) ?: [];
+        foreach ($lines as $line) {
+            if (preg_match('/^([a-z0-9-]+)\s+([a-z0-9-]+)\s+#/', $line, $matches) !== 1) {
+                continue;
+            }
+            $edges[$matches[1]][$matches[2]] = true;
+        }
+
+        return $edges;
     }
 
     /**

--- a/tools/package-layers-undeclared-baseline.txt
+++ b/tools/package-layers-undeclared-baseline.txt
@@ -6,10 +6,10 @@
 #   the dep to that package's require, then delete the line. New undeclared edges NOT in this
 #   list fail CI (PL007, fail-on-new). Regenerate: php bin/check-package-layers --generate-baseline
 #
-# STATUS: empty. The 48 historical edges (W4-3 sweep) were all resolved by declaring
-# the dependency in the importing package's composer.json require (issue #1806,
-# batches 1-4). PL007 is now a strict zero-tolerance gate — any new undeclared
-# same/lower-layer use-edge fails CI. Keep this file (do not delete it): the gate
-# reads it, and a future legitimate can't-declare exception would be listed here
-# with a rationale comment.
-
+# The following edges are deliberate optional integrations. Making them hard
+# requirements would restore the domain coupling tracked by #2091.
+ai-agent wayfinding  # Trail-tool source remains an optional Wayfinding integration.
+api oidc  # Client administration must not install OIDC for every API consumer.
+cli ai-agent  # AI console integration must not install Agent for every CLI consumer.
+cli oidc  # OIDC console integration must not install OIDC for every CLI consumer.
+routing oidc  # Issuer integration must not install OIDC for every routing consumer.

--- a/tools/policy-discovery-smoke.php
+++ b/tools/policy-discovery-smoke.php
@@ -25,8 +25,8 @@ $actual = [
     'schedule_entries' => count($manifest->scheduleEntries),
 ];
 $expected = [
-    'policies' => 19,
-    'agent_tools' => 21,
+    'policies' => 16,
+    'agent_tools' => 11,
     'formatters' => 6,
     'middleware' => 16,
     'schedule_entries' => 4,


### PR DESCRIPTION
Part of #2091

## Summary
- move CLI AI-agent/OIDC, API OIDC, routing OIDC, and AI-agent Wayfinding edges from hard requirements to Composer suggestions
- document the five intentional optional-import exceptions in the package-layer allowlist
- pin the minimal scratch discovery baseline after the transitive packages disappear

## Verification
- regression proved red, then green: `tests/Architecture/OptionalDomainDefaultsTest.php`
- minimal scratch install resolves with none of the seven target domains
- AI-agent-only scratch install boots without Wayfinding
- `bin/check-composer-policy`
- `bin/check-package-layers`
- `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit --no-coverage` (9894 tests, 224764 assertions)
- pre-push phpstan and Unit gate green