### PR TITLE
Keep release lock metadata synchronized

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -196,14 +196,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # CRITICAL: also stage the packages/*/composer.json files mutated by the
-          # earlier "Sync internal waaseyaa/* version constraints" step. Forgetting
-          # this leaves the synced files dirty in the runner and they're discarded
-          # on shutdown — the resulting tag commit only promotes CHANGELOG, every
-          # internal `waaseyaa/*` constraint still points at the prior version,
-          # and the next pre-push composer-policy gate fails with 200+ CP-NEW
-          # violations. See incident: alpha.178 cut on 2026-05-14.
-          git add CHANGELOG.md VERSION packages/*/composer.json
+          # CRITICAL: stage every file mutated by the internal-version sync:
+          # package manifests, the create-project skeleton, and copied path-
+          # package metadata in the root lock. Omitting any one creates a tag
+          # whose manifests disagree with its install or consumer metadata.
+          # See alpha.178 (unstaged packages) and alpha.287 gate attempt 1
+          # (unstaged skeleton and stale root-lock metadata).
+          git add CHANGELOG.md VERSION composer.lock packages/*/composer.json skeleton/composer.json
           git commit -m "chore: release ${VERSION}"
           # The release commit goes to a throwaway gate branch FIRST. Main is
           # only fast-forwarded after Gate 2 proves CI green on this exact SHA.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **release tooling (#2238):** Keep root-lock path-package metadata and the create-project skeleton in the same atomic internal-version sync as split-package manifests, and make optional-domain architecture tests derive the release-managed version. Exact release-commit CI can now validate the advanced constraints without comparing them to stale lock metadata or a hardcoded previous alpha.
