### PR TITLE
Upgrade the framework test stack to PHPUnit 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tools/spec-retrieval/node_modules/
 
 # PHPUnit
 .phpunit.result.cache
+.phpunit.cache/
 packages/*/.phpunit.result.cache
 packages/*/.phpunit.cache/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - **testing (#2235):** Publish the 2026 test-quality audit and a reproducible Git-tracked-only inventory for PHP, PHPUnit, Vitest, Playwright, nondeterminism, and shared-helper adoption signals. The testing doctrine now defines behavioral layers, deterministic replay, honest coverage, supported-tooling, mutation-pilot, and helper-adoption standards without prescribing a syntax rewrite.
+
+- **testing (#2240):** Upgrade the PHP 8.5 test stack to PHPUnit 13 across the root, split packages, skeleton, and packaged-form fixture; normalize all tracked PHPUnit configurations to the installed schema and isolated cache; convert the remaining docblock data providers to attributes; remove a duplicate GitHub suite that double-executed tests; and update removed mock/type APIs without weakening warning enforcement.
 
 ## [0.1.0-alpha.287] - 2026-08-05
 

--- a/composer.json
+++ b/composer.json
@@ -377,7 +377,7 @@
         "opis/json-schema": "^2.6",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "sendgrid/sendgrid": "^8.1",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "shipmonk/dead-code-detector": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83e6583818397a474cd0e4beea7947ce",
+    "content-hash": "87c00eaa90d66efbb47ca3394a2580f2",
     "packages": [
         {
             "name": "deployer/deployer",
@@ -462,20 +462,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -514,9 +513,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "psr/cache",
@@ -3187,7 +3186,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/access",
-                "reference": "9156dc5e86ed7ee10aef22db54ce465336f79d84"
+                "reference": "6818facb6e816fe2045395d37b564d125271de4c"
             },
             "require": {
                 "php": ">=8.5",
@@ -3198,7 +3197,7 @@
                 "waaseyaa/plugin": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3236,7 +3235,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/admin-surface",
-                "reference": "f2e3c8a6f1069cc49c50dae295a2243570387351"
+                "reference": "bfe2f30a004a24bf1dc6bfba0fc412a555c1ca2f"
             },
             "require": {
                 "php": ">=8.5",
@@ -3249,10 +3248,10 @@
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/config": "^0.1.0-alpha.286",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.286",
-                "waaseyaa/node": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/config": "^0.1.0-alpha.287",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.287",
+                "waaseyaa/node": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -3290,7 +3289,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-pipeline",
-                "reference": "a03ba13c3cc0bbb9e07fb104430da59d0c821741"
+                "reference": "2203065fb81723160ef93cb491360268f7a5f709"
             },
             "require": {
                 "php": ">=8.5",
@@ -3298,7 +3297,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3336,14 +3335,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-schema",
-                "reference": "b5c866ac9dc3a5fa962b5bf0f1c8074bc99a8c51"
+                "reference": "ddbd8bf2961e9b8099926c0c21bde5b840ada209"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/entity": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3376,7 +3375,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-tools",
-                "reference": "ba06d6af54bd4eb99e7f8c1d2f067ceef856d7c0"
+                "reference": "b7079b398649b828e1d68274ba845882834b108d"
             },
             "require": {
                 "php": ">=8.5",
@@ -3387,9 +3386,16 @@
                 "waaseyaa/media": "^0.1.0-alpha.287",
                 "waaseyaa/publishing": "^0.1.0-alpha.287"
             },
+            "conflict": {
+                "waaseyaa/search": "<0.1.0-alpha.287 || >=0.2.0"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/testing": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/search": "^0.1.0-alpha.287",
+                "waaseyaa/testing": "^0.1.0-alpha.287"
+            },
+            "suggest": {
+                "waaseyaa/search": "Provides principal-safe ranked CMS search tools and content resources"
             },
             "type": "library",
             "extra": {
@@ -3427,7 +3433,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-vector",
-                "reference": "b0661873e363b04524b114fdb63643bf5a0dea5b"
+                "reference": "9e804158b6cb018654c37c6184a0b439226e78b4"
             },
             "require": {
                 "php": ">=8.5",
@@ -3440,7 +3446,7 @@
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3513,7 +3519,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/api",
-                "reference": "1a879eff1407841b6061728ba67322fe44c06886"
+                "reference": "baf8f823e6e32068611a7fa113e9825d32052695"
             },
             "require": {
                 "php": ">=8.5",
@@ -3535,16 +3541,24 @@
                 "waaseyaa/scheduler": "^0.1.0-alpha.287",
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
+            "conflict": {
+                "waaseyaa/auth": "<0.1.0-alpha.287 || >=0.2.0",
+                "waaseyaa/search": "<0.1.0-alpha.287 || >=0.2.0"
+            },
             "require-dev": {
                 "opis/json-schema": "^2.6",
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/audit": "^0.1.0-alpha.286",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.286",
-                "waaseyaa/media": "^0.1.0-alpha.286",
-                "waaseyaa/telescope": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/audit": "^0.1.0-alpha.287",
+                "waaseyaa/auth": "^0.1.0-alpha.287",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.287",
+                "waaseyaa/media": "^0.1.0-alpha.287",
+                "waaseyaa/search": "^0.1.0-alpha.287",
+                "waaseyaa/telescope": "^0.1.0-alpha.287"
             },
             "suggest": {
-                "waaseyaa/oidc": "Provides optional OIDC client administration routes"
+                "waaseyaa/auth": "Provides atomic rate limiting for the optional public content search endpoint",
+                "waaseyaa/oidc": "Provides optional OIDC client administration routes",
+                "waaseyaa/search": "Provides principal-safe search for the optional public content search endpoint"
             },
             "type": "library",
             "extra": {
@@ -3582,7 +3596,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/attachment",
-                "reference": "e64717649ad89d950580c4e126a8f48ff7608c31"
+                "reference": "5e1bf48fdb9842aea2733f6586868e587aa94571"
             },
             "require": {
                 "php": "^8.5",
@@ -3594,9 +3608,9 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^13.0",
                 "symfony/event-dispatcher": "^7.0",
-                "waaseyaa/entity-storage": "^0.1.0-alpha.286"
+                "waaseyaa/entity-storage": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -3633,7 +3647,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/audit",
-                "reference": "3793b00c4defa36cc172ca0ae5e230e281c6989e"
+                "reference": "2025b40c7f2340721b9fabc030258fbd15d22873"
             },
             "require": {
                 "php": ">=8.5",
@@ -3645,8 +3659,8 @@
                 "waaseyaa/scheduler": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/entity-storage": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -3684,7 +3698,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/auth",
-                "reference": "819d92d2bd127ca5605263a48a83ad55af8e8c25"
+                "reference": "79345ecd4204b75980b894870ac2d94edfbbb9ac"
             },
             "require": {
                 "php": ">=8.5",
@@ -3696,7 +3710,7 @@
                 "waaseyaa/user": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3733,7 +3747,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/billing",
-                "reference": "3887faf5ea390728700100c5a991ceaa961d3957"
+                "reference": "801c828bd8b6244783b2405eca13783d9d77a068"
             },
             "require": {
                 "php": ">=8.5",
@@ -3741,7 +3755,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -3778,7 +3792,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/bimaaji",
-                "reference": "2870cd2ea62bdc41a0e444197842013ee3a8f33b"
+                "reference": "56b9d4c7d71fafbb286f4e51f475b91401817c9c"
             },
             "require": {
                 "nikic/php-parser": "^5.0",
@@ -3789,7 +3803,7 @@
                 "waaseyaa/routing": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "waaseyaa/cli": "Enables the graph:dump and bimaaji:install command integrations."
@@ -3830,14 +3844,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/cache",
-                "reference": "2f33ad6aa9b2e4dfebdb8b0a0cd54b9cc5389f33"
+                "reference": "cf7a6a481696bc2b9c1e6387272a905fd0dd4e32"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "waaseyaa/config": "^0.1.0-alpha.261",
@@ -3875,7 +3889,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/cli",
-                "reference": "5e6284049b147f8f7d0195ec061395dfafff3842"
+                "reference": "eb6e83305371b809c00d6263e30d3d66e13cb13f"
             },
             "require": {
                 "php": ">=8.5",
@@ -3903,7 +3917,7 @@
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-intl": "For ICU transliteration of diacritic titles to readable Latin ingest keys; a deterministic hash key is used otherwise",
@@ -3974,7 +3988,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/config",
-                "reference": "d6bbe610286a288e280b42e31396f55dda0eb6e9"
+                "reference": "50e430357826178d0e600e045afca0acfaba203c"
             },
             "require": {
                 "php": ">=8.5",
@@ -3983,7 +3997,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4021,14 +4035,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/database-legacy",
-                "reference": "3b634de02549d708120428e289e3eef09a3b6712"
+                "reference": "bf705f331d26a79678ceac59291e5d2ed87880e9"
             },
             "require": {
                 "doctrine/dbal": "^4.0",
                 "php": ">=8.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4061,7 +4075,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/debug",
-                "reference": "47d706b0ca8e86cb049b2921164c4cbb899bf0d7"
+                "reference": "b1b9c8515cd9bd0c825abcc8df09a5825fc19586"
             },
             "require": {
                 "php": ">=8.5",
@@ -4071,7 +4085,7 @@
                 "waaseyaa/routing": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4138,7 +4152,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/entity",
-                "reference": "de512ab41de308466c33b08231f849f6b8947c7a"
+                "reference": "95d42f213358034a113bc5dfe6aca5bca2125b44"
             },
             "require": {
                 "php": ">=8.5",
@@ -4156,7 +4170,7 @@
             },
             "require-dev": {
                 "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "nesbot/carbon": "Optional domain for datetime_immutable cast with domain carbon_immutable (#1183)."
@@ -4195,7 +4209,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/entity-storage",
-                "reference": "3b76f44c366e52df273e4d884c4c34e789c142c7"
+                "reference": "e314b0e1cc73531265c88f76b4bf42aabf47f7bb"
             },
             "require": {
                 "php": ">=8.5",
@@ -4210,7 +4224,7 @@
                 "waaseyaa/i18n": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4249,14 +4263,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/error-handler",
-                "reference": "39398f0c9367effe0050bfc1aa8134008b4bfc97"
+                "reference": "5b6f5b4465ea6c6e987e5ea70da59f586f8fc6a6"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4289,7 +4303,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/field",
-                "reference": "07aa2ff83dc91be3d39b638eda8a099c04bf706a"
+                "reference": "1f337cc74c0d973f4199c281464d7c71b18e468b"
             },
             "require": {
                 "php": ">=8.5",
@@ -4303,7 +4317,7 @@
                 "waaseyaa/typed-data": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4345,7 +4359,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/foundation",
-                "reference": "629df63a6b2b59f2b661f9c922e38d26dcf11ca7"
+                "reference": "271982acdcfd12e319dcad5ccfc6b5f6df643254"
             },
             "require": {
                 "doctrine/dbal": "^4.0",
@@ -4363,10 +4377,10 @@
                 "waaseyaa/queue": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/entity": "^0.1.0-alpha.286",
-                "waaseyaa/error-handler": "^0.1.0-alpha.286",
-                "waaseyaa/routing": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/entity": "^0.1.0-alpha.287",
+                "waaseyaa/error-handler": "^0.1.0-alpha.287",
+                "waaseyaa/routing": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -4408,7 +4422,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/frankenphp",
-                "reference": "6a8d114515eb23b4d1a6586475a51a4a426708c4"
+                "reference": "0589fb3fe08d4feb5defc773ab50ebddbb66ac57"
             },
             "require": {
                 "ext-json": "*",
@@ -4417,7 +4431,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4455,14 +4469,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/geo",
-                "reference": "0022b6e182ecfb25c9f8842d487df453f340df6d"
+                "reference": "c70b8b9426ed1ad710a92a4173672b219ed0bd28"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4530,7 +4544,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/graphql",
-                "reference": "e4562f52459db28e95a288237be5986e16422b4d"
+                "reference": "672e25bff7b0b1c7e37a4b2d8509d517145cfd4c"
             },
             "require": {
                 "php": ">=8.5",
@@ -4544,7 +4558,7 @@
                 "webonyx/graphql-php": "^15.31.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4583,7 +4597,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/groups",
-                "reference": "6d42603a17a8e448abe0200b5df635d48ff2f8cd"
+                "reference": "fec742a9db3cf2eec53f5ff014a3e60716092bfc"
             },
             "require": {
                 "php": ">=8.5",
@@ -4596,8 +4610,8 @@
                 "waaseyaa/relationship": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/user": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/user": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -4645,13 +4659,13 @@
             "dist": {
                 "type": "path",
                 "url": "packages/http-client",
-                "reference": "a810922f90e52d5a18dc3db1d66c546f181268c3"
+                "reference": "5865db54d1b9d14277465ca7d26d362260db8e88"
             },
             "require": {
                 "php": ">=8.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4684,14 +4698,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/i18n",
-                "reference": "2819ba4f59d06c82f3df88bfb41602c9a9b0330d"
+                "reference": "18b55f45be53fb6250f69382e6e1cb9846dabd7b"
             },
             "require": {
                 "php": ">=8.5",
                 "twig/twig": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4724,7 +4738,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/inertia",
-                "reference": "0737fa78bd9fcfc00b570e8d3ec1f5b68ccef9d3"
+                "reference": "6e6102cdf14756344eb4e3f4fd07d6ea38c0591d"
             },
             "require": {
                 "php": ">=8.5",
@@ -4732,7 +4746,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4769,13 +4783,13 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ingestion",
-                "reference": "de022132fae6f0125aa67f6ceabb567166313d6f"
+                "reference": "87993306f8d354893b0b96991beeee16ab06d754"
             },
             "require": {
                 "php": ">=8.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4807,7 +4821,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/listing",
-                "reference": "1013684cfb51626ab0465bcd9c8de5763b3b2c2c"
+                "reference": "c3fa6fa1ae2f6736f109537e01ed7e6d52b654ff"
             },
             "require": {
                 "php": ">=8.5",
@@ -4820,7 +4834,7 @@
                 "waaseyaa/typed-data": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -4858,14 +4872,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/mail",
-                "reference": "cd091a78785e30b5491cdaf3264a535210f72ec6"
+                "reference": "605d5e9cf269df19f44c74e8ad79e3955e8e4f15"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^13.0",
                 "twig/twig": "^3.0"
             },
             "suggest": {
@@ -4908,7 +4922,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/media",
-                "reference": "fe986e41dc739be6a9c2c0e546336210bf7a0bdc"
+                "reference": "e48f3b9810f4a75331752ce9f8c27ec3e3812a22"
             },
             "require": {
                 "php": ">=8.5",
@@ -4920,10 +4934,10 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/access": "^0.1.0-alpha.286",
-                "waaseyaa/api": "^0.1.0-alpha.286",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/access": "^0.1.0-alpha.287",
+                "waaseyaa/api": "^0.1.0-alpha.287",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -4965,7 +4979,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/menu",
-                "reference": "6a6ee971ea2ab0d927bfed22ee2ef1310a25de6a"
+                "reference": "ae3b6c38eea8cd50bb275fdd606c9d71ebcacb19"
             },
             "require": {
                 "php": ">=8.5",
@@ -4974,7 +4988,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5015,14 +5029,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/mercure",
-                "reference": "4141e0db09e89a8409107fc531a6d4b853ef1b2a"
+                "reference": "d8ce68f54915929c9ea9ddb78060477c5091d8cc"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5059,7 +5073,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/migration",
-                "reference": "e1dc6dfb755978418cb8eb61b855462ed0d2df65"
+                "reference": "dbcf79ca53b5b2d15899cf29e6b197a1ba8a776f"
             },
             "require": {
                 "php": ">=8.5",
@@ -5074,7 +5088,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^13.0",
                 "symfony/event-dispatcher": "^7.0"
             },
             "type": "library",
@@ -5116,7 +5130,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/node",
-                "reference": "3b89223f09b418d01873c10d5a3698ef0c143231"
+                "reference": "08a66d3041c2b6f009aba8e787a09238aecab314"
             },
             "require": {
                 "php": ">=8.5",
@@ -5128,7 +5142,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5170,7 +5184,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/note",
-                "reference": "8045437d6111ea8df0f597845eb110f156716dcd"
+                "reference": "5dfbe370ed5031b7c0c167ca59c0c06dfcba749a"
             },
             "require": {
                 "php": ">=8.5",
@@ -5179,7 +5193,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5220,7 +5234,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/notification",
-                "reference": "6f150e96b3edd5cdc1510c61e3afee650eb02bfa"
+                "reference": "2b66d26df91ef2dbfb3a7dc9c10af39087a9c7c0"
             },
             "require": {
                 "php": ">=8.5",
@@ -5230,7 +5244,7 @@
                 "waaseyaa/queue": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5268,14 +5282,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/oauth-provider",
-                "reference": "f49bd2f9d5f48f534ee353721a0b1f47ebef7ba5"
+                "reference": "c97b154dfd0ebe3ec462d86eda56c939258b2be0"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/http-client": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5307,7 +5321,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/path",
-                "reference": "ac5b9e31025240a3f69c3f0adabbe6290e090c53"
+                "reference": "b5435be00bb6f722991ac3e6729223a96e17cebf"
             },
             "require": {
                 "php": ">=8.5",
@@ -5317,7 +5331,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5358,14 +5372,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/plugin",
-                "reference": "769b655370a53b19725f5e4015bbca85788c652f"
+                "reference": "0efdb62781b63e35b96e17a4ce82fc1b4f2a01c5"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/cache": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5398,7 +5412,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/publishing",
-                "reference": "cba6c8514cb724775ddc3b669533dff5f2c363d9"
+                "reference": "45a3faad144690b36fd377a408f8c621d783141b"
             },
             "require": {
                 "php": ">=8.5",
@@ -5410,7 +5424,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^13.0",
                 "symfony/html-sanitizer": "^8.0"
             },
             "type": "library",
@@ -5444,7 +5458,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/queue",
-                "reference": "8dd210df77c449d4bd0c3e6ecf66d28b664c45c8"
+                "reference": "cae8b0392d1f9998d240232fa1357e0f94c7af9d"
             },
             "require": {
                 "php": ">=8.5",
@@ -5453,8 +5467,8 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/entity": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/entity": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -5493,7 +5507,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/relationship",
-                "reference": "dbba9d19de1db9545e92c2be4d245b34e18bfe15"
+                "reference": "2bf4ac553d3400052cda75b0e4ef8e3dca0687fb"
             },
             "require": {
                 "php": ">=8.5",
@@ -5542,7 +5556,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/routing",
-                "reference": "b0c9f442a02212c8b4913e8fb19b97d291b68fb9"
+                "reference": "348f4cd72ab3ae1f6018ccf64ae3b3b15c5f077b"
             },
             "require": {
                 "php": ">=8.5",
@@ -5555,7 +5569,7 @@
                 "waaseyaa/user": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "waaseyaa/oidc": "Provides optional OpenID Connect issuer routes"
@@ -5596,7 +5610,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/scheduler",
-                "reference": "b9187103d67f6a82296fe375ae6ff5e2e34036ae"
+                "reference": "5e4089df112f58a3a9b00029e96eb10553b65e51"
             },
             "require": {
                 "dragonmantank/cron-expression": "^3.0",
@@ -5606,7 +5620,7 @@
                 "waaseyaa/queue": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5644,7 +5658,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/search",
-                "reference": "f5ba2ad9ae7978cc9f902c24b317c31b80298804"
+                "reference": "f83835078c602918c1b4aff95841b62610d065b8"
             },
             "require": {
                 "php": ">=8.5",
@@ -5657,7 +5671,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5695,7 +5709,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/seo",
-                "reference": "7573d57b9dd9a012e831fb96aae161a3cae23fc8"
+                "reference": "d7baa42d265b6c2785cb1c2ca7b356e3fa6120b7"
             },
             "require": {
                 "php": ">=8.5",
@@ -5705,7 +5719,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5743,7 +5757,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ssr",
-                "reference": "12f14941ab6f92720ee818ceccbad6f714036407"
+                "reference": "5803fe8b7f57d86b393ff53277058c207aaf169b"
             },
             "require": {
                 "php": ">=8.5",
@@ -5766,7 +5780,7 @@
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5805,14 +5819,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/state",
-                "reference": "387196a33f1a4a17bf44873cb5af999c5a544d93"
+                "reference": "c14c1d9605d9eccec842079ebb4b8db6b8ece51d"
             },
             "require": {
                 "php": ">=8.5",
                 "waaseyaa/database-legacy": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5845,7 +5859,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/structured-import",
-                "reference": "36bc6d62664ef2d8cabd869cab66383c12b48ca8"
+                "reference": "4d7f276334214eb921d425bb58d255fad2264dd1"
             },
             "require": {
                 "php": "^8.5",
@@ -5854,7 +5868,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5888,7 +5902,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/taxonomy",
-                "reference": "2e347d917dfe3e228ffd3d8968cee21c32e0a48a"
+                "reference": "7d481b3dac7be9f981787e45bd48860039fd3472"
             },
             "require": {
                 "php": ">=8.5",
@@ -5899,7 +5913,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -5968,14 +5982,14 @@
             "dist": {
                 "type": "path",
                 "url": "packages/typed-data",
-                "reference": "4543218f2fbed39e95753b4e3bb952db838a37a5"
+                "reference": "dc7a5274241df0951bf61938bd8f2065befb4ea6"
             },
             "require": {
                 "php": ">=8.5",
                 "symfony/validator": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -6008,7 +6022,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/user",
-                "reference": "b7843d075344c98597baeaea8a8adc1bba498c59"
+                "reference": "667d91b58b03a0ef6f2fc03b2692a93d84386731"
             },
             "require": {
                 "php": ">=8.5",
@@ -6020,7 +6034,7 @@
                 "waaseyaa/mail": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -6062,7 +6076,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/validation",
-                "reference": "45f1067c0578a5ce713427fb1d0e264b30245eb1"
+                "reference": "8c8188db0dc9f2a3e3d760ca9e9dd234e37d2010"
             },
             "require": {
                 "php": ">=8.5",
@@ -6070,7 +6084,7 @@
                 "waaseyaa/typed-data": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -6103,7 +6117,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/workflows",
-                "reference": "770c9801b6a6f3daa669e58f5be2e8866257b8a8"
+                "reference": "6ed943a87039be71486505baa6b994f5126097bc"
             },
             "require": {
                 "php": ">=8.5",
@@ -6119,9 +6133,9 @@
                 "waaseyaa/relationship": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.286",
-                "waaseyaa/node": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.287",
+                "waaseyaa/node": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -7863,35 +7877,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "14.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "ext-mbstring": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/git-state": "^1.0",
+                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/version": "^7.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^13.2.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -7900,7 +7914,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -7929,40 +7943,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2026-07-30T17:01:07+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -7990,36 +8016,48 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2026-02-06T04:33:26+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -8027,7 +8065,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -8053,40 +8091,53 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2026-02-06T04:34:47+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -8113,40 +8164,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2026-02-06T04:36:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -8172,28 +8235,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2026-02-06T04:37:53+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.63",
+            "version": "13.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
+                "reference": "cdd419c33c040c6b570e51dba8ecbe81d399da53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
-                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cdd419c33c040c6b570e51dba8ecbe81d399da53",
+                "reference": "cdd419c33c040c6b570e51dba8ecbe81d399da53",
                 "shasum": ""
             },
             "require": {
@@ -8206,26 +8282,24 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.5",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.4",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.1",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
+                "php": ">=8.4.1",
+                "phpunit/php-code-coverage": "^14.1.10",
+                "phpunit/php-file-iterator": "^7.0.0",
+                "phpunit/php-invoker": "^7.0.0",
+                "phpunit/php-text-template": "^6.0.0",
+                "phpunit/php-timer": "^9.0.0",
+                "sebastian/cli-parser": "^5.0.0",
+                "sebastian/comparator": "^8.2.1",
+                "sebastian/diff": "^8.3.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.0",
+                "sebastian/git-state": "^1.0",
+                "sebastian/global-state": "^9.0.1",
+                "sebastian/object-enumerator": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/type": "^7.0.1",
+                "sebastian/version": "^7.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "bin": [
                 "phpunit"
@@ -8233,7 +8307,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "13.1-dev"
                 }
             },
             "autoload": {
@@ -8265,31 +8339,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.14"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:48:37+00:00"
+            "time": "2026-06-04T06:16:42+00:00"
         },
         {
             "name": "psr/http-server-handler",
@@ -8932,28 +8990,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -8977,155 +9035,59 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-03-02T07:12:49+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:58:43+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2026-08-01T04:27:14+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.5",
+            "version": "8.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+                "reference": "ce999bf08b2c387a5423fe56961c32eed3f88089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ce999bf08b2c387a5423fe56961c32eed3f88089",
+                "reference": "ce999bf08b2c387a5423fe56961c32eed3f88089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.4",
+                "sebastian/diff": "^8.3",
+                "sebastian/exporter": "^8.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.1.10"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "8.2-dev"
                 }
             },
             "autoload": {
@@ -9165,7 +9127,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.2.1"
             },
             "funding": [
                 {
@@ -9185,33 +9147,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:25:16+00:00"
+            "time": "2026-05-21T04:46:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -9235,41 +9197,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2026-02-06T04:41:32+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^13.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -9302,35 +9276,47 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2026-05-15T04:58:09+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "9.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.1.11"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -9338,7 +9324,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "9.3-dev"
                 }
             },
             "autoload": {
@@ -9366,42 +9352,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2026-05-25T13:41:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.4",
+            "version": "8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -9444,7 +9442,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
             },
             "funding": [
                 {
@@ -9464,35 +9462,104 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:09:11+00:00"
+            "time": "2026-07-13T11:35:11+00:00"
         },
         {
-            "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "name": "sebastian/git-state",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "url": "https://github.com/sebastianbergmann/git-state.git",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for describing the state of a Git checkout",
+            "homepage": "https://github.com/sebastianbergmann/git-state",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/git-state/issues",
+                "security": "https://github.com/sebastianbergmann/git-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/git-state/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/git-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T12:54:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^13.1.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -9518,41 +9585,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2026-06-01T15:11:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -9576,42 +9655,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2026-07-09T08:42:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -9633,40 +9724,53 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2026-02-06T04:46:36+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -9688,40 +9792,53 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2026-02-06T04:47:13+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.1",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -9752,7 +9869,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.1"
             },
             "funding": [
                 {
@@ -9772,32 +9889,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:50:56+00:00"
+            "time": "2026-08-03T05:58:12+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -9820,37 +9937,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2026-05-20T06:49:11+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -9873,15 +10003,28 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2026-02-06T04:52:52+00:00"
         },
         {
             "name": "sendgrid/php-http-client",
@@ -10163,6 +10306,58 @@
                 "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/1.1.1"
             },
             "time": "2026-05-04T14:15:08+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "starkbank/ecdsa",
@@ -10886,23 +11081,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -10924,7 +11119,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -10932,7 +11127,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
@@ -10940,7 +11135,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-agent",
-                "reference": "9bad961aa73b563884bfbbac5dd8c140b5ad466b"
+                "reference": "f00eb21425bee09be19556229c75ebb58b92fc39"
             },
             "require": {
                 "php": ">=8.5",
@@ -10961,7 +11156,7 @@
                 "waaseyaa/routing": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "waaseyaa/wayfinding": "Provides optional trail tools for AI agents"
@@ -11010,7 +11205,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/ai-observability",
-                "reference": "b45aaf29dabb9601e4b83b644d4bfdecb6bea667"
+                "reference": "b31460c0abe24dfafbaf33558fd4b197754cc601"
             },
             "require": {
                 "php": ">=8.5",
@@ -11021,8 +11216,8 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/access": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/access": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -11061,7 +11256,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/engagement",
-                "reference": "ff7a068b8dd6f18cf2a18ecc5b859617af1f3e7c"
+                "reference": "5cd672564848391318900c93089540c2374b3ad4"
             },
             "require": {
                 "php": ">=8.5",
@@ -11070,7 +11265,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -11110,7 +11305,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/genealogy",
-                "reference": "97eb4acca2609ceafd44d0af1f7918550ea9397f"
+                "reference": "5de72e90343d040a2b777c1325d56b9efd5e6c9f"
             },
             "require": {
                 "php": ">=8.5",
@@ -11126,10 +11321,10 @@
                 "waaseyaa/workflows": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/api": "^0.1.0-alpha.286",
-                "waaseyaa/database-legacy": "^0.1.0-alpha.286",
-                "waaseyaa/entity-storage": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/api": "^0.1.0-alpha.287",
+                "waaseyaa/database-legacy": "^0.1.0-alpha.287",
+                "waaseyaa/entity-storage": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -11176,7 +11371,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/mcp",
-                "reference": "ac4032d5806d56125e6b048fd1123658642233f3"
+                "reference": "b1ee785206743993786fbba9f1174dc5c4fe49c6"
             },
             "require": {
                 "composer-runtime-api": "^2.2",
@@ -11192,8 +11387,8 @@
                 "waaseyaa/user": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5",
-                "waaseyaa/audit": "^0.1.0-alpha.286"
+                "phpunit/phpunit": "^13.0",
+                "waaseyaa/audit": "^0.1.0-alpha.287"
             },
             "type": "library",
             "extra": {
@@ -11231,7 +11426,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/messaging",
-                "reference": "efcb92a4bfbc1761920938d6716a6c9fbbe357de"
+                "reference": "e4787b529655844844465374e85f9c13de7e020e"
             },
             "require": {
                 "php": ">=8.5",
@@ -11241,7 +11436,7 @@
                 "waaseyaa/foundation": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -11281,7 +11476,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/oidc",
-                "reference": "c2ff04a36904b2805205f59d3ac2b0225c8a7a90"
+                "reference": "111960c99bf4f1e62314cf26b04faacfd2a0e68d"
             },
             "require": {
                 "ext-sodium": "*",
@@ -11296,7 +11491,7 @@
                 "waaseyaa/user": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -11337,7 +11532,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/testing",
-                "reference": "7f98305d5860cb68e9ee518a12ddeb3cc96d0410"
+                "reference": "6c110252bf87a8f05359533628baeb53f31049de"
             },
             "require": {
                 "php": ">=8.5",
@@ -11346,7 +11541,7 @@
                 "waaseyaa/field": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "fakerphp/faker": "Optional realistic strings and emails for EntityTypeFixtureValues (framework#1186)."
@@ -11382,7 +11577,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/wayfinding",
-                "reference": "02725e203ddb08d7b2f25eb7bb5031f9a60371b5"
+                "reference": "cd19c2d4199de851cab0846c4bd68379bee405d8"
             },
             "require": {
                 "php": ">=8.5",
@@ -11394,7 +11589,7 @@
                 "waaseyaa/routing": "^0.1.0-alpha.287"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
@@ -11432,7 +11627,77 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "waaseyaa/access": 20,
+        "waaseyaa/admin-surface": 20,
+        "waaseyaa/ai-agent": 20,
+        "waaseyaa/ai-observability": 20,
+        "waaseyaa/ai-pipeline": 20,
+        "waaseyaa/ai-schema": 20,
+        "waaseyaa/ai-tools": 20,
+        "waaseyaa/ai-vector": 20,
+        "waaseyaa/analytics": 20,
+        "waaseyaa/api": 20,
+        "waaseyaa/attachment": 20,
+        "waaseyaa/auth": 20,
+        "waaseyaa/billing": 20,
+        "waaseyaa/bimaaji": 20,
+        "waaseyaa/cache": 20,
+        "waaseyaa/cli": 20,
+        "waaseyaa/config": 20,
+        "waaseyaa/database-legacy": 20,
+        "waaseyaa/debug": 20,
+        "waaseyaa/deployer": 20,
+        "waaseyaa/engagement": 20,
+        "waaseyaa/entity": 20,
+        "waaseyaa/entity-storage": 20,
+        "waaseyaa/error-handler": 20,
+        "waaseyaa/field": 20,
+        "waaseyaa/foundation": 20,
+        "waaseyaa/frankenphp": 20,
+        "waaseyaa/genealogy": 20,
+        "waaseyaa/geo": 20,
+        "waaseyaa/github": 20,
+        "waaseyaa/graphql": 20,
+        "waaseyaa/groups": 20,
+        "waaseyaa/http-client": 20,
+        "waaseyaa/i18n": 20,
+        "waaseyaa/inertia": 20,
+        "waaseyaa/ingestion": 20,
+        "waaseyaa/listing": 20,
+        "waaseyaa/mail": 20,
+        "waaseyaa/mcp": 20,
+        "waaseyaa/media": 20,
+        "waaseyaa/menu": 20,
+        "waaseyaa/mercure": 20,
+        "waaseyaa/messaging": 20,
+        "waaseyaa/migration": 20,
+        "waaseyaa/node": 20,
+        "waaseyaa/note": 20,
+        "waaseyaa/notification": 20,
+        "waaseyaa/oauth-provider": 20,
+        "waaseyaa/oidc": 20,
+        "waaseyaa/path": 20,
+        "waaseyaa/plugin": 20,
+        "waaseyaa/publishing": 20,
+        "waaseyaa/queue": 20,
+        "waaseyaa/relationship": 20,
+        "waaseyaa/routing": 20,
+        "waaseyaa/scheduler": 20,
+        "waaseyaa/search": 20,
+        "waaseyaa/seo": 20,
+        "waaseyaa/ssr": 20,
+        "waaseyaa/state": 20,
+        "waaseyaa/structured-import": 20,
+        "waaseyaa/taxonomy": 20,
+        "waaseyaa/telescope": 20,
+        "waaseyaa/testing": 20,
+        "waaseyaa/typed-data": 20,
+        "waaseyaa/user": 20,
+        "waaseyaa/validation": 20,
+        "waaseyaa/wayfinding": 20,
+        "waaseyaa/workflows": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/docs/extension-authoring/migration-source-readers.md
+++ b/docs/extension-authoring/migration-source-readers.md
@@ -51,7 +51,7 @@ waaseyaa-migrate-source-xml/
         "waaseyaa/migration": "^0.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/packagist/package-inventory.json
+++ b/docs/packagist/package-inventory.json
@@ -17,7 +17,7 @@
       "symfony/http-foundation": "^7.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -44,7 +44,7 @@
       "waaseyaa/access": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/ai-schema": "@dev",
@@ -70,7 +70,7 @@
       "waaseyaa/ai-vector": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -95,7 +95,7 @@
       "waaseyaa/entity": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev"
@@ -122,7 +122,7 @@
       "waaseyaa/workflows": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -152,7 +152,7 @@
       "waaseyaa/access": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -179,7 +179,7 @@
       "psr/simple-cache": "^3.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 11,
@@ -205,7 +205,7 @@
       "symfony/console": "^7.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -257,7 +257,7 @@
       "symfony/yaml": "^7.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 11,
@@ -310,7 +310,7 @@
       "php": ">=8.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 10,
@@ -339,7 +339,7 @@
       "symfony/validator": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/typed-data": "@dev",
@@ -371,7 +371,7 @@
       "symfony/event-dispatcher": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -399,7 +399,7 @@
       "waaseyaa/typed-data": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -430,7 +430,7 @@
       "waaseyaa/queue": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/queue": "@dev"
@@ -478,7 +478,7 @@
       "waaseyaa/access": "^0.1"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 4,
@@ -498,7 +498,7 @@
       "php": ">=8.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 4,
@@ -519,7 +519,7 @@
       "waaseyaa/foundation": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5",
+      "phpunit/phpunit": "^13.0",
       "twig/twig": "^3.0"
     },
     "dev_constraints": {
@@ -551,7 +551,7 @@
       "waaseyaa/workflows": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/ai-schema": "@dev",
@@ -582,7 +582,7 @@
       "waaseyaa/entity": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev"
@@ -605,7 +605,7 @@
       "waaseyaa/entity": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev"
@@ -629,7 +629,7 @@
       "waaseyaa/access": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -654,7 +654,7 @@
       "waaseyaa/access": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -678,7 +678,7 @@
       "waaseyaa/entity": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev"
@@ -701,7 +701,7 @@
       "waaseyaa/cache": "*"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 10,
@@ -722,7 +722,7 @@
       "symfony/messenger": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 9,
@@ -773,7 +773,7 @@
       "symfony/routing": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -798,7 +798,7 @@
       "twig/twig": "^3.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 5,
@@ -825,7 +825,7 @@
       "twig/twig": "^3.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/access": "@dev",
@@ -853,7 +853,7 @@
       "waaseyaa/database-legacy": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/database-legacy": "@dev"
@@ -877,7 +877,7 @@
       "waaseyaa/access": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -900,7 +900,7 @@
       "php": ">=8.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 6,
@@ -918,7 +918,7 @@
     ],
     "require": {
       "php": ">=8.3",
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "require_dev": {},
     "dev_constraints": {},
@@ -940,7 +940,7 @@
       "symfony/validator": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {},
     "commit_count": 10,
@@ -964,7 +964,7 @@
       "symfony/http-foundation": "^7.0"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/entity": "@dev",
@@ -990,7 +990,7 @@
       "symfony/validator": "^7.3"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/typed-data": "@dev"
@@ -1014,7 +1014,7 @@
       "waaseyaa/entity": "@dev"
     },
     "require_dev": {
-      "phpunit/phpunit": "^10.5"
+      "phpunit/phpunit": "^13.0"
     },
     "dev_constraints": {
       "waaseyaa/access": "@dev",

--- a/docs/specs/per-site-convergence-audit.md
+++ b/docs/specs/per-site-convergence-audit.md
@@ -97,7 +97,7 @@ Compare the app’s layout and Composer metadata to the skeleton. Deviations are
 | Check | Pass |
 |-------|------|
 | `autoload` / `autoload-dev` | PSR-4 roots present and match `src/` and `tests/` (or documented alternate) |
-| `require-dev` | PHPUnit **10.5+** (skeleton allows `^10.5 \|\| ^11.0`). **PHPStan** is recommended for mature apps; minimal skeleton does not require it — if the app runs static analysis in CI, align `phpstan/phpstan` (or org standard) with lockfile |
+| `require-dev` | PHPUnit **13.x** on PHP 8.5. **PHPStan** is recommended for mature apps; minimal skeleton does not require it — if the app runs static analysis in CI, align `phpstan/phpstan` (or org standard) with lockfile |
 | `scripts` | Includes skeleton-equivalent `post-create-project-cmd` where the app is created from skeleton (chmod bins + post-create setup); existing apps may chmod in docs/CI |
 | `extra.waaseyaa.providers` | **If** the app registers a custom `App\*` (or branded-namespace) service provider, it appears under `extra.waaseyaa.providers` |
 | `config.optimize-autoloader` | `true` |

--- a/docs/specs/testing-strategy.md
+++ b/docs/specs/testing-strategy.md
@@ -16,7 +16,7 @@
 
 | Layer | Tooling | Scope |
 |-------|---------|--------|
-| Unit | PHPUnit 10.5, `#[Test]` attributes | Single class, deterministic collaborators |
+| Unit | PHPUnit 13, native attributes | Single class, deterministic collaborators |
 | Integration | PHPUnit, in-memory SQLite | Kernel boot, migrations, route dispatch smoke |
 | Admin SPA | Vitest (`packages/admin`) | Plugins, composables; stub `useRuntimeConfig` / `$fetch` |
 | E2E | Playwright (`packages/admin`) | Requires Nuxt + PHP backend; run from main repo |
@@ -37,7 +37,9 @@ The behavioral taxonomy is:
 
 ## Conventions
 
-- Use `#[CoversClass]` / `#[CoversNothing]` per project rules.
+- Use PHPUnit attributes for test and coverage metadata. Docblock metadata is unsupported.
+- Use stubs for collaborators whose calls are not asserted; reserve mocks for explicit interaction expectations.
+- Use `#[CoversClass]` or `#[CoversNothing]`, never both on the same test class.
 - Prefer real value objects over heavy mocks for logs and DTOs.
 - When adding packages, register `autoload-dev` PSR-4 namespaces in the **root** `composer.json` dev autoload map so CI discovers tests.
 - Prefer injected clocks and seeded generators. Do not wait for wall-clock time

--- a/packages/access/composer.json
+++ b/packages/access/composer.json
@@ -26,7 +26,7 @@
         "symfony/routing": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/access/tests/Unit/AccessResultTest.php
+++ b/packages/access/tests/Unit/AccessResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Access\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Waaseyaa\Access\AccessResult;
 use Waaseyaa\Access\AccessStatus;
 use PHPUnit\Framework\TestCase;
@@ -75,9 +76,7 @@ class AccessResultTest extends TestCase
     // andIf combinations
     // ---------------------------------------------------------------
 
-    /**
-     * @dataProvider andIfProvider
-     */
+    #[DataProvider('andIfProvider')]
     public function testAndIf(AccessResult $a, AccessResult $b, AccessStatus $expected): void
     {
         $combined = $a->andIf($b);
@@ -178,9 +177,7 @@ class AccessResultTest extends TestCase
     // orIf combinations
     // ---------------------------------------------------------------
 
-    /**
-     * @dataProvider orIfProvider
-     */
+    #[DataProvider('orIfProvider')]
     public function testOrIf(AccessResult $a, AccessResult $b, AccessStatus $expected): void
     {
         $combined = $a->orIf($b);

--- a/packages/admin-surface/composer.json
+++ b/packages/admin-surface/composer.json
@@ -52,7 +52,7 @@
         "waaseyaa/workflows": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/config": "^0.1.0-alpha.287",
         "waaseyaa/database-legacy": "^0.1.0-alpha.287",
         "waaseyaa/node": "^0.1.0-alpha.287"

--- a/packages/ai-agent/composer.json
+++ b/packages/ai-agent/composer.json
@@ -79,7 +79,7 @@
         "waaseyaa/wayfinding": "Provides optional trail tools for AI agents"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/ai-observability/composer.json
+++ b/packages/ai-observability/composer.json
@@ -20,7 +20,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/access": "^0.1.0-alpha.287"
     },
     "autoload": {

--- a/packages/ai-pipeline/composer.json
+++ b/packages/ai-pipeline/composer.json
@@ -19,7 +19,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/ai-schema/composer.json
+++ b/packages/ai-schema/composer.json
@@ -8,7 +8,7 @@
         "waaseyaa/entity": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/ai-tools/composer.json
+++ b/packages/ai-tools/composer.json
@@ -19,7 +19,7 @@
         "waaseyaa/search": "<0.1.0-alpha.287 || >=0.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/search": "^0.1.0-alpha.287",
         "waaseyaa/testing": "^0.1.0-alpha.287"
     },

--- a/packages/ai-vector/composer.json
+++ b/packages/ai-vector/composer.json
@@ -44,7 +44,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -112,7 +112,7 @@
     },
     "require-dev": {
         "opis/json-schema": "^2.6",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/auth": "^0.1.0-alpha.287",
         "waaseyaa/audit": "^0.1.0-alpha.287",
         "waaseyaa/database-legacy": "^0.1.0-alpha.287",

--- a/packages/attachment/composer.json
+++ b/packages/attachment/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "symfony/event-dispatcher": "^7.0",
         "waaseyaa/entity-storage": "^0.1.0-alpha.287"
     },

--- a/packages/attachment/phpunit.xml
+++ b/packages/attachment/phpunit.xml
@@ -2,7 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         colors="true">
+         colors="true"
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>

--- a/packages/attachment/tests/Integration/ParentDelegatedAccessTest.php
+++ b/packages/attachment/tests/Integration/ParentDelegatedAccessTest.php
@@ -222,9 +222,11 @@ final class ParentDelegatedAccessTest extends TestCase
     private function buildEntityTypeManager(string $entityTypeId, EntityStorageInterface $storage): EntityTypeManagerInterface
     {
         $manager = $this->createStub(EntityTypeManagerInterface::class);
-        $manager->method('getStorage')->with($entityTypeId)->willReturn($storage);
+        $manager->method('getStorage')->willReturnMap([[$entityTypeId, $storage]]);
         // C-22 WP3: read path now goes through the canonical repository.
-        $manager->method('getRepository')->with($entityTypeId)->willReturn(new StorageBackedStubRepository($storage));
+        $manager->method('getRepository')->willReturnMap([
+            [$entityTypeId, new StorageBackedStubRepository($storage)],
+        ]);
 
         return $manager;
     }

--- a/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
+++ b/packages/attachment/tests/Integration/SetActiveConcurrencyTest.php
@@ -35,7 +35,6 @@ use Waaseyaa\EntityStorage\EntityRepository;
  *
  * See: research.md Q6 (setActive atomicity rationale), NFR-010.
  *
- * @requires extension pcntl
  */
 #[CoversNothing]
 #[RequiresPhpExtension('pcntl')]

--- a/packages/attachment/tests/Unit/Policy/ParentDelegatedAccessPolicyTest.php
+++ b/packages/attachment/tests/Unit/Policy/ParentDelegatedAccessPolicyTest.php
@@ -128,13 +128,14 @@ final class ParentDelegatedAccessPolicyTest extends TestCase
         ]);
 
         $storage = $this->createStub(EntityStorageInterface::class);
-        $storage->method('load')->with('999')->willReturn(null);
+        $storage->method('load')->willReturnMap([['999', null]]);
 
         $this->entityTypeManager
             ->method('getStorage')
-            ->with('node')
-            ->willReturn($storage);
-        $this->entityTypeManager->method('getRepository')->with('node')->willReturn(new StorageBackedStubRepository($storage));
+            ->willReturnMap([['node', $storage]]);
+        $this->entityTypeManager->method('getRepository')->willReturnMap([
+            ['node', new StorageBackedStubRepository($storage)],
+        ]);
 
         $result = $this->policy->access($attachment, 'view', $this->account);
 
@@ -153,14 +154,20 @@ final class ParentDelegatedAccessPolicyTest extends TestCase
         ]);
 
         $storage = $this->createStub(EntityStorageInterface::class);
-        $storage->method('load')->with('1')->willReturn($parentEntity);
-        $this->entityTypeManager->method('getStorage')->with('node')->willReturn($storage);
-        $this->entityTypeManager->method('getRepository')->with('node')->willReturn(new StorageBackedStubRepository($storage));
+        $storage->method('load')->willReturnMap([['1', $parentEntity]]);
+        $this->entityTypeManager->method('getStorage')->willReturnMap([['node', $storage]]);
+        $this->entityTypeManager->method('getRepository')->willReturnMap([
+            ['node', new StorageBackedStubRepository($storage)],
+        ]);
 
         $this->accessHandler
             ->method('check')
-            ->with($parentEntity, 'view', $this->account)
-            ->willReturn(AccessResult::allowed('parent allows view'));
+            ->willReturnMap([[
+                $parentEntity,
+                'view',
+                $this->account,
+                AccessResult::allowed('parent allows view'),
+            ]]);
 
         $result = $this->policy->access($attachment, 'view', $this->account);
 
@@ -177,14 +184,20 @@ final class ParentDelegatedAccessPolicyTest extends TestCase
         ]);
 
         $storage = $this->createStub(EntityStorageInterface::class);
