### PR TITLE
Audit and inventory framework test quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **testing (#2235):** Publish the 2026 test-quality audit and a reproducible Git-tracked-only inventory for PHP, PHPUnit, Vitest, Playwright, nondeterminism, and shared-helper adoption signals. The testing doctrine now defines behavioral layers, deterministic replay, honest coverage, supported-tooling, mutation-pilot, and helper-adoption standards without prescribing a syntax rewrite.
+
 ## [0.1.0-alpha.287] - 2026-08-05
 
 ### Changed

--- a/bin/test-quality-inventory
+++ b/bin/test-quality-inventory
@@ -1,0 +1,161 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$format = 'json';
+foreach (array_slice($argv, 1) as $argument) {
+    if (str_starts_with($argument, '--format=')) {
+        $format = substr($argument, strlen('--format='));
+    }
+}
+
+if (!in_array($format, ['json', 'markdown'], true)) {
+    fwrite(STDERR, "Usage: php bin/test-quality-inventory [--format=json|markdown]\n");
+    exit(2);
+}
+
+$process = proc_open(
+    [$root . '/bin/git', '-C', $root, 'ls-files', '-z'],
+    [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+    $pipes,
+);
+if (!is_resource($process)) {
+    fwrite(STDERR, "Unable to enumerate tracked files.\n");
+    exit(1);
+}
+
+$stdout = stream_get_contents($pipes[1]);
+$stderr = stream_get_contents($pipes[2]);
+fclose($pipes[1]);
+fclose($pipes[2]);
+$exitCode = proc_close($process);
+if ($exitCode !== 0 || $stdout === false) {
+    fwrite(STDERR, trim((string) $stderr) . "\n");
+    exit(1);
+}
+
+$trackedFiles = array_values(array_filter(explode("\0", $stdout)));
+$phpTestFiles = [];
+$phpunitConfigs = [];
+$vitestFiles = [];
+$playwrightFiles = [];
+
+foreach ($trackedFiles as $path) {
+    if (preg_match('#(?:^|/)tests/(?:.*/)?[^/]+Test\.php$#', $path) === 1) {
+        $phpTestFiles[] = $path;
+    }
+    if (preg_match('#(?:^|/)phpunit(?:\.[^/]+)?\.xml(?:\.dist)?$#', $path) === 1) {
+        $phpunitConfigs[] = $path;
+    }
+    if (
+        str_starts_with($path, 'packages/admin/tests/')
+        && preg_match('/\.(?:test|spec)\.[cm]?[jt]sx?$/', $path) === 1
+    ) {
+        $vitestFiles[] = $path;
+    }
+    if (
+        str_starts_with($path, 'packages/admin/e2e/')
+        && preg_match('/\.(?:test|spec)\.[cm]?[jt]sx?$/', $path) === 1
+    ) {
+        $playwrightFiles[] = $path;
+    }
+}
+
+$signals = [
+    'test_methods' => 0,
+    'assertion_calls' => 0,
+    'coverage_metadata_files' => 0,
+    'randomness_signal_files' => 0,
+    'sleep_signal_files' => 0,
+    'conditional_skip_files' => 0,
+    'small_group_files' => 0,
+    'medium_group_files' => 0,
+    'large_group_files' => 0,
+];
+
+foreach ($phpTestFiles as $path) {
+    $contents = file_get_contents($root . '/' . $path);
+    if ($contents === false) {
+        fwrite(STDERR, "Unable to read tracked test file: {$path}\n");
+        exit(1);
+    }
+
+    $attributeTests = preg_match_all('/#\[Test(?:\([^\]]*\))?\]/', $contents);
+    $namedTests = preg_match_all('/\bfunction\s+test[A-Za-z0-9_]*\s*\(/', $contents);
+    $attributedNamedTests = preg_match_all(
+        '/#\[Test(?:\([^\]]*\))?\](?:(?!\bfunction\b).)*\bfunction\s+test[A-Za-z0-9_]*\s*\(/s',
+        $contents,
+    );
+    $signals['test_methods'] += $attributeTests + $namedTests - $attributedNamedTests;
+    $signals['assertion_calls'] += preg_match_all(
+        '/(?:\b(?:self|static)::|\$this->)assert[A-Z][A-Za-z0-9_]*/',
+        $contents,
+    );
+    $signals['coverage_metadata_files'] += preg_match('/#\[(?:CoversClass|CoversNothing)\b/', $contents);
+    $signals['randomness_signal_files'] += preg_match(
+        '/\b(?:random_int|random_bytes|mt_rand|array_rand|shuffle|uniqid)\s*\(/',
+        $contents,
+    );
+    $signals['sleep_signal_files'] += preg_match('/\b(?:sleep|usleep)\s*\(/', $contents);
+    $signals['conditional_skip_files'] += preg_match('/\bmarkTest(?:Skipped|Incomplete)\s*\(/', $contents);
+    $signals['small_group_files'] += preg_match('/#\[Small\b/', $contents);
+    $signals['medium_group_files'] += preg_match('/#\[Medium\b/', $contents);
+    $signals['large_group_files'] += preg_match('/#\[Large\b/', $contents);
+}
+
+$testingHelperConsumers = 0;
+foreach ($trackedFiles as $path) {
+    if (
+        !str_ends_with($path, '.php')
+        || str_starts_with($path, 'packages/testing/')
+        || !str_contains($path, '/tests/') && !str_starts_with($path, 'tests/')
+    ) {
+        continue;
+    }
+
+    $contents = file_get_contents($root . '/' . $path);
+    if ($contents !== false && str_contains($contents, 'Waaseyaa\\Testing')) {
+        ++$testingHelperConsumers;
+    }
+}
+
+$inventory = [
+    'schema_version' => 1,
+    'scope' => 'git-tracked files only',
+    'php' => [
+        'test_files' => count($phpTestFiles),
+        ...$signals,
+    ],
+    'phpunit' => [
+        'config_files' => count($phpunitConfigs),
+    ],
+    'admin' => [
+        'vitest_files' => count($vitestFiles),
+        'playwright_files' => count($playwrightFiles),
+    ],
+    'testing_package' => [
+        'consumer_test_files_outside_package' => $testingHelperConsumers,
+    ],
+];
+
+if ($format === 'json') {
+    echo json_encode($inventory, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR), "\n";
+    exit(0);
+}
+
+echo "# Test quality inventory\n\n";
+echo "Scope: Git-tracked files only. Counts are lexical signals, not quality scores.\n\n";
+echo "| Signal | Count |\n|---|---:|\n";
+echo "| PHP test files | {$inventory['php']['test_files']} |\n";
+echo "| PHP test methods | {$inventory['php']['test_methods']} |\n";
+echo "| Explicit assertion calls | {$inventory['php']['assertion_calls']} |\n";
+echo "| PHPUnit configuration files | {$inventory['phpunit']['config_files']} |\n";
+echo "| Tests with coverage metadata | {$inventory['php']['coverage_metadata_files']} |\n";
+echo "| Files with randomness signals | {$inventory['php']['randomness_signal_files']} |\n";
+echo "| Files with sleep signals | {$inventory['php']['sleep_signal_files']} |\n";
+echo "| Files with conditional skip signals | {$inventory['php']['conditional_skip_files']} |\n";
+echo "| Vitest files | {$inventory['admin']['vitest_files']} |\n";
+echo "| Playwright files | {$inventory['admin']['playwright_files']} |\n";
+echo "| External consumers of waaseyaa/testing | {$inventory['testing_package']['consumer_test_files_outside_package']} |\n";

--- a/composer.json
+++ b/composer.json
@@ -479,6 +479,7 @@
         "check-no-secrets": "bash bin/check-no-secrets",
         "check-package-layers": "php bin/check-package-layers",
         "check-symfony-imports": "php bin/check-symfony-imports",
+        "test:inventory": "php bin/test-quality-inventory --format=json",
         "hooks:install": "bash bin/project-hooks install",
         "hooks:doctor": "bash bin/project-hooks doctor",
         "cs-check": "php-cs-fixer fix --dry-run --diff",
@@ -551,7 +552,8 @@
         "dev": "Start the PHP dev server (delegates to dev:php). For the admin SPA, run `composer dev:admin` in a second terminal — see docs/specs/operations-playbooks.md.",
         "dev:admin": "Start the Nuxt admin SPA dev server. NUXT_BACKEND_URL points at the PHP server (default :8080); set APP_PORT to override.",
         "dev:php": "Start the PHP built-in dev server via bin/waaseyaa serve. Single typed long-running process with no shell forking.",
-        "verify": "Run all repo-wide gates: cs-check, phpstan, composer-policy, package-layers, no-secrets, ingestion-defaults, symfony-imports, dead-code (fail-on-new), and the test suite. Canonical CI entry point — see docs/specs/operations-playbooks.md."
+        "verify": "Run all repo-wide gates: cs-check, phpstan, composer-policy, package-layers, no-secrets, ingestion-defaults, symfony-imports, dead-code (fail-on-new), and the test suite. Canonical CI entry point — see docs/specs/operations-playbooks.md.",
+        "test:inventory": "Emit a reproducible Git-tracked-only JSON inventory of PHP, PHPUnit, Vitest, Playwright, nondeterminism, and shared-helper adoption signals."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/docs/audits/2026-08-05-test-quality-modernization.md
+++ b/docs/audits/2026-08-05-test-quality-modernization.md
@@ -1,0 +1,221 @@
+# Test quality modernization audit
+
+Date: 2026-08-05
+Program issue: #2235
+
+## Decision
+
+Waaseyaa has a broad and unusually strong test estate, but it does not yet
+measure whether that estate remains deterministic, effective, or economical.
+Keep PHPUnit, Vitest, and Playwright. Modernize them in controlled work
+packages rather than adopting a new test syntax or rewriting passing tests.
+
+The immediate priorities are:
+
+1. move PHP tests to a supported PHPUnit generation;
+2. make test inventory and configuration drift machine-readable;
+3. expose and remediate order, clock, random, sleep, and global-state coupling;
+4. replace the currently empty coverage artifact with measured coverage and a
+   changed-code ratchet;
+5. rebuild `waaseyaa/testing` around real framework contracts, then adopt it;
+6. pilot mutation testing at security and editorial boundaries;
+7. apply equivalent coverage and determinism standards to the admin SPA.
+
+Parallel execution comes after isolation work. It is not itself a quality
+signal and would make existing shared-state defects harder to diagnose.
+
+## Reproducible baseline
+
+Run:
+
+```bash
+composer test:inventory
+php bin/test-quality-inventory --format=markdown
+```
+
+The command enumerates only paths returned by the repository's guarded Git
+entrypoint. It therefore excludes vendor trees, generated worktrees, ignored
+artifacts, and local probes. Counts are lexical signals, not quality scores.
+
+Baseline on the pre-audit main revision:
+
+| Signal | Count |
+|---|---:|
+| PHP test files | 1,660 |
+| PHP test methods | 11,756 |
+| Explicit assertion calls | 27,843 |
+| PHPUnit configuration files | 20 |
+| Test files with coverage metadata | 1,473 |
+| Files with randomness signals | 189 |
+| Files with sleep signals | 7 |
+| Files with conditional skip signals | 23 |
+| Vitest files | 74 |
+| Playwright files | 17 |
+| External test consumers of `waaseyaa/testing` | 0 |
+
+The inventory is intentionally conservative. A random call can be properly
+seeded, a skip can be a valid environment guard, and a missing `CoversClass`
+can be correct for a contract or architecture test. Each signal requires
+classification before remediation.
+
+## What is already strong
+
+- The root suite separates unit, integration, architecture, contract,
+  fresh-install, packaged-form, and application-consumer evidence.
+- Release cuts require green CI on both main and the exact release commit.
+- Architecture gates cover package layering, Symfony imports, public surfaces,
+  Composer policy, stale test paths, dead code, distribution shape, generated
+  admin assets, and security-sensitive recurring regressions.
+- SQLite-backed integration tests exercise real storage and kernel seams.
+- The admin SPA has Vitest, production-build Playwright, Chromium and Firefox
+  smoke coverage, traces on retry, and artifact retention.
+- The repository generally uses PHPUnit attributes and coverage metadata.
+
+These are valuable assets. Modernization should improve their signal and
+maintenance cost, not replace them for fashion.
+
+## Findings
+
+### F1. PHPUnit 10 is outside upstream support
+
+The root and package manifests constrain PHPUnit to `^10.5`. Upstream's
+[supported versions](https://phpunit.de/supported-versions.html) page marks
+PHPUnit 10 as unsupported, while the framework already requires PHP 8.5.
+This creates avoidable security, compatibility, and maintenance debt.
+
+Remediation: upgrade in its own reversible work package. First run the suite
+under PHPUnit 13, inventory deprecations and removed APIs, update all canonical
+configurations mechanically, and prove packaged consumers. Do not combine the
+upgrade with semantic test rewrites.
+
+### F2. Coverage is configured but not produced or governed
+
+CI installs PCOV, invokes all PHP suites with `--no-coverage`, then uploads
+`build/logs/clover.xml`. The advertised Clover artifact is therefore normally
+absent. No line, branch, package, or changed-code threshold is enforced. The
+admin Vitest configuration declares V8 coverage but CI runs plain Vitest and
+sets no thresholds.
+
+Remediation: first publish honest PHP and admin coverage reports. Establish
+baselines by package and critical boundary, then add a changed-code ratchet.
+Avoid an arbitrary repository-wide 100 percent target; coverage identifies
+untested code but does not prove useful assertions.
+
+### F3. Test order and nondeterminism are not continuously challenged
+
+PHPUnit runs in its default order. There is no random-order CI lane or logged
+seed. The inventory finds 189 files with randomness signals, seven with sleep
+signals, and 23 with conditional skip signals. Known defects such as #2231
+and #2069 demonstrate real clock and static-environment coupling.
+
+Remediation: classify the signals, introduce fixed clock and seeded-random
+helpers, remove sleeps where observable synchronization is possible, and run
+a reproducible random-order lane. PHPUnit documents both
+[test ordering](https://docs.phpunit.de/en/13.0/textui.html#test-order) and
+[random order seeds](https://docs.phpunit.de/en/13.0/configuration.html#the-executionorder-attribute).
+Every CI failure must print the seed needed for local replay.
+
+### F4. Twenty PHPUnit configurations can drift independently
+
+The root, skeletons, packaged-form fixture, and 17 packages own PHPUnit XML.
+The existing path gate prevents orphaned tests, but it does not enforce a
+shared schema version or the project's required strictness, cache, color,
+coverage-source, and failure-policy attributes.
+
+Remediation: declare canonical invariants and add a mechanical conformance
+gate. Keep package-specific suite paths, extensions, and bootstrap files where
+they express real isolation. Do not copy the complete root configuration into
+every package.
+
+### F5. `waaseyaa/testing` is disconnected from the real suite
+
+No tracked test outside `packages/testing` consumes its namespace. Its README
+claims shared in-memory storage and integration bootstrap utilities that its
+public surface does not provide. `CreatesApplication` is a no-op service bag,
+`InteractsWithApi` returns request-shaped arrays instead of Symfony requests,
+`InteractsWithAuth` stores arrays instead of framework principals, and
+`RefreshDatabase` asks tests for raw PDO rather than the framework DBAL
+boundary. Blind adoption would standardize unrealistic tests.
+
+Remediation: treat the current package as an unadopted prototype. Add small,
+typed helpers only where repeated real-suite fixtures prove demand: mutable
+entity clock, immutable decision account/principal, isolated DBAL database and
+temporary directory, kernel/request builder, and MCP request/auth fixtures.
+Deprecate or repair helpers that bypass production contracts. Require at least
+three representative adopters before calling a helper canonical.
+
+### F6. Test taxonomy is mostly directory-based
+
+Only a handful of files use PHPUnit `Small`, `Medium`, or `Large` attributes.
+The suite has meaningful directories, but runtime and isolation expectations
+are not machine-readable. This blocks safe parallelization and makes slow-test
+budgets hard to enforce.
+
+Remediation: define taxonomy by behavior, not merely directory:
+
+- unit: no filesystem, network, process, sleep, or persistent database;
+- contract: one public cross-package contract, implementation-independent;
+- integration: real framework collaborators and isolated SQLite/filesystem;
+- consumer/application: skeleton or external app compatibility;
+- architecture: static repository invariant;
+- E2E: browser plus production-shaped frontend/backend boundary.
+
+Add size metadata incrementally when tests are touched or when runtime data
+identifies outliers. Do not bulk-label without measurement.
+
+### F7. Mutation effectiveness is unknown
+
+The estate counts many assertions, but no mutation tool checks whether those
+assertions detect plausible production defects. High-risk authorization,
+workflow, MCP approval, sanitization, and revision code deserves stronger
+evidence than line execution.
+
+Remediation: pilot [Infection](https://infection.github.io/guide/) on two or
+three bounded critical packages with MSI and covered-MSI reported first. Tune
+or ignore equivalent mutants with documented reasons. Set blocking thresholds
+only after two stable baseline runs.
+
+### F8. Admin test execution has policy drift
+
+The main CI uses Node 22 and both Chromium and Firefox. The path-filtered admin
+workflow uses Node 25 and Chromium only for integration, while the package
+requires Node `>=22.12.0`. Vitest coverage exists as a local script but is not
+an artifact or gate. Playwright retries can hide first-attempt flakiness unless
+retry outcomes are tracked.
+
+Remediation: choose one pinned Node major across workflows, publish Vitest
+coverage, define component/composable/adapter changed-code expectations, and
+record first-attempt failures separately from final pass/fail. Keep the dual
+browser main gate; add WebKit only if supported user or platform requirements
+justify its cost.
+
+## Delivery plan and exit measures
+
+| Work package | Exit measure |
+|---|---|
+| Inventory and config conformance | Git-aware JSON/Markdown inventory in CI; all 20 configs pass declared invariants |
+| PHPUnit upgrade | Supported major; full, packaged-form, and skeleton suites green; no unclassified deprecations |
+| Determinism | Random-order seed logged and replayable; clock/random/sleep/skip ledger classified; no known order leak |
+| Coverage | Real PHP and Vitest artifacts; package baselines; changed-code ratchet blocks regression |
+| Shared fixtures | Real-contract clock/account/DBAL/request/MCP helpers; at least three critical-package adopters each where applicable |
+| Mutation pilot | Stable MSI and covered-MSI for selected critical packages; evidence-based threshold decision |
+| Admin quality | One Node policy; Vitest coverage gate; browser retry/flake scorecard |
+| Parallelization | Enabled only for suites proven process-isolated; runtime improves without new flakes |
+
+Tracked delivery issues:
+
+- #2240 - supported PHPUnit major and configuration conformance;
+- #2241 - replayable random order and deterministic fixtures;
+- #2242 - honest PHP/admin coverage and changed-code ratchets;
+- #2243 - real-contract `waaseyaa/testing` helpers and adopters;
+- #2244 - bounded Infection mutation pilot;
+- #2245 - admin Node, Vitest, and Playwright policy alignment.
+
+## Explicit non-goals
+
+- No Pest or Behat migration without a demonstrated capability gap.
+- No mass rewrite of passing PHPUnit tests for syntax consistency.
+- No mocking framework added merely to reduce typing.
+- No repository-wide 100 percent coverage mandate.
+- No parallel runner until shared global, filesystem, port, and database state
+  is classified and controlled.

--- a/docs/specs/testing-strategy.md
+++ b/docs/specs/testing-strategy.md
@@ -5,6 +5,12 @@
 - **Fast feedback:** local pre-push hooks run quick architecture gates; CI runs the complete unit suite.
 - **Integration where contracts matter:** HTTP kernel, routing, entity storage, and multi-package flows use SQLite (`DBALDatabase::createSqlite()` or project fixtures) under `tests/Integration/` or package integration suites.
 - **No network in unit tests:** Mock HTTP, mail, and external services; reserve real I/O for explicit integration cases.
+- **Deterministic replay:** Clock, random, filesystem, database, process, port,
+  and global state are explicit test inputs. A CI failure must expose enough
+  seed and environment information to reproduce its execution order locally.
+- **Measured effectiveness:** Coverage and mutation results are evidence about
+  untested behavior, not targets to game. Changed code may not reduce the
+  established package baseline without an explicit review.
 
 ## Layers
 
@@ -15,11 +21,34 @@
 | Admin SPA | Vitest (`packages/admin`) | Plugins, composables; stub `useRuntimeConfig` / `$fetch` |
 | E2E | Playwright (`packages/admin`) | Requires Nuxt + PHP backend; run from main repo |
 
+The behavioral taxonomy is:
+
+- **Unit:** one behavior with no filesystem, network, process, sleep, or
+  persistent database dependency.
+- **Contract:** a public cross-package contract, independent of one concrete
+  implementation.
+- **Integration:** real framework collaborators with an isolated SQLite
+  database and/or temporary filesystem.
+- **Consumer/application:** skeleton, packaged-form, or external application
+  compatibility.
+- **Architecture:** a static repository or dependency invariant.
+- **E2E:** a real browser crossing the production-shaped frontend/backend
+  boundary.
+
 ## Conventions
 
 - Use `#[CoversClass]` / `#[CoversNothing]` per project rules.
 - Prefer real value objects over heavy mocks for logs and DTOs.
 - When adding packages, register `autoload-dev` PSR-4 namespaces in the **root** `composer.json` dev autoload map so CI discovers tests.
+- Prefer injected clocks and seeded generators. Do not wait for wall-clock time
+  when an observable state transition can be driven directly.
+- A helper in `waaseyaa/testing` is canonical only when it models a real
+  framework contract and has representative consumers outside that package.
+  Request-shaped arrays, raw PDO shortcuts, and identity-shaped arrays are not
+  substitutes for Symfony requests, the framework DBAL, or decision
+  principals.
+- Keep PHPUnit, Vitest, and Playwright as the canonical tools. A second test
+  syntax or mocking framework requires a demonstrated capability gap.
 
 ## CI / Hooks
 
@@ -27,3 +56,23 @@
 - **Pre-push:** the tracked project hook runs Composer policy, Symfony import, and package-layer gates sequentially. Spec drift is advisory locally and blocking in CI.
 - **Full gate:** `composer verify` is the canonical complete local gate. CI is authoritative for published revisions.
 - **Installation:** `composer hooks:install` installs small worktree-aware shims; `composer hooks:doctor` verifies them. Unknown user hooks are never overwritten.
+- **Inventory:** `composer test:inventory` reports Git-tracked-only PHP,
+  PHPUnit, Vitest, Playwright, nondeterminism, and helper-adoption signals.
+  These counts are inputs to review, not quality scores.
+
+## Modernization policy
+
+- Run a supported PHPUnit major for the repository's minimum PHP version.
+- Keep the 20 PHPUnit configurations mechanically conformant on schema and
+  required strictness while preserving package-specific suites and bootstrap
+  needs.
+- Publish real PHP and Vitest coverage artifacts before enforcing baselines;
+  never advertise an artifact produced by a `--no-coverage` run.
+- Introduce random-order execution with a logged replayable seed before
+  enabling PHP test parallelization.
+- Pilot mutation testing on bounded security/editorial packages. Blocking MSI
+  thresholds follow stable evidence; they are not guessed in advance.
+- Track first-attempt browser failures even when Playwright retry succeeds.
+
+The baseline evidence and staged exit measures live in
+`docs/audits/2026-08-05-test-quality-modernization.md`.

--- a/tests/Architecture/TestQualityInventoryTest.php
+++ b/tests/Architecture/TestQualityInventoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class TestQualityInventoryTest extends TestCase
+{
+    private string $repoRoot;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 2);
+    }
+
+    #[Test]
+    public function it_reports_a_git_aware_machine_readable_inventory(): void
+    {
+        $inventory = $this->runInventory();
+
+        self::assertSame(1, $inventory['schema_version']);
+        self::assertGreaterThan(1_000, $inventory['php']['test_files']);
+        self::assertGreaterThan(5_000, $inventory['php']['test_methods']);
+        self::assertGreaterThan(10_000, $inventory['php']['assertion_calls']);
+        self::assertSame(20, $inventory['phpunit']['config_files']);
+        self::assertGreaterThan(50, $inventory['admin']['vitest_files']);
+        self::assertGreaterThan(10, $inventory['admin']['playwright_files']);
+    }
+
+    #[Test]
+    public function it_excludes_untracked_test_shaped_files(): void
+    {
+        $before = $this->runInventory();
+        $probe = $this->repoRoot . '/tests/UntrackedInventoryProbeTest.php';
+        self::assertFileDoesNotExist($probe);
+
+        file_put_contents($probe, <<<'PHP'
+            <?php
+            final class UntrackedInventoryProbeTest
+            {
+                public function test_probe(): void {}
+            }
+            PHP);
+
+        try {
+            $after = $this->runInventory();
+        } finally {
+            unlink($probe);
+        }
+
+        self::assertSame($before, $after);
+    }
+
+    /** @return array<string, mixed> */
+    private function runInventory(): array
+    {
+        $output = [];
+        $exitCode = 0;
+        exec(
+            escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($this->repoRoot . '/bin/test-quality-inventory')
+            . ' --format=json 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        self::assertSame(0, $exitCode, implode("\n", $output));
+
+        $decoded = json_decode(implode("\n", $output), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
Part of #2235.

## Summary
- publish an evidence-backed 2026 test-quality modernization audit
- add a Git-aware JSON and Markdown inventory for PHP, PHPUnit, Vitest, Playwright, nondeterminism, and helper-adoption signals
- define behavioral test layers, deterministic replay, honest coverage, supported-tooling, mutation-pilot, and shared-helper adoption standards
- link the six bounded implementation issues #2240 through #2245

## Baseline
- 1,660 PHP test files
- 11,756 test methods
- 27,843 explicit assertions
- 20 PHPUnit configurations
- 74 Vitest files and 17 Playwright files
- zero external consumers of waaseyaa/testing

## Verification
- red-first inventory architecture test
- Architecture suite: 94 tests, 1,557 assertions
- PHPStan: 2,007 files, no errors
- coding standards: 2,254 files, clean
- composer validate --strict
- composer test:inventory
- git diff --check

spec-reviewed: docs/specs/testing-strategy.md