### PR TITLE
ci: coordinated release state machine — gate the GitHub Release on installability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,19 @@ on:
         type: string
 
 jobs:
+  release-pipeline-fixtures:
+    name: Release pipeline fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+      # Guards the decision logic that was wrong at alpha.285: an accepted POST
+      # is not publication, and an existing package is not a published version.
+      # No network, no credentials — canned P2 fixtures only.
+      - name: Packagist verification fixtures
+        run: bash tests/release/packagist-verification.bats.sh
+
   composer-policy:
     name: composer-policy
     runs-on: ubuntu-latest

--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -1,5 +1,18 @@
-name: Publish to Packagist
+name: Verify Packagist Publication (standalone)
 
+# STANDALONE VERIFIER — this workflow never submits anything.
+#
+# Named "Publish to Packagist" until alpha.285, which was actively misleading:
+# an operator reading a failed run reasonably concluded publication had been
+# attempted here, when submission actually happens in split.yml's
+# `publish-packagist` job. The `package_filter` input said "update" for the
+# same reason. Both are corrected.
+#
+# The release path no longer depends on this workflow at all: verification is
+# now a job INSIDE split.yml (`verify-packagist`), so it cannot race the
+# GitHub Release. This remains for ad-hoc checks — "is alpha.281 still fully
+# installable?" — and for re-checking after a recovery run.
+#
 # Verifies every `waaseyaa/*` package (monorepo + split packages, discovered
 # dynamically from `packages/*/composer.json` so the matrix can't drift) is
 # published to Packagist after a release tag.
@@ -32,7 +45,7 @@ on:
         required: false
         default: ''
       package_filter:
-        description: 'Only update packages whose name CONTAINS this substring. Empty = all.'
+        description: 'Only VERIFY packages whose name CONTAINS this substring. Empty = all. (This workflow never submits an update.)'
         required: false
         default: ''
 

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -280,11 +280,103 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SPLIT_GITHUB_TOKEN }}
         run: bash bin/check-release-require-parity
 