-        $storage->method('load')->with('2')->willReturn($parentEntity);
-        $this->entityTypeManager->method('getStorage')->with('node')->willReturn($storage);
-        $this->entityTypeManager->method('getRepository')->with('node')->willReturn(new StorageBackedStubRepository($storage));
+        $storage->method('load')->willReturnMap([['2', $parentEntity]]);
+        $this->entityTypeManager->method('getStorage')->willReturnMap([['node', $storage]]);
+        $this->entityTypeManager->method('getRepository')->willReturnMap([
+            ['node', new StorageBackedStubRepository($storage)],
+        ]);
 
         $this->accessHandler
             ->method('check')
-            ->with($parentEntity, 'view', $this->account)
-            ->willReturn(AccessResult::forbidden('parent forbids view'));
+            ->willReturnMap([[
+                $parentEntity,
+                'view',
+                $this->account,
+                AccessResult::forbidden('parent forbids view'),
+            ]]);
 
         $result = $this->policy->access($attachment, 'view', $this->account);
 
@@ -203,14 +216,20 @@ final class ParentDelegatedAccessPolicyTest extends TestCase
         ]);
 
         $storage = $this->createStub(EntityStorageInterface::class);
-        $storage->method('load')->with('3')->willReturn($parentEntity);
-        $this->entityTypeManager->method('getStorage')->with('node')->willReturn($storage);
-        $this->entityTypeManager->method('getRepository')->with('node')->willReturn(new StorageBackedStubRepository($storage));
+        $storage->method('load')->willReturnMap([['3', $parentEntity]]);
+        $this->entityTypeManager->method('getStorage')->willReturnMap([['node', $storage]]);
+        $this->entityTypeManager->method('getRepository')->willReturnMap([
+            ['node', new StorageBackedStubRepository($storage)],
+        ]);
 
         $this->accessHandler
             ->method('check')
