### PR TITLE
Keep SSR render results independent of transport time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ssr (#2231):** Keep the intermediate page-render result independent of Symfony's wall-clock `Date` header. The final router-created response remains responsible for transport dating, while resolver/no-resolver rendering is byte-stable across second boundaries.
+
 - **release tooling (#2234):** Require exactly one canonical `[Unreleased]` changelog section in local verification and release-cut CI, rejecting duplicate or near-miss headings before a tag can strand release notes.
 
 - **admin / CI:** Consolidate the stale admin dependency queue on Node 22 and npm 10: update Nuxt, Vue, the Nuxt ESLint integration, Vue TypeScript tooling, DOM and Node test types, refresh transitive PostCSS/SVGO/tar and Vite/esbuild tooling, and remediate the brace-expansion, shell-quote, js-yaml, Vite, and esbuild audit findings. Regenerate the committed admin SPA from that exact lock and move the isolated artifact download workflow to `actions/download-artifact@v8`.

--- a/docs/specs/ssr-page-composition.md
+++ b/docs/specs/ssr-page-composition.md
@@ -127,6 +127,10 @@ headers otherwise remain intact. A future shared-cache opt-in requires a
 separate dependency-metadata contract.
 Repeatable response headers remain repeatable across the handler/router
 boundary; in particular, multiple `Set-Cookie` values are not flattened.
+The intermediate handler result excludes Symfony's automatically generated
+`Date` header. `SsrRouter` constructs the final outbound response and owns its
+transport date, keeping intermediate render output deterministic without
+removing HTTP response dating.
 
 ## Cache partition
 

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -16,6 +16,12 @@ The `?raw` / `Accept: text/markdown` representation renders via `SsrPageHandler:
 
 Applications may bind `Waaseyaa\SSR\PageComposition\EntityPageComposerInterface` to wrap an authorized generic entity page in application chrome. The composer receives only an immutable `EntityPageRenderPayload`: the access-checked title, normalized inbound path, type/bundle/view/language metadata, schema.org JSON-LD, and formatter-produced strings for fields that survived field access. Its one structure-preserving channel, `bodyCompositionHtml`, is created after field access and sanitized while retaining safe CSS classes and relative media/link URLs; forbidden, missing, array, and object bodies yield an empty string. It never receives an entity, account, arbitrary raw field bag, repository, or template name. The seam is HTML-only and runs after alias resolution and all existing editorial/entity access gates. No binding or a deliberate `null` return uses the framework renderer. Resolution failure, exceptions, empty content, redirects, non-200 output, and explicitly non-HTML output fall back to that complete renderer as `private, no-store`; accepted composed documents are also non-shareable until the contract can represent app-shell cache dependencies. See `docs/specs/ssr-page-composition.md`.
 
+The intermediate render result preserves application response headers except
+for the transport-owned `Date` header. `SsrRouter` constructs the actual
+outbound Symfony response and therefore owns its final date; retaining the
+composer or fallback response's wall-clock value would make otherwise
+identical render results timing-dependent and could persist a stale date.
+
 Twig functions: `asset()`, `env()`, `config()` (when wired), `csrf_token()` (when User middleware present).
 
 Key classes: `SsrPageHandler`, `RenderController`, `ThemeServiceProvider`, `EntityRenderer`, `EntityPageComposerInterface`, `EntityPageRenderPayload`, `WaaseyaaExtension`.

--- a/packages/ssr/src/SsrPageHandler.php
+++ b/packages/ssr/src/SsrPageHandler.php
@@ -1591,6 +1591,14 @@ final class SsrPageHandler
     {
         $headers = [];
         foreach ($response->headers->all() as $name => $values) {
+            // Symfony assigns Date when this internal response is created, but
+            // SsrRouter constructs the real outbound response afterwards. Do
+            // not persist or compare a wall-clock transport header at this
+            // intermediate render boundary; the outbound response owns it.
+            if (strtolower($name) === 'date') {
+                continue;
+            }
+
             $presentValues = array_values(array_filter(
                 $values,
                 static fn(?string $value): bool => $value !== null,

--- a/packages/ssr/tests/Unit/SsrEntityPageCompositionTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityPageCompositionTest.php
@@ -187,6 +187,11 @@ final class SsrEntityPageCompositionTest extends TestCase
             new CallbackServiceResolver(static fn(string $class): ?object => null),
         )->handleRenderPage($path, $account, Request::create($path));
 
+        self::assertArrayNotHasKey(
+            'date',
+            $withoutResolver['headers'],
+            'The intermediate render result must not retain a transport-owned Date header.',
+        );
         self::assertSame($withoutResolver, $withEmptyResolver);
         self::assertStringContainsString('<framework>', (string) $withoutResolver['content']);
     }


### PR DESCRIPTION
Closes #2231

## Summary
- exclude Symfony's automatically generated Date header from the intermediate SSR render result
- retain final HTTP Date ownership in the router-created outbound response
- document the boundary in the SSR README and formal page-composition spec

## Evidence
- red first: the new assertion deterministically exposed Date in the intermediate result
- focused composition suite: 17 tests, 132 assertions
- complete SSR suite: 319 tests, 879 assertions
- regression repeated across real second boundaries
- PHPStan: 2,007 files, zero errors
- PHP-CS-Fixer: 2,253 files clean
- git diff --check: clean