### PR TITLE
fix(#2056): hide FTS5 virtual/shadow tables from DBAL schema introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schema operations no longer crash kernel boot on SQLite databases containing an FTS5 search index (#2056).** Every diff-based `DBALSchema` operation (`addField()` and six siblings) introspects the entire catalog, and DBAL's `SQLiteSchemaManager` cannot parse the typeless columns FTS5 virtual tables and their shadow tables expose — so the first schema evolution against a real app database (e.g. alpha.266's `thread_participant.thread_id` add) threw `strtolower(null)` and 500'd every request, blocking the whole SQLite portfolio from upgrading past alpha.250. `DBALDatabase` now installs a connection-level DBAL schema-assets filter that hides SQLite internals (`sqlite_*`) and virtual/shadow tables (classified precisely via `pragma_table_list`, with a `sqlite_master` heuristic fallback for SQLite < 3.37) from all DBAL introspection. The exclusion snapshot self-refreshes when an unknown table appears, so virtual tables created mid-process (long-running FrankenPHP workers; the search indexer materializes `search_index` lazily) are still filtered. Consequence, by design: virtual/shadow tables are invisible to `tableExists()`/`listTableNames()` — they are not manageable through DBAL, and the search package already uses raw `sqlite_master` probes. Non-SQLite platforms are untouched (the filter passes everything through; platform detection is deferred into the filter so lazy connections stay lazy).
+
 ## [0.1.0-alpha.275] - 2026-07-27
 
 ### Fixed

--- a/packages/database-legacy/src/DBALDatabase.php
+++ b/packages/database-legacy/src/DBALDatabase.php
@@ -6,6 +6,7 @@ namespace Waaseyaa\Database;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Waaseyaa\Database\Query\DBALDelete;
 use Waaseyaa\Database\Query\DBALInsert;
 use Waaseyaa\Database\Query\DBALSelect;
@@ -16,7 +17,109 @@ final class DBALDatabase implements ConsistentReadDatabaseInterface
 {
     public function __construct(
         private readonly Connection $connection,
-    ) {}
+    ) {
+        $this->installVirtualTableSchemaAssetsFilter();
+    }
+
+    /**
+     * Hide SQLite virtual tables (FTS5 &c.), their shadow tables, and SQLite
+     * internals from DBAL schema introspection (#2056).
+     *
+     * FTS5 tables expose typeless columns that DBAL's SQLiteSchemaManager
+     * cannot parse, so any full-catalog introspection (`DBALSchema::addField()`
+     * and every other diff-based schema op) crashed kernel boot once a search
+     * index existed in the database. Virtual/shadow tables are not manageable
+     * through DBAL anyway — raw SQL (`sqlite_master`) is the only correct
+     * interface, which is what the search package uses. Consequence: these
+     * tables are also invisible to `tableExists()`/`listTableNames()`, by
+     * design.
+     *
+     * The exclusion set is snapshot-cached per instance; an asset name the
+     * snapshot has never seen triggers one refresh, so a virtual table created
+     * mid-process (long-running FrankenPHP workers; the search indexer creates
+     * its table lazily) is still filtered on the next schema operation.
+     * Platform detection happens inside the filter — by the time DBAL invokes
+     * it a live connection exists, so lazy non-SQLite connections stay lazy.
+     */
+    private function installVirtualTableSchemaAssetsFilter(): void
+    {
+        $snapshot = null;
+        $this->connection->getConfiguration()->setSchemaAssetsFilter(
+            function (mixed $asset) use (&$snapshot): bool {
+                if (!$this->connection->getDatabasePlatform() instanceof SQLitePlatform) {
+                    return true;
+                }
+
+                $name = \is_string($asset) ? $asset : (string) $asset;
+                if (str_starts_with($name, 'sqlite_')) {
+                    return false;
+                }
+
+                $snapshot ??= $this->virtualTableSnapshot();
+                if (!\in_array($name, $snapshot['known'], true)) {
+                    // A table the snapshot predates — refresh once so newly
+                    // created virtual tables are classified correctly.
+                    $snapshot = $this->virtualTableSnapshot();
+                }
+
+                return !\in_array($name, $snapshot['excluded'], true);
+            },
+        );
+    }
+
+    /**
+     * Classify the catalog via `pragma_table_list` (SQLite ≥ 3.37): rows typed
+     * `virtual`/`shadow` are excluded from DBAL introspection. Falls back to a
+     * `sqlite_master` scan (virtual tables by their CREATE statement, shadows
+     * by the `<virtual>_<suffix>` naming SQLite reserves for them) on builds
+     * without the pragma.
+     *
+     * @return array{known: list<string>, excluded: list<string>}
+     */
+    private function virtualTableSnapshot(): array
+    {
+        $known = [];
+        $excluded = [];
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                "SELECT name, type FROM pragma_table_list WHERE schema = 'main'",
+            );
+            foreach ($rows as $row) {
+                $name = (string) $row['name'];
+                $known[] = $name;
+                if (\in_array($row['type'], ['virtual', 'shadow'], true)) {
+                    $excluded[] = $name;
+                }
+            }
+
+            return ['known' => $known, 'excluded' => $excluded];
+        } catch (\Throwable) {
+            // SQLite < 3.37 — fall through to the sqlite_master heuristic.
+        }
+
+        $virtual = [];
+        $rows = $this->connection->fetchAllAssociative(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'table'",
+        );
+        foreach ($rows as $row) {
+            $name = (string) $row['name'];
+            $known[] = $name;
+            if (preg_match('/^\s*CREATE\s+VIRTUAL\s+TABLE/i', (string) ($row['sql'] ?? '')) === 1) {
+                $virtual[] = $name;
+            }
+        }
+        foreach ($known as $name) {
+            foreach ($virtual as $virtualTable) {
+                if ($name === $virtualTable || str_starts_with($name, $virtualTable . '_')) {
+                    $excluded[] = $name;
+                    break;
+                }
+            }
+        }
+
+        return ['known' => $known, 'excluded' => $excluded];
+    }
 
     public static function createSqlite(string $path = ':memory:'): self
     {

--- a/packages/database-legacy/tests/Unit/Schema/DBALSchemaVirtualTableTest.php
+++ b/packages/database-legacy/tests/Unit/Schema/DBALSchemaVirtualTableTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Database\Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Database\Schema\DBALSchema;
+
+/**
+ * Regression: #2056 — schema operations must survive SQLite databases that
+ * contain FTS5 virtual tables.
+ *
+ * FTS5 virtual tables (the search package's `search_index`) and their shadow
+ * tables expose typeless columns that DBAL's SQLiteSchemaManager cannot parse
+ * (`strtolower(null)` TypeError / AssertionError). Every DBALSchema operation
+ * that introspects the catalog (`addField()` and friends) therefore crashed
+ * kernel boot on any real app DB once a search index existed — the alpha.266
+ * portfolio blocker. Virtual/shadow tables and SQLite internals are now
+ * invisible to the DBAL schema surface via a connection-level schema-assets
+ * filter; raw SQL (`sqlite_master`) remains the only correct interface to
+ * them, which is what the search package already uses.
+ */
+#[CoversClass(DBALSchema::class)]
+#[CoversClass(DBALDatabase::class)]
+final class DBALSchemaVirtualTableTest extends TestCase
+{
+    private DBALDatabase $db;
+
+    protected function setUp(): void
+    {
+        $this->db = DBALDatabase::createSqlite();
+        if (!$this->sqliteHasFts5()) {
+            self::markTestSkipped('SQLite build lacks FTS5 support.');
+        }
+
+        $this->db->schema()->createTable('article', [
+            'fields' => [
+                'id' => ['type' => 'serial'],
+                'title' => ['type' => 'varchar', 'length' => 255, 'not null' => true],
+            ],
+            'primary key' => ['id'],
+        ]);
+        // Materialize sqlite_sequence (autoincrement bookkeeping — also a
+        // typeless-column internal table DBAL must never introspect).
+        $this->db->insert('article')->fields(['title' => 'seed'])->execute();
+
+        $this->db->query('CREATE VIRTUAL TABLE search_index USING fts5(entity_type, entity_id, title, body)');
+        $this->db->query("INSERT INTO search_index (entity_type, entity_id, title, body) VALUES ('article', '1', 'seed', 'body')");
+    }
+
+    #[Test]
+    public function addFieldSucceedsWhenAnFts5SearchIndexExists(): void
+    {
+        $this->db->schema()->addField('article', 'subtitle', [
+            'type' => 'varchar',
+            'length' => 255,
+        ]);
+
+        self::assertTrue($this->db->schema()->fieldExists('article', 'subtitle'));
+    }
+
+    #[Test]
+    public function addIndexSucceedsWhenAnFts5SearchIndexExists(): void
+    {
+        $this->db->schema()->addIndex('article', 'article_title_idx', ['title']);
+
+        self::assertTrue(true); // reaching here without a throw is the assertion
+    }
+
+    #[Test]
+    public function listTableNamesExcludesVirtualShadowAndInternalTables(): void
+    {
+        $names = $this->db->schema()->listTableNames();
+
+        self::assertContains('article', $names);
+        self::assertNotContains('search_index', $names);
+        foreach ($names as $name) {
+            self::assertStringStartsNotWith('search_index_', $name);
+            self::assertStringStartsNotWith('sqlite_', $name);
+        }
+    }
+
+    #[Test]
+    public function virtualTableCreatedAfterFirstIntrospectionIsStillFiltered(): void
+    {
+        // Snapshot the catalog before a second virtual table exists…
+        $this->db->schema()->listTableNames();
+
+        // …then create one mid-process (FrankenPHP worker shape: the search
+        // indexer materializes its table lazily after boot).
+        $this->db->query('CREATE VIRTUAL TABLE late_index USING fts5(body)');
+
+        $this->db->schema()->addField('article', 'summary', ['type' => 'varchar', 'length' => 255]);
+
+        self::assertTrue($this->db->schema()->fieldExists('article', 'summary'));
+        self::assertNotContains('late_index', $this->db->schema()->listTableNames());
+    }
+
+    private function sqliteHasFts5(): bool
+    {
+        try {
+            $this->db->query('CREATE VIRTUAL TABLE fts5_probe USING fts5(x)');
+            $this->db->query('DROP TABLE fts5_probe');
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #2056

## Summary

Every diff-based `DBALSchema` operation (`addField()` and six siblings) introspects the **entire** catalog, and DBAL 4.4's `SQLiteSchemaManager` cannot parse the typeless columns FTS5 virtual tables and their shadow tables expose (`assert($matchResult === 1)` / `strtolower(null)`). The first schema evolution against a real app database — alpha.266's `thread_participant.thread_id` add — therefore crashed kernel boot and 500'd every request on any SQLite app with a `search_index`, which is what pinned the whole portfolio (intersnipe, fnpi-waaseyaa, rhtcircle, minoo) at alpha.250.

`DBALDatabase` now installs a connection-level DBAL **schema-assets filter** (the issue's "filter virtual/shadow tables out of introspection" option — it fixes all seven introspection sites at once, plus every `listTableNames()` consumer such as `HealthChecker` and `LegacyEntityDataPayloadUpgrader`):

- SQLite internals (`sqlite_*`) and virtual/shadow tables are invisible to all DBAL introspection. DBAL applies the filter **before** converting a table's columns to portable definitions, so the unparseable columns are never touched (verified against vendored DBAL 4.4.3 `AbstractSchemaManager::listTables()`).
- Classification is exact via `pragma_table_list` (SQLite ≥ 3.37 types rows `virtual`/`shadow`), with a `sqlite_master` `CREATE VIRTUAL TABLE` + shadow-prefix heuristic fallback for older builds.
- The exclusion snapshot self-refreshes when an unknown table name appears, so a virtual table created mid-process (long-running FrankenPHP workers; the search indexer materializes its table lazily) is still filtered on the next schema operation.
- Non-SQLite platforms pass everything through; the platform check is deferred into the filter so lazy connections stay lazy.

**Deliberate consequence:** virtual/shadow tables are also invisible to `tableExists()`/`listTableNames()`. They are not manageable through DBAL anyway (introspecting them is exactly the crash), and the search package already probes `sqlite_master` with raw SQL — grep confirms no framework code checks for FTS tables through the DBAL schema surface.

## Tests

TDD — all four tests watched failing with the exact `SQLiteSchemaManager.php:77` assertion crash from the issue before the fix:

- `addField()` succeeds with an FTS5 `search_index` (+ populated shadow tables + `sqlite_sequence`) present — the #2056 boot-path shape.
- `addIndex()` succeeds under the same catalog.
- `listTableNames()` includes real tables, excludes the virtual table, its shadows, and `sqlite_*`.
- A virtual table created **after** the first introspection is still filtered (snapshot-refresh path).

Local verification on this head: database-legacy suite 116 ✓, full Unit 10,047 ✓, full Integration 1,601 ✓, PHPStan clean, cs-fixer clean, drift detector ✓.

## Checklist

- [x] **Traceability:** `Closes #2056` above references the GitHub issue this PR delivers — see `docs/specs/workflow.md`
- [x] PR title includes `#2056`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWCmjqR65kRTUQNApajnDx