-            ->with($parentEntity, 'update', $this->account)
-            ->willReturn(AccessResult::allowed('parent allows update'));
+            ->willReturnMap([[
+                $parentEntity,
+                'update',
+                $this->account,
+                AccessResult::allowed('parent allows update'),
+            ]]);
 
         $result = $this->policy->access($attachment, 'update', $this->account);
 
@@ -229,14 +248,20 @@ final class ParentDelegatedAccessPolicyTest extends TestCase
         ]);
 
         $storage = $this->createStub(EntityStorageInterface::class);
-        $storage->method('load')->with('4')->willReturn($parentEntity);
-        $this->entityTypeManager->method('getStorage')->with('node')->willReturn($storage);
-        $this->entityTypeManager->method('getRepository')->with('node')->willReturn(new StorageBackedStubRepository($storage));
+        $storage->method('load')->willReturnMap([['4', $parentEntity]]);
+        $this->entityTypeManager->method('getStorage')->willReturnMap([['node', $storage]]);
+        $this->entityTypeManager->method('getRepository')->willReturnMap([
+            ['node', new StorageBackedStubRepository($storage)],
+        ]);
 
         $this->accessHandler
             ->method('check')
-            ->with($parentEntity, 'delete', $this->account)
-            ->willReturn(AccessResult::allowed('parent allows delete'));
+            ->willReturnMap([[
+                $parentEntity,
+                'delete',
+                $this->account,
+                AccessResult::allowed('parent allows delete'),
+            ]]);
 
         $result = $this->policy->access($attachment, 'delete', $this->account);
 

