### PR TITLE
#2091: Strengthen optional-domain install verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Optional-domain install smoke now exercises the real public surfaces (#2091).** The two-shape regression protects the retained core package set, invokes authenticated API discovery, and reads admin catalogue and MCP capability payloads through the registered admin-surface routes.
 - **Fresh-install CI now verifies minimal and opt-in domain shapes (#2091).** Isolated Composer installs assert that Genealogy, AI-agent, OIDC, MCP, Wayfinding, Messaging, and social engagement are absent from the minimal package graph, admin catalogue/navigation capability, discovery manifest, and route table, and restored when explicitly required; the AI-agent package now declares its existing HTTP route provider so explicit installs restore the documented executor endpoints.
 - **Admin and API discovery now expose only installed opt-in domains (#2091).** OIDC and MCP routes are absent without their packages, the MCP admin menu follows an installed capability flag, and Wayfinding agent tools are discovered only when Wayfinding is installed; entity-driven catalogue and JSON:API discovery continue to follow registered definitions.
 - **Reusable package edges no longer force unrelated optional domains (#2091).** CLI, API, and routing advertise their AI-agent and OIDC integrations through Composer suggestions, while AI-agent advertises its Wayfinding trail tools; installing any reusable package alone therefore leaves those domains absent.

--- a/tools/optional-domain-install-smoke.php
+++ b/tools/optional-domain-install-smoke.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use Composer\InstalledVersions;
 use Symfony\Component\HttpFoundation\Request;
-use Waaseyaa\AdminSurface\Host\AdminSurfaceSessionData;
-use Waaseyaa\AdminSurface\Host\GenericAdminSurfaceHost;
+use Waaseyaa\Access\AccountPrincipalFactoryInterface;
+use Waaseyaa\Api\ApiDiscoveryController;
 use Waaseyaa\Foundation\Kernel\HttpKernel;
+use Waaseyaa\User\User;
 
 $projectRoot = isset($argv[1]) ? realpath($argv[1]) : false;
 $shape = $argv[2] ?? '';
@@ -31,6 +32,18 @@ $packages = [
     'waaseyaa/messaging',
     'waaseyaa/engagement',
 ];
+$corePackages = [
+    'waaseyaa/entity',
+    'waaseyaa/entity-storage',
+    'waaseyaa/node',
+    'waaseyaa/taxonomy',
+    'waaseyaa/media',
+    'waaseyaa/menu',
+    'waaseyaa/user',
+    'waaseyaa/workflows',
+    'waaseyaa/config',
+    'waaseyaa/groups',
+];
 
 $failures = [];
 $assert = static function (bool $condition, string $message) use (&$failures): void {
@@ -45,9 +58,13 @@ foreach ($packages as $package) {
         sprintf('%s package %s', $package, $expectedPresent ? 'is not installed' : 'is installed'),
     );
 }
+foreach ($corePackages as $package) {
+    $assert(InstalledVersions::isInstalled($package), sprintf('core package %s is not installed', $package));
+}
 
 $kernel = new HttpKernel($projectRoot);
 (new ReflectionMethod($kernel, 'boot'))->invoke($kernel);
+$matchRoute = new ReflectionMethod($kernel, 'matchRoute');
 
 $entityIdsByPackage = [
     'waaseyaa/genealogy' => ['genealogy_tree', 'genealogy_person', 'genealogy_event', 'genealogy_family'],
@@ -60,12 +77,52 @@ $entityIdsByPackage = [
 
 $entityTypeManager = $kernel->getEntityTypeManager();
 $definitionIds = array_keys($entityTypeManager->getDefinitions());
-$session = new AdminSurfaceSessionData('smoke-admin', 'Smoke Admin', ['admin'], []);
-$catalog = (new GenericAdminSurfaceHost(
-    entityTypeManager: $entityTypeManager,
-    features: ['mcp' => InstalledVersions::isInstalled('waaseyaa/mcp')],
-))->buildCatalog($session)->build();
-$catalogIds = array_column($catalog, 'id');
+$adminAccount = User::make([
+    'uid' => 1,
+    'name' => 'smoke-admin',
+    'roles' => ['administrator'],
+    'status' => true,
+]);
+$principalFactory = $kernel->getHttpServiceResolver()->resolve(AccountPrincipalFactoryInterface::class);
+$assert(
+    $principalFactory instanceof AccountPrincipalFactoryInterface,
+    'account principal factory is not available',
+);
+$adminPrincipal = $principalFactory instanceof AccountPrincipalFactoryInterface
+    ? $principalFactory->fromAccount($adminAccount)
+    : null;
+
+$invokeSurfaceRoute = static function (string $path, string $expectedRouteName) use ($kernel, $matchRoute, $adminAccount, $adminPrincipal, $assert): array {
+    $matched = $matchRoute->invoke($kernel, $path, 'GET');
+    $assert($matched instanceof Request, sprintf('admin surface route %s did not match', $path));
+    if (!$matched instanceof Request) {
+        return [];
+    }
+    $assert(
+        $matched->attributes->get('_route') === $expectedRouteName,
+        sprintf('admin surface path %s matched %s instead of %s', $path, $matched->attributes->get('_route'), $expectedRouteName),
+    );
+
+    $controller = $matched->attributes->get('_controller');
+    $assert(is_callable($controller), sprintf('admin surface route %s has no callable controller', $path));
+    if (!is_callable($controller)) {
+        return [];
+    }
+
+    $request = Request::create($path);
+    $request->attributes->set('_account', $adminAccount);
+    if ($adminPrincipal !== null) {
+        $request->attributes->set('_authorization_principal', $adminPrincipal);
+    }
+    $payload = $controller($request);
+    $assert(is_array($payload), sprintf('admin surface route %s returned no payload', $path));
+
+    return is_array($payload) ? $payload : [];
+};
+
+$sessionPayload = $invokeSurfaceRoute('/admin/_surface/session', 'admin_surface.session');
+$catalogPayload = $invokeSurfaceRoute('/admin/_surface/catalog', 'admin_surface.catalog');
+$catalogIds = array_column($catalogPayload['data']['entities'] ?? [], 'id');
 
 foreach ($entityIdsByPackage as $package => $entityIds) {
     foreach ($entityIds as $entityId) {
@@ -80,17 +137,34 @@ foreach ($entityIdsByPackage as $package => $entityIds) {
     }
 }
 
-$sessionPayload = (new AdminSurfaceSessionData(
-    'smoke-admin',
-    'Smoke Admin',
-    ['admin'],
-    [],
-    features: ['mcp' => InstalledVersions::isInstalled('waaseyaa/mcp')],
-))->toArray();
 $assert(
-    ($sessionPayload['features']['mcp'] ?? false) === $expectedPresent,
+    ($sessionPayload['data']['features']['mcp'] ?? false) === $expectedPresent,
     sprintf('MCP admin navigation capability is %s', $expectedPresent ? 'absent' : 'present'),
 );
+
+$apiDiscoveryRoute = $matchRoute->invoke($kernel, '/api', 'GET');
+$assert($apiDiscoveryRoute instanceof Request, 'API discovery route /api did not match');
+if ($apiDiscoveryRoute instanceof Request) {
+    $assert(
+        $apiDiscoveryRoute->attributes->get('_route') === 'api.discovery',
+        sprintf('API discovery path /api matched %s instead of api.discovery', $apiDiscoveryRoute->attributes->get('_route')),
+    );
+}
+$apiDiscovery = (new ApiDiscoveryController($entityTypeManager, account: $adminAccount))->discover();
+$apiDiscoveryIds = array_keys($apiDiscovery['links']);
+$apiEntityIds = array_merge(
+    $entityIdsByPackage['waaseyaa/genealogy'],
+    $entityIdsByPackage['waaseyaa/oidc'],
+    $entityIdsByPackage['waaseyaa/wayfinding'],
+    $entityIdsByPackage['waaseyaa/messaging'],
+    $entityIdsByPackage['waaseyaa/engagement'],
+);
+foreach ($apiEntityIds as $entityId) {
+    $assert(
+        in_array($entityId, $apiDiscoveryIds, true) === $expectedPresent,
+        sprintf('%s API discovery link is %s', $entityId, $expectedPresent ? 'absent' : 'present'),
+    );
+}
 
 $manifestJson = json_encode($kernel->getManifest()->toArray(), JSON_THROW_ON_ERROR);
 $manifestNamespaces = [
@@ -118,7 +192,6 @@ $routes = [
     'waaseyaa/messaging' => ['GET', '/api/message_thread', 'api.message_thread.index'],
     'waaseyaa/engagement' => ['GET', '/api/comment', 'api.comment.index'],
 ];
-$matchRoute = new ReflectionMethod($kernel, 'matchRoute');
 foreach ($routes as $package => [$method, $path, $expectedRouteName]) {
     $routeResult = $matchRoute->invoke($kernel, $path, $method);
     $actualRouteName = $routeResult instanceof Request ? $routeResult->attributes->get('_route') : null;


### PR DESCRIPTION
Closes the two low-severity regression-quality gaps found by the required fresh-context adversarial verifier.

- asserts every retained core package in both install shapes
- invokes the registered authenticated admin session and catalog routes
- verifies `/api` resolves to `api.discovery` and checks authenticated discovery links
- derives the MCP capability from the real admin provider payload
- adds the required `[Unreleased]` changelog entry

Local verification:
- `tools/optional-domain-install-shapes.sh` (minimal PASS; full PASS)
- `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit` (9896 tests, 224773 assertions)
- `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Architecture`
- `composer cs-check`
- `composer check-composer-policy`
- `bin/check-package-layers`

Anchor: #2091