### PR TITLE
fix(#2234): guard the canonical release changelog

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -145,14 +145,7 @@ jobs:
 
       - name: Verify CHANGELOG [Unreleased] has content
         run: |
-          if [ ! -f CHANGELOG.md ]; then
-            echo "::error::CHANGELOG.md not found"
-            exit 1
-          fi
-          if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
-            echo "::error::no [Unreleased] section in CHANGELOG.md"
-            exit 1
-          fi
+          php bin/check-changelog-shape
           unreleased=$(sed -n '/^## \[Unreleased\]/,/^## \[/{/^## \[/d;/^$/d;/^### /d;p;}' CHANGELOG.md)
           if [ -z "$unreleased" ]; then
             echo "::error::[Unreleased] section has no entries — add bullets before cutting a release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## Unreleased
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **release tooling (#2234):** Require exactly one canonical `[Unreleased]` changelog section in local verification and release-cut CI, rejecting duplicate or near-miss headings before a tag can strand release notes.
 
 - **admin / CI:** Consolidate the stale admin dependency queue on Node 22 and npm 10: update Nuxt, Vue, the Nuxt ESLint integration, Vue TypeScript tooling, DOM and Node test types, refresh transitive PostCSS/SVGO/tar and Vite/esbuild tooling, and remediate the brace-expansion, shell-quote, js-yaml, Vite, and esbuild audit findings. Regenerate the committed admin SPA from that exact lock and move the isolated artifact download workflow to `actions/download-artifact@v8`.
 
@@ -47,15 +56,6 @@
 - **mcp / ai-tools**: Make `ContentToolSet` the canonical remotely callable editorial mutation surface. `/mcp/write` now structurally withholds the five cross-bundle generic `entity.*` mutation tools even when their broad capabilities are allowlisted; applications must set the strict `mcp.write_tier.allow_generic_entity_mutations=true` escape hatch to accept that risk. The embedded agent catalogue remains unchanged.
 
 - **mcp / bimaaji / ai-agent**: Remove privileged `bimaaji.read` architectural introspection from anonymous MCP defaults and make filesystem spec indexing explicit opt-in via `bimaaji.specs_directory`. Graph failures now use the shared sanitized internal-error envelope, spec-search queries are bounded and reject control characters, and results expose only logical filenames rather than absolute server paths.
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Changed
 
 - **MCP / search contract truth (#2191).** Reconciled the MCP, AI-schema,
   extension, operations, and search documentation with the current runtime:

--- a/bin/check-changelog-shape
+++ b/bin/check-changelog-shape
@@ -1,0 +1,52 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$path = $argv[1] ?? dirname(__DIR__) . '/CHANGELOG.md';
+if (!is_file($path) || !is_readable($path)) {
+    fwrite(STDERR, sprintf("changelog-shape: cannot read %s.\n", $path));
+    exit(2);
+}
+
+$contents = (string) file_get_contents($path);
+$headings = [];
+foreach (preg_split('/\R/', $contents) ?: [] as $lineNumber => $line) {
+    if (preg_match('/^##\s+.*unreleased.*$/i', trim($line)) === 1) {
+        $headings[] = ['line' => $lineNumber + 1, 'text' => trim($line)];
+    }
+}
+
+$canonical = array_values(array_filter(
+    $headings,
+    static fn(array $heading): bool => $heading['text'] === '## [Unreleased]',
+));
+$nearMisses = array_values(array_filter(
+    $headings,
+    static fn(array $heading): bool => $heading['text'] !== '## [Unreleased]',
+));
+
+if (count($canonical) !== 1) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "changelog-shape: expected exactly one canonical ## [Unreleased] heading; found %d.\n",
+            count($canonical),
+        ),
+    );
+    exit(1);
+}
+
+if ($nearMisses !== []) {
+    $locations = array_map(
+        static fn(array $heading): string => sprintf('line %d (%s)', $heading['line'], $heading['text']),
+        $nearMisses,
+    );
+    fwrite(
+        STDERR,
+        "changelog-shape: found Unreleased near-miss heading(s): " . implode(', ', $locations) . ".\n",
+    );
+    exit(1);
+}
+
+fwrite(STDOUT, "changelog-shape: exactly one canonical Unreleased section found.\n");