--- a/packages/audit/composer.json
+++ b/packages/audit/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/scheduler": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/entity-storage": "^0.1.0-alpha.287"
     },
     "autoload": {

--- a/packages/auth/composer.json
+++ b/packages/auth/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/mail": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/billing/composer.json
+++ b/packages/billing/composer.json
@@ -15,7 +15,7 @@
         "stripe/stripe-php": "^16.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/bimaaji/composer.json
+++ b/packages/bimaaji/composer.json
@@ -12,7 +12,7 @@
         "waaseyaa/routing": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "suggest": {
         "waaseyaa/cli": "Enables the graph:dump and bimaaji:install command integrations."

--- a/packages/cache/composer.json
+++ b/packages/cache/composer.json
@@ -13,7 +13,7 @@
         "waaseyaa/entity-storage": "^0.1.0-alpha.261"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -121,7 +121,7 @@
         "waaseyaa/oidc": "Provides the optional oidc:* operator commands"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "bin": [
         "bin/waaseyaa"

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -10,7 +10,7 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/database-legacy/composer.json
+++ b/packages/database-legacy/composer.json
@@ -8,7 +8,7 @@
         "doctrine/dbal": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/debug/composer.json
+++ b/packages/debug/composer.json
@@ -11,7 +11,7 @@
         "waaseyaa/routing": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/engagement/composer.json
+++ b/packages/engagement/composer.json
@@ -24,7 +24,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/entity-storage/composer.json
+++ b/packages/entity-storage/composer.json
@@ -50,7 +50,7 @@
         "symfony/event-dispatcher": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/entity/composer.json
+++ b/packages/entity/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "suggest": {
         "nesbot/carbon": "Optional domain for datetime_immutable cast with domain carbon_immutable (#1183)."

--- a/packages/entity/tests/Unit/Validation/EntityValidatorTest.php
+++ b/packages/entity/tests/Unit/Validation/EntityValidatorTest.php
@@ -101,7 +101,7 @@ final class EntityValidatorTest extends TestCase
         $symfonyValidator = $this->createMock(ValidatorInterface::class);
         $symfonyValidator->expects($this->once())
             ->method('validate')
-            ->with('', $this->isType('array'))
+            ->with('', $this->isArray())
             ->willReturn(new ConstraintViolationList([$violation]));
 
         $validator = new EntityValidator($symfonyValidator);

--- a/packages/error-handler/composer.json
+++ b/packages/error-handler/composer.json
@@ -8,7 +8,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/field/composer.json
+++ b/packages/field/composer.json
@@ -49,7 +49,7 @@
         "waaseyaa/typed-data": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/field/tests/Unit/FieldDefinitionJsonSchemaRegressionTest.php
+++ b/packages/field/tests/Unit/FieldDefinitionJsonSchemaRegressionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Waaseyaa\Field\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Field\FieldDefinition;
 use Waaseyaa\Field\FieldTypeManager;
@@ -63,10 +64,8 @@ final class FieldDefinitionJsonSchemaRegressionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider legacySchemaProvider
-     * @param array<string, mixed> $expected
-     */
+    /** @param array<string, mixed> $expected */
+    #[DataProvider('legacySchemaProvider')]
     public function testManagerlessFallbackEmitsLegacySchema(string $type, array $expected): void
     {
         $def = new FieldDefinition(name: 'f', type: $type);
@@ -74,10 +73,8 @@ final class FieldDefinitionJsonSchemaRegressionTest extends TestCase
         $this->assertSame($expected, $def->toJsonSchema());
     }
 
-    /**
-     * @dataProvider legacySchemaProvider
-     * @param array<string, mixed> $expected
-     */
+    /** @param array<string, mixed> $expected */
+    #[DataProvider('legacySchemaProvider')]
     public function testManagerDelegationEmitsLegacySchema(string $type, array $expected): void
     {
         $def = new FieldDefinition(

--- a/packages/foundation/composer.json
+++ b/packages/foundation/composer.json
@@ -45,7 +45,7 @@
         "waaseyaa/queue": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/entity": "^0.1.0-alpha.287",
         "waaseyaa/error-handler": "^0.1.0-alpha.287",
         "waaseyaa/routing": "^0.1.0-alpha.287"

--- a/packages/frankenphp/composer.json
+++ b/packages/frankenphp/composer.json
@@ -16,7 +16,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/genealogy/composer.json
+++ b/packages/genealogy/composer.json
@@ -81,7 +81,7 @@
         "waaseyaa/workflows": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/api": "^0.1.0-alpha.287",
         "waaseyaa/database-legacy": "^0.1.0-alpha.287",
         "waaseyaa/entity-storage": "^0.1.0-alpha.287"

--- a/packages/geo/composer.json
+++ b/packages/geo/composer.json
@@ -14,7 +14,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/graphql/composer.json
+++ b/packages/graphql/composer.json
@@ -45,7 +45,7 @@
         "waaseyaa/workflows": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/groups/composer.json
+++ b/packages/groups/composer.json
@@ -48,7 +48,7 @@
         "waaseyaa/relationship": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/user": "^0.1.0-alpha.287"
     },
     "autoload": {

--- a/packages/http-client/composer.json
+++ b/packages/http-client/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/i18n/composer.json
+++ b/packages/i18n/composer.json
@@ -8,7 +8,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/inertia/composer.json
+++ b/packages/inertia/composer.json
@@ -19,7 +19,7 @@
         "waaseyaa/entity": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/ingestion/composer.json
+++ b/packages/ingestion/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/listing/composer.json
+++ b/packages/listing/composer.json
@@ -44,7 +44,7 @@
         "waaseyaa/typed-data": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/mail/composer.json
+++ b/packages/mail/composer.json
@@ -8,7 +8,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "twig/twig": "^3.0"
     },
     "suggest": {

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -59,7 +59,7 @@
         "waaseyaa/user": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/audit": "^0.1.0-alpha.287"
     },
     "autoload": {

--- a/packages/media/composer.json
+++ b/packages/media/composer.json
@@ -43,7 +43,7 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/access": "^0.1.0-alpha.287",
         "waaseyaa/api": "^0.1.0-alpha.287",
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"

--- a/packages/media/tests/Integration/MediaDownloadRouterTest.php
+++ b/packages/media/tests/Integration/MediaDownloadRouterTest.php
@@ -203,7 +203,9 @@ final class MediaDownloadRouterTest extends TestCase
         $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($media);
         $manager = $this->createStub(EntityTypeManagerInterface::class);
-        $manager->method('getRepository')->with('media')->willReturn(new StorageBackedStubRepository($storage));
+        $manager->method('getRepository')->willReturnMap([
+            ['media', new StorageBackedStubRepository($storage)],
+        ]);
 
         return new MediaDownloadRouter($manager, new EntityAccessHandler([$policy]), $this->filesRoot, $this->sourceReader);
     }

--- a/packages/menu/composer.json
+++ b/packages/menu/composer.json
@@ -24,7 +24,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/mercure/composer.json
+++ b/packages/mercure/composer.json
@@ -8,7 +8,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/messaging/composer.json
+++ b/packages/messaging/composer.json
@@ -29,7 +29,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/migration/composer.json
+++ b/packages/migration/composer.json
@@ -46,7 +46,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "symfony/event-dispatcher": "^7.0"
     },
     "autoload": {

--- a/packages/migration/tests/Integration/EntityDestinationBundleAwareCreateAccessTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationBundleAwareCreateAccessTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Migration\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -46,7 +45,6 @@ use Waaseyaa\Node\NodeAccessPolicy;
  */
 #[CoversClass(EntityDestination::class)]
 #[CoversClass(EntityAccessGate::class)]
-#[CoversNothing]
 final class EntityDestinationBundleAwareCreateAccessTest extends TestCase
 {
     private const string MIGRATION_ID = 'migration_test_bundle_aware';

--- a/packages/migration/tests/Integration/EntityDestinationRevisionsTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationRevisionsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Migration\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -45,7 +44,6 @@ use Waaseyaa\Migration\Tests\Fixtures\MigrationTestWidgetType;
  *   - Re-run with an unchanged hash does NOT create a new revision (FR-031).
  */
 #[CoversClass(EntityDestination::class)]
-#[CoversNothing]
 final class EntityDestinationRevisionsTest extends TestCase
 {
     private DBALDatabase $db;

--- a/packages/migration/tests/Integration/EntityDestinationSystemAccountAccessTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationSystemAccountAccessTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Migration\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -43,7 +42,6 @@ use Waaseyaa\Migration\Tests\Fixtures\MigrationTestWidget;
  * policy like `NodeAccessPolicy`.
  */
 #[CoversClass(EntityDestination::class)]
-#[CoversNothing]
 final class EntityDestinationSystemAccountAccessTest extends TestCase
 {
     private const string MIGRATION_ID = 'migration_test_system_account';

--- a/packages/migration/tests/Integration/EntityDestinationTest.php
+++ b/packages/migration/tests/Integration/EntityDestinationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Migration\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -48,7 +47,6 @@ use Waaseyaa\Migration\Tests\Fixtures\MigrationTestWidgetType;
  * mocking the pipeline would defeat the test.
  */
 #[CoversClass(EntityDestination::class)]
-#[CoversNothing]
 final class EntityDestinationTest extends TestCase
 {
     private DBALDatabase $db;

--- a/packages/migration/tests/Integration/RollbackTest.php
+++ b/packages/migration/tests/Integration/RollbackTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Waaseyaa\Migration\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -54,7 +53,6 @@ use Waaseyaa\Migration\Tests\Fixtures\MigrationTestWidgetType;
  */
 #[CoversClass(RollbackWalker::class)]
 #[CoversClass(EntityDestination::class)]
-#[CoversNothing]
 final class RollbackTest extends TestCase
 {
     private const string MIGRATION_ID = 'rollback_widgets';

--- a/packages/node/composer.json
+++ b/packages/node/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/note/composer.json
+++ b/packages/note/composer.json
@@ -24,7 +24,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/notification/composer.json
+++ b/packages/notification/composer.json
@@ -29,7 +29,7 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/oauth-provider/composer.json
+++ b/packages/oauth-provider/composer.json
@@ -8,7 +8,7 @@
         "waaseyaa/http-client": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/oidc/composer.json
+++ b/packages/oidc/composer.json
@@ -42,7 +42,7 @@
         "waaseyaa/user": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/path/composer.json
+++ b/packages/path/composer.json
@@ -29,7 +29,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/plugin/composer.json
+++ b/packages/plugin/composer.json
@@ -14,7 +14,7 @@
         "waaseyaa/cache": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/publishing/composer.json
+++ b/packages/publishing/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "symfony/html-sanitizer": "^8.0"
     },
     "autoload": {

--- a/packages/queue/composer.json
+++ b/packages/queue/composer.json
@@ -24,7 +24,7 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/entity": "^0.1.0-alpha.287"
     },
     "autoload": {

--- a/packages/routing/composer.json
+++ b/packages/routing/composer.json
@@ -43,7 +43,7 @@
         "waaseyaa/oidc": "Provides optional OpenID Connect issuer routes"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/scheduler/composer.json
+++ b/packages/scheduler/composer.json
@@ -25,7 +25,7 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/search/composer.json
+++ b/packages/search/composer.json
@@ -14,7 +14,7 @@
         "symfony/event-dispatcher": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/seo/composer.json
+++ b/packages/seo/composer.json
@@ -11,7 +11,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/seo/tests/Unit/SitemapGeneratorTest.php
+++ b/packages/seo/tests/Unit/SitemapGeneratorTest.php
@@ -108,7 +108,7 @@ final class SitemapGeneratorTest extends TestCase
         $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('getDefinitions')->willReturn(['article' => $articleDef]);
         $etm->method('hasDefinition')->willReturn(true);
-        $etm->method('getStorage')->with('article')->willReturn($articleStorage);
+        $etm->method('getStorage')->willReturnMap([['article', $articleStorage]]);
 
         $gen = new SitemapGenerator();
         $urls = $gen->collectFromEntityTypes(
@@ -131,9 +131,11 @@ final class SitemapGeneratorTest extends TestCase
         $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('getDefinitions')->willReturn(['article' => $def]);
         $etm->method('hasDefinition')->willReturn(true);
-        $etm->method('getStorage')->with('article')->willReturn($storage);
+        $etm->method('getStorage')->willReturnMap([['article', $storage]]);
         // C-22: the query builder now lives on the repository.
-        $etm->method('getRepository')->with('article')->willReturn(new QueryOnlyStubRepository($query));
+        $etm->method('getRepository')->willReturnMap([
+            ['article', new QueryOnlyStubRepository($query)],
+        ]);
 
         $gen = new SitemapGenerator();
         $urls = $gen->collectFromEntityTypes(

--- a/packages/ssr/composer.json
+++ b/packages/ssr/composer.json
@@ -86,7 +86,7 @@
         "waaseyaa/user": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/state/composer.json
+++ b/packages/state/composer.json
@@ -10,7 +10,7 @@
         "waaseyaa/database-legacy": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "repositories": [
         {

--- a/packages/structured-import/composer.json
+++ b/packages/structured-import/composer.json
@@ -24,7 +24,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/structured-import/phpunit.xml
+++ b/packages/structured-import/phpunit.xml
@@ -2,7 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         colors="true">
+         colors="true"
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>

--- a/packages/taxonomy/composer.json
+++ b/packages/taxonomy/composer.json
@@ -34,7 +34,7 @@
         "waaseyaa/foundation": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/testing/composer.json
+++ b/packages/testing/composer.json
@@ -20,7 +20,7 @@
         "waaseyaa/field": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "suggest": {
         "fakerphp/faker": "Optional realistic strings and emails for EntityTypeFixtureValues (framework#1186)."

--- a/packages/typed-data/composer.json
+++ b/packages/typed-data/composer.json
@@ -8,7 +8,7 @@
         "symfony/validator": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/user/composer.json
+++ b/packages/user/composer.json
@@ -31,7 +31,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/validation/composer.json
+++ b/packages/validation/composer.json
@@ -15,7 +15,7 @@
         "symfony/validator": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/wayfinding/composer.json
+++ b/packages/wayfinding/composer.json
@@ -39,7 +39,7 @@
         "waaseyaa/access": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/workflows/composer.json
+++ b/packages/workflows/composer.json
@@ -67,7 +67,7 @@
         "waaseyaa/relationship": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^13.0",
         "waaseyaa/database-legacy": "^0.1.0-alpha.287",
         "waaseyaa/node": "^0.1.0-alpha.287"
     },

--- a/packages/workspace/composer.json
+++ b/packages/workspace/composer.json
@@ -25,7 +25,7 @@
         "waaseyaa/routing": "^0.1.0-alpha.287"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
+         cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
@@ -22,9 +23,6 @@
             <directory>packages/analytics/tests</directory>
             <directory>packages/oauth-provider/tests</directory>
             <file>packages/bimaaji/tests/SmokeTest.php</file>
-        </testsuite>
-        <testsuite name="GitHub">
-            <directory>packages/github/tests</directory>
         </testsuite>
         <testsuite name="Integration">
             <directory>packages/*/tests/Integration</directory>

--- a/skeleton/composer.json
+++ b/skeleton/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0",
+        "phpunit/phpunit": "^13.0",
         "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {

--- a/tests/Architecture/PhpUnit13ConformanceTest.php
+++ b/tests/Architecture/PhpUnit13ConformanceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class PhpUnit13ConformanceTest extends TestCase
+{
+    private const EXPECTED_CONFIGURATION_COUNT = 20;
+
+    private string $repoRoot;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 2);
+    }
+
+    #[Test]
+    public function every_test_manifest_requires_the_supported_phpunit_major(): void
+    {
+        foreach ($this->trackedFiles('composer.json') as $path) {
+            $manifest = json_decode(
+                (string) file_get_contents($this->repoRoot . '/' . $path),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            );
+
+            if (!isset($manifest['require-dev']['phpunit/phpunit'])) {
+                continue;
+            }
+
+            self::assertSame(
+                '^13.0',
+                $manifest['require-dev']['phpunit/phpunit'],
+                sprintf('%s must use the supported PHPUnit major.', $path),
+            );
+        }
+    }
+
+    #[Test]
+    public function every_tracked_phpunit_configuration_uses_the_canonical_schema_and_cache(): void
+    {
+        $configurations = array_values(array_filter(
+            $this->trackedFiles(),
+            static fn(string $path): bool => preg_match('#(?:^|/)phpunit\.xml(?:\.dist)?$#', $path) === 1,
+        ));
+
+        self::assertCount(self::EXPECTED_CONFIGURATION_COUNT, $configurations);
+
+        foreach ($configurations as $path) {
+            $xml = simplexml_load_file($this->repoRoot . '/' . $path);
+            self::assertNotFalse($xml, sprintf('%s must contain valid XML.', $path));
+
+            $schema = (string) $xml->attributes('xsi', true)->noNamespaceSchemaLocation;
+            self::assertMatchesRegularExpression(
+                '#^(?:\.\./\.\./)?vendor/phpunit/phpunit/phpunit\.xsd$#',
+                $schema,
+                sprintf('%s must use the installed PHPUnit schema.', $path),
+            );
+            self::assertSame(
+                '.phpunit.cache',
+                (string) $xml['cacheDirectory'],
+                sprintf('%s must isolate PHPUnit cache output.', $path),
+            );
+        }
+    }
+
+    #[Test]
+    public function removed_docblock_execution_metadata_and_conflicting_coverage_attributes_are_absent(): void
+    {
+        foreach ($this->trackedFiles() as $path) {
+            if (!str_ends_with($path, 'Test.php')) {
+                continue;
+            }
+
+            $source = (string) file_get_contents($this->repoRoot . '/' . $path);
+            foreach (['dataProvider', 'depends', 'requires ', 'testWith', 'test '] as $metadataName) {
+                $removedMetadata = '@' . $metadataName;
+                self::assertStringNotContainsString(
+                    $removedMetadata,
+                    $source,
+                    sprintf('%s must use PHPUnit attributes for execution metadata.', $path),
+                );
+            }
+
+            $classDeclarationPrefix = '';
+            foreach (token_get_all($source) as $token) {
+                if (is_array($token) && $token[0] === T_CLASS) {
+                    break;
+                }
+                $classDeclarationPrefix .= is_array($token) ? $token[1] : $token;
+            }
+
+            self::assertFalse(
+                str_contains($classDeclarationPrefix, '#[CoversNothing]')
+                    && str_contains($classDeclarationPrefix, '#[CoversClass('),
+                sprintf('%s cannot declare both CoversNothing and CoversClass.', $path),
+            );
+        }
+    }
+
+    #[Test]
+    public function root_test_suites_do_not_discover_the_same_file_twice(): void
+    {
+        $xml = simplexml_load_file($this->repoRoot . '/phpunit.xml.dist');
+        self::assertNotFalse($xml);
+
+        $owners = [];
+        foreach ($xml->testsuites->testsuite as $suite) {
+            $suiteName = (string) $suite['name'];
+            foreach ($suite->directory as $directory) {
+                foreach (glob($this->repoRoot . '/' . (string) $directory, GLOB_ONLYDIR) ?: [] as $root) {
+                    $iterator = new \RecursiveIteratorIterator(
+                        new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+                    );
+                    foreach ($iterator as $file) {
+                        if (!$file->isFile() || !str_ends_with($file->getFilename(), 'Test.php')) {
+                            continue;
+                        }
+
+                        $path = $file->getPathname();
+                        self::assertArrayNotHasKey(
+                            $path,
+                            $owners,
+                            sprintf('%s is discovered by both %s and %s.', $path, $owners[$path] ?? '', $suiteName),
+                        );
+                        $owners[$path] = $suiteName;
+                    }
+                }
+            }
+
+            foreach ($suite->file as $file) {
+                $path = $this->repoRoot . '/' . (string) $file;
+                self::assertArrayNotHasKey(
+                    $path,
+                    $owners,
+                    sprintf('%s is discovered by multiple test suites.', $path),
+                );
+                $owners[$path] = $suiteName;
+            }
+        }
+
+        self::assertNotEmpty($owners);
+    }
+
+    /** @return list<string> */
+    private function trackedFiles(?string $basename = null): array
+    {
+        $command = escapeshellarg($this->repoRoot . '/bin/git')
+            . ' -C '
+            . escapeshellarg($this->repoRoot)
+            . ' ls-files -z';
+        exec($command, $output, $exitCode);
+        self::assertSame(0, $exitCode, 'Unable to enumerate tracked files through the repository git guard.');
+
+        $files = array_values(array_filter(explode("\0", implode("\n", $output))));
+        if ($basename === null) {
+            return $files;
+        }
+
+        return array_values(array_filter(
+            $files,
+            static fn(string $path): bool => basename($path) === $basename,
+        ));
+    }
+}

--- a/tests/Fixtures/release-tooling/manifest-with-require-dev.json
+++ b/tests/Fixtures/release-tooling/manifest-with-require-dev.json
@@ -7,6 +7,6 @@
     },
     "require-dev": {
         "waaseyaa/testing": "^0.1.0-alpha.150",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^13.0"
     }
 }

--- a/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
+++ b/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
@@ -90,7 +90,7 @@ final class SyncInternalVersionsTest extends TestCase
                 'waaseyaa/entity' => '^0.1.0-alpha.150',
             ],
             'require-dev' => [
-                'phpunit/phpunit' => '^10.5',
+                'phpunit/phpunit' => '^13.0',
                 'waaseyaa/testing' => '^0.1.0-alpha.150',
             ],
         ];
@@ -288,7 +288,7 @@ final class SyncInternalVersionsTest extends TestCase
         self::assertSame('^0.1.0-alpha.999', $manifest['require']['waaseyaa/foundation']);
         self::assertSame('^0.1.0-alpha.999', $manifest['require-dev']['waaseyaa/testing']);
         // Non-waaseyaa require-dev must be untouched
-        self::assertSame('^10.5', $manifest['require-dev']['phpunit/phpunit']);
+        self::assertSame('^13.0', $manifest['require-dev']['phpunit/phpunit']);
     }
 
     #[Test]

--- a/tests/PackagedForm/skeleton/composer.json
+++ b/tests/PackagedForm/skeleton/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0"
+        "phpunit/phpunit": "^13.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/PackagedForm/skeleton/composer.lock
+++ b/tests/PackagedForm/skeleton/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d72de5c89036485ef5d1e3cdd030cacc",
+    "content-hash": "97bffe14406a570acf59c1a70a7edecf",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -4280,20 +4280,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -4332,9 +4331,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4456,35 +4455,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.12",
+            "version": "14.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "ext-mbstring": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.7.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.3.1"
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/git-state": "^1.0",
+                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/version": "^7.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.46"
+                "phpunit/phpunit": "^13.2.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -4493,7 +4492,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -4522,7 +4521,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.4"
             },
             "funding": [
                 {
@@ -4542,32 +4541,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:01:01+00:00"
+            "time": "2026-07-30T17:01:07+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4595,7 +4594,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -4615,28 +4614,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T13:52:54+00:00"
+            "time": "2026-02-06T04:33:26+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -4644,7 +4643,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4671,40 +4670,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2026-02-06T04:34:47+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4731,40 +4742,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2026-02-06T04:36:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -4791,61 +4814,71 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2026-02-06T04:37:53+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.55",
+            "version": "13.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5d2afe181339a56348ef9a80fa7eb806b7eae508",
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.3",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.2",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
+                "php": ">=8.4.1",
+                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-file-iterator": "^7.0.0",
+                "phpunit/php-invoker": "^7.0.0",
+                "phpunit/php-text-template": "^6.0.0",
+                "phpunit/php-timer": "^9.0.0",
+                "sebastian/cli-parser": "^5.0.0",
+                "sebastian/comparator": "^8.3.0",
+                "sebastian/diff": "^9.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.1",
+                "sebastian/file-filter": "^1.0",
+                "sebastian/git-state": "^1.0",
+                "sebastian/global-state": "^9.0.1",
+                "sebastian/object-enumerator": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/type": "^7.0.1",
+                "sebastian/version": "^7.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -4853,7 +4886,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-main": "13.2-dev"
                 }
             },
             "autoload": {
@@ -4885,56 +4918,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.6"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-18T12:37:06+00:00"
+            "time": "2026-07-28T14:00:09+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4958,152 +4975,51 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:41:36+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2026-08-01T04:27:14+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.3",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=8.4",
+                "sebastian/diff": "^9.0",
+                "sebastian/exporter": "^8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
+                "phpunit/phpunit": "^13.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -5111,7 +5027,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -5151,7 +5067,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
             },
             "funding": [
                 {
@@ -5171,33 +5087,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:26:40+00:00"
+            "time": "2026-06-05T03:06:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5221,41 +5137,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2026-02-06T04:41:32+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^13.2",
+                "symfony/process": "^7.4.13"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -5288,35 +5216,47 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2026-06-05T03:04:51+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "9.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^13.1.11"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -5324,7 +5264,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-main": "9.3-dev"
                 }
             },
             "autoload": {
@@ -5352,7 +5292,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
             },
             "funding": [
                 {
@@ -5372,34 +5312,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2026-05-25T13:41:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.2",
+            "version": "8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -5442,7 +5382,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
             },
             "funding": [
                 {
@@ -5462,35 +5402,173 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:12:51+00:00"
+            "time": "2026-07-13T11:35:11+00:00"
         },
         {
-            "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "name": "sebastian/file-filter",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T07:20:04+00:00"
+        },
+        {
+            "name": "sebastian/git-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/git-state.git",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for describing the state of a Git checkout",
+            "homepage": "https://github.com/sebastianbergmann/git-state",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/git-state/issues",
+                "security": "https://github.com/sebastianbergmann/git-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/git-state/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/git-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T12:54:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^13.1.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -5516,41 +5594,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2026-06-01T15:11:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5574,42 +5664,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2026-07-09T08:42:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -5632,40 +5734,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2026-02-06T04:46:36+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5688,40 +5802,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2026-02-06T04:47:13+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^13.2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -5752,7 +5878,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.1"
             },
             "funding": [
                 {
@@ -5772,32 +5898,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2026-08-03T05:58:12+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -5821,7 +5947,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
             },
             "funding": [
                 {
@@ -5841,29 +5967,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2026-05-20T06:49:11+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -5887,15 +6013,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2026-02-06T04:52:52+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -5951,23 +6089,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -5989,7 +6127,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -5997,7 +6135,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         }
     ],
     "aliases": [],

--- a/tests/PackagedForm/skeleton/phpunit.xml.dist
+++ b/tests/PackagedForm/skeleton/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          colors="true">
     <testsuites>


### PR DESCRIPTION
Closes #2240.

## Summary

- upgrade the root, every test-bearing split package, the create-project skeleton, and packaged-form fixture from PHPUnit 10/11 constraints to PHPUnit 13 on PHP 8.5
- normalize all 20 tracked PHPUnit configurations to the installed schema and isolated `.phpunit.cache` output
- convert the last docblock data providers and execution requirement to native attributes, restoring 36 provider cases under PHPUnit 13
- migrate removed mock and constraint APIs without weakening warning enforcement
- remove an overlapping GitHub suite that executed two unit test files twice
- add a Git-tracked conformance test for manifests, configuration shape, removed execution metadata, contradictory coverage metadata, and duplicate suite discovery

## Verification

- `composer test`: 12,603 tests, 249,304 assertions, 2 expected skips; zero PHPUnit warnings
- focused architecture and compatibility suite: 246 tests, 13,623 assertions
- `packages/menu` isolated install: PHPUnit 13.2.6, 53 tests, 110 assertions
- packaged-form fixture: PHPUnit 13.2.6, 1 test, 7 assertions
- PHPStan: 2,007 files, no errors
- strict Composer validation, Composer policy, package layers, Symfony import boundary, changelog shape, and diff check all pass
- test-quality inventory remains reproducible: 1,662 PHP test files, 11,767 methods, 27,887 assertion calls, 20 PHPUnit configs

## Follow-up evidence

PHPUnit 13 now exposes 94 deprecations and 1,167 notices, primarily legacy `with*()` calls without expectations and mocks used as stubs. This PR keeps those diagnostics visible and does not opt out globally. Their measured remediation belongs to the modernization program in #2235.

The isolated package probe also found that `waaseyaa/access` tests depend on undeclared user classes and an entity package test helper; #2251 records that separate split-test boundary defect.
