### PR TITLE
Fail specification drift closed for unmapped packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.
 
+- **tooling (#2278):** Fail specification-drift verification closed when changed production package source has no spec mapping, and cover the admin-surface host contract through the admin SPA specification instead of leaving it as an advisory blind spot.
+
 ## [0.1.0-alpha.289] - 2026-08-06
 
 ### Changed

--- a/tests/Architecture/DriftDetectorAcknowledgementTest.php
+++ b/tests/Architecture/DriftDetectorAcknowledgementTest.php
@@ -89,6 +89,52 @@ final class DriftDetectorAcknowledgementTest extends TestCase
         self::assertStringContainsString('STALE: docs/specs/search.md', $output);
     }
 
+    #[Test]
+    public function admin_surface_source_is_coupled_to_the_admin_spa_spec(): void
+    {
+        mkdir($this->fixtureRoot . '/packages/admin-surface/src', 0o777, true);
+        file_put_contents($this->fixtureRoot . '/packages/admin-surface/src/Host.php', "<?php\nfinal class Host {}\n");
+        file_put_contents($this->fixtureRoot . '/docs/specs/admin-spa.md', "# Admin SPA\n");
+        $this->executeCommand('git add .');
+        $this->executeCommand("git commit --quiet -m 'test: add admin surface baseline'");
+        file_put_contents(
+            $this->fixtureRoot . '/packages/admin-surface/src/Host.php',
+            "<?php\nfinal class Host { public const CHANGED = true; }\n",
+        );
+        $this->executeCommand('git add packages/admin-surface/src/Host.php');
+        $this->executeCommand("git commit --quiet -m 'feat: change admin surface contract'");
+
+        [$exitCode, $output] = $this->executeCommand('bash tools/drift-detector.sh HEAD~1', allowFailure: true);
+
+        self::assertSame(1, $exitCode, $output);
+        self::assertStringContainsString('STALE: docs/specs/admin-spa.md', $output);
+        self::assertStringNotContainsString('not mapped to any spec', $output);
+    }
+
+    #[Test]
+    public function unmapped_production_package_source_fails_closed(): void
+    {
+        mkdir($this->fixtureRoot . '/packages/unmapped-contract/src', 0o777, true);
+        file_put_contents(
+            $this->fixtureRoot . '/packages/unmapped-contract/src/Contract.php',
+            "<?php\nfinal class Contract {}\n",
+        );
+        $this->executeCommand('git add .');
+        $this->executeCommand("git commit --quiet -m 'test: add unmapped package baseline'");
+        file_put_contents(
+            $this->fixtureRoot . '/packages/unmapped-contract/src/Contract.php',
+            "<?php\nfinal class Contract { public const CHANGED = true; }\n",
+        );
+        $this->executeCommand('git add packages/unmapped-contract/src/Contract.php');
+        $this->executeCommand("git commit --quiet -m 'feat: change unmapped package contract'");
+
+        [$exitCode, $output] = $this->executeCommand('bash tools/drift-detector.sh HEAD~1', allowFailure: true);
+
+        self::assertSame(1, $exitCode, $output);
+        self::assertStringContainsString('BLOCKED: contract-bearing source changed in package(s) not mapped to any spec:', $output);
+        self::assertStringContainsString('1 unmapped package(s) block specification-drift verification.', $output);
+    }
+
     /** @return array{int, string} */
     private function executeCommand(string $command, bool $allowFailure = false): array
     {

--- a/tools/drift-detector.sh
+++ b/tools/drift-detector.sh
@@ -135,6 +135,7 @@ declare -A PATTERN_TO_SPEC=(
   ["packages/mail/"]="docs/specs/infrastructure.md"
   ["packages/http-client/"]="docs/specs/infrastructure.md"
   ["packages/admin/"]="docs/specs/admin-spa.md"
+  ["packages/admin-surface/"]="docs/specs/admin-spa.md"
   ["packages/note/"]="docs/specs/ingestion-defaults.md"
   ["packages/node/"]="docs/specs/revision-system-unified.md"
   ["packages/relationship/"]="docs/specs/relationship-modeling.md"
@@ -171,12 +172,11 @@ record_spec() {
 warn_unmapped() {
   [ "${#UNMAPPED_PKGS[@]}" -eq 0 ] && return 0
   {
-    echo "WARNING: contract-bearing source changed in package(s) not mapped to any spec:"
+    echo "BLOCKED: contract-bearing source changed in package(s) not mapped to any spec:"
     for pkg in $(printf '%s\n' "${!UNMAPPED_PKGS[@]}" | sort); do
       echo "  - ${pkg} (no entry in PATTERN_TO_SPEC or the secondary case map)"
     done
-    echo "  These changes were NOT coupling-checked. If the package has a spec,"
-    echo "  add it to PATTERN_TO_SPEC in tools/drift-detector.sh so drift is caught."
+    echo "  These changes were NOT coupling-checked. Map every package before merging."
   } >&2
 }
 
@@ -214,7 +214,9 @@ done <<< "$SOURCE_FILES"
 if [ "${#AFFECTED_SPECS[@]}" -eq 0 ]; then
   echo "No specs mapped to the changed source."
   warn_unmapped
-  exit 0
+  [ "${#UNMAPPED_PKGS[@]}" -eq 0 ] && exit 0
+  echo "${#UNMAPPED_PKGS[@]} unmapped package(s) block specification-drift verification."
+  exit 1
 fi
 
 # --- collect spec-reviewed acknowledgements from commit messages in range ---
@@ -270,6 +272,7 @@ for spec in $(printf '%s\n' "${!AFFECTED_SPECS[@]}" | sort); do
 done
 
 warn_unmapped
+STALE_COUNT=$((STALE_COUNT + ${#UNMAPPED_PKGS[@]}))
 
 echo ""
 if [ $STALE_COUNT -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Map `packages/admin-surface/` production source to the admin SPA specification.
- Make changed production packages without a specification mapping fail verification instead of emitting a successful advisory warning.
- Add fixture-backed coverage for both the mapping and fail-closed behavior.

## Root cause

The drift detector tracked unmapped packages but always exited successfully. It also omitted the framework-owned admin-surface host package, leaving contract-bearing changes outside the specification gate.

## Verification

- Focused architecture suite: 5 tests, 53 assertions.
- Canonical `composer verify`: 12,712 tests, 250,004 assertions.
- Native pre-push Composer policy, Symfony import, package layer, and drift checks passed.
- `git diff --check` passed.

This is the first PR in the remediation stack and targets `main` directly.

Closes #2278
