### PR TITLE
Classify framework-owned field-read defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Framework-owned entity fields now carry one runtime/preflight classification default (#2064).** Applications no longer have to classify universal language/bundle selectors, first-party config labels, relationship infrastructure, parked media-version internals, or legacy User account infrastructure. Explicit metadata must agree with the shared default source. Credential hashes remain Internal and outward-denied even to administrators; consent/reset/disabled state is administrator-only Protected; application directory fields remain deliberately unclassified.
+
 ## [0.1.0-alpha.272] - 2026-07-24
 
 ### Changed

--- a/docs/specs/entity-field-read-boundary.md
+++ b/docs/specs/entity-field-read-boundary.md
@@ -332,6 +332,13 @@ legacy payloads remain blockers. `--write-artifact` atomically writes the exact
 checksum-bound candidate result. Classification, package-lock, definition, or
 schema changes produce a different artifact identity.
 
+Framework-owned defaults are not a preflight-only waiver. The exact table in
+`field-access.md` is resolved by the same source during sealed runtime layout
+compilation and preflight scanning. Explicit definitions and classification
+artifacts must agree with that source or produce a blocker. This keeps
+applications responsible only for their bundle fields while preventing a green
+artifact from widening or narrowing runtime visibility.
+
 The reusable `FieldReadGuard` decision/cache path is exercised only by WP3
 fixtures and benchmarks. `EntityBase`, queries, serialization, and normal boot
 do not install it in this tranche; WP4 performs that single no-shim activation.

--- a/docs/specs/field-access.md
+++ b/docs/specs/field-access.md
@@ -1,5 +1,6 @@
 # Field-Level Access
 
+<!-- Spec reviewed 2026-07-24 - #2064 framework-owned field defaults: one shared default-classification source is consumed by both sealed runtime layout compilation and activation preflight. It covers universal structural selectors plus the exact first-party config labels, relationship infrastructure, parked media-version internals, and legacy User account-infrastructure fields listed below. Explicit metadata that disagrees with a framework default is a hard conflict. Application bundle fields and directory-exposure policy remain consumer-owned. -->
 <!-- Spec reviewed 2026-07-21 - #2064 media hotfix: Media Protected fields now compose with the complete hydrated entity-view decision. Application contextual grants can release bundle-defined Protected media metadata, application Forbidden results still win, and a missing/mismatched hydrated entity fails closed. This does not change legacy open-by-default FieldAccessPolicyInterface filtering or Internal-field sealing. -->
 <!-- Spec reviewed 2026-07-19 - #2064 alpha.270 boolean-field hotfix: resolved boolean/bool field definitions now canonicalize values to native PHP bool while the private entity value container is sealed and on every write. Closed validation, persistence extraction, guarded reads, and public projections observe that same type. Protected/Internal sealing and missing-context denial are unchanged. -->
 
@@ -84,6 +85,35 @@ When `EntityAccessHandler::checkFieldAccess()` runs:
 When no policy implements `FieldAccessPolicyInterface` for the entity type, the result is Neutral. Neutral is not Forbidden, so all fields pass through. This ensures zero behavioral change when no field policies exist.
 
 This legacy presentation/edit filtering is distinct from accessor-level Protected reads. A first-party `ProtectedFieldReadPolicyInterface` may implement the internal `EntityViewProtectedFieldReadPolicyInterface` marker. At that point the handler requires the exact hydrated entity and composes the field opinion with the complete entity-level `view` decision. Field Forbidden and any entity Forbidden remain deny-overrides-allow; Neutral is released only by an Allowed entity view. Without the matching entity the read is denied. Media uses this mechanism for core and application-defined Protected fields, allowing a contextual consumer media policy to govern serialized API/admin metadata consistently with downloads and other entity-level views.
+
+## Framework-owned default classifications
+
+Applications classify fields they add. They do not repeat classifications for
+storage and account infrastructure defined by first-party framework packages.
+`FrameworkFieldReadDefaults` is the single source consumed by both
+`EntityReadRuntime` and `FieldAccessPreflightScanner`; a green preflight can
+therefore never describe a different level than sealed runtime compilation.
+An explicit definition or application artifact may restate a default only at
+the same level. A disagreement is a hard conflict.
+
+All registered entity types receive Public `bundle`, `langcode`, and
+`default_langcode` structural defaults, matching the runtime's existing
+structural treatment. The remaining exact defaults are:
+
+| Entity fields | Default | Newly readable channel and role | Safety basis |
+|---|---|---|---|
+| Config labels: `classification_label_definition.display_name`, `group_type.label`, `group.name`, `media_type.label`, `menu.label` | Public | Ordinary entity/API presentation after entity-level view succeeds | These are the framework-defined human labels used to identify already-viewable configuration or groups; they contain no credential, membership, or storage authority. |
+| `retention_policy.name` | Protected | Only a principal admitted by the classification-retention governance policy | Even its operator-facing label identifies governance configuration, so the default preserves the field's existing Protected level instead of broadening it. |
+| `relationship.{confidence,directionality,end_date,from_entity_id,from_entity_type,notes,source_ref,start_date,status,to_entity_id,to_entity_type,weight}` | Protected | Only an account allowed by the relationship Protected-read policy and entity view | These values describe relationship topology and lifecycle. They are never anonymous-by-default and remain subject to endpoint/entity visibility. |
+| `media_version.{blob_uri,created_at,created_by,label,media_uuid,mime,sha256,size,vid}` | Internal | No account-facing role or channel | Parked content-addressed storage metadata is available only to typed, audited system/admin infrastructure; ordinary and administrator API reads cannot release it. |
+| `user.password_hash`, `user.role` | Internal | No account-facing role or channel | Credential and authorization material never enters an outward projection. `password_hash` is also covered by serializer/schema deny floors, including administrator requests. |
+| `user.{consent_date,consent_on_file,must_reset_password,disabled}` | Protected | Authenticated principals with `administer users`, after User entity view | These are administrative account-state facts. The exact User policy rejects every other role and any unexpected policy-subject input. |
+
+User `display_name`, `first_name`, `last_name`, and
+`member_directory_visible` intentionally have no framework default. Directory
+exposure is application policy. The canonical framework login identifier
+`name` retains its existing Protected profile policy; it is not a consumer
+directory-field default and is not widened by this table.
 
 ```php
 // EntityAccessHandler::checkFieldAccess() excerpt:

--- a/packages/api/tests/Unit/ResourceSerializerFieldAccessTest.php
+++ b/packages/api/tests/Unit/ResourceSerializerFieldAccessTest.php
@@ -112,6 +112,26 @@ final class ResourceSerializerFieldAccessTest extends TestCase
     }
 
     #[Test]
+    public function administrator_context_cannot_serialize_a_password_hash(): void
+    {
+        $accessHandler = new EntityAccessHandler([
+            $this->createViewDenyPolicy('article', []),
+        ]);
+        $account = $this->createAccount();
+        $account->method('hasPermission')->with('administer users')->willReturn(true);
+        $entity = new TestEntity([
+            'id' => 1,
+            'uuid' => 'uuid-1',
+            'title' => 'Test',
+            'password_hash' => '$2y$12$NEVER_LEAK',
+        ]);
+
+        $resource = $this->serializer->serialize($entity, $accessHandler, $account);
+
+        self::assertArrayNotHasKey('password_hash', $resource->attributes);
+    }
+
+    #[Test]
     public function serializeOmitsMultipleViewDeniedFields(): void
     {
         $policy = $this->createViewDenyPolicy('article', ['secret', 'internal_notes']);

--- a/packages/entity/src/EntityReadRuntime.php
+++ b/packages/entity/src/EntityReadRuntime.php
@@ -144,7 +144,12 @@ final class EntityReadRuntime
         $definitions = self::mergeReadDefinitions($entityTypeId, ...$definitionSources);
         $classificationInputs = [];
         foreach ($definitions as $name => $definition) {
-            $level = self::metadataResolver()->resolve($definition)->level ?? FieldReadLevel::Internal;
+            $level = self::metadataResolver()->resolve(
+                $definition,
+                frameworkDefaultLevel: $registeredEntityType
+                    ? FrameworkFieldReadDefaults::resolve($entityTypeId, $bundle, $name)
+                    : null,
+            )->level ?? FieldReadLevel::Internal;
             $classificationInputs[] = $name . ':' . $level->value . ':'
                 . self::canonicalDefinitionType($definition->getType()) . ':'
                 . ($definition->getSetting('authorizationInput') === true ? 'auth' : 'ordinary');
@@ -173,7 +178,12 @@ final class EntityReadRuntime
         $authorizationInputs = [];
         $booleanFields = [];
         foreach ($definitions as $name => $definition) {
-            $level = self::metadataResolver()->resolve($definition)->level ?? FieldReadLevel::Internal;
+            $level = self::metadataResolver()->resolve(
+                $definition,
+                frameworkDefaultLevel: $registeredEntityType
+                    ? FrameworkFieldReadDefaults::resolve($entityTypeId, $bundle, $name)
+                    : null,
+            )->level ?? FieldReadLevel::Internal;
             $levels[$name] = $level;
             if ($definition->getSetting('authorizationInput') === true) {
                 if ($level !== FieldReadLevel::Protected) {
@@ -183,6 +193,15 @@ final class EntityReadRuntime
             }
             if (in_array(strtolower($definition->getType()), ['bool', 'boolean'], true)) {
                 $booleanFields[] = $name;
+            }
+        }
+
+        if ($registeredEntityType) {
+            foreach ($fieldNames as $field) {
+                $default = FrameworkFieldReadDefaults::resolve($entityTypeId, $bundle, $field);
+                if ($default !== null) {
+                    $levels[$field] = $default;
+                }
             }
         }
 

--- a/packages/entity/src/FrameworkFieldReadDefaults.php
+++ b/packages/entity/src/FrameworkFieldReadDefaults.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Entity;
+
+/**
+ * Framework-owned classifications for physical fields not declared by an
+ * application bundle definition.
+ *
+ * This is the single source for runtime layout compilation and activation
+ * preflight. Consumers must classify only the fields they add.
+ *
+ * @api
+ */
+final class FrameworkFieldReadDefaults
+{
+    /** @var array<string, string> */
+    private const array EXACT = [
+        'classification_label_definition|*|display_name' => 'public',
+        'group_type|*|label' => 'public',
+        'group|*|name' => 'public',
+        'media_type|*|label' => 'public',
+        'menu|*|label' => 'public',
+        'retention_policy|*|name' => 'protected',
+
+        'relationship|*|confidence' => 'protected',
+        'relationship|*|directionality' => 'protected',
+        'relationship|*|end_date' => 'protected',
+        'relationship|*|from_entity_id' => 'protected',
+        'relationship|*|from_entity_type' => 'protected',
+        'relationship|*|notes' => 'protected',
+        'relationship|*|source_ref' => 'protected',
+        'relationship|*|start_date' => 'protected',
+        'relationship|*|status' => 'protected',
+        'relationship|*|to_entity_id' => 'protected',
+        'relationship|*|to_entity_type' => 'protected',
+        'relationship|*|weight' => 'protected',
+
+        'media_version|*|blob_uri' => 'internal',
+        'media_version|*|created_at' => 'internal',
+        'media_version|*|created_by' => 'internal',
+        'media_version|*|label' => 'internal',
+        'media_version|*|media_uuid' => 'internal',
+        'media_version|*|mime' => 'internal',
+        'media_version|*|sha256' => 'internal',
+        'media_version|*|size' => 'internal',
+        'media_version|*|vid' => 'internal',
+
+        'user|*|password_hash' => 'internal',
+        'user|*|role' => 'internal',
+        'user|*|consent_date' => 'protected',
+        'user|*|consent_on_file' => 'protected',
+        'user|*|disabled' => 'protected',
+        'user|*|must_reset_password' => 'protected',
+    ];
+
+    private const array UNIVERSAL_STRUCTURAL_FIELDS = [
+        'bundle',
+        'langcode',
+        'default_langcode',
+    ];
+
+    private function __construct() {}
+
+    /** @return array<string, FieldReadLevel> */
+    public static function exactDefaults(): array
+    {
+        return array_map(
+            static fn(string $level): FieldReadLevel => FieldReadLevel::from($level),
+            self::EXACT,
+        );
+    }
+
+    public static function resolve(string $entityType, string $bundle, string $field): ?FieldReadLevel
+    {
+        if (in_array($field, self::UNIVERSAL_STRUCTURAL_FIELDS, true)) {
+            return FieldReadLevel::Public;
+        }
+
+        $level = self::EXACT[$entityType . '|' . $bundle . '|' . $field]
+            ?? self::EXACT[$entityType . '|*|' . $field]
+            ?? null;
+
+        return $level !== null ? FieldReadLevel::from($level) : null;
+    }
+
+    public static function canonicalKey(string $entityType, string $bundle, string $field): ?string
+    {
+        if (in_array($field, self::UNIVERSAL_STRUCTURAL_FIELDS, true)) {
+            return $entityType . '|*|' . $field;
+        }
+        $bundleKey = $entityType . '|' . $bundle . '|' . $field;
+        if (isset(self::EXACT[$bundleKey])) {
+            return $bundleKey;
+        }
+        $coreKey = $entityType . '|*|' . $field;
+
+        return isset(self::EXACT[$coreKey]) ? $coreKey : null;
+    }
+}

--- a/packages/field/src/FieldReadMetadataResolver.php
+++ b/packages/field/src/FieldReadMetadataResolver.php
@@ -35,6 +35,7 @@ final class FieldReadMetadataResolver
     public function resolve(
         FieldDefinitionInterface $definition,
         ?FieldReadLevel $artifactLevel = null,
+        ?FieldReadLevel $frameworkDefaultLevel = null,
     ): FieldReadMetadata {
         $declared = $definition instanceof FieldReadDefinitionInterface
             ? $definition->getReadLevel()
@@ -43,7 +44,7 @@ final class FieldReadMetadataResolver
             ? FieldReadLevel::Internal
             : null;
 
-        $levels = array_values(array_filter([$declared, $legacy, $artifactLevel]));
+        $levels = array_values(array_filter([$declared, $legacy, $frameworkDefaultLevel, $artifactLevel]));
         foreach ($levels as $level) {
             if ($level !== $levels[0]) {
                 throw new \LogicException(sprintf(
@@ -58,6 +59,9 @@ final class FieldReadMetadataResolver
         }
         if ($legacy !== null) {
             return new FieldReadMetadata($legacy, FieldReadMetadataSource::LegacyInternal);
+        }
+        if ($frameworkDefaultLevel !== null) {
+            return new FieldReadMetadata($frameworkDefaultLevel, FieldReadMetadataSource::FrameworkDefault);
         }
         if ($artifactLevel !== null) {
             return new FieldReadMetadata($artifactLevel, FieldReadMetadataSource::ClassificationArtifact);

--- a/packages/field/src/FieldReadMetadataSource.php
+++ b/packages/field/src/FieldReadMetadataSource.php
@@ -9,6 +9,7 @@ enum FieldReadMetadataSource: string
 {
     case Definition = 'definition';
     case LegacyInternal = 'legacy_internal';
+    case FrameworkDefault = 'framework_default';
     case ClassificationArtifact = 'classification_artifact';
     case Unclassified = 'unclassified';
 }

--- a/packages/field/src/Preflight/FieldAccessPreflightScanner.php
+++ b/packages/field/src/Preflight/FieldAccessPreflightScanner.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Field\Preflight;
 
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Entity\FieldReadLevel;
+use Waaseyaa\Entity\FrameworkFieldReadDefaults;
 use Waaseyaa\Entity\Preflight\FieldAccessPreflightData;
 use Waaseyaa\Entity\Preflight\FieldAccessPreflightResult;
 use Waaseyaa\Field\FieldDefinitionInterface;
@@ -42,7 +43,16 @@ final readonly class FieldAccessPreflightScanner
                     continue;
                 }
                 $key = self::key($entityType, '*', $definition->getName());
-                $this->classify($definition, $inventory, $key, isset($structuralNames[$definition->getName()]), $fields, $conflicts, $unclassified);
+                $this->classify(
+                    $definition,
+                    $inventory,
+                    $key,
+                    isset($structuralNames[$definition->getName()]),
+                    FrameworkFieldReadDefaults::resolve($entityType, '*', $definition->getName()),
+                    $fields,
+                    $conflicts,
+                    $unclassified,
+                );
             }
 
             foreach ($registry->bundleNamesFor($entityType) as $bundle) {
@@ -52,7 +62,16 @@ final readonly class FieldAccessPreflightScanner
                         continue;
                     }
                     $key = self::key($entityType, $bundle, $definition->getName());
-                    $this->classify($definition, $inventory, $key, false, $fields, $conflicts, $unclassified);
+                    $this->classify(
+                        $definition,
+                        $inventory,
+                        $key,
+                        false,
+                        FrameworkFieldReadDefaults::resolve($entityType, $bundle, $definition->getName()),
+                        $fields,
+                        $conflicts,
+                        $unclassified,
+                    );
                 }
             }
         }
@@ -60,6 +79,17 @@ final readonly class FieldAccessPreflightScanner
         foreach ($inventory->liveKeys as $key) {
             [$entityType, $bundle, $field] = self::parseKey($key);
             $coreKey = self::key($entityType, '*', $field);
+            $default = FrameworkFieldReadDefaults::resolve($entityType, $bundle, $field);
+            $defaultKey = FrameworkFieldReadDefaults::canonicalKey($entityType, $bundle, $field);
+            if ($default !== null && $defaultKey !== null) {
+                $artifact = $inventory->artifactLevels[$key] ?? $inventory->artifactLevels[$defaultKey] ?? null;
+                if ($artifact !== null && $artifact !== $default) {
+                    $conflicts[] = $defaultKey;
+                } else {
+                    $fields[$defaultKey] = $default->value . ':framework_default';
+                }
+                continue;
+            }
             if (!isset($fields[$key]) && !isset($fields[$coreKey]) && !in_array($key, $conflicts, true) && !in_array($coreKey, $conflicts, true)) {
                 $unclassified[] = self::key($entityType, $bundle, $field);
             }
@@ -90,12 +120,17 @@ final readonly class FieldAccessPreflightScanner
         FieldAccessLiveInventory $inventory,
         string $key,
         bool $structural,
+        ?FieldReadLevel $frameworkDefault,
         array &$fields,
         array &$conflicts,
         array &$unclassified,
     ): void {
         try {
-            $metadata = $this->metadata->resolve($definition, $inventory->artifactLevels[$key] ?? null);
+            $metadata = $this->metadata->resolve(
+                $definition,
+                $inventory->artifactLevels[$key] ?? null,
+                $frameworkDefault,
+            );
         } catch (\LogicException) {
             $conflicts[] = $key;
             return;

--- a/packages/field/tests/Unit/Preflight/FrameworkFieldReadDefaultsParityTest.php
+++ b/packages/field/tests/Unit/Preflight/FrameworkFieldReadDefaultsParityTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Field\Tests\Unit\Preflight;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Entity\EntityBase;
+use Waaseyaa\Entity\EntityReadRuntime;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\FieldReadLevel;
+use Waaseyaa\Entity\FrameworkFieldReadDefaults;
+use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Field\FieldDefinitionRegistry;
+use Waaseyaa\Field\Preflight\FieldAccessLiveInventory;
+use Waaseyaa\Field\Preflight\FieldAccessPreflightScanner;
+
+final class FrameworkFieldReadDefaultsParityTest extends TestCase
+{
+    /** @return iterable<string, array{string, string, string, FieldReadLevel}> */
+    public static function exactDefaults(): iterable
+    {
+        foreach (FrameworkFieldReadDefaults::exactDefaults() as $key => $level) {
+            [$entityType, $bundle, $field] = explode('|', $key);
+            yield $key => [$entityType, $bundle, $field, $level];
+        }
+    }
+
+    #[Test]
+    #[DataProvider('exactDefaults')]
+    public function every_exact_default_is_identical_in_runtime_and_preflight(
+        string $entityType,
+        string $bundle,
+        string $field,
+        FieldReadLevel $level,
+    ): void {
+        $runtimeBundle = $bundle === '*' ? $entityType : $bundle;
+        $values = ['id' => 1, 'bundle' => $runtimeBundle, $field => 'fixture'];
+        $layout = EntityReadRuntime::layoutFor(
+            FrameworkDefaultFixtureEntity::class,
+            $values,
+            $entityType,
+            ['id' => 'id', 'bundle' => 'bundle'],
+            registeredEntityType: true,
+        );
+
+        $registry = new FieldDefinitionRegistry();
+        $manager = new EntityTypeManager(new EventDispatcher(), fieldRegistry: $registry);
+        $manager->registerEntityType(new EntityType(
+            id: $entityType,
+            label: $entityType,
+            class: FrameworkDefaultFixtureEntity::class,
+            keys: ['id' => 'id', 'bundle' => 'bundle'],
+        ));
+        $preflightKey = $entityType . '|' . $runtimeBundle . '|' . $field;
+        $result = (new FieldAccessPreflightScanner())->scan(
+            $manager,
+            new FieldAccessLiveInventory('candidate', 'schema', liveKeys: [$preflightKey]),
+        );
+
+        self::assertSame($level, $layout->level($field), 'runtime ' . $preflightKey);
+        self::assertSame(
+            $level->value . ':framework_default',
+            $result->data->fields[$entityType . '|*|' . $field] ?? $result->data->fields[$preflightKey] ?? null,
+            'preflight ' . $preflightKey,
+        );
+        self::assertNotContains($preflightKey, $result->data->unclassifiedEntries);
+    }
+
+    #[Test]
+    public function universal_bundle_and_language_defaults_are_runtime_preflight_public(): void
+    {
+        $values = ['id' => 1, 'bundle' => 'article', 'langcode' => 'en', 'default_langcode' => 'en'];
+        $layout = EntityReadRuntime::layoutFor(
+            FrameworkDefaultFixtureEntity::class,
+            $values,
+            'consumer_entity',
+            ['id' => 'id'],
+            registeredEntityType: true,
+        );
+
+        $registry = new FieldDefinitionRegistry();
+        $manager = new EntityTypeManager(new EventDispatcher(), fieldRegistry: $registry);
+        $manager->registerEntityType(new EntityType(
+            id: 'consumer_entity',
+            label: 'Consumer entity',
+            class: FrameworkDefaultFixtureEntity::class,
+            keys: ['id' => 'id'],
+        ));
+        $result = (new FieldAccessPreflightScanner())->scan(
+            $manager,
+            new FieldAccessLiveInventory(
+                'candidate',
+                'schema',
+                liveKeys: [
+                    'consumer_entity|article|bundle',
+                    'consumer_entity|article|langcode',
+                    'consumer_entity|article|default_langcode',
+                ],
+            ),
+        );
+
+        foreach (['bundle', 'langcode', 'default_langcode'] as $field) {
+            self::assertSame(FieldReadLevel::Public, $layout->level($field), 'runtime ' . $field);
+            self::assertSame(
+                'public:framework_default',
+                $result->data->fields['consumer_entity|*|' . $field] ?? null,
+                'preflight ' . $field,
+            );
+        }
+        self::assertSame([], $result->data->unclassifiedEntries);
+    }
+
+    #[Test]
+    public function explicit_metadata_cannot_disagree_with_a_framework_default(): void
+    {
+        $definition = new FieldDefinition(
+            'password_hash',
+            'string',
+            targetEntityTypeId: 'user',
+            read: FieldReadLevel::Public,
+        );
+
+        try {
+            EntityReadRuntime::layoutFor(
+                FrameworkDefaultFixtureEntity::class,
+                ['id' => 1, 'password_hash' => 'never'],
+                'user',
+                ['id' => 'id'],
+                registeredEntityType: true,
+                entityTypeDefinitions: ['password_hash' => $definition],
+            );
+            self::fail('Runtime must reject a definition/default conflict.');
+        } catch (\LogicException) {
+        }
+
+        $registry = new FieldDefinitionRegistry();
+        $manager = new EntityTypeManager(new EventDispatcher(), fieldRegistry: $registry);
+        $manager->registerEntityType(new EntityType(
+            id: 'user',
+            label: 'User',
+            class: FrameworkDefaultFixtureEntity::class,
+            keys: ['id' => 'id'],
+            _fieldDefinitions: ['password_hash' => $definition],
+        ));
+        $result = (new FieldAccessPreflightScanner())->scan(
+            $manager,
+            new FieldAccessLiveInventory('candidate', 'schema', liveKeys: ['user|user|password_hash']),
+        );
+
+        self::assertContains('user|*|password_hash', $result->data->conflicts);
+        self::assertFalse($result->ready);
+    }
+}
+
+final class FrameworkDefaultFixtureEntity extends EntityBase
+{
+    public function __construct(array $values = [])
+    {
+        parent::__construct($values, 'fixture', ['id' => 'id', 'bundle' => 'bundle']);
+    }
+}

--- a/packages/user/src/UserProtectedFieldReadPolicy.php
+++ b/packages/user/src/UserProtectedFieldReadPolicy.php
@@ -30,6 +30,8 @@ final class UserProtectedFieldReadPolicy implements ProtectedFieldReadPolicyInte
         return match ($fieldName) {
             'status' => $this->statusAccess($principal, $structure, $subject),
             'name' => $this->nameAccess($principal, $subject),
+            'consent_date', 'consent_on_file', 'must_reset_password', 'disabled'
+                => $this->administrativeStateAccess($principal, $subject),
             default => AccessResult::forbidden(sprintf("User field '%s' is not a Protected release surface.", $fieldName)),
         };
     }
@@ -75,5 +77,19 @@ final class UserProtectedFieldReadPolicy implements ProtectedFieldReadPolicyInte
         }
 
         return AccessResult::forbidden('Reading a User name requires profile-view permission.');
+    }
+
+    private function administrativeStateAccess(
+        AuthorizationPrincipalInterface $principal,
+        PolicySubjectViewInterface $subject,
+    ): AccessResult {
+        if ($subject->fields() !== []) {
+            return AccessResult::forbidden('Administrative User state reads accept no policy subject inputs.');
+        }
+        if ($principal->hasPermission('administer users')) {
+            return AccessResult::allowed('User has "administer users" permission.');
+        }
+
+        return AccessResult::forbidden('Administrative User state requires "administer users".');
     }
 }

--- a/packages/user/tests/Unit/UserV2ReadPolicyTest.php
+++ b/packages/user/tests/Unit/UserV2ReadPolicyTest.php
@@ -112,8 +112,30 @@ final class UserV2ReadPolicyTest extends TestCase
         $policy = new UserProtectedFieldReadPolicy();
         $admin = $this->principal(1, ['administer users']);
 
-        foreach (['mail', 'pass', 'roles', 'permissions', 'email_verified', 'two_factor_secret', 'two_factor_recovery_codes_hash', 'two_factor_last_used_step'] as $field) {
+        foreach (['mail', 'pass', 'password_hash', 'role', 'roles', 'permissions', 'email_verified', 'two_factor_secret', 'two_factor_recovery_codes_hash', 'two_factor_last_used_step'] as $field) {
             self::assertTrue($policy->access($admin, $this->structure(5), $this->subject([]), $field)->isForbidden(), $field);
+        }
+    }
+
+    #[Test]
+    public function legacy_administrative_account_state_is_admin_only_and_requires_an_empty_subject(): void
+    {
+        $policy = new UserProtectedFieldReadPolicy();
+        $structure = $this->structure(5);
+
+        foreach (['consent_date', 'consent_on_file', 'must_reset_password', 'disabled'] as $field) {
+            self::assertTrue(
+                $policy->access($this->principal(1, ['administer users']), $structure, $this->subject([]), $field)->isAllowed(),
+                $field . ' admin',
+            );
+            self::assertTrue(
+                $policy->access($this->principal(5), $structure, $this->subject([]), $field)->isForbidden(),
+                $field . ' self',
+            );
+            self::assertTrue(
+                $policy->access($this->principal(1, ['administer users']), $structure, $this->subject(['status' => true]), $field)->isForbidden(),
+                $field . ' polluted subject',
+            );
         }
     }
 


### PR DESCRIPTION
Part of #2064.

## What changed

- adds one framework-owned default-classification source shared by sealed runtime layout compilation and activation preflight
- classifies universal bundle/language selectors, exact first-party config labels, relationship infrastructure, parked media-version internals, and legacy User account infrastructure
- rejects explicit metadata or artifact levels that disagree with a framework default
- keeps User directory-exposure fields consumer-owned
- makes legacy consent/reset/disabled state Protected and administrator-only
- pins `password_hash` Internal and proves an administrator-context JSON:API serialization still cannot emit it
- documents the per-default disclosure analysis and updates `[Unreleased]`

## Why

The SFN migrated database was blocked by framework-owned physical fields. Requiring every consumer to reclassify framework storage/account infrastructure made activation readiness describe app diligence rather than framework policy. The fresh-context adversarial review rejected a preflight-only table because that could produce a green artifact while runtime visibility differed; this PR uses the same source for both paths.

## Verification

- focused: 57 tests, 187 assertions
- affected package sweep: 801 tests, 1,705 assertions
- Unit suite: 9,999 tests, 225,239 assertions; all tests pass, with the repository-configured no-coverage-driver warning reported as an issue
- PHPStan: no errors across 1,882 files
- CS check: clean
- disposable real SFN migrated DB copy: 59 unclassified app-owned fields, 5 legacy payload blockers, 0 conflicts, 0 V1 drivers, 0 serialized entities

The local pre-push composer-policy check reports the existing alpha.272-vs-alpha.271 repository-wide version baseline (366 entries); no Composer manifests are changed here.