+
 - **ssr (#2231):** Keep the intermediate page-render result independent of Symfony's wall-clock `Date` header. The final router-created response remains responsible for transport dating, while resolver/no-resolver rendering is byte-stable across second boundaries.
 
 - **release tooling (#2234):** Require exactly one canonical `[Unreleased]` changelog section in local verification and release-cut CI, rejecting duplicate or near-miss headings before a tag can strand release notes.

--- a/bin/lib/internal-version-sync.php
+++ b/bin/lib/internal-version-sync.php
@@ -239,3 +239,134 @@ function syncManifestFile(string $manifestPath, string $constraint): bool
 
     return true;
 }
+
+/**
+ * Synchronize path-package dependency metadata embedded in the root lock.
+ *
+ * Composer copies each path package's production `require` object into
+ * composer.lock. The release cut mutates package manifests without running a
+ * network-dependent Composer update, so that copied metadata must move in the
+ * same deterministic operation. Third-party packages, content-hash, versions,
+ * references, and every other lock field remain untouched.
+ *
+ * @param list<string> $manifestPaths Absolute package manifest paths.
+ *
+ * @throws \RuntimeException On malformed JSON or read/write failure.
+ */
+function syncRootLockFile(string $lockPath, array $manifestPaths): bool
+{
+    $original = file_get_contents($lockPath);
+    if ($original === false) {
+        throw new \RuntimeException(sprintf('Cannot read %s', $lockPath));
+    }
+
+    try {
+        $lock = json_decode($original, false, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $e) {
+        throw new \RuntimeException(sprintf('Cannot parse %s: %s', $lockPath, $e->getMessage()), 0, $e);
+    }
+    if (!$lock instanceof \stdClass) {
+        throw new \RuntimeException(sprintf('%s must contain a JSON object.', $lockPath));
+    }
+
+    /** @var array<string, array<string, string>> $requiresByPackage */
+    $requiresByPackage = [];
+    foreach ($manifestPaths as $manifestPath) {
+        $contents = file_get_contents($manifestPath);
+        if ($contents === false) {
+            throw new \RuntimeException(sprintf('Cannot read %s', $manifestPath));
+        }
+
+        try {
+            $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(sprintf('Cannot parse %s: %s', $manifestPath, $e->getMessage()), 0, $e);
+        }
+
+        $name = is_array($manifest) ? ($manifest['name'] ?? null) : null;
+        $require = is_array($manifest) ? ($manifest['require'] ?? null) : null;
+        if (is_string($name) && is_array($require)) {
+            /** @var array<string, string> $require */
+            $requiresByPackage[$name] = $require;
+        }
+    }
+
+    $changed = false;
+    foreach (['packages', 'packages-dev'] as $section) {
+        $packages = $lock->{$section} ?? null;
+        if (!is_array($packages)) {
+            continue;
+        }
+
+        foreach ($packages as $package) {
+            if (!$package instanceof \stdClass) {
+                continue;
+            }
+            $name = $package->name ?? null;
+            if (!is_string($name) || !isset($requiresByPackage[$name])) {
+                continue;
+            }
+            $lockedRequireObject = $package->require ?? null;
+            $lockedRequire = $lockedRequireObject instanceof \stdClass
+                ? get_object_vars($lockedRequireObject)
+                : [];
+            $expectedRequire = $requiresByPackage[$name];
+            $lockedKeys = array_keys($lockedRequire);
+            $expectedKeys = array_keys($expectedRequire);
+            sort($lockedKeys);
+            sort($expectedKeys);
+            if ($lockedKeys !== $expectedKeys) {
+                throw new \RuntimeException(sprintf(
+                    '%s package %s has dependency-key drift; regenerate the root lock before release.',
+                    $lockPath,
+                    $name,
+                ));
+            }
+
+            foreach ($expectedRequire as $dependency => $constraint) {
+                if (!str_starts_with($dependency, 'waaseyaa/')) {
+                    if (($lockedRequire[$dependency] ?? null) !== $constraint) {
+                        throw new \RuntimeException(sprintf(
+                            '%s package %s has non-internal dependency drift for %s; regenerate the root lock before release.',
+                            $lockPath,
+                            $name,
+                            $dependency,
+                        ));
+                    }
+                    continue;
+                }
+
+                if (($lockedRequire[$dependency] ?? null) !== $constraint) {
+                    if (!$lockedRequireObject instanceof \stdClass) {
+                        throw new \RuntimeException(sprintf(
+                            '%s package %s has invalid require metadata.',
+                            $lockPath,
+                            $name,
+                        ));
+                    }
+                    $lockedRequireObject->{$dependency} = $constraint;
+                    $changed = true;
+                }
+            }
+        }
+    }
+
+    if (!$changed) {
+        return false;
+    }
+
+    try {
+        $updated = json_encode(
+            $lock,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        ) . "\n";
+    } catch (\JsonException $e) {
+        throw new \RuntimeException(sprintf('Cannot encode %s: %s', $lockPath, $e->getMessage()), 0, $e);
+    }
+
+    if (file_put_contents($lockPath, $updated) === false) {
+        throw new \RuntimeException(sprintf('Cannot write %s', $lockPath));
+    }
+
+    return true;
+}

--- a/bin/sync-internal-versions
+++ b/bin/sync-internal-versions
@@ -67,5 +67,17 @@ foreach ($manifests as $manifestPath) {
     }
 }
 
+$lockPath = $repoRoot . '/composer.lock';
+if (is_file($lockPath)) {
+    try {
+        if (syncRootLockFile($lockPath, $manifests)) {
+            ++$updatedCount;
+        }
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+        exit(2);
+    }
+}
+
 echo "Updated {$updatedCount} file(s) — version {$constraint}\n";
 exit(0);

--- a/docs/specs/workflow.md
+++ b/docs/specs/workflow.md
@@ -133,8 +133,8 @@ The workflow:
    canonical section has content. The same shape guard runs in
    `composer verify`, so duplicate release-note authorities fail on ordinary
    PR CI before the release workflow is dispatched.
-6. Mutates the changelog: renames `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, inserts fresh `[Unreleased]`; syncs internal `waaseyaa/*` constraints; stamps `VERSION`.
-7. Commits as `github-actions[bot]` and pushes the release commit to a throwaway gate branch (`release-cut/<version>`) — **not** to main.
+6. Mutates the changelog: renames `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, inserts fresh `[Unreleased]`; syncs internal `waaseyaa/*` constraints in split-package manifests and the create-project skeleton; updates the corresponding path-package `require` metadata embedded in the root `composer.lock`; stamps `VERSION`. The lock sync is local and deterministic: it does not resolve or update third-party packages.
+7. Stages every release mutation (`CHANGELOG.md`, `VERSION`, root lock, split-package manifests, and skeleton manifest), commits as `github-actions[bot]`, and pushes the release commit to a throwaway gate branch (`release-cut/<version>`) — **not** to main.
 8. **Gate 2: requires green CI on the exact commit being tagged.** Dispatches `ci.yml` on the gate branch (it has a `workflow_dispatch` trigger for this) and waits for a green conclusion at the release commit's SHA.
 9. Only then creates the annotated tag and pushes main fast-forward + tag in one **atomic** push using `SPLIT_GITHUB_TOKEN`. The gate branch is deleted either way.
 

--- a/tests/Architecture/CiReleaseWorkflowParityTest.php
+++ b/tests/Architecture/CiReleaseWorkflowParityTest.php
@@ -102,6 +102,17 @@ final class CiReleaseWorkflowParityTest extends TestCase
         self::assertLessThan($extract, $verify, 'Checksum verification must precede archive extraction.');
     }
 
+    #[Test]
+    public function release_commit_stages_every_file_mutated_by_internal_version_sync(): void
+    {
+        $release = $this->read('.github/workflows/release-cut.yml');
+
+        self::assertStringContainsString(
+            'git add CHANGELOG.md VERSION composer.lock packages/*/composer.json skeleton/composer.json',
+            $release,
+        );
+    }
+
     private function read(string $relativePath): string
     {
         $path = $this->repoRoot . '/' . $relativePath;

--- a/tests/Architecture/OptionalDomainDefaultsTest.php
+++ b/tests/Architecture/OptionalDomainDefaultsTest.php
@@ -88,6 +88,7 @@ final class OptionalDomainDefaultsTest extends TestCase
     public function api_declares_public_search_as_an_optional_version_coupled_domain(): void
     {
         $root = dirname(__DIR__, 2);
+        $releaseConstraint = '^' . trim((string) file_get_contents($root . '/VERSION'));
         $manifest = json_decode(
             (string) file_get_contents($root . '/packages/api/composer.json'),
             true,
@@ -98,7 +99,7 @@ final class OptionalDomainDefaultsTest extends TestCase
         foreach (['waaseyaa/auth', 'waaseyaa/search'] as $package) {
             self::assertArrayNotHasKey($package, $manifest['require']);
             self::assertArrayHasKey($package, $manifest['suggest']);
-            self::assertSame('^0.1.0-alpha.286', $manifest['require-dev'][$package]);
+            self::assertSame($releaseConstraint, $manifest['require-dev'][$package]);
             self::assertSame('<0.1.0-alpha.287 || >=0.2.0', $manifest['conflict'][$package]);
         }
     }
@@ -129,6 +130,7 @@ final class OptionalDomainDefaultsTest extends TestCase
     public function ai_tools_declares_content_search_as_an_optional_version_coupled_domain(): void
     {
         $root = dirname(__DIR__, 2);
+        $releaseConstraint = '^' . trim((string) file_get_contents($root . '/VERSION'));
         $manifest = json_decode(
             (string) file_get_contents($root . '/packages/ai-tools/composer.json'),
             true,
@@ -138,7 +140,7 @@ final class OptionalDomainDefaultsTest extends TestCase
 
         self::assertArrayNotHasKey('waaseyaa/search', $manifest['require']);
         self::assertArrayHasKey('waaseyaa/search', $manifest['suggest']);
-        self::assertSame('^0.1.0-alpha.286', $manifest['require-dev']['waaseyaa/search']);
+        self::assertSame($releaseConstraint, $manifest['require-dev']['waaseyaa/search']);
         self::assertSame('<0.1.0-alpha.287 || >=0.2.0', $manifest['conflict']['waaseyaa/search']);
     }
 

--- a/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
+++ b/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
@@ -292,6 +292,88 @@ final class SyncInternalVersionsTest extends TestCase
     }
 
     #[Test]
+    public function sync_updates_root_lock_path_package_metadata_without_touching_unrelated_packages(): void
+    {
+        $dir = $this->makeTempPackageDir([
+            'packages/agent/composer.json' => json_encode([
+                'name' => 'waaseyaa/agent',
+                'require' => [
+                    'php' => '>=8.5',
+                    'waaseyaa/foundation' => '^0.1.0-alpha.150',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+            'composer.lock' => json_encode([
+                '_readme' => ['fixture'],
+                'content-hash' => 'unchanged-root-hash',
+                'packages' => [
+                    [
+                        'name' => 'third-party/example',
+                        'version' => '1.2.3',
+                        'require' => ['php' => '>=8.2'],
+                    ],
+                    [
+                        'name' => 'waaseyaa/agent',
+                        'version' => 'dev-main',
+                        'require' => [
+                            'php' => '>=8.5',
+                            'waaseyaa/foundation' => '^0.1.0-alpha.150',
+                        ],
+                    ],
+                ],
+                'packages-dev' => [],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+        ]);
+
+        $this->runSyncScript($dir, '0.1.0-alpha.999');
+
+        $lock = $this->readManifest($dir . '/composer.lock');
+        self::assertSame('unchanged-root-hash', $lock['content-hash']);
+        self::assertSame(
+            ['php' => '>=8.2'],
+            $lock['packages'][0]['require'],
+            'Third-party lock metadata must not be rewritten.',
+        );
+        self::assertSame(
+            [
+                'php' => '>=8.5',
+                'waaseyaa/foundation' => '^0.1.0-alpha.999',
+            ],
+            $lock['packages'][1]['require'],
+        );
+
+        $first = (string) file_get_contents($dir . '/composer.lock');
+        $this->runSyncScript($dir, '0.1.0-alpha.999');
+        self::assertSame($first, file_get_contents($dir . '/composer.lock'));
+    }
+
+    #[Test]
+    public function sync_refuses_to_hide_structural_manifest_lock_drift(): void
+    {
+        $dir = $this->makeTempPackageDir([
+            'packages/agent/composer.json' => json_encode([
+                'name' => 'waaseyaa/agent',
+                'require' => [
+                    'php' => '>=8.5',
+                    'waaseyaa/foundation' => '^0.1.0-alpha.150',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+            'composer.lock' => json_encode([
+                'packages' => [[
+                    'name' => 'waaseyaa/agent',
+                    'version' => 'dev-main',
+                    'require' => ['php' => '>=8.5'],
+                ]],
+                'packages-dev' => [],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('dependency-key drift');
+
+        $this->runSyncScript($dir, '0.1.0-alpha.999');
+    }
+
+    #[Test]
     public function sync_preserves_internal_suggest_descriptions(): void
     {
         $description = 'Enables the optional CLI command integrations.';
@@ -371,6 +453,11 @@ final class SyncInternalVersionsTest extends TestCase
 
         foreach (discoverSyncManifests($repoRoot) as $manifestPath) {
             syncManifestFile($manifestPath, $constraint);
+        }
+
+        $lockPath = $repoRoot . '/composer.lock';
+        if (is_file($lockPath)) {
+            syncRootLockFile($lockPath, discoverSyncManifests($repoRoot));
         }
     }
 


### PR DESCRIPTION
Closes #2238

## Summary
- synchronize root composer.lock path-package require metadata in the same deterministic operation as package manifest constraints
- preserve third-party metadata and fail closed when dependency keys or non-internal constraints drift
- stage the root lock and create-project skeleton in the release commit
- derive optional-domain test expectations from the release-managed VERSION file

## Release-blocker evidence
The first alpha.287 attempt stopped safely at exact-commit Gate 2: unit tests passed, but Architecture reported three stale-version failures. No tag or main mutation occurred.

## Verification
- red first: missing lock synchronizer and unstaged release files failed focused tests
- focused release and architecture regression set: 44 tests, 272 assertions
- SyncInternalVersionsTest: 30 tests, 68 assertions
- complete Architecture suite: 91 tests, 1,526 assertions
- disposable alpha.287 release mutation: 67 files updated, all three formerly failing architecture classes green (15 tests, 206 assertions)
- root lock diff contains only alpha.286 to alpha.287 internal constraints
- PHPStan: 2,007 files, zero errors
- PHP-CS-Fixer: 2,253 files clean
- Composer validation and git diff check clean