### PR TITLE
Add replayable random-order test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,37 @@ jobs:
             build/logs/clover.xml
           retention-days: 30
 
+  ci-random-order:
+    name: ci/random-order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: '8.5'
+          extensions: pdo_sqlite, sqlite3, mbstring, xml
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-v2-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-v2-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run the complete suite in replayable random order
+        run: |
+          seed=$(( (GITHUB_RUN_ID % 2147483647) + 1 ))
+          echo "::notice title=PHPUnit random-order seed::$seed"
+          TEST_RANDOM_SEED="$seed" composer test:random
+
   skeleton-create-project:
     name: ci/skeleton-create-project
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **testing (#2240):** Upgrade the PHP 8.5 test stack to PHPUnit 13 across the root, split packages, skeleton, and packaged-form fixture; normalize all tracked PHPUnit configurations to the installed schema and isolated cache; convert the remaining docblock data providers to attributes; remove a duplicate GitHub suite that double-executed tests; and update removed mock/type APIs without weakening warning enforcement.
 
+- **testing (#2241):** Add a dedicated replayable PHPUnit random-order CI lane and machine-readable determinism classification for random inputs, waits, conditional skips, clocks, process globals, filesystems, databases, subprocesses, and ports. Repair leaked session and static-cache state, make expected database bootstrap failures warning-free, keep child-process PHP selection hermetic, replace controllable wall-clock sleeps with direct state, and reject unclassified waits, unclassified skips, and framework-gap skips.
+
 ## [0.1.0-alpha.287] - 2026-08-05
 
 ### Changed

--- a/bin/test-quality-inventory
+++ b/bin/test-quality-inventory
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 $root = dirname(__DIR__);
 $format = 'json';
-foreach (array_slice($argv, 1) as $argument) {
+foreach (array_slice($_SERVER['argv'] ?? [], 1) as $argument) {
     if (str_starts_with($argument, '--format=')) {
         $format = substr($argument, strlen('--format='));
     }
@@ -36,7 +36,10 @@ if ($exitCode !== 0 || $stdout === false) {
     exit(1);
 }
 
-$trackedFiles = array_values(array_filter(explode("\0", $stdout)));
+$trackedFiles = array_values(array_filter(
+    explode("\0", $stdout),
+    static fn(string $path): bool => $path !== '',
+));
 $phpTestFiles = [];
 $phpunitConfigs = [];
 $vitestFiles = [];
@@ -74,6 +77,33 @@ $signals = [
     'medium_group_files' => 0,
     'large_group_files' => 0,
 ];
+$determinism = [
+    'randomness' => [
+        'cryptographic_entropy' => [],
+        'bounded_selection' => [],
+        'fixture_uniqueness' => [],
+    ],
+    'waits' => [
+        'subprocess_polling' => [],
+        'filesystem_retry' => [],
+        'unclassified' => [],
+    ],
+    'conditional_skips' => [
+        'environment_capability' => [],
+        'optional_dependency' => [],
+        'fixture_or_provenance_availability' => [],
+        'framework_gap' => [],
+        'unclassified' => [],
+    ],
+    'state_boundaries' => [
+        'wall_clock' => [],
+        'process_globals' => [],
+        'filesystem' => [],
+        'database' => [],
+        'subprocess' => [],
+        'network_or_port' => [],
+    ],
+];
 
 foreach ($phpTestFiles as $path) {
     $contents = file_get_contents($root . '/' . $path);
@@ -103,7 +133,72 @@ foreach ($phpTestFiles as $path) {
     $signals['small_group_files'] += preg_match('/#\[Small\b/', $contents);
     $signals['medium_group_files'] += preg_match('/#\[Medium\b/', $contents);
     $signals['large_group_files'] += preg_match('/#\[Large\b/', $contents);
+
+    if (preg_match('/\brandom_bytes\s*\(/', $contents) === 1) {
+        $determinism['randomness']['cryptographic_entropy'][] = $path;
+    }
+    if (preg_match('/\b(?:random_int|mt_rand|array_rand|shuffle)\s*\(/', $contents) === 1) {
+        $determinism['randomness']['bounded_selection'][] = $path;
+    }
+    if (preg_match('/\buniqid\s*\(/', $contents) === 1) {
+        $determinism['randomness']['fixture_uniqueness'][] = $path;
+    }
+
+    if (preg_match('/\b(?:sleep|usleep)\s*\(/', $contents) === 1) {
+        $waitCategory = match ($path) {
+            'tests/Integration/FieldReadPagePerformance/PagePerformanceHarnessContractTest.php',
+            'tests/Integration/FreshInstall/CutoverFreshInstallSmokeTest.php' => 'subprocess_polling',
+            'tests/Integration/Phase13/SsrHttpKernelIntegrationTest.php' => 'filesystem_retry',
+            default => 'unclassified',
+        };
+        $determinism['waits'][$waitCategory][] = $path;
+    }
+
+    if (preg_match('/\bmarkTest(?:Skipped|Incomplete)\s*\(/', $contents) === 1) {
+        $skipCategories = [];
+        if (preg_match('/full kernel boot|framework gap/i', $contents) === 1) {
+            $skipCategories[] = 'framework_gap';
+        }
+        if (preg_match('/not installed|requires ext-|Carbon not installed/i', $contents) === 1) {
+            $skipCategories[] = 'optional_dependency';
+        }
+        if (preg_match('/not found|No semver git tags|No vX\.Y\.Z git tag/i', $contents) === 1) {
+            $skipCategories[] = 'fixture_or_provenance_availability';
+        }
+        if (preg_match('/extension|SAPI|symlink|chmod|root|FTS5|JSON1|pcntl|proc_open|tempnam|server unavailable|not permitted|not supported/i', $contents) === 1) {
+            $skipCategories[] = 'environment_capability';
+        }
+        if ($skipCategories === []) {
+            $skipCategories[] = 'unclassified';
+        }
+        foreach (array_unique($skipCategories) as $skipCategory) {
+            $determinism['conditional_skips'][$skipCategory][] = $path;
+        }
+    }
+
+    $statePatterns = [
+        'wall_clock' => '/\b(?:time|microtime|hrtime|new\s+\\?DateTimeImmutable)\s*\(/',
+        'process_globals' => '/\b(?:getenv|putenv|ini_set|ini_restore|session_start|session_id)\s*\(|\$_(?:ENV|SERVER|SESSION)\b/',
+        'filesystem' => '/\b(?:file_put_contents|file_get_contents|mkdir|rmdir|unlink|rename|copy|touch|chmod|tempnam)\s*\(/',
+        'database' => '/\b(?:PDO|DBALDatabase|createSqlite|sqlite:)\b/',
+        'subprocess' => '/\b(?:proc_open|shell_exec|exec|passthru)\s*\(|new\s+Process\s*\(/',
+        'network_or_port' => '/\b(?:stream_socket_server|fsockopen|curl_init)\s*\(|127\.0\.0\.1:\d/',
+    ];
+    foreach ($statePatterns as $category => $pattern) {
+        if (preg_match($pattern, $contents) === 1) {
+            $determinism['state_boundaries'][$category][] = $path;
+        }
+    }
 }
+
+foreach ($determinism as &$categories) {
+    foreach ($categories as &$files) {
+        $files = array_values(array_unique($files));
+        sort($files);
+    }
+    unset($files);
+}
+unset($categories);
 
 $testingHelperConsumers = 0;
 foreach ($trackedFiles as $path) {
@@ -138,6 +233,7 @@ $inventory = [
     'testing_package' => [
         'consumer_test_files_outside_package' => $testingHelperConsumers,
     ],
+    'determinism' => $determinism,
 ];
 
 if ($format === 'json') {
@@ -159,3 +255,9 @@ echo "| Files with conditional skip signals | {$inventory['php']['conditional_sk
 echo "| Vitest files | {$inventory['admin']['vitest_files']} |\n";
 echo "| Playwright files | {$inventory['admin']['playwright_files']} |\n";
 echo "| External consumers of waaseyaa/testing | {$inventory['testing_package']['consumer_test_files_outside_package']} |\n";
+echo "\n## Determinism classification\n\n";
+foreach ($inventory['determinism'] as $signal => $categories) {
+    foreach ($categories as $category => $files) {
+        echo '| ' . str_replace('_', ' ', $signal . ': ' . $category) . ' | ' . count($files) . " |\n";
+    }
+}

--- a/bin/test-random-order
+++ b/bin/test-random-order
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$seed = null;
+$phpunitArguments = [];
+
+foreach (array_slice($_SERVER['argv'] ?? [], 1) as $argument) {
+    if (str_starts_with($argument, '--seed=')) {
+        if ($seed !== null) {
+            fwrite(STDERR, "The random-order seed may be specified only once.\n");
+            exit(2);
+        }
+        $seed = substr($argument, strlen('--seed='));
+        continue;
+    }
+
+    $phpunitArguments[] = $argument;
+}
+
+if ($seed === null) {
+    $environmentSeed = getenv('TEST_RANDOM_SEED');
+    $seed = $environmentSeed === false || $environmentSeed === ''
+        ? (string) random_int(1, 2_147_483_647)
+        : $environmentSeed;
+}
+
+if (preg_match('/^[1-9][0-9]*$/', $seed) !== 1 || (int) $seed > 2_147_483_647) {
+    fwrite(STDERR, "The random-order seed must be a positive integer no greater than 2147483647.\n");
+    exit(2);
+}
+
+echo "PHPUnit random-order seed: {$seed}\n";
+echo "Replay: TEST_RANDOM_SEED={$seed} composer test:random\n";
+flush();
+
+$path = getenv('PATH');
+putenv('PATH=' . dirname(PHP_BINARY) . PATH_SEPARATOR . ($path === false ? '' : $path));
+
+$command = [
+    PHP_BINARY,
+    '-d',
+    'memory_limit=1G',
+    $root . '/vendor/bin/phpunit',
+    '--no-coverage',
+    '--order-by=random',
+    '--random-order-seed=' . $seed,
+    ...$phpunitArguments,
+];
+
+$escapedCommand = implode(' ', array_map(escapeshellarg(...), $command));
+passthru($escapedCommand, $exitCode);
+exit($exitCode);

--- a/composer.json
+++ b/composer.json
@@ -509,6 +509,7 @@
         "check-field-guards": "bash tests/Tooling/FieldGuardsTest.sh",
         "check-access-hardening": "bash tests/Tooling/AccessHardeningGateTest.sh",
         "test": "php -d memory_limit=1G vendor/bin/phpunit --no-coverage",
+        "test:random": "php bin/test-random-order",
         "verify": [
             "@cs-check",
             "@phpstan",

--- a/docs/testing/determinism.md
+++ b/docs/testing/determinism.md
@@ -1,0 +1,74 @@
+# Deterministic test policy
+
+Waaseyaa's primary PHP suite runs in the canonical configuration order. A
+second CI lane challenges order coupling on every change and prints the seed
+before PHPUnit starts.
+
+Run a fresh local order:
+
+```bash
+composer test:random
+```
+
+Replay a reported order exactly:
+
+```bash
+TEST_RANDOM_SEED=2241 composer test:random
+```
+
+The runner prepends the active `PHP_BINARY` directory to `PATH`. Subprocess
+tests therefore use the same interpreter as PHPUnit and do not depend on a
+developer shell or CI setup action to make `php` discoverable.
+
+## Machine-readable classification
+
+`composer test:inventory` emits the determinism inventory under the
+`determinism` JSON key. The architecture suite fails when a sleep or
+conditional skip is unclassified, or when a conditional skip represents a
+framework gap. Categories can overlap because one test file can exercise more
+than one boundary.
+
+The baseline after the first random-order remediation is:
+
+| Signal | Classification | Files |
+|---|---|---:|
+| randomness | cryptographic entropy | 46 |
+| randomness | bounded selection | 7 |
+| randomness | fixture uniqueness | 139 |
+| waits | subprocess polling | 2 |
+| waits | filesystem retry | 1 |
+| waits | unclassified | 0 |
+| conditional skips | environment capability | 20 |
+| conditional skips | optional dependency | 2 |
+| conditional skips | fixture or provenance availability | 10 |
+| conditional skips | framework gap | 0 |
+| conditional skips | unclassified | 0 |
+| state boundaries | wall clock | 41 |
+| state boundaries | process globals | 45 |
+| state boundaries | filesystem | 220 |
+| state boundaries | database | 373 |
+| state boundaries | subprocess | 42 |
+| state boundaries | network or port | 5 |
+
+Random bytes used for credentials, opaque identifiers, and isolated fixture
+paths are inputs, not behavioral assertions. Tests that use random selection
+to vary behavior must accept a seed and print it on failure. Prefer explicit
+examples when the set is small.
+
+Wall-clock sleeps are forbidden when the state can be controlled directly.
+The three retained waits poll observable subprocess completion or retry a
+filesystem operation with a deadline and bounded delay. Adding another wait
+requires adding its path and category to `bin/test-quality-inventory`.
+
+Conditional skips must describe a real environment capability, optional
+dependency, or unavailable external fixture/provenance input. A missing
+framework capability is a blocker, not an acceptable skip. Permanently skipped
+placeholder tests are removed; production-shaped coverage should live in the
+suite that can execute it.
+
+Tests that change sessions, environment variables, INI values, static caches,
+temporary files, databases, subprocesses, or ports own their cleanup. Restore
+process globals in `tearDown()` or `finally`, allocate filesystem and database
+state per test, use operating-system-assigned ports, and enforce deadlines on
+all polling loops. Parallel execution remains blocked until these boundaries
+have explicit isolation evidence.

--- a/packages/api/tests/Unit/Controller/BroadcastStorageTest.php
+++ b/packages/api/tests/Unit/Controller/BroadcastStorageTest.php
@@ -124,7 +124,9 @@ final class BroadcastStorageTest extends TestCase
     public function pruneRemovesOldMessages(): void
     {
         $this->storage->push('admin', 'old', []);
-        usleep(10_000); // Ensure the message timestamp is strictly in the past.
+        $connection = $this->database->getConnection()->getNativeConnection();
+        self::assertInstanceOf(\PDO::class, $connection);
+        $connection->exec('UPDATE _broadcast_log SET created_at = created_at - 1');
         $this->storage->prune(0); // prune everything older than 0 seconds
 
         $messages = $this->storage->poll(0);

--- a/packages/cache/src/Backend/MemoryBackend.php
+++ b/packages/cache/src/Backend/MemoryBackend.php
@@ -18,13 +18,18 @@ use Waaseyaa\Cache\TaggedCacheInterface;
 final class MemoryBackend implements TagAwareCacheInterface, TaggedCacheInterface
 {
     private readonly ProjectionDeprecationDiagnostic $projectionDiagnostic;
+    /** @var \Closure(): int */
+    private readonly \Closure $clock;
 
-    public function __construct(?ProjectionDeprecationDiagnostic $projectionDiagnostic = null)
-    {
+    public function __construct(
+        ?ProjectionDeprecationDiagnostic $projectionDiagnostic = null,
+        ?callable $clock = null,
+    ) {
         $this->projectionDiagnostic = $projectionDiagnostic ?? ProjectionDeprecationDiagnostic::forEntityPayloads(
             static function (): void {},
             EntityPayloadBoundaryConfig::enforced(),
         );
+        $this->clock = $clock === null ? time(...) : \Closure::fromCallable($clock);
     }
 
     /** @var array<string, CacheItem> */
@@ -63,7 +68,7 @@ final class MemoryBackend implements TagAwareCacheInterface, TaggedCacheInterfac
 
         // Check expiration: expired items are removed and return false.
         // PERMANENT items never expire.
-        if ($item->expire !== CacheBackendInterface::PERMANENT && $item->expire < time()) {
+        if ($item->expire !== CacheBackendInterface::PERMANENT && $item->expire < ($this->clock)()) {
             unset($this->cache[$cid]);
             return false;
         }
@@ -97,7 +102,7 @@ final class MemoryBackend implements TagAwareCacheInterface, TaggedCacheInterfac
         $this->cache[$cid] = new CacheItem(
             cid: $cid,
             data: $data,
-            created: time(),
+            created: ($this->clock)(),
             expire: $expire,
             tags: $tags,
             valid: true,
@@ -199,7 +204,7 @@ final class MemoryBackend implements TagAwareCacheInterface, TaggedCacheInterfac
         // expired (rejected by the existing get() path on next read).
         $expire = $ttl === null
             ? CacheBackendInterface::PERMANENT
-            : time() + $ttl;
+            : (int) (($this->clock)() + $ttl);
 
         // Reuse existing set() so legacy CacheItem::$tags and ::$expire stay
         // populated for any subscriber that reads them.

--- a/packages/entity/tests/Unit/EntityReadRuntimeCacheTest.php
+++ b/packages/entity/tests/Unit/EntityReadRuntimeCacheTest.php
@@ -22,6 +22,18 @@ use Waaseyaa\Field\FieldReadDefinitionInterface;
 
 final class EntityReadRuntimeCacheTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetImmutableSemanticTemplates();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetImmutableSemanticTemplates();
+        parent::tearDown();
+    }
+
     #[Test]
     public function immutable_semantic_templates_are_shared_without_sharing_registry_generation_authority(): void
     {
@@ -630,6 +642,13 @@ final class EntityReadRuntimeCacheTest extends TestCase
         $properties = (new \ReflectionClass(EntityReadRuntime::class))->getStaticProperties();
 
         return count($properties['immutableSemanticTemplates']);
+    }
+
+    private function resetImmutableSemanticTemplates(): void
+    {
+        $property = (new \ReflectionClass(EntityReadRuntime::class))
+            ->getProperty('immutableSemanticTemplates');
+        $property->setValue(null, []);
     }
 
     private function resolvedLayoutCacheCountFor(FieldDefinitionRegistryInterface $registry): int

--- a/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
+++ b/packages/foundation/src/Kernel/Bootstrap/DatabaseBootstrapper.php
@@ -87,7 +87,7 @@ final class DatabaseBootstrapper
 
         // Ensure the parent directory exists so SQLite can create the file.
         $dir = dirname($dbPath);
-        if (!is_dir($dir) && !mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
+        if (!is_dir($dir) && !@mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
             throw new \RuntimeException(sprintf(
                 'Failed to create the database directory "%s" for the SQLite database at "%s". '
                 . 'Check that the parent path exists and is writable.',

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelBootFailureTest.php
@@ -34,14 +34,15 @@ final class HttpKernelBootFailureTest extends TestCase
         // Point to a non-existent directory so PDO cannot create the file.
         file_put_contents(
             $root . '/config/waaseyaa.php',
-            "<?php return ['database' => '/nonexistent/deep/path/db.sqlite'];",
+            "<?php return ['environment' => 'local', 'database' => '/nonexistent/deep/path/db.sqlite'];",
         );
 
         $kernel = new HttpKernel($root);
         $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
 
         try {
-            $this->expectException(\Throwable::class);
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Failed to create the database directory');
             $boot->invoke($kernel);
         } finally {
             @unlink($root . '/config/waaseyaa.php');

--- a/packages/listing/tests/Integration/CacheIntegrationTest.php
+++ b/packages/listing/tests/Integration/CacheIntegrationTest.php
@@ -257,7 +257,10 @@ final class CacheIntegrationTest extends TestCase
     {
         $driver = new InMemoryStorageDriver();
         $this->seedThreeRows($driver);
-        $cache = new MemoryBackend();
+        $now = 1_800_000_000;
+        $cache = new MemoryBackend(clock: static function () use (&$now): int {
+            return $now;
+        });
         $resolver = $this->buildResolver($driver, $cache, new ListingCacheKeyBuilder());
 
         // 1-second TTL — short enough to expire mid-test without burning CI budget.
@@ -273,8 +276,7 @@ final class CacheIntegrationTest extends TestCase
         // Mutate the underlying storage. A cache hit would mask this change.
         $driver->write('article', '4', ['id' => '4', 'title' => 'd', 'status' => 1, 'weight' => 40]);
 
-        // Sleep just over the TTL boundary.
-        sleep(2);
+        $now += 2;
 
         $second = $resolver->resolve($def);
 

--- a/packages/queue/tests/Unit/AttributeGuardTest.php
+++ b/packages/queue/tests/Unit/AttributeGuardTest.php
@@ -112,10 +112,8 @@ final class AttributeGuardTest extends TestCase
             public function handle(): void {}
         };
 
-        // Lock duration is 0 s — the lock expires immediately, so even a tiny
-        // sleep allows a second dispatch.  We use usleep to avoid flakiness.
+        // A zero-duration lock is inactive immediately.
         $this->assertTrue($this->guard->allows($job));
-        usleep(1_000); // 1 ms — more than enough for a 0-second lock
         $this->assertTrue($this->guard->allows($job));
     }
 
@@ -191,10 +189,8 @@ final class AttributeGuardTest extends TestCase
             public function handle(): void {}
         };
 
-        // decaySeconds is 0 — the window is already expired for any previous
-        // attempt recorded at the same moment.  usleep ensures clock advances.
+        // A zero-duration rate window retains no previous attempt.
         $this->assertTrue($this->guard->allows($job));
-        usleep(1_000); // 1 ms
         $this->assertTrue($this->guard->allows($job));
     }
 

--- a/packages/routing/tests/Integration/EntityDeepLinkResolutionTest.php
+++ b/packages/routing/tests/Integration/EntityDeepLinkResolutionTest.php
@@ -21,8 +21,8 @@ use Waaseyaa\Routing\WaaseyaaRouter;
  *   - 404 response when entity ID is not found in storage
  *   - 401/403 access-policy enforcement via AccessChecker
  *
- * These access-policy and param-conversion behaviours are deferred per DIR-003:
- * ship working partial coverage over fake-green stubs.
+ * Those behaviours are covered by the production-shaped WP10 E2E suite rather
+ * than represented here by permanently skipped placeholder tests.
  */
 #[CoversNothing]
 final class EntityDeepLinkResolutionTest extends TestCase
@@ -117,22 +117,5 @@ final class EntityDeepLinkResolutionTest extends TestCase
         $parameters = $registeredRoute->getOption('parameters');
         $this->assertIsArray($parameters);
         $this->assertSame(['type' => 'entity:node'], $parameters['id']);
-    }
-
-    // -------------------------------------------------------------------------
-    // Access-policy and entity-hydration assertions require full kernel boot.
-    // Marked as skipped per DIR-003 guidance — see WP10 E2E tests.
-    // -------------------------------------------------------------------------
-
-    #[Test]
-    public function entityNotFoundReturns404SkippedRequiresKernelBoot(): void
-    {
-        $this->markTestSkipped('Requires full kernel boot with EntityTypeManager. See WP10 E2E test.');
-    }
-
-    #[Test]
-    public function accessPolicyEnforcementSkippedRequiresKernelBoot(): void
-    {
-        $this->markTestSkipped('Requires full kernel boot with AccessChecker and session middleware. See WP10 E2E test.');
     }
 }

--- a/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
@@ -23,6 +23,18 @@ use Waaseyaa\User\User;
 #[CoversClass(SessionMiddleware::class)]
 final class SessionMiddlewareTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
     #[Test]
     public function sets_anonymous_user_when_no_session(): void
     {

--- a/tests/Architecture/RandomOrderRunnerTest.php
+++ b/tests/Architecture/RandomOrderRunnerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class RandomOrderRunnerTest extends TestCase
+{
+    private string $repoRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 2);
+    }
+
+    #[Test]
+    public function it_rejects_an_invalid_replay_seed(): void
+    {
+        $result = $this->runCommand(['--seed=not-an-integer', '--list-suites']);
+
+        self::assertSame(2, $result['exit_code']);
+        self::assertStringContainsString('positive integer', $result['output']);
+    }
+
+    #[Test]
+    public function it_logs_a_fixed_seed_and_forwards_phpunit_arguments(): void
+    {
+        $result = $this->runCommand(['--seed=2241', '--list-suites']);
+
+        self::assertSame(0, $result['exit_code'], $result['output']);
+        self::assertStringContainsString('PHPUnit random-order seed: 2241', $result['output']);
+        self::assertStringContainsString('TEST_RANDOM_SEED=2241 composer test:random', $result['output']);
+        self::assertStringContainsString('Available test suite', $result['output']);
+
+        $runner = (string) file_get_contents($this->repoRoot . '/bin/test-random-order');
+        self::assertStringContainsString("putenv('PATH=' . dirname(PHP_BINARY)", $runner);
+    }
+
+    #[Test]
+    public function ci_derives_and_logs_a_replayable_seed_for_a_dedicated_lane(): void
+    {
+        $workflow = (string) file_get_contents($this->repoRoot . '/.github/workflows/ci.yml');
+
+        self::assertStringContainsString('name: ci/random-order', $workflow);
+        self::assertStringContainsString('GITHUB_RUN_ID', $workflow);
+        self::assertStringContainsString('TEST_RANDOM_SEED', $workflow);
+        self::assertStringContainsString('composer test:random', $workflow);
+    }
+
+    /** @param list<string> $arguments
+     *  @return array{exit_code: int, output: string}
+     */
+    private function runCommand(array $arguments): array
+    {
+        $command = [PHP_BINARY, $this->repoRoot . '/bin/test-random-order', ...$arguments];
+        $process = proc_open(
+            $command,
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $this->repoRoot,
+        );
+        self::assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [
+            'exit_code' => proc_close($process),
+            'output' => (string) $stdout . (string) $stderr,
+        ];
+    }
+}

--- a/tests/Architecture/TestQualityInventoryTest.php
+++ b/tests/Architecture/TestQualityInventoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversNothing]
 final class TestQualityInventoryTest extends TestCase
 {
-    private string $repoRoot;
+    private string $repoRoot = '';
 
     protected function setUp(): void
     {
@@ -30,6 +30,13 @@ final class TestQualityInventoryTest extends TestCase
         self::assertSame(20, $inventory['phpunit']['config_files']);
         self::assertGreaterThan(50, $inventory['admin']['vitest_files']);
         self::assertGreaterThan(10, $inventory['admin']['playwright_files']);
+        self::assertSame([], $inventory['determinism']['waits']['unclassified']);
+        self::assertSame([], $inventory['determinism']['conditional_skips']['framework_gap']);
+        self::assertSame([], $inventory['determinism']['conditional_skips']['unclassified']);
+        self::assertCount(3, array_merge(
+            $inventory['determinism']['waits']['subprocess_polling'],
+            $inventory['determinism']['waits']['filesystem_retry'],
+        ));
     }
 
     #[Test]

--- a/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
+++ b/tests/Integration/ReleaseTooling/SyncInternalVersionsTest.php
@@ -209,14 +209,16 @@ final class SyncInternalVersionsTest extends TestCase
 
         $this->runSyncScript($dir, '0.1.0-alpha.999');
 
-        $mtimeBefore = filemtime($dir . '/packages/mypackage/composer.json');
-
-        // Small sleep to ensure mtime would differ if file was rewritten
-        usleep(10000);
+        $manifest = $dir . '/packages/mypackage/composer.json';
+        $controlledMtime = time() - 10;
+        touch($manifest, $controlledMtime);
+        clearstatcache(true, $manifest);
+        $mtimeBefore = filemtime($manifest);
 
         $this->runSyncScript($dir, '0.1.0-alpha.999');
 
-        $mtimeAfter = filemtime($dir . '/packages/mypackage/composer.json');
+        clearstatcache(true, $manifest);
+        $mtimeAfter = filemtime($manifest);
 
         self::assertSame($mtimeBefore, $mtimeAfter, 'Second run must not touch already-current files.');
     }


### PR DESCRIPTION
## Summary

- add a dedicated CI random-order lane with a logged, locally replayable seed and hermetic child-process PHP selection
- classify random, wait, skip, clock, global-state, filesystem, database, subprocess, and port signals in the Git-aware inventory
- fix session and static-cache order leaks, warning-prone bootstrap failure, controllable wall-clock sleeps, and permanently skipped routing placeholders
- document and gate the deterministic test policy, including zero tolerance for framework-gap skips

## Verification

- full random suite seed 2241: 12,606 tests, 249,320 assertions, green before the final sleep cleanup
- full random suite seed 2242: green after all final changes
- focused determinism and policy suite: 49 tests, 145 assertions, green
- affected cache/API/listing/queue/release suites: 256 tests, 575 assertions, green
- PHPStan: 2,007 files, zero errors
- all repository verification gates excluding the redundant embedded full test command: green
- package-layer and Symfony-import boundaries: clean
- git diff --check: clean

Closes #2241