-  # Publish only after split matrix + monorepo integrity + parity —
-  # avoids racing github-release.yml on tag push, and blocks releases if main was overwritten.
+  # Stage 4 of the release state machine: split tags -> verify split parity ->
+  # submit Packagist updates -> VERIFY 76/76 -> publish GitHub Release.
+  #
+  # This lived in a separate workflow (`packagist-update.yml`) that ran on the
+  # same tag push, so the two raced: the release could publish while
+  # verification was still polling, and stayed published when it failed.
+  # Inlining it makes the ordering a dependency rather than a coincidence.
+  #
+  # The window is deliberately generous. At alpha.285 three packages were
+  # reported missing after ~12 minutes of polling and then appeared on their
+  # own — they were queued and slow, not dropped, and the old 24-attempt
+  # ceiling could not tell those apart. Observed wait is recorded so the real
+  # latency distribution becomes visible instead of guessed at.
+  verify-packagist:
+    name: Verify every package is installable
+    needs: [publish-packagist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Poll P2 until every package lists the tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -uo pipefail
+          UA='waaseyaa-release/1.0 (+https://github.com/waaseyaa/framework; release verification)'
+
+          {
+            for f in packages/*/composer.json; do jq -r '.name // empty' "$f"; done
+            jq -r '.name // empty' composer.json
+          } | grep '^waaseyaa/' | sort -u > /tmp/pkgs.txt
+          total=$(wc -l < /tmp/pkgs.txt)
+          echo "Verifying ${total} package(s) at ${TAG}."
+
+          deadline=$(( $(date +%s) + 2400 ))   # 40 minutes
+          missing_file=/tmp/missing.txt
+          cp /tmp/pkgs.txt "${missing_file}"
+          start=$(date +%s)
+
+          while [ -s "${missing_file}" ] && [ "$(date +%s)" -lt "${deadline}" ]; do
+            : > /tmp/still-missing.txt
+            while IFS= read -r pkg; do
+              [ -z "${pkg}" ] && continue
+              if curl -sS -A "${UA}" "https://repo.packagist.org/p2/${pkg}.json" \
+                   | jq -e --arg t "${TAG}" '.packages[][] | select(.version == $t)' >/dev/null 2>&1; then
+                echo "::notice::${pkg}: visible after $(( $(date +%s) - start ))s."
+              else
+                echo "${pkg}" >> /tmp/still-missing.txt
+              fi
+            done < "${missing_file}"
+            mv /tmp/still-missing.txt "${missing_file}"
+            [ -s "${missing_file}" ] || break
+            echo "$(wc -l < "${missing_file}") still pending after $(( $(date +%s) - start ))s; waiting."
+            sleep $(( 45 + RANDOM % 30 ))
+          done
+
+          elapsed=$(( $(date +%s) - start ))
+
+          if [ -s "${missing_file}" ]; then
+            list=$(paste -sd, "${missing_file}")
+            {
+              echo "## Packagist verification FAILED after ${elapsed}s"
+              echo
+              echo '```json'
+              jq -R -s -c 'split("\n") | map(select(length > 0)) | {missing: .}' < "${missing_file}"
+              echo '```'
+              echo
+              echo "Recover only these packages, without republishing the rest:"
+              echo
+              echo '```'
+              echo "gh workflow run packagist-recover.yml -f packages=${list} -f tag=${TAG}"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "::error::Not installable at ${TAG}: ${list}"
+            echo "::error::Recover: gh workflow run packagist-recover.yml -f packages=${list} -f tag=${TAG}"
+            exit 1
+          fi
+
+          echo "## Packagist verification passed" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "All ${total} packages installable at \`${TAG}\` after ${elapsed}s." >> "${GITHUB_STEP_SUMMARY}"
+          echo "::notice::All ${total} packages visible at ${TAG} after ${elapsed}s."
+
+  # Publish only after split matrix + monorepo integrity + parity + PACKAGIST
+  # VERIFICATION — avoids racing github-release.yml on tag push, blocks releases
+  # if main was overwritten, and (alpha.285) refuses to announce a release whose
+  # packages a consumer cannot yet install.
+  #
+  # `verify-packagist` was previously a separate workflow that raced this job:
+  # the GitHub Release published while Packagist verification was still running,
+  # and stayed published when it failed. A release note pointing at packages
+  # that `composer require` cannot resolve is worse than a late release note.
   publish-github-release:
     name: Publish GitHub Release
-    needs: [verify-monorepo-main-intact, verify-tag-parity, verify-require-parity]
+    needs: [verify-monorepo-main-intact, verify-tag-parity, verify-require-parity, verify-packagist]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -341,9 +433,21 @@ jobs:
             echo "::error::so without these secrets nothing publishes. Configure them, then re-run."
             exit 1
           fi
+          # Packagist asks API consumers to identify themselves.
+          UA='waaseyaa-release/1.0 (+https://github.com/waaseyaa/framework; release fan-out)'
+
           rc=0
+          n=0
+          : > /tmp/packagist-jobs.txt
           while IFS= read -r pkg; do
             [ -z "${pkg}" ] && continue
+            n=$(( n + 1 ))
+            # Spacing between submissions (alpha.285). This loop previously
+            # fired ~76 POSTs back to back; the three packages that took
+            # longest to appear were the first three alphabetically, i.e. the
+            # front of that burst. Jitter avoids synchronising with anything
+            # else hitting the same endpoint.
+            [ "${n}" -gt 1 ] && sleep $(( 3 + RANDOM % 4 ))
             # waaseyaa/<x> is registered on Packagist at github.com/<owner>/<x>
             # (each split package's own repo; the monorepo for waaseyaa/framework).
             repo_url="https://github.com/${REPO_OWNER}/${pkg#waaseyaa/}"
@@ -352,7 +456,16 @@ jobs:
               -H 'Content-Type: application/json' \
               -d "{\"repository\":{\"url\":\"${repo_url}\"}}" || echo "000")
             if [ "${code}" = "200" ] || [ "${code}" = "202" ]; then
-              echo "::notice::${pkg}: update-package accepted (HTTP ${code})."
+              # ACCEPTED, NOT PUBLISHED. 202 means the crawl is queued. The
+              # `verify-packagist` job below decides whether it actually
+              # happened; this step must never be read as publication.
+              #
+              # The job id is recorded because without it a package that never
+              # appears is indistinguishable from one still in the queue —
+              # which is exactly what made the alpha.285 investigation guesswork.
+              job_id=$(jq -r '.job // .jobs[0] // empty' /tmp/resp.json 2>/dev/null)
+              printf '%s\t%s\t%s\n' "${pkg}" "${code}" "${job_id:-none}" >> /tmp/packagist-jobs.txt
+              echo "::notice::${pkg}: update-package QUEUED (HTTP ${code}, job ${job_id:-none}) — not yet published."
             elif [ "${code}" = "404" ]; then
               # Package not yet registered on Packagist — first release of a new
               # split package (e.g. waaseyaa/publishing, alpha.277). Register it
@@ -379,4 +492,15 @@ jobs:
               rc=1
             fi
           done < /tmp/pkgs.txt
+
+          {
+            echo "## Packagist crawl submissions"
+            echo
+            echo "Queued, **not** published — see the \`verify-packagist\` job."
+            echo
+            echo "| Package | HTTP | Job |"
+            echo "|---|---|---|"
+            while IFS=$'\t' read -r pk co jb; do echo "| \`${pk}\` | ${co} | \`${jb}\` |"; done < /tmp/packagist-jobs.txt
+          } >> "${GITHUB_STEP_SUMMARY}"
+
           exit "${rc}"

--- a/tests/release/packagist-verification.bats.sh
+++ b/tests/release/packagist-verification.bats.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Shell-level fixtures for the Packagist release state machine.
+#
+# These exercise the DECISION LOGIC — "is this package installable?" — against
+# canned P2 responses, with no network and no credentials. That is the logic
+# that was wrong at alpha.285: the pipeline could not distinguish a package
+# that was queued-and-slow from one that was never crawled, and it treated an
+# accepted POST as publication.
+#
+# Run: bash tests/release/packagist-verification.bats.sh
+#
+# Deliberately plain bash rather than a framework: this must be runnable inside
+# a workflow container with nothing installed but jq.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+ok()   { printf '  ok   %s\n' "$1"; PASS=$(( PASS + 1 )); }
+bad()  { printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; FAIL=$(( FAIL + 1 )); }
+
+# ---------------------------------------------------------------------------
+# The unit under test: the same jq predicate the workflows use.
+# Kept identical on purpose — a fixture that tests a paraphrase of the
+# production check proves nothing about the production check.
+# ---------------------------------------------------------------------------
+is_visible() {
+  local fixture="$1" pkg="$2" tag="$3"
+  jq -e --arg t "${tag}" '.packages[][] | select(.version == $t)' < "${fixture}" >/dev/null 2>&1
+}
+
+p2() { # p2 <pkg> <version...>  -> path to a fixture file
+  local pkg="$1"; shift
+  local f="${WORK}/${pkg//\//_}.json" versions=""
+  for v in "$@"; do versions="${versions}{\"version\":\"${v}\"},"; done
+  versions="${versions%,}"
+  printf '{"packages":{"%s":[%s]}}' "${pkg}" "${versions}" > "${f}"
+  printf '%s' "${f}"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Accepted AND published — the happy path.
+# ---------------------------------------------------------------------------
+f=$(p2 waaseyaa/analytics v0.1.0-alpha.285 v0.1.0-alpha.284)
+if is_visible "${f}" waaseyaa/analytics v0.1.0-alpha.285; then
+  ok "accepted and published -> visible"
+else
+  bad "accepted and published -> visible" "the tag is present but was not detected"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Accepted but NEVER published — the alpha.285 shape.
+#    The package exists and has an older release. A check that merely asked
+#    "does this package exist?" would pass here, which is the bug.
+# ---------------------------------------------------------------------------
+f=$(p2 waaseyaa/analytics v0.1.0-alpha.284 v0.1.0-alpha.283)
+if is_visible "${f}" waaseyaa/analytics v0.1.0-alpha.285; then
+  bad "accepted but never published -> NOT visible" "reported installable while only alpha.284 exists"
+else
+  ok "accepted but never published -> NOT visible"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The v-prefix trap.
+#    Packagist publishes "v0.1.0-alpha.285". Matching the unprefixed string
+#    finds nothing and reports every package missing — a false alarm that
+#    reads exactly like a catastrophic failed publish.
+# ---------------------------------------------------------------------------
+f=$(p2 waaseyaa/analytics v0.1.0-alpha.285)
+if is_visible "${f}" waaseyaa/analytics 0.1.0-alpha.285; then
+  bad "unprefixed tag must not match" "matched without the v prefix"
+else
+  ok "unprefixed tag must not match (guards the false-alarm sweep)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Substring near-misses must not satisfy the check.
+#    alpha.28 must not match alpha.285, and alpha.285 must not be satisfied by
+#    alpha.2851.
+# ---------------------------------------------------------------------------
+f=$(p2 waaseyaa/analytics v0.1.0-alpha.2851)
+if is_visible "${f}" waaseyaa/analytics v0.1.0-alpha.285; then
+  bad "near-miss version must not match" "alpha.2851 satisfied a request for alpha.285"
+else
+  ok "near-miss version must not match"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Transient API failure then success.
+#    An unreadable/empty body must read as "not visible" rather than crashing
+#    or, worse, being treated as success.
+# ---------------------------------------------------------------------------
+broken="${WORK}/broken.json"; printf 'gateway timeout' > "${broken}"
+if is_visible "${broken}" waaseyaa/analytics v0.1.0-alpha.285; then
+  bad "malformed response -> NOT visible" "garbage was treated as a hit"
+else
+  ok "malformed response -> NOT visible"
+fi
+f=$(p2 waaseyaa/analytics v0.1.0-alpha.285)
+if is_visible "${f}" waaseyaa/analytics v0.1.0-alpha.285; then
+  ok "recovery after transient failure -> visible"
+else
+  bad "recovery after transient failure -> visible" "retry did not observe the published tag"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. One missing package repaired WITHOUT republishing all 76.
+#    The missing set must shrink to exactly the unpublished package, so the
+#    recovery command targets one name rather than the whole matrix.
+# ---------------------------------------------------------------------------
+declare -a missing=()
+for pkg in waaseyaa/foundation waaseyaa/analytics waaseyaa/entity; do
+  if [ "${pkg}" = "waaseyaa/analytics" ]; then
+    f=$(p2 "${pkg}" v0.1.0-alpha.284)
+  else
+    f=$(p2 "${pkg}" v0.1.0-alpha.285)
+  fi
+  is_visible "${f}" "${pkg}" v0.1.0-alpha.285 || missing+=("${pkg}")
+done
+if [ "${#missing[@]}" -eq 1 ] && [ "${missing[0]}" = "waaseyaa/analytics" ]; then
+  ok "targeted recovery names only the unpublished package"
+else
+  bad "targeted recovery names only the unpublished package" "got: ${missing[*]:-none}"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. The GitHub Release gate.
+#    Modelled as the predicate the workflow dependency encodes: the release may
+#    proceed only when the missing set is empty. Before alpha.285 the release
+#    job did not depend on verification at all, so this was vacuously true.
+# ---------------------------------------------------------------------------
+release_allowed() { [ "$1" -eq 0 ]; }
+if release_allowed "${#missing[@]}"; then
+  bad "release blocked while a package is missing" "release would have proceeded with 1 missing"
+else
+  ok "release blocked while a package is missing"
+fi
+if release_allowed 0; then
+  ok "release permitted when every package is visible"
+else
+  bad "release permitted when every package is visible" "release blocked despite a complete set"
+fi
+
+# ---------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Permanent repair following the alpha.285 recovery (#2175). **alpha.285 is now 76/76 and this changes no package versions.**

## What actually happened

alpha.285 published **73 of 76** on its first pass. `waaseyaa/admin-surface`, `waaseyaa/analytics` and `waaseyaa/attachment` were queued and crawled **late** — they appeared on their own shortly after the verifier's 24-attempt ceiling expired, without resubmission. The recovery workflow found all three already visible and correctly submitted nothing.

So the failure was **not dropped jobs**. It was a pipeline that could not distinguish *slow* from *dropped*, reported the release complete regardless, and offered no way to act on the difference.

## The four defects

**1. The GitHub Release did not depend on Packagist at all.**

```yaml
publish-github-release:
  needs: [verify-monorepo-main-intact, verify-tag-parity, verify-require-parity]
```

It published while verification was still polling, and stayed published when verification failed — announcing a release whose packages `composer require` could not resolve.

**2. Verification raced the thing it was gating.** It lived in a separate workflow triggered by the same tag push. Ordering was a coincidence, not a dependency.

**3. Acceptance was recorded as publication.** The submitter treated HTTP 200/202 as success — 202 means *queued* — and wrote the response body to `/tmp/resp.json` without ever reading it, discarding the job ids. After the fact there was nothing to trace.

**4. Names lied.** `packagist-update.yml` was called "Publish to Packagist" and never submitted anything; its `package_filter` said "update" while only filtering verification. An operator reading a failed run reasonably concluded publication had been attempted there.

## The repair

```
split tags → verify split parity → submit → verify 76/76 → publish GitHub Release
```

- `publish-github-release` now `needs: verify-packagist`.
- `verify-packagist` moves **into** `split.yml`, so it cannot race the release.
- Window is **40 minutes**, not a 24-attempt ceiling, and it **records how long each package took** — the latency distribution becomes visible instead of guessed at.
- Submitter: **3–7s spacing with jitter** (the three slowest packages were the first three alphabetically in an unspaced ~76-request burst), **parses and records job ids** in the log and step summary, and says `QUEUED … not yet published` rather than `accepted`.
- Failure emits **machine-readable JSON** plus the exact recovery command for only the missing packages.
- `packagist-update.yml` renamed **"Verify Packagist Publication (standalone)"**, re-described, and removed from the release path.

## Fixtures

`tests/release/packagist-verification.bats.sh` — 9 cases against canned P2 responses, no network, no credentials, wired into `ci.yml`:

| Case | Guards |
|---|---|
| accepted and published | happy path |
| **accepted but never published** | the alpha.285 shape — an existing package with only an older version must not pass |
| **unprefixed tag must not match** | the `v`-prefix trap that once reported all 75 packages missing |
| near-miss version | `alpha.2851` must not satisfy `alpha.285` |
| malformed response | garbage must read as *not visible*, never as success |
| transient failure then success | retry observes the published tag |
| **targeted recovery** | the missing set names one package, not the matrix |
| release gate, both directions | blocked with 1 missing; permitted with 0 |

It calls the **same jq predicate** the workflows use — a fixture testing a paraphrase of the production check would prove nothing about the production check.

## Deliberately not changed

**Auth stays on the query-parameter form.** The Bearer header was rejected `406 Missing or invalid username/apiToken` on the alpha.277 cut, recorded inline in `split.yml`. Switching it blind while repairing the release pipeline would risk breaking the one mechanism currently known to work. That move needs a safe test against the live API first, which is its own change.