### PR TITLE
Fix field-access activation edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Framework-owned entity fields now carry one runtime/preflight classification default (#2064).** Applications no longer have to classify universal language/bundle selectors, first-party config labels, relationship infrastructure, parked media-version internals, or legacy User account infrastructure. Explicit metadata must agree with the shared default source. Credential hashes remain Internal and outward-denied even to administrators; consent/reset/disabled state is administrator-only Protected; application directory fields remain deliberately unclassified.
 - **Legacy empty-list entity payloads have an idempotent object-shape upgrade (#2064).** `field-access:upgrade-legacy-entity-data` runs before activation through the restricted bootstrap, compare-and-swaps only whitespace-wrapped `[]` values to `{}`, reports its work, and leaves objects, non-empty arrays, scalars, malformed JSON, and readiness artifacts untouched.
 
+### Fixed
+
+- **Application classification artifacts now classify live database keys that have no restricted-bootstrap definition (#2064).** The preflight records the exact artifact level instead of leaving such consumer-owned fields unclassified, while registered definitions and framework defaults retain their existing conflict checks.
+- **JSON:API serialization now omits accessor-denied Protected fields instead of failing an otherwise authorized entity response (#2064).** The activated accessor remains the final authority when the legacy field policy is Neutral; denied values are never read or emitted.
+
 ## [0.1.0-alpha.272] - 2026-07-24
 
 ### Changed

--- a/docs/specs/api-layer.md
+++ b/docs/specs/api-layer.md
@@ -1,5 +1,6 @@
 # API Layer
 
+<!-- Spec reviewed 2026-07-24 - #2064 activation follow-up: ResourceSerializer now treats the activated entity accessor as the final Protected-read authority. If legacy field filtering is Neutral but the accessor denies or lacks a read context, the field is omitted without reading its value; an otherwise authorized entity response does not become a 500. Internal fields retain their unconditional outward-denial floors. -->
 <!-- Spec reviewed 2026-07-21 - #2101 WP-2: JSON:API create attributes an authenticated creator when an entity type declares a non-identity uid authorization-input field and the client omits it. The shape-based rule covers node, media, note, and future authored quick-entry types without a type-id allowlist, while explicitly excluding User.uid and any other identity key. Explicit uid remains subject to the entity type's field policy. -->
 <!-- Spec reviewed 2026-07-21 - #2101 WP-3: the update path accepts ConfigEntityInterface targets after the same declared-field allowlist and access checks used for FieldableInterface targets. This activates bounded PATCH support for explicitly surfaced config rows without changing identity/bookkeeping rejection. -->
 
@@ -723,7 +724,7 @@ final class ResourceSerializer
 ### Serialization Logic
 
 1. Uses UUID as resource ID if available, otherwise falls back to numeric ID (config entities: string machine name when UUID is empty).
-2. Builds attributes via **`EntityValues::toCastAwareMap($entity)`**, then drops keys that map to entity keys `id` and `uuid` (storage column names from `EntityType::getKeys()`), so every attribute value passes through `EntityInterface::get()` and `EntityBase::$casts` apply (#1181 ST-7 / ST-9). See `docs/specs/jsonapi.md` for the pipeline diagram.
+2. Iterates the resolved field names, drops keys that map to entity keys `id` and `uuid` (storage column names from `EntityType::getKeys()`), and reads each remaining value through `EntityInterface::get()`, so `EntityBase::$casts` apply (#1181 ST-7 / ST-9). If the activated accessor denies a Protected read (or no read context is available), that field is omitted without reading its value. This accessor check is the final authority when the legacy field policy is Neutral and cannot turn an otherwise authorized entity response into a 500. See `docs/specs/jsonapi.md` for the pipeline diagram.
 3. **Filters internal/credential fields** (#1531). Two layers, both applied **before** the per-account access handler so credentials never reach policy code:
    - `ResourceSerializer::ALWAYS_INTERNAL_FIELDS = ['pass', 'password', 'password_hash']` — dropped unconditionally even when no `FieldDefinition` exists. Covers raw `_data` keys that hold credential material (e.g. `User::$pass` is set via `setRawPassword()` with no `#[Field]` attribute).
    - Any `FieldDefinition` whose `getSetting('internal') === true` is dropped (e.g. `User::two_factor_secret`, `User::two_factor_recovery_codes_hash`). New sensitive fields opt in via `#[Field(... settings: ['internal' => true])]`.

--- a/docs/specs/field-access.md
+++ b/docs/specs/field-access.md
@@ -1,5 +1,6 @@
 # Field-Level Access
 
+<!-- Spec reviewed 2026-07-24 - #2064 activation follow-up: the deployment classification artifact is authoritative for a live application-owned field even when restricted bootstrap cannot reconstruct that field's runtime definition. The preflight records the artifact level for that exact live key; registered definitions and framework defaults still undergo the existing equality/conflict checks. Runtime/artifact parity for consumer fields remains an application test obligation. -->
 <!-- Spec reviewed 2026-07-24 - #2064 framework-owned field defaults: one shared default-classification source is consumed by both sealed runtime layout compilation and activation preflight. It covers universal structural selectors plus the exact first-party config labels, relationship infrastructure, parked media-version internals, and legacy User account-infrastructure fields listed below. Explicit metadata that disagrees with a framework default is a hard conflict. Application bundle fields and directory-exposure policy remain consumer-owned. -->
 <!-- Spec reviewed 2026-07-21 - #2064 media hotfix: Media Protected fields now compose with the complete hydrated entity-view decision. Application contextual grants can release bundle-defined Protected media metadata, application Forbidden results still win, and a missing/mismatched hydrated entity fails closed. This does not change legacy open-by-default FieldAccessPolicyInterface filtering or Internal-field sealing. -->
 <!-- Spec reviewed 2026-07-19 - #2064 alpha.270 boolean-field hotfix: resolved boolean/bool field definitions now canonicalize values to native PHP bool while the private entity value container is sealed and on every write. Closed validation, persistence extraction, guarded reads, and public projections observe that same type. Protected/Internal sealing and missing-context denial are unchanged. -->
@@ -95,6 +96,15 @@ storage and account infrastructure defined by first-party framework packages.
 therefore never describe a different level than sealed runtime compilation.
 An explicit definition or application artifact may restate a default only at
 the same level. A disagreement is a hard conflict.
+
+For application-owned fields, the deployment classification artifact is also
+the restricted-bootstrap source of truth. If a field key is live in storage
+but its definition cannot be reconstructed in restricted bootstrap, an exact
+artifact entry still classifies that key at the declared level. This is not a
+runtime bypass: activated boot still seals the runtime definitions, and the
+consumer must test that every artifact entry equals the application's runtime
+classification. Registered definitions and framework defaults continue to
+conflict on any unequal artifact level.
 
 All registered entity types receive Public `bundle`, `langcode`, and
 `default_langcode` structural defaults, matching the runtime's existing

--- a/packages/api/src/ResourceSerializer.php
+++ b/packages/api/src/ResourceSerializer.php
@@ -12,6 +12,8 @@ use Waaseyaa\Entity\EntityBase;
 use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\EntityValues;
+use Waaseyaa\Entity\Exception\FieldReadDenied;
+use Waaseyaa\Entity\Exception\MissingFieldReadContext;
 use Waaseyaa\Field\FieldDefinitionInterface;
 
 /**
@@ -213,11 +215,19 @@ final class ResourceSerializer
         $excluded = array_flip($this->getExcludedFields($keys));
         $attributes = [];
 
-        foreach (EntityValues::toCastAwareMap($entity, $fieldNames) as $fieldName => $value) {
+        foreach ($fieldNames as $fieldName) {
             if (isset($excluded[$fieldName])) {
                 continue;
             }
-            $attributes[$fieldName] = $value;
+            try {
+                $attributes[$fieldName] = $entity->get($fieldName);
+            } catch (FieldReadDenied | MissingFieldReadContext) {
+                // The V2 accessor is the final Protected-read authority. A
+                // legacy field-access policy may be Neutral while that
+                // authority denies; omit the field rather than turning an
+                // otherwise authorized entity response into a 500.
+                continue;
+            }
         }
 
         return $attributes;

--- a/packages/api/tests/Unit/ResourceSerializerCastAwareTest.php
+++ b/packages/api/tests/Unit/ResourceSerializerCastAwareTest.php
@@ -8,14 +8,23 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AuthorizationPrincipal;
+use Waaseyaa\Access\Context\AccountFieldReadScope;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Access\FieldReadGuard;
 use Waaseyaa\Api\ResourceSerializer;
 use Waaseyaa\Api\Tests\Fixtures\ApiSerializeTestEnum;
 use Waaseyaa\Api\Tests\Fixtures\CastAwareSerializeTestEntity;
 use Waaseyaa\Api\Tests\Fixtures\TestEntity;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityReadRuntime;
+use Waaseyaa\Entity\FieldReadLevel;
 use Waaseyaa\Entity\Tests\Helper\TestEntityType;
 use Waaseyaa\Field\FieldDefinition;
+use Waaseyaa\Field\FieldDefinitionRegistry;
 
 #[CoversClass(ResourceSerializer::class)]
 final class ResourceSerializerCastAwareTest extends TestCase
@@ -73,5 +82,48 @@ final class ResourceSerializerCastAwareTest extends TestCase
 
         $this->assertIsString($resource->attributes['published_at']);
         $this->assertStringContainsString('2024-03-04', $resource->attributes['published_at']);
+    }
+
+    #[Test]
+    public function serializeOmitsAnAccessorDeniedProtectedFieldInsteadOfThrowing(): void
+    {
+        $registry = new FieldDefinitionRegistry();
+        $registry->registerBundleFields('article', 'blog', [
+            new FieldDefinition('migration_note', 'string', targetEntityTypeId: 'article', targetBundle: 'blog', read: FieldReadLevel::Protected),
+        ]);
+        $manager = new EntityTypeManager(new EventDispatcher(), fieldRegistry: $registry);
+        $manager->registerEntityType(new EntityType(
+            id: 'article',
+            label: 'Article',
+            class: TestEntity::class,
+            keys: TestEntity::definitionKeys(),
+        ));
+        ContentEntityBase::setFieldRegistry($registry);
+        $scope = new AccountFieldReadScope();
+        EntityReadRuntime::installGuard(new FieldReadGuard(
+            $scope,
+            static fn(): AccessResult => AccessResult::forbidden('Fixture denies the Protected field.'),
+        ));
+
+        try {
+            $entity = new TestEntity([
+                'id' => 1,
+                'uuid' => 'uuid-protected',
+                'title' => 'Visible',
+                'type' => 'blog',
+                'migration_note' => 'must stay sealed',
+            ]);
+            $principal = new AuthorizationPrincipal(7, true, [], ['access content'], 'serializer-test');
+            $resource = $scope->run(
+                $principal,
+                fn() => (new ResourceSerializer($manager))->serialize($entity, new EntityAccessHandler([]), $principal),
+            );
+
+            self::assertSame('Visible', $resource->attributes['title']);
+            self::assertArrayNotHasKey('migration_note', $resource->attributes);
+        } finally {
+            EntityReadRuntime::installGuard(null);
+            ContentEntityBase::setFieldRegistry(null);
+        }
     }
 }

--- a/packages/field/src/Preflight/FieldAccessPreflightScanner.php
+++ b/packages/field/src/Preflight/FieldAccessPreflightScanner.php
@@ -90,6 +90,15 @@ final readonly class FieldAccessPreflightScanner
                 }
                 continue;
             }
+            $artifactKey = isset($inventory->artifactLevels[$key])
+                ? $key
+                : (isset($inventory->artifactLevels[$coreKey]) ? $coreKey : null);
+            if ($artifactKey !== null) {
+                if (!isset($fields[$key]) && !isset($fields[$coreKey])) {
+                    $fields[$artifactKey] = $inventory->artifactLevels[$artifactKey]->value . ':classification_artifact';
+                }
+                continue;
+            }
             if (!isset($fields[$key]) && !isset($fields[$coreKey]) && !in_array($key, $conflicts, true) && !in_array($coreKey, $conflicts, true)) {
                 $unclassified[] = self::key($entityType, $bundle, $field);
             }

--- a/packages/field/tests/Unit/Preflight/FieldAccessPreflightScannerTest.php
+++ b/packages/field/tests/Unit/Preflight/FieldAccessPreflightScannerTest.php
@@ -79,6 +79,27 @@ final class FieldAccessPreflightScannerTest extends TestCase
         self::assertSame(['legacy.profile'], $result->data->v1Drivers);
     }
 
+    public function test_classification_artifact_classifies_an_application_owned_live_key_without_a_registered_definition(): void
+    {
+        $manager = new EntityTypeManager(new EventDispatcher(), fieldRegistry: new FieldDefinitionRegistry());
+        $manager->registerEntityType(new EntityType(
+            id: 'profile',
+            label: 'Profile',
+            class: PreflightProfile::class,
+        ));
+
+        $result = (new FieldAccessPreflightScanner())->scan($manager, new FieldAccessLiveInventory(
+            frameworkVersion: 'candidate',
+            schemaFingerprint: 'schema',
+            liveKeys: ['profile|member|directory_visible'],
+            artifactLevels: ['profile|member|directory_visible' => FieldReadLevel::Internal],
+        ));
+
+        self::assertTrue($result->ready);
+        self::assertSame('internal:classification_artifact', $result->data->fields['profile|member|directory_visible']);
+        self::assertSame([], $result->data->unclassifiedEntries);
+    }
+
     public function test_candidate_schema_and_definition_changes_each_invalidate_the_checksum(): void
     {
         $registry = new FieldDefinitionRegistry();

--- a/tests/Architecture/FieldReadBoundaryArchitectureTest.php
+++ b/tests/Architecture/FieldReadBoundaryArchitectureTest.php
@@ -211,6 +211,7 @@ final class FieldReadBoundaryArchitectureTest extends TestCase
         'packages/ai-vector/src/EntityEmbedder.php' => 'Embedding label projection is reviewed activation-compatible through the canonical guarded accessor.',
         'packages/ai-vector/src/EntityEmbeddingListener.php' => 'Embedding listener label projection is reviewed activation-compatible through the canonical guarded accessor.',
         'packages/api/src/Audit/ApiAuditQueryAdapter.php' => 'Audit query adapter input is reviewed activation-compatible through the canonical guarded accessor.',
+        'packages/api/src/ResourceSerializer.php' => 'JSON:API reads each outward field through the guarded accessor and omits Protected denials without observing the value.',
         'packages/api/src/Workflow/WorkflowDefinitionsController.php' => 'Workflow label projection is reviewed activation-compatible through the canonical guarded accessor.',
         'packages/audit/src/AuditedFieldRead.php' => 'Reserved strict-audit fallback for third-party entity implementations.',
         'packages/audit/src/Entity/AuditCheckpoint.php' => 'Audit-checkpoint domain helpers use the canonical guarded accessor for explicitly classified fields.',


### PR DESCRIPTION
## What changed

- Treat an exact application classification-artifact entry as authoritative for a live consumer-owned field that restricted bootstrap cannot reconstruct.
- Keep registered definitions and framework defaults under the existing conflict checks.
- Make JSON:API omit an accessor-denied Protected field without reading it or failing an otherwise authorized entity response.
- Document both activation contracts and add regression coverage, including the closed accessor inventory.

## Why

The SFN 59-field worksheet exposed two activation gaps atop #2119/#2120: four consumer User fields stayed unclassified because provider ordering removes their restricted-bootstrap definitions, and an admin entity response could become a 500 when legacy field policy was Neutral but the activated accessor denied a Protected field.

## Validation

- `vendor/bin/phpunit --no-coverage packages/field/tests/Unit/Preflight/FieldAccessPreflightScannerTest.php packages/api/tests/Unit/ResourceSerializerCastAwareTest.php` — 7 tests, 21 assertions
- `php -d memory_limit=1G vendor/bin/phpunit --no-coverage tests/Architecture/FieldReadBoundaryArchitectureTest.php packages/listing/tests/Integration/CacheIntegrationTest.php` — 27 tests, 181 assertions
- pre-push PHPUnit selection — 10,003 tests, 225,248 assertions
- `composer cs-check` — pass
- `composer phpstan` via pre-push — pass

The ordinary 512 MB full-suite invocation exhausted memory at the final architecture inventory. The 1 GB rerun reached all 11,676 tests; its only product-related failure was the newly reviewed ResourceSerializer accessor inventory, which is fixed and green in the focused rerun. The other failure was the existing timing-sensitive listing TTL test, also green in the focused rerun.

Stacked on #2120 (`agent/legacy-entity-data-upgrade`).
