### PR TITLE
ci(#2136): register new split packages on Packagist via create-package fallback

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -307,8 +307,10 @@ jobs:
   # per pushed ref -> 2-3 crawls/republishes per release). Instead we trigger
   # EXACTLY ONE idempotent update-package POST per package, AFTER split + tag
   # parity + require parity succeed. This is the only crawl trigger, so each
-  # package is published once per release. Requires repo secrets
-  # PACKAGIST_USERNAME + PACKAGIST_TOKEN.
+  # package is published once per release. A 404 from update-package means the
+  # package was never registered (first release of a new split package) — in
+  # that case we fall back to create-package once, which registers + crawls it.
+  # Requires repo secrets PACKAGIST_USERNAME + PACKAGIST_TOKEN.
   publish-packagist:
     name: Publish to Packagist (one crawl per package)
     needs: [split, verify-monorepo-main-intact, verify-tag-parity, verify-require-parity]
@@ -351,6 +353,26 @@ jobs:
               -d "{\"repository\":{\"url\":\"${repo_url}\"}}" || echo "000")
             if [ "${code}" = "200" ] || [ "${code}" = "202" ]; then
               echo "::notice::${pkg}: update-package accepted (HTTP ${code})."
+            elif [ "${code}" = "404" ]; then
+              # Package not yet registered on Packagist — first release of a new
+              # split package (e.g. waaseyaa/publishing, alpha.277). Register it
+              # via create-package, which requires the MAIN API token as a
+              # Bearer header and a plain-string repository payload (per
+              # packagist.org/apidoc), then falls through to Packagist's own
+              # initial crawl. Idempotent by construction: once registered, the
+              # update-package call above succeeds and this branch never runs.
+              echo "::notice::${pkg}: not registered on Packagist yet — creating."
+              ccode=$(curl -sS -o /tmp/create.json -w '%{http_code}' -X POST \
+                "https://packagist.org/api/create-package" \
+                -H 'Content-Type: application/json' \
+                -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}" \
+                -d "{\"repository\":\"${repo_url}\"}" || echo "000")
+              if [ "${ccode}" = "200" ] || [ "${ccode}" = "202" ]; then
+                echo "::notice::${pkg}: create-package accepted (HTTP ${ccode})."
+              else
+                echo "::error::${pkg}: create-package failed (HTTP ${ccode}): $(cat /tmp/create.json 2>/dev/null)"
+                rc=1
+              fi
             else
               echo "::error::${pkg}: update-package failed (HTTP ${code}): $(cat /tmp/resp.json 2>/dev/null)"
               rc=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **First release of a new split package now self-registers on Packagist (#2136).** `split.yml`'s single-crawl publish step only ever called `update-package`, which 404s for a package that was never registered — so onboarding a new split package (like `waaseyaa/publishing` in this release) required a manual packagist.org/packages/submit step nobody could automate. On a 404 the step now falls back to exactly one `create-package` call (main-API-token Bearer auth, per the Packagist apidoc), registering the package and triggering its initial crawl; once registered, later releases take the normal `update-package` path and the fallback never fires.
 - **Publishing idempotency now distinguishes operator notes (#2136).** Publish, unpublish, and rollback include the operator `note` in their canonical idempotency request hashes, so an identical retry replays the stored result while reusing a key with a changed note raises `IdempotencyConflictException` instead of silently returning the first operation's result.
 
 ## [0.1.0-alpha.276] - 2026-07-27

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -120,7 +120,10 @@ not adopt a moved tag (anti-tamper). Therefore:
   2-3x (audit alpha.245 §1). Publishing is instead a single idempotent
   `POST /api/update-package` per package, run by the `publish-packagist` job in
   `split.yml` **after** split + tag-parity + require-parity succeed. That POST is
-  the only crawl trigger, so each package is published exactly once.
+  the only crawl trigger, so each package is published exactly once. If
+  `update-package` returns 404 (a brand-new split package's first release), the
+  step falls back to exactly one `create-package` call to register the package;
+  subsequent releases take the normal `update-package` path.
 
   Requires repo secrets `PACKAGIST_USERNAME` + `PACKAGIST_TOKEN`. The
   invariant is enforced in CI by `bin/check-release-publish-shape`.


### PR DESCRIPTION
## Summary
- `split.yml` publish-packagist only called `update-package`, which 404s for a never-registered package — a new split package's first release required a manual packagist.org submit.
- On 404 the step now makes exactly one `create-package` call (main-API-token Bearer auth per the Packagist apidoc) so `waaseyaa/publishing` self-registers during the alpha.277 release.
- Documented in VERSIONING.md §8; `bin/check-release-publish-shape` still passes (single-crawl invariants hold).

Part of #2136 (WP4 release plumbing — the `waaseyaa/publishing` split repo now exists with the forward-only tag ruleset applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWCmjqR65kRTUQNApajnDx