### PR TITLE
ci(#2136): fix Packagist create-package auth + dispatchable register workflow

### DIFF
--- a/.github/workflows/packagist-register.yml
+++ b/.github/workflows/packagist-register.yml
@@ -1,0 +1,69 @@
+name: Packagist Register Package
+
+# One-shot manual registration of a waaseyaa/* package on Packagist.
+#
+# Normal releases never need this: split.yml's publish-packagist step
+# self-registers a brand-new split package via its create-package fallback.
+# This dispatchable workflow exists for recovery — when that fallback failed
+# mid-release (as on the alpha.277 cut, where the Bearer-auth form was
+# rejected) the tag is already pushed and split, so re-running the whole tag
+# pipeline just to retry one HTTP call is disproportionate. Dispatch this with
+# the package name instead; it performs the same idempotent
+# update-package -> 404 -> create-package dance with the same secrets.
+#
+#   gh workflow run packagist-register.yml -f package=waaseyaa/publishing
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package name to register (waaseyaa/<name>)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  register:
+    name: Register ${{ inputs.package }} on Packagist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Register (update-package, create-package on 404)
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+          PKG: ${{ inputs.package }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -z "${PACKAGIST_USERNAME}" ] || [ -z "${PACKAGIST_TOKEN}" ]; then
+            echo "::error::PACKAGIST_USERNAME / PACKAGIST_TOKEN secret not set."
+            exit 1
+          fi
+          if ! printf '%s' "${PKG}" | grep -Eq '^waaseyaa/[a-z0-9][a-z0-9-]*$'; then
+            echo "::error::package must match waaseyaa/<name> (got: ${PKG})"
+            exit 1
+          fi
+          repo_url="https://github.com/${REPO_OWNER}/${PKG#waaseyaa/}"
+          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"repository\":{\"url\":\"${repo_url}\"}}" || echo "000")
+          if [ "${code}" = "200" ] || [ "${code}" = "202" ]; then
+            echo "::notice::${PKG}: already registered — update-package accepted (HTTP ${code})."
+            exit 0
+          fi
+          if [ "${code}" != "404" ]; then
+            echo "::error::${PKG}: update-package failed (HTTP ${code}): $(cat /tmp/resp.json 2>/dev/null)"
+            exit 1
+          fi
+          echo "::notice::${PKG}: not registered yet — calling create-package."
+          ccode=$(curl -sS -o /tmp/create.json -w '%{http_code}' -X POST \
+            "https://packagist.org/api/create-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"repository\":\"${repo_url}\"}" || echo "000")
+          if [ "${ccode}" = "200" ] || [ "${ccode}" = "202" ]; then
+            echo "::notice::${PKG}: create-package accepted (HTTP ${ccode})."
+          else
+            echo "::error::${PKG}: create-package failed (HTTP ${ccode}): $(cat /tmp/create.json 2>/dev/null)"
+            exit 1
+          fi

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -356,16 +356,17 @@ jobs:
             elif [ "${code}" = "404" ]; then
               # Package not yet registered on Packagist — first release of a new
               # split package (e.g. waaseyaa/publishing, alpha.277). Register it
-              # via create-package, which requires the MAIN API token as a
-              # Bearer header and a plain-string repository payload (per
-              # packagist.org/apidoc), then falls through to Packagist's own
-              # initial crawl. Idempotent by construction: once registered, the
-              # update-package call above succeeds and this branch never runs.
+              # via create-package with the same username/apiToken query-param
+              # auth the update-package call above provably authenticates with
+              # (the Bearer-header form from the apidoc example was rejected 406
+              # "Missing or invalid username/apiToken" on the alpha.277 cut).
+              # Payload is a plain-string repository URL per packagist.org/apidoc.
+              # Idempotent by construction: once registered, the update-package
+              # call above succeeds and this branch never runs.
               echo "::notice::${pkg}: not registered on Packagist yet — creating."
               ccode=$(curl -sS -o /tmp/create.json -w '%{http_code}' -X POST \
-                "https://packagist.org/api/create-package" \
+                "https://packagist.org/api/create-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
                 -H 'Content-Type: application/json' \
-                -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_TOKEN}" \
                 -d "{\"repository\":\"${repo_url}\"}" || echo "000")
               if [ "${ccode}" = "200" ] || [ "${ccode}" = "202" ]; then
                 echo "::notice::${pkg}: create-package accepted (HTTP ${ccode})."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Packagist create-package fallback now authenticates (#2136).** The alpha.277 cut proved the Bearer-header auth form from the Packagist apidoc example is rejected (HTTP 406 "Missing or invalid username/apiToken"); the `split.yml` fallback now uses the same `username`/`apiToken` query-param auth the adjacent `update-package` call provably works with. Added a dispatchable `packagist-register.yml` recovery workflow that registers a single named package (the same idempotent update→404→create dance) so a mid-release registration failure never requires re-running a tag pipeline.
+
 ## [0.1.0-alpha.277] - 2026-07-29
 
 ### Added


### PR DESCRIPTION
## Summary
- The alpha.277 `publish-packagist` run registered 74/75 packages; the new `create-package` fallback for `waaseyaa/publishing` was rejected with HTTP 406 ("Missing or invalid username/apiToken") — the Bearer-header auth form from the apidoc example is not accepted.
- Switch the fallback to the `username`/`apiToken` query-param auth the adjacent `update-package` call provably authenticates with.
- Add `packagist-register.yml` (workflow_dispatch, validated `package` input) so a mid-release registration failure can be recovered with one dispatch instead of re-running a tag pipeline. Will be dispatched for `waaseyaa/publishing` immediately after merge.

Part of #2136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWCmjqR65kRTUQNApajnDx