--- a/composer.json
+++ b/composer.json
@@ -471,6 +471,7 @@
     },
     "scripts": {
         "check-composer-policy": "php bin/check-composer-policy",
+        "check-changelog-shape": "php bin/check-changelog-shape",
         "check-distribution-extensions": "php bin/check-distribution-extensions",
         "check-openapi": "bash bin/check-openapi",
         "check-external-consumers": "php bin/check-external-consumers ai-agent-orphans",
@@ -510,6 +511,7 @@
         "verify": [
             "@cs-check",
             "@phpstan",
+            "@check-changelog-shape",
             "@check-phpstan-paths",
             "@check-phpunit-paths",
             "@check-contract-suite-coverage",

--- a/docs/specs/workflow.md
+++ b/docs/specs/workflow.md
@@ -128,7 +128,11 @@ The workflow:
 2. Guards `v1.0*` tags against missing `release-approvals/v1.0.approved` (same gate `split.yml` runs after the fact — fails earlier).
 3. **Gate 1: requires green CI on the release base.** `bin/wait-for-green-ci` polls the Actions API for a completed, successful `ci.yml` run at main HEAD. A red base fails the cut before anything is mutated.
 4. Verifies the tag does not already exist (locally or on origin).
-5. Verifies `CHANGELOG.md` has a `[Unreleased]` section with content.
+5. Runs `bin/check-changelog-shape`, which requires exactly one canonical
+   `## [Unreleased]` heading and rejects near-miss variants, then verifies that
+   canonical section has content. The same shape guard runs in
+   `composer verify`, so duplicate release-note authorities fail on ordinary
+   PR CI before the release workflow is dispatched.
 6. Mutates the changelog: renames `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, inserts fresh `[Unreleased]`; syncs internal `waaseyaa/*` constraints; stamps `VERSION`.
 7. Commits as `github-actions[bot]` and pushes the release commit to a throwaway gate branch (`release-cut/<version>`) — **not** to main.
 8. **Gate 2: requires green CI on the exact commit being tagged.** Dispatches `ci.yml` on the gate branch (it has a `workflow_dispatch` trigger for this) and waits for a green conclusion at the release commit's SHA.

--- a/tests/Architecture/ChangelogShapeGuardTest.php
+++ b/tests/Architecture/ChangelogShapeGuardTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ChangelogShapeGuardTest extends TestCase
+{
+    private string $repoRoot;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 2);
+    }
+
+    #[Test]
+    public function it_accepts_exactly_one_canonical_unreleased_section(): void
+    {
+        $result = $this->runGuard(<<<'MARKDOWN'
+            # Changelog
+
+            ## [Unreleased]
+
+            ### Fixed
+
+            - A release fix.
+
+            ## [0.1.0-alpha.286] - 2026-08-04
+            MARKDOWN);
+
+        self::assertSame(0, $result['exit_code'], $result['output']);
+    }
+
+    #[Test]
+    public function it_rejects_duplicate_canonical_unreleased_sections(): void
+    {
+        $result = $this->runGuard(<<<'MARKDOWN'
+            # Changelog
+
+            ## [Unreleased]
+
+            - First entry.
+
+            ## [Unreleased]
+
+            - Stranded entry.
+            MARKDOWN);
+
+        self::assertSame(1, $result['exit_code']);
+        self::assertStringContainsString('exactly one', $result['output']);
+    }
+
+    #[Test]
+    public function it_rejects_unbracketed_near_miss_headings(): void
+    {
+        $result = $this->runGuard(<<<'MARKDOWN'
+            # Changelog
+
+            ## Unreleased
+
+            - This entry would be skipped by release-cut.
+
+            ## [Unreleased]
+
+            - Canonical entry.
+            MARKDOWN);
+
+        self::assertSame(1, $result['exit_code']);
+        self::assertStringContainsString('near-miss', $result['output']);
+    }
+
+    #[Test]
+    public function ci_and_release_cut_both_run_the_shape_guard(): void
+    {
+        $composer = json_decode(
+            (string) file_get_contents($this->repoRoot . '/composer.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+        $verify = $composer['scripts']['verify'] ?? [];
+
+        self::assertContains('@check-changelog-shape', $verify);
+        self::assertStringContainsString(
+            'php bin/check-changelog-shape',
+            (string) file_get_contents($this->repoRoot . '/.github/workflows/release-cut.yml'),
+        );
+    }
+
+    /** @return array{exit_code: int, output: string} */
+    private function runGuard(string $contents): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'waaseyaa-changelog-');
+        self::assertNotFalse($path);
+        file_put_contents($path, $contents . "\n");
+
+        $output = [];
+        $exitCode = 0;
+        exec(
+            escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($this->repoRoot . '/bin/check-changelog-shape')
+            . ' '
+            . escapeshellarg($path)
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+        unlink($path);
+
+        return ['exit_code' => $exitCode, 'output' => implode("\n", $output)];
+    }
+}


### PR DESCRIPTION
## Summary

- restore one canonical bracketed Unreleased changelog authority containing every post-alpha.286 entry
- add a behavioral shape guard that rejects duplicate and near-miss headings
- run the guard from Composer verification and release-cut before release-note extraction
- document the enforced release contract

## Root cause

Merged changes had accumulated under both bracketed and unbracketed Unreleased headings. The release workflow only parsed the bracketed form, so an alpha.287 cut would have omitted much of the merged work.

## Verification

- red-first guard: 3 expected failures before implementation
- focused guard: 4 tests, 10 assertions
- full Architecture suite: 90 tests, 1,524 assertions
- PHP-CS-Fixer: clean
- PHPStan: clean
- Composer validate strict: clean
- changelog shape guard: clean
- staged diff check: clean

Closes #2234