### PR TITLE
Index ordinary nodes in public search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.
 
+- **search (#2270):** Index ordinary Node content through one search-owned projection registry shared by reindexing, lifecycle updates, and query-time access checks. Application projectors can override canonical URLs and searchable fields without weakening entity- or field-level authorization.
+
+- **search (#2270):** Bound public search to one 1,001-pointer FTS statement and expose truncated totals as incomplete instead of presenting lower bounds as exhaustive results. Reindexing now exits non-zero on projection failure.
+
 - **tooling (#2278):** Fail specification-drift verification closed when changed production package source has no spec mapping, and cover the admin-surface host contract through the admin SPA specification instead of leaving it as an advisory blind spot.
 
 ## [0.1.0-alpha.289] - 2026-08-06

--- a/docs/public-surface-map.md
+++ b/docs/public-surface-map.md
@@ -390,6 +390,12 @@ Configuration Management v1 — active/sync store split, six `config:*` CLI comm
 | `ProvidesSearchSourceResolversInterface` | interface | Contributes exact-namespace resolvers for canonical non-entity search sources |
 | `SearchIndexerInterface` | interface | Adds, updates, and removes documents from the search index |
 | `SearchIndexableInterface` | interface | Marks an entity as searchable and provides its document ID and text fields |
+| `Projection\EntitySearchProjectorInterface` | interface | Projects a normal entity (Node) into an indexable search document without an upward search dependency |
+| `Projection\EntitySearchDocumentId` | class | Creates stable search document identifiers for projected entities |
+| `Projection\EntitySearchProjectionRegistry` | class | Selects the first application or framework projector that supports an entity |
+| `Projection\NodeSearchProjector` | class | Provides the framework default projection for public Node content |
+| `Projection\SearchTextNormalizer` | class | Converts CMS field values into inert plain searchable text |
+| `ProvidesEntitySearchProjectorsInterface` | interface | Contributes application entity search projectors ordered ahead of the built-in node default |
 
 ### notification
 

--- a/docs/public-surface-map.php
+++ b/docs/public-surface-map.php
@@ -461,6 +461,14 @@ return [
     'Waaseyaa\Search\SearchIndexerInterface' => 'public',
     'Waaseyaa\Search\BatchSearchIndexerInterface' => 'public',
     'Waaseyaa\Search\SearchIndexableInterface' => 'public',
+    // Entity search projection contract (#2270): projector extension point +
+    // application contribution interface for site-specific searchable fields.
+    'Waaseyaa\Search\Projection\EntitySearchProjectorInterface' => 'public',
+    'Waaseyaa\Search\Projection\EntitySearchDocumentId' => 'public',
+    'Waaseyaa\Search\Projection\EntitySearchProjectionRegistry' => 'public',
+    'Waaseyaa\Search\Projection\NodeSearchProjector' => 'public',
+    'Waaseyaa\Search\Projection\SearchTextNormalizer' => 'public',
+    'Waaseyaa\Search\ProvidesEntitySearchProjectorsInterface' => 'public',
     'Waaseyaa\Notification\NotificationInterface' => 'public',
     'Waaseyaa\Notification\NotifiableInterface' => 'public',
     'Waaseyaa\Notification\NotifiableTrait' => 'public',

--- a/docs/specs/search.md
+++ b/docs/specs/search.md
@@ -1,19 +1,45 @@
 # Search
 
+Canonical contract documentation lives in [`packages/search/README.md`](../../packages/search/README.md)
+(the orchestration table's spec target for `packages/search/*`). This file
+keeps only the cross-cutting invariants.
+
 ## Scope
 
 `waaseyaa/search` is a Layer 3 service package for full-text and structured
-entity search. The write-side indexer is active for existing consumers. The
-FTS5 read provider, request/result objects, access checker, and Twig helper are
-internal and have no first-party HTTP, CLI, SSR, or admin caller on main.
+entity search. The principal-safe read surface is consumed by the published
+`/api/content/search` endpoint and MCP `content.search` (#2268). The
+write-side indexer serves both self-indexable entities and — since #2270 —
+ordinary content entities through the search-owned entity projection
+contract (`Projection\EntitySearchProjectorInterface`, resolved through one
+shared `Projection\EntitySearchProjectionRegistry`).
 
-## Read-surface activation boundary
+## Entity projection invariant (#2270)
 
-Do not publish the parked read surface until a first-party endpoint supplies an
-acting-account access boundary and tests access-filtered pagination. Count,
-facets, page selection, and rank order must share one bounded ordered ID basis;
-titles and snippets are fetched only for the approved page IDs. Asynchronous
-indexing also requires a production queue consumer before a job is introduced.
+Full `search:reindex`, the save/delete/revision-pointer lifecycle, and
+query-time candidate resolution all resolve entities through the same
+projection registry — never through divergent per-surface logic. The
+built-in `NodeSearchProjector` keys off the `node` entity type id via the
+generic entity contract (no `Waaseyaa\Node` import; search must not gain a
+composer edge to `waaseyaa/node` — they sit in different metapackages).
+Projection reads only guarded field accessors, so index-time projection
+(unscoped) can only capture Public-classified fields, and query-time
+re-projection runs inside the acting principal's field-read scope after the
+entity `view` check. Applications contribute or override projectors by
+binding `ProvidesEntitySearchProjectorsInterface`; app projectors precede
+the built-in default and a supporting projector's null decline is final.
+
+## Read-surface access boundary
+
+Count, facets, page selection, and rank order must share one ordered pointer
+basis fetched by a single bounded statement. The provider projects at most
+1,000 candidates and uses one extra pointer as a truncation sentinel; when it
+is present, every public adapter must expose `isComplete: false` and treat the
+reported totals, pages, and facets as lower bounds. Titles and snippets derive
+only from principal-safe canonical projections (see the README's
+"Principal-safe read surface"). Asynchronous
+indexing still requires a production queue consumer before a job is
+introduced.
 
 ## Index contract
 

--- a/packages/ai-tools/src/ContentSearch/ContentSearchTool.php
+++ b/packages/ai-tools/src/ContentSearch/ContentSearchTool.php
@@ -88,10 +88,11 @@ final class ContentSearchTool extends AbstractAgentTool
                 'total_pages' => ['type' => 'integer', 'minimum' => 0],
                 'current_page' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 200],
                 'page_size' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+                'is_complete' => ['type' => 'boolean'],
                 'hits' => ['type' => 'array', 'maxItems' => 100, 'items' => $hit],
                 'facets' => ['type' => 'array', 'maxItems' => 20, 'items' => $facet],
             ],
-            'required' => ['total_hits', 'total_pages', 'current_page', 'page_size', 'hits', 'facets'],
+            'required' => ['total_hits', 'total_pages', 'current_page', 'page_size', 'is_complete', 'hits', 'facets'],
             'additionalProperties' => false,
         ];
     }

--- a/packages/ai-tools/src/ContentSearch/SearchPackageContentSearchAdapter.php
+++ b/packages/ai-tools/src/ContentSearch/SearchPackageContentSearchAdapter.php
@@ -90,6 +90,7 @@ final class SearchPackageContentSearchAdapter
             'total_pages' => self::nonNegativeInt($result, 'totalPages'),
             'current_page' => self::boundedInt($result, 'currentPage', 1, 200),
             'page_size' => self::boundedInt($result, 'pageSize', 1, 100),
+            'is_complete' => self::boolProperty($result, 'isComplete'),
             'hits' => self::hits($result),
             'facets' => self::facets($result),
         ];
@@ -193,6 +194,16 @@ final class SearchPackageContentSearchAdapter
         $value = self::property($object, $property);
         if (!is_int($value) || $value < 0) {
             throw new ContentSearchBoundaryException('The optional search result contains an invalid integer.');
+        }
+
+        return $value;
+    }
+
+    private static function boolProperty(object $object, string $property): bool
+    {
+        $value = self::property($object, $property);
+        if (!is_bool($value)) {
+            throw new ContentSearchBoundaryException('The optional search result contains an invalid boolean.');
         }
 
         return $value;

--- a/packages/ai-tools/tests/Unit/ContentSearch/ContentSearchToolTest.php
+++ b/packages/ai-tools/tests/Unit/ContentSearch/ContentSearchToolTest.php
@@ -43,7 +43,7 @@ final class ContentSearchToolTest extends TestCase
 
                 return new SearchResult(1, 1, 1, 20, [
                     new SearchHit('page:7', 'Water', '/water', 'site', '2026-08-04T00:00:00Z', 92, 'page', ['culture'], 4.25, '/water.jpg', 'Clean water'),
-                ], [new SearchFacet('topics', [new FacetBucket('culture', 1)])]);
+                ], [new SearchFacet('topics', [new FacetBucket('culture', 1)])], isComplete: false);
             }
         };
         $tool = new ContentSearchTool(static fn(): object => $provider);
@@ -53,6 +53,7 @@ final class ContentSearchToolTest extends TestCase
         self::assertFalse($result->isError, json_encode($result->content, JSON_THROW_ON_ERROR));
         self::assertSame($account, $seenPrincipal);
         self::assertSame(1, $result->structuredContent['total_hits']);
+        self::assertFalse($result->structuredContent['is_complete']);
         self::assertSame('/water', $result->structuredContent['hits'][0]['url']);
         self::assertSame('Clean water', $result->structuredContent['hits'][0]['highlight']);
         self::assertSame([['key' => 'culture', 'count' => 1]], $result->structuredContent['facets'][0]['buckets']);

--- a/packages/ai-tools/tests/Unit/Resource/SearchPackageContentResourceProviderTest.php
+++ b/packages/ai-tools/tests/Unit/Resource/SearchPackageContentResourceProviderTest.php
@@ -86,7 +86,7 @@ final class SearchPackageContentResourceProviderTest extends TestCase
     #[Test]
     public function denied_and_unknown_catalogue_reads_both_return_null(): void
     {
-        $catalogue = $this->createMock(SearchContentCatalogueInterface::class);
+        $catalogue = $this->createStub(SearchContentCatalogueInterface::class);
         $catalogue->method('readByPublicPath')->willReturn(null);
         $provider = new SearchPackageContentResourceProvider(static fn(): object => $catalogue);
 

--- a/packages/api/src/ContentSearch/ContentSearchPage.php
+++ b/packages/api/src/ContentSearch/ContentSearchPage.php
@@ -17,6 +17,7 @@ final readonly class ContentSearchPage
         public int $pageSize,
         public array $hits,
         public array $facets,
+        public bool $isComplete = true,
     ) {
         if ($totalHits < 0 || $totalPages < 0 || $currentPage < 1 || $pageSize < 1 || $pageSize > 100) {
             throw new ContentSearchBoundaryException('Search page metadata violates the API contract.');

--- a/packages/api/src/ContentSearch/SearchPackageContentSearchAdapter.php
+++ b/packages/api/src/ContentSearch/SearchPackageContentSearchAdapter.php
@@ -63,6 +63,7 @@ final class SearchPackageContentSearchAdapter implements ContentSearchReadModelI
             pageSize: self::intProperty($result, 'pageSize'),
             hits: self::hits($result),
             facets: self::facets($result),
+            isComplete: self::boolProperty($result, 'isComplete'),
         );
     }
 
@@ -122,6 +123,16 @@ final class SearchPackageContentSearchAdapter implements ContentSearchReadModelI
         $value = self::property($object, $property);
         if (!is_int($value)) {
             throw new ContentSearchBoundaryException('The optional search result contains an invalid integer.');
+        }
+
+        return $value;
+    }
+
+    private static function boolProperty(object $object, string $property): bool
+    {
+        $value = self::property($object, $property);
+        if (!is_bool($value)) {
+            throw new ContentSearchBoundaryException('The optional search result contains an invalid boolean.');
         }
 
         return $value;

--- a/packages/api/src/Controller/ContentSearchController.php
+++ b/packages/api/src/Controller/ContentSearchController.php
@@ -204,6 +204,7 @@ final class ContentSearchController
                 'totalPages' => $result->totalPages,
                 'currentPage' => $result->currentPage,
                 'pageSize' => $result->pageSize,
+                'isComplete' => $result->isComplete,
                 'facets' => $result->safeFacets(),
             ],
         ];

--- a/packages/api/tests/Unit/ContentSearchControllerTest.php
+++ b/packages/api/tests/Unit/ContentSearchControllerTest.php
@@ -83,6 +83,7 @@ final class ContentSearchControllerTest extends TestCase
         ], array_keys($payload['data'][0]['attributes']));
         self::assertSame('Community update', $payload['data'][0]['attributes']['title']);
         self::assertSame(1, $payload['meta']['totalHits']);
+        self::assertTrue($payload['meta']['isComplete']);
         self::assertSame('events', $payload['meta']['facets'][0]['buckets'][0]['key']);
         self::assertArrayNotHasKey('body', $payload['data'][0]['attributes']);
         self::assertArrayNotHasKey('tookMs', $payload['meta']);
@@ -107,7 +108,7 @@ final class ContentSearchControllerTest extends TestCase
         foreach ([[false], [true, false]] as $decisions) {
             $provider = $this->createMock(ContentSearchReadModelInterface::class);
             $provider->expects($this->never())->method('search');
-            $limiter = $this->createMock(ContentSearchRateLimiterInterface::class);
+            $limiter = $this->createStub(ContentSearchRateLimiterInterface::class);
             $limiter->method('consume')->willReturnOnConsecutiveCalls(...$decisions);
 
             $response = (new ContentSearchController($provider, $limiter))->search(

--- a/packages/cli/src/Handler/SearchReindexHandler.php
+++ b/packages/cli/src/Handler/SearchReindexHandler.php
@@ -5,22 +5,38 @@ declare(strict_types=1);
 namespace Waaseyaa\CLI\Handler;
 
 use Waaseyaa\CLI\Command\SymfonyCommandIO;
+use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Search\BatchSearchIndexerInterface;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
 use Waaseyaa\Search\SearchIndexableInterface;
 use Waaseyaa\Search\SearchIndexerInterface;
 
 /**
+ * Rebuilds the search index from every indexable document.
+ *
+ * #2270: entities are resolved through the shared
+ * {@see EntitySearchProjectionRegistry} — self-indexable entities pass
+ * through unchanged, ordinary content entities (Node) are projected by the
+ * registered projectors, and everything else is skipped. This is the same
+ * projection contract the lifecycle subscriber and query-time candidate
+ * resolution use, so a full reindex cannot drift from incremental indexing.
+ *
  * @api
  */
 final class SearchReindexHandler
 {
     private const BATCH_SIZE = 100;
 
+    private readonly EntitySearchProjectionRegistry $projectionRegistry;
+
     public function __construct(
         private readonly SearchIndexerInterface $indexer,
         private readonly EntityTypeManagerInterface $entityTypeManager,
-    ) {}
+        ?EntitySearchProjectionRegistry $projectionRegistry = null,
+    ) {
+        $this->projectionRegistry = $projectionRegistry ?? new EntitySearchProjectionRegistry([]);
+    }
 
     public function execute(SymfonyCommandIO $io): int
     {
@@ -40,6 +56,7 @@ final class SearchReindexHandler
         $batchIndexer = $this->indexer instanceof BatchSearchIndexerInterface ? $this->indexer : null;
 
         $totalIndexed = 0;
+        $totalProjectionFailures = 0;
 
         foreach ($this->entityTypeManager->getDefinitions() as $entityType) {
             // C-22 WP2/WP3: both the query surface and the read path now live on the repository.
@@ -67,10 +84,24 @@ final class SearchReindexHandler
                 $offset += count($ids);
 
                 $indexables = [];
+                $projectionFailures = 0;
                 foreach ($repository->findMany($ids) as $entity) {
-                    if ($entity instanceof SearchIndexableInterface) {
-                        $indexables[] = $entity;
+                    try {
+                        $indexable = $this->resolveIndexable($entity);
+                    } catch (\Throwable) {
+                        // Fail soft per entity, content-free: one unprojectable
+                        // entity must not abort the whole reindex or leak its
+                        // values into operator output.
+                        ++$projectionFailures;
+                        continue;
                     }
+                    if ($indexable !== null) {
+                        $indexables[] = $indexable;
+                    }
+                }
+                if ($projectionFailures > 0) {
+                    $totalProjectionFailures += $projectionFailures;
+                    $io->writeln("  [{$entityType->id()}] Skipped $projectionFailures entities whose search projection failed.");
                 }
 
                 if ($indexables !== []) {
@@ -103,6 +134,16 @@ final class SearchReindexHandler
         $io->writeln("Reindex complete. $totalIndexed documents indexed.");
         $io->writeln('Schema version: ' . $this->indexer->getSchemaVersion());
 
+        if ($totalProjectionFailures > 0) {
+            $io->writeln("Reindex failed: $totalProjectionFailures entities could not be projected.");
+            return 1;
+        }
+
         return 0;
+    }
+
+    private function resolveIndexable(EntityInterface $entity): ?SearchIndexableInterface
+    {
+        return $this->projectionRegistry->resolveIndexable($entity);
     }
 }

--- a/packages/cli/tests/Unit/Handler/SearchReindexHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/SearchReindexHandlerTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\CLI\Tests\Unit\Handler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\CLI\Command\HandlerCommand;
+use Waaseyaa\CLI\Command\HandlerOption;
+use Waaseyaa\CLI\Command\HandlerOptionMode;
+use Waaseyaa\CLI\Handler\SearchReindexHandler;
+use Waaseyaa\CLI\Testing\CliTester;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\Entity\Storage\EntityQueryInterface;
+use Waaseyaa\Search\BatchSearchIndexerInterface;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
+use Waaseyaa\Search\Projection\NodeSearchProjector;
+use Waaseyaa\Search\SearchIndexableInterface;
+use Waaseyaa\Search\SearchIndexerInterface;
+
+#[CoversClass(SearchReindexHandler::class)]
+final class SearchReindexHandlerTest extends TestCase
+{
+    #[Test]
+    public function plain_node_entities_are_projected_and_indexed_during_a_full_reindex(): void
+    {
+        $indexer = new RecordingSearchIndexer();
+        $tester = $this->tester($indexer, [
+            $this->nodeEntity(1, 'Community Health Services', '<p>Wellness clinic hours</p>'),
+            $this->nodeEntity(2, 'Band Office Jobs', 'Apply today'),
+        ]);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getExitCode());
+        $this->assertStringContainsString('Reindex complete. 2 documents indexed.', $tester->getStdout());
+        $this->assertSame(['node:1', 'node:2'], array_keys($indexer->documents));
+        $this->assertSame('Community Health Services', $indexer->documents['node:1']['title']);
+        $this->assertSame('Wellness clinic hours', $indexer->documents['node:1']['body']);
+    }
+
+    #[Test]
+    public function self_indexable_entities_keep_their_own_projection(): void
+    {
+        $indexer = new RecordingSearchIndexer();
+        $tester = $this->tester($indexer, [
+            $this->selfIndexableEntity('custom:9', 'Self projected'),
+            $this->nodeEntity(1, 'Plain node', 'body'),
+        ]);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getExitCode());
+        $this->assertStringContainsString('Reindex complete. 2 documents indexed.', $tester->getStdout());
+        $this->assertSame(['custom:9', 'node:1'], array_keys($indexer->documents));
+        $this->assertSame('Self projected', $indexer->documents['custom:9']['title']);
+    }
+
+    #[Test]
+    public function entities_nobody_projects_are_skipped(): void
+    {
+        $indexer = new RecordingSearchIndexer();
+        $tester = $this->tester($indexer, [
+            $this->plainEntity('taxonomy_term', 3),
+        ]);
+
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getExitCode());
+        $this->assertStringContainsString('Reindex complete. 0 documents indexed.', $tester->getStdout());
+        $this->assertSame([], $indexer->documents);
+    }
+
+    #[Test]
+    public function a_projection_failure_is_reported_and_fails_the_command(): void
+    {
+        $indexer = new RecordingSearchIndexer();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public function supports(EntityInterface $entity): bool { return true; }
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                throw new \RuntimeException('projection failure');
+            }
+        };
+        $tester = $this->tester(
+            $indexer,
+            [$this->nodeEntity(1, 'Private title', 'Private body')],
+            new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        $tester->execute([]);
+
+        self::assertSame(1, $tester->getExitCode());
+        self::assertStringContainsString('Skipped 1 entities whose search projection failed.', $tester->getStdout());
+        self::assertStringContainsString('Reindex failed: 1 entities could not be projected.', $tester->getStdout());
+        self::assertStringNotContainsString('Private title', $tester->getStdout());
+        self::assertSame([], $indexer->documents);
+    }
+
+    /**
+     * @param list<EntityInterface> $entities
+     */
+    private function tester(
+        RecordingSearchIndexer $indexer,
+        array $entities,
+        ?EntitySearchProjectionRegistry $projectionRegistry = null,
+    ): CliTester
+    {
+        $handler = new SearchReindexHandler(
+            $indexer,
+            $this->entityTypeManager($entities),
+            $projectionRegistry ?? new EntitySearchProjectionRegistry([new NodeSearchProjector()]),
+        );
+        $definition = new HandlerCommand(
+            name: 'search:reindex',
+            description: 'Rebuild the search index from all indexable entities',
+            options: [
+                new HandlerOption(name: 'batch-size', shortcut: 'b', mode: HandlerOptionMode::Required, description: 'Entities per batch', default: '100'),
+            ],
+            handler: \Closure::fromCallable([$handler, 'execute']),
+        );
+
+        $container = new class implements \Psr\Container\ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException("Not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        };
+
+        return CliTester::for($definition, $container);
+    }
+
+    /**
+     * @param list<EntityInterface> $entities
+     */
+    private function entityTypeManager(array $entities): EntityTypeManagerInterface
+    {
+        $ids = array_map(static fn(EntityInterface $entity): string => (string) $entity->id(), $entities);
+
+        $query = $this->createStub(EntityQueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
+        $query->method('range')->willReturnSelf();
+        $query->method('execute')->willReturn($ids);
+
+        $repository = $this->createStub(EntityRepositoryInterface::class);
+        $repository->method('getQuery')->willReturn($query);
+        $repository->method('findMany')->willReturn($entities);
+
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
+        $manager->method('getDefinitions')->willReturn([
+            'node' => new EntityType(id: 'node', label: 'Content', class: \stdClass::class, keys: ['id' => 'nid']),
+        ]);
+        $manager->method('getRepository')->willReturn($repository);
+
+        return $manager;
+    }
+
+    private function nodeEntity(int $id, string $title, string $body): EntityInterface
+    {
+        return new class (['nid' => $id, 'title' => $title, 'body' => $body, 'type' => 'page']) extends ContentEntityBase {
+            public function __construct(array $values)
+            {
+                parent::__construct($values, 'node', ['id' => 'nid', 'label' => 'title', 'bundle' => 'type']);
+            }
+        };
+    }
+
+    private function plainEntity(string $entityTypeId, int $id): EntityInterface
+    {
+        return new class ($entityTypeId, $id) extends \Waaseyaa\Entity\EntityBase {
+            public function __construct(string $entityTypeId, int $id)
+            {
+                parent::__construct(['id' => $id], $entityTypeId, ['id' => 'id']);
+            }
+        };
+    }
+
+    private function selfIndexableEntity(string $documentId, string $title): EntityInterface
+    {
+        return new class ($documentId, $title) extends \Waaseyaa\Entity\EntityBase implements SearchIndexableInterface {
+            public function __construct(private readonly string $documentId, private readonly string $title)
+            {
+                parent::__construct(['id' => 9], 'custom', ['id' => 'id']);
+            }
+
+            public function getSearchDocumentId(): string
+            {
+                return $this->documentId;
+            }
+
+            public function toSearchDocument(): array
+            {
+                return ['title' => $this->title, 'body' => 'B'];
+            }
+
+            public function toSearchMetadata(): array
+            {
+                return ['entity_type' => 'custom'];
+            }
+        };
+    }
+}
+
+final class RecordingSearchIndexer implements SearchIndexerInterface, BatchSearchIndexerInterface
+{
+    /** @var array<string, array<string, string>> */
+    public array $documents = [];
+
+    public function index(SearchIndexableInterface $item): void
+    {
+        $this->documents[$item->getSearchDocumentId()] = $item->toSearchDocument();
+    }
+
+    public function reindexBatch(iterable $items): int
+    {
+        $count = 0;
+        foreach ($items as $item) {
+            $this->index($item);
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    public function remove(string $documentId): void
+    {
+        unset($this->documents[$documentId]);
+    }
+
+    public function removeAll(): void
+    {
+        $this->documents = [];
+    }
+
+    public function getSchemaVersion(): string
+    {
+        return '2';
+    }
+}

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -7,8 +7,11 @@ Full-text and structured search for Waaseyaa applications.
 Provides a search index abstraction and query builder for finding entities
 across types. The FTS5 implementation indexes a fixed title/body document,
 supports faceting and relevance ranking, preserves Indigenous orthography in
-tokenization, and performs bounded access-filtered pagination. No first-party
-API endpoint currently calls this read surface.
+tokenization, and performs batched access-filtered pagination. Entities become
+documents either by implementing `SearchIndexableInterface` themselves or —
+for ordinary content such as `node` — through the search-owned entity
+projection contract (see below). The principal-safe read surface is consumed
+by `/api/content/search` and MCP `content.search`.
 
 Key classes: `SearchRequest`, `SearchResult`, `SearchProviderInterface`.
 
@@ -22,13 +25,13 @@ entity, proves entity `view`, and regenerates its search projection inside the
 principal's field-read scope before the candidate can affect a hit, count,
 facet, rank, snippet, filter, or page boundary.
 
-FTS5 is only a bounded candidate generator. Returned values and aggregates are
-derived exclusively from the principal-safe projection. A request resolves at
-most 200 candidates; the entity resolver safely truncates authorized title
-and body text to 512 characters and 64 KiB respectively. If
-inaccessible or non-matching canonical projections consume that window,
-results conservatively under-count; the provider never exposes a raw count,
-`hasMore`, or cap-exhaustion flag. `SearchResult` deliberately omits server
+FTS5 is only a batched candidate generator. Returned values and aggregates are
+derived exclusively from the principal-safe projection. Raw pointers are read
+in fixed batches of 200 until the ordered match set is exhausted, so protected
+or stale candidates cannot dilute accessible results or make totals, facets,
+and pagination silently incomplete. The entity resolver safely truncates
+authorized title and body text to 512 characters and 64 KiB respectively.
+`SearchResult` deliberately omits server
 duration so the API does not amplify protected-index cardinality as response
 data. Ordinary end-to-end latency remains a weak residual channel and must not
 be logged or exposed at per-query granularity on a public adapter.
@@ -65,6 +68,81 @@ remains live for existing consumers. The unused `SearchIndexJob` was deleted;
 asynchronous indexing must wait for a production queue consumer rather than
 publishing an undrained message.
 
+## Entity search projection (#2270)
+
+Core content entities cannot depend upward on `waaseyaa/search`, so `node`
+never implements `SearchIndexableInterface`. The projection contract closes
+that gap from the search side:
+
+- `Projection\EntitySearchProjectorInterface` — `supports()` / `project()`;
+  turns a normal entity into an indexable document (`Document\SearchDocument`).
+- `Projection\EntitySearchProjectionRegistry` — the **single resolution
+  point** used by all four surfaces: `search:reindex`, the save/pointer-move
+  lifecycle, lifecycle deletion, and query-time candidate re-projection. A
+  self-indexable entity is its own document view; otherwise the first
+  supporting projector owns the entity and its result (including a null
+  decline) is final. Because every surface resolves through the same
+  registry, index-time and query-time semantics cannot drift apart.
+- `Projection\NodeSearchProjector` — the built-in default, registered last.
+  It keys off the `node` entity type id through the generic entity contract
+  (no `Waaseyaa\Node` import, no composer edge, metapackage-clean) and reads
+  every value through the guarded accessor: label-key title, the declared
+  `body` field, the public `slug` (projected as the root-relative canonical
+  URL `/{slug}` after conservative segment validation), the bundle as
+  `content_type`, and `created` as `created_at`. Document ids are the stable
+  canonical entity form `node:{id}` (`Projection\EntitySearchDocumentId`) —
+  the same form the entity candidate resolver parses and the deletion path
+  derives without projecting.
+
+**Read-level mechanics are the indexing filter.** Index-time projection runs
+without an account scope, so only `FieldReadLevel::Public` fields release
+values; a Protected or unclassified (Internal-defaulted) field throws on
+read, the default projector omits that field's text, and protected content
+never enters the index file at all. At query time the same projector runs
+inside the acting principal's field-read scope after the entity `view` check,
+so per-principal field grants apply and the re-generated document id must
+round-trip the index pointer. A projector may instead let the denial
+propagate — the resolver then drops the whole candidate fail-closed (the
+strict variant); the default node projector uses per-field omission,
+mirroring `ResourceSerializer`. Practical consequence: a bundle's `body`
+must be classified `read: public` in its field definition to be searchable;
+unclassified bundle fields fail closed to Internal and are silently omitted.
+
+Unpublished content is indexed (the index is a protected datastore; reads are
+gated per principal at query time, and a draft resolves to nothing for
+principals without view access — indistinguishable from absence). The
+lifecycle subscriber still re-sources saves from the served base row, so
+forward-draft revisions never enter the index, and deletion removes the
+projected document even though the entity is not `SearchIndexableInterface`.
+
+Field text is untrusted CMS data: `Projection\SearchTextNormalizer` drops
+script/style/template payloads and comments with their content, strips
+remaining markup with word boundaries preserved, decodes entities, scrubs
+re-introduced angle brackets, repairs invalid UTF-8, and collapses
+whitespace. Search text is data, never agent instructions.
+
+**Application override.** Bind `ProvidesEntitySearchProjectorsInterface` in a
+service provider's `register()` (normal container contribution — no config
+closures, no service location):
+
+```php
+final class AppSearchProvider extends ServiceProvider implements ProvidesEntitySearchProjectorsInterface
+{
+    public function register(): void
+    {
+        $this->singleton(ProvidesEntitySearchProjectorsInterface::class, fn() => $this);
+    }
+
+    public function entitySearchProjectors(): array
+    {
+        // Consulted ahead of NodeSearchProjector: supports('node') here
+        // replaces the default projection (site URL scheme, extra fields),
+        // and project() may return null to keep content out of the index.
+        return [new AppNodeSearchProjector()];
+    }
+}
+```
+
 ## Protected index trust boundary
 
 `search_index` and `search_metadata` are a protected, derived datastore, not a
@@ -96,4 +174,4 @@ is never authority for declaring a source public.
 - **Indigenous orthography is the tokenizer acceptance bar (#2010, R21):** `search_index` uses `tokenize="unicode61 remove_diacritics 0 tokenchars '''’ʼ'"` — Unicode word boundaries, no English Porter stemmer, no diacritic folding, and ASCII apostrophe/U+2019/U+02BC retained inside tokens. Round-trip coverage pins Anishinaabemowin double vowels, apostrophe/glottal forms, macrons/acute diacritics, and Canadian syllabics. Because SQLite cannot alter an FTS5 tokenizer in place, `search:reindex` recreates the virtual table before repopulating it; upgraded indexes must be fully reindexed.
 - **FTS5 `SELECT m.*` misses FTS5 columns**: When joining `search_index` (FTS5) with `search_metadata`, `m.*` only selects metadata columns. To get FTS5 content columns (title, body), select them explicitly: `si.title`, `si.body`. The `snippet()` function also requires column index references into the FTS5 table.
 - **FTS5 query syntax is never accepted from callers**: the provider extracts Unicode word/apostrophe tokens from plain text and submits every term individually quoted, including literal words such as `and`, `or`, `not`, and `near`. Punctuation such as `full-text`, `node.js`, and `C++` becomes the same token sequence used by SQLite's tokenizer; operators and wildcards cannot enter the query grammar.
-- **Every observable uses one safe bounded basis** (#1915, R16; #2010, R21): a pointer-only raw scan selects document ID, entity type, schema version, and raw rank for no more than 200 candidates. The resolver canonically reloads and authorizes each candidate; safe projections then determine token matching, filters, rank, sort, totals, facets, pagination, and snippets. Alternate sort fields operate within this conservative candidate window, not across the entire protected index. See `Fts5SearchProviderPaginationAccessFilteredTest`, `Fts5SearchProviderAccessFilteredCountTest`, and `Fts5SearchProviderTwoPhaseFetchTest`.
+- **Every observable uses one bounded safe basis** (#1915, R16; #2010, R21; #2270): one pointer-only statement selects document ID, entity type, and schema version for at most 1,001 ranked rows, using the final row only as a truncation sentinel. There is no `OFFSET` loop, so concurrent lifecycle writes cannot duplicate or skip candidates between scan statements and work cannot grow quadratically. The resolver canonically reloads and authorizes at most 1,000 candidates; safe projections then determine token matching, filters, rank, sort, totals, facets, pagination, and snippets. When the sentinel is present, `SearchResult::isComplete` is false and exposed by the HTTP API and agent tool; totals, pages, and facets are explicitly lower bounds. See `Fts5SearchProviderPaginationAccessFilteredTest`, `Fts5SearchProviderAccessFilteredCountTest`, and `Fts5SearchProviderTwoPhaseFetchTest`.

--- a/packages/search/src/Access/EntitySearchCandidateResolver.php
+++ b/packages/search/src/Access/EntitySearchCandidateResolver.php
@@ -8,8 +8,9 @@ use Waaseyaa\Access\AuthorizationPrincipalInterface;
 use Waaseyaa\Access\Context\AccountFieldReadScopeInterface;
 use Waaseyaa\Access\EntityAccessHandler;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
-use Waaseyaa\Entity\Exception\FieldReadDenied;
-use Waaseyaa\Entity\Exception\MissingFieldReadContext;
+use Waaseyaa\Foundation\Log\LoggerInterface;
+use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
 use Waaseyaa\Search\SearchCandidateProjection;
 use Waaseyaa\Search\SearchCandidateReference;
 use Waaseyaa\Search\SearchCandidateResolverInterface;
@@ -18,11 +19,20 @@ use Waaseyaa\Search\SearchIndexableInterface;
 /** Canonical entity-backed candidate resolver. @api */
 final readonly class EntitySearchCandidateResolver implements SearchCandidateResolverInterface
 {
+    private EntitySearchProjectionRegistry $projectionRegistry;
+
+    private LoggerInterface $logger;
+
     public function __construct(
         private EntityTypeManagerInterface $entityTypeManager,
         private EntityAccessHandler $accessHandler,
         private AccountFieldReadScopeInterface $fieldReadScope,
-    ) {}
+        ?EntitySearchProjectionRegistry $projectionRegistry = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->projectionRegistry = $projectionRegistry ?? new EntitySearchProjectionRegistry([]);
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     public function resolve(
         SearchCandidateReference $reference,
@@ -44,20 +54,52 @@ final readonly class EntitySearchCandidateResolver implements SearchCandidateRes
         }
 
         $entity = $this->entityTypeManager->getRepository($reference->entityType)->find($entityId);
-        if (!$entity instanceof SearchIndexableInterface) {
+        if ($entity === null) {
+            return null;
+        }
+        // Entities that are not their own document view resolve through the
+        // shared projection registry — the same contract the reindex and
+        // lifecycle paths use — so query-time semantics cannot drift from
+        // index-time semantics. An unsupported entity fails closed.
+        if (!$entity instanceof SearchIndexableInterface
+            && !$this->projectionRegistry->supports($entity)
+        ) {
             return null;
         }
         if (!$this->accessHandler->check($entity, 'view', $principal)->isAllowed()) {
             return null;
         }
 
+        $registry = $this->projectionRegistry;
+
         try {
-            $resolved = $this->fieldReadScope->run($principal, static fn(): array => [
-                $entity->getSearchDocumentId(),
-                $entity->toSearchDocument(),
-                $entity->toSearchMetadata(),
+            $resolved = $this->fieldReadScope->run($principal, static function () use ($entity, $registry): ?array {
+                $indexable = $entity instanceof SearchIndexableInterface
+                    ? $entity
+                    : $registry->resolveIndexable($entity);
+                if ($indexable === null) {
+                    return null;
+                }
+
+                return [
+                    $indexable->getSearchDocumentId(),
+                    $indexable->toSearchDocument(),
+                    $indexable->toSearchMetadata(),
+                ];
+            });
+        } catch (\Throwable $exception) {
+            // A malformed or failing third-party projector must fail this
+            // candidate closed rather than abort the whole search request,
+            // but the outage must remain operationally visible without
+            // logging any entity or field values.
+            $this->logger->warning('Search candidate projection failed; candidate omitted.', [
+                'exception_class' => $exception::class,
+                'entity_type' => $reference->entityType,
             ]);
-        } catch (FieldReadDenied|MissingFieldReadContext) {
+            return null;
+        }
+
+        if ($resolved === null) {
             return null;
         }
 

--- a/packages/search/src/EventSubscriber/SearchIndexSubscriber.php
+++ b/packages/search/src/EventSubscriber/SearchIndexSubscriber.php
@@ -12,6 +12,7 @@ use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\EntityStorage\Event\RevisionPointerMovedEvent;
 use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Foundation\Log\NullLogger;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
 use Waaseyaa\Search\SearchIndexableInterface;
 use Waaseyaa\Search\SearchIndexerInterface;
 
@@ -37,17 +38,32 @@ use Waaseyaa\Search\SearchIndexerInterface;
  * triggering event's own entity object (pre-option-1 behavior, unchanged);
  * `onRevisionPointerMoved()` (which carries no entity object at all) then
  * has nothing to re-source and no-ops.
+ *
+ * #2270: entities that do not implement {@see SearchIndexableInterface} are
+ * resolved through the shared {@see EntitySearchProjectionRegistry} — the
+ * same projection contract `search:reindex` and query-time candidate
+ * resolution use — so ordinary Node content is indexed on save, refreshed on
+ * pointer moves, and removed on delete. Deletion derives the document id from
+ * entity identity alone (no projection), so it succeeds even for content
+ * whose fields are no longer readable. The framework provider always wires
+ * the shared registry. The optional final constructor argument preserves
+ * source compatibility for standalone consumers, which receive an empty
+ * registry and retain self-indexable behavior until they opt into projectors.
  */
 final class SearchIndexSubscriber implements EventSubscriberInterface
 {
     private readonly LoggerInterface $logger;
 
+    private readonly EntitySearchProjectionRegistry $projectionRegistry;
+
     public function __construct(
         private readonly SearchIndexerInterface $indexer,
         ?LoggerInterface $logger = null,
         private readonly ?EntityTypeManagerInterface $entityTypeManager = null,
+        ?EntitySearchProjectionRegistry $projectionRegistry = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
+        $this->projectionRegistry = $projectionRegistry ?? new EntitySearchProjectionRegistry([]);
     }
 
     public static function getSubscribedEvents(): array
@@ -69,14 +85,19 @@ final class SearchIndexSubscriber implements EventSubscriberInterface
     {
         $entity = $event->entity;
 
-        if (!$entity instanceof SearchIndexableInterface) {
-            return;
-        }
-
         try {
-            $this->indexer->remove($entity->getSearchDocumentId());
+            $documentId = $this->projectionRegistry->documentIdFor($entity);
+            if ($documentId === null) {
+                return;
+            }
+
+            $this->indexer->remove($documentId);
         } catch (\Throwable $e) {
-            $this->logger->error(sprintf('Search index removal failed for %s: %s', $entity->getSearchDocumentId(), $e->getMessage()));
+            $this->logger->error(sprintf(
+                'Search index removal failed for a deleted %s entity: %s',
+                $entity->getEntityTypeId(),
+                $e->getMessage(),
+            ));
         }
     }
 
@@ -111,14 +132,28 @@ final class SearchIndexSubscriber implements EventSubscriberInterface
             $entity = $fallbackEntity;
         }
 
-        if (!$entity instanceof SearchIndexableInterface) {
+        if ($entity === null) {
             return;
         }
 
         try {
-            $this->indexer->index($entity);
+            $indexable = $this->projectionRegistry->resolveIndexable($entity);
+            if ($indexable === null) {
+                // A projector may deliberately stop projecting an entity (for
+                // example, when it becomes unpublished). Remove any document
+                // written by an earlier projection so lifecycle indexing does
+                // not leave stale or newly-ineligible content searchable.
+                $documentId = $this->projectionRegistry->documentIdFor($entity);
+                if ($documentId !== null) {
+                    $this->indexer->remove($documentId);
+                }
+
+                return;
+            }
+
+            $this->indexer->index($indexable);
         } catch (\Throwable $e) {
-            $this->logger->error(sprintf('Search indexing failed for %s: %s', $entity->getSearchDocumentId(), $e->getMessage()));
+            $this->logger->error(sprintf('Search indexing failed for a %s entity: %s', $entityType, $e->getMessage()));
         }
     }
 }

--- a/packages/search/src/Fts5/Fts5SearchProvider.php
+++ b/packages/search/src/Fts5/Fts5SearchProvider.php
@@ -27,7 +27,8 @@ use Waaseyaa\Search\SearchResult;
  */
 final class Fts5SearchProvider implements SearchProviderInterface
 {
-    private const int MAX_CANDIDATE_SCAN = 200;
+    /** Public-query work bound, aligned with the agent surface result window. */
+    private const int MAX_CANDIDATE_SCAN = 1_000;
     private const int SNIPPET_LENGTH = 240;
 
     private readonly LoggerInterface $logger;
@@ -59,17 +60,30 @@ final class Fts5SearchProvider implements SearchProviderInterface
             $queryTokens,
         ));
         $rankExpression = $this->rankExpression();
-        $sql = "SELECT m.document_id, m.entity_type, m.schema_version FROM search_index si JOIN search_metadata m ON m.document_id = si.document_id WHERE search_index MATCH :query ORDER BY $rankExpression, m.document_id ASC LIMIT :scanCap";
+        // One bounded statement gives this request a stable pointer snapshot:
+        // no OFFSET race across concurrent lifecycle writes, no quadratic
+        // rescans, and no unbounded projection/access-check amplification.
+        // The extra row is a content-free truncation sentinel.
+        $sql = "SELECT m.document_id, m.entity_type, m.schema_version FROM search_index si JOIN search_metadata m ON m.document_id = si.document_id WHERE search_index MATCH :query ORDER BY $rankExpression, m.document_id ASC LIMIT :scanLimit";
 
         /** @var list<array{projection: SearchCandidateProjection, score: float}> $safeMatches */
         $safeMatches = [];
         $staleDetected = false;
         $schemaVersion = $this->indexer->getSchemaVersion();
 
-        foreach ($this->database->query($sql, [
+        $candidateRows = iterator_to_array($this->database->query($sql, [
             'query' => $ftsQuery,
-            'scanCap' => self::MAX_CANDIDATE_SCAN,
-        ]) as $row) {
+            'scanLimit' => self::MAX_CANDIDATE_SCAN + 1,
+        ]), false);
+        $isComplete = count($candidateRows) <= self::MAX_CANDIDATE_SCAN;
+        if (!$isComplete) {
+            array_pop($candidateRows);
+            $this->logger->warning('Search candidate window exhausted; result totals and facets are lower bounds.', [
+                'candidate_limit' => self::MAX_CANDIDATE_SCAN,
+            ]);
+        }
+
+        foreach ($candidateRows as $row) {
             try {
                 $reference = new SearchCandidateReference(
                     documentId: (string) ($row['document_id'] ?? ''),
@@ -100,7 +114,7 @@ final class Fts5SearchProvider implements SearchProviderInterface
         $this->sortSafeMatches($safeMatches, $request->filters);
         $totalHits = count($safeMatches);
         if ($totalHits === 0) {
-            return $this->emptyResult($request);
+            return $this->emptyResult($request, $isComplete);
         }
 
         $offset = ($request->page - 1) * $request->pageSize;
@@ -117,6 +131,7 @@ final class Fts5SearchProvider implements SearchProviderInterface
             pageSize: $request->pageSize,
             hits: $hits,
             facets: $request->includeFacets ? $this->facets($safeMatches) : [],
+            isComplete: $isComplete,
         );
     }
 
@@ -309,7 +324,7 @@ final class Fts5SearchProvider implements SearchProviderInterface
         );
     }
 
-    private function emptyResult(SearchRequest $request): SearchResult
+    private function emptyResult(SearchRequest $request, bool $isComplete = true): SearchResult
     {
         return new SearchResult(
             totalHits: 0,
@@ -317,6 +332,7 @@ final class Fts5SearchProvider implements SearchProviderInterface
             currentPage: $request->page,
             pageSize: $request->pageSize,
             hits: [],
+            isComplete: $isComplete,
         );
     }
 }

--- a/packages/search/src/Projection/EntitySearchDocumentId.php
+++ b/packages/search/src/Projection/EntitySearchDocumentId.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Projection;
+
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Canonical search document id for entity-backed documents: "type:id".
+ *
+ * The query-time entity candidate resolver parses exactly this shape (and
+ * re-verifies it against the re-generated projection), so projectors MUST use
+ * it. Because it derives from identity alone — no field reads — it is also
+ * safe on the deletion path, where the entity may already be unreadable.
+ *
+ * @api
+ */
+final class EntitySearchDocumentId
+{
+    private function __construct() {}
+
+    public static function fromEntity(EntityInterface $entity): ?string
+    {
+        $entityTypeId = $entity->getEntityTypeId();
+        $id = $entity->id();
+        if ($entityTypeId === '' || $id === null || $id === '') {
+            return null;
+        }
+
+        return $entityTypeId . ':' . $id;
+    }
+}

--- a/packages/search/src/Projection/EntitySearchProjectionRegistry.php
+++ b/packages/search/src/Projection/EntitySearchProjectionRegistry.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Projection;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Search\SearchIndexableInterface;
+
+/**
+ * Single resolution point from an entity to its indexable document view.
+ *
+ * Every search surface — full reindex, the save/delete/revision lifecycle
+ * subscriber, and query-time candidate re-projection — resolves entities
+ * through this registry, so index-time and query-time semantics cannot drift
+ * apart. Resolution order:
+ *
+ *   1. An entity that itself implements {@see SearchIndexableInterface} is
+ *      its own document view (unchanged legacy behaviour).
+ *   2. Otherwise the first projector whose `supports()` accepts the entity
+ *      owns it; that projector's `project()` result — including null — is
+ *      final. Application projectors are registered ahead of the built-in
+ *      ones, so an application can override the default node projection or
+ *      deliberately exclude content.
+ *   3. Entities nobody supports resolve to null and are not indexed.
+ *
+ * @api
+ */
+final class EntitySearchProjectionRegistry
+{
+    /** @var list<EntitySearchProjectorInterface> */
+    private readonly array $projectors;
+
+    /** @param array<EntitySearchProjectorInterface> $projectors Consulted in order; normalized to a list. */
+    public function __construct(array $projectors)
+    {
+        foreach ($projectors as $projector) {
+            // @phpstan-ignore instanceof.alwaysTrue (runtime API boundary)
+            if (!$projector instanceof EntitySearchProjectorInterface) {
+                throw new \InvalidArgumentException('Search projectors must implement EntitySearchProjectorInterface.');
+            }
+        }
+        $this->projectors = array_values($projectors);
+    }
+
+    public function supports(EntityInterface $entity): bool
+    {
+        if ($entity instanceof SearchIndexableInterface) {
+            return true;
+        }
+        foreach ($this->projectors as $projector) {
+            if ($projector->supports($entity)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function resolveIndexable(EntityInterface $entity): ?SearchIndexableInterface
+    {
+        if ($entity instanceof SearchIndexableInterface) {
+            return $entity;
+        }
+        foreach ($this->projectors as $projector) {
+            if ($projector->supports($entity)) {
+                $indexable = $projector->project($entity);
+                if ($indexable !== null && $indexable->getSearchDocumentId() !== EntitySearchDocumentId::fromEntity($entity)) {
+                    throw new \UnexpectedValueException(sprintf(
+                        'Search projector for %s must return canonical document id %s.',
+                        $entity->getEntityTypeId(),
+                        EntitySearchDocumentId::fromEntity($entity) ?? '(unavailable)',
+                    ));
+                }
+
+                return $indexable;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Document id for lifecycle removal, derivable without a projection.
+     *
+     * Deletion must succeed even when the entity can no longer be projected
+     * (already deleted state, unreadable fields), so projected entities use
+     * the canonical identity-only form rather than a `project()` round trip.
+     */
+    public function documentIdFor(EntityInterface $entity): ?string
+    {
+        if ($entity instanceof SearchIndexableInterface) {
+            return $entity->getSearchDocumentId();
+        }
+        foreach ($this->projectors as $projector) {
+            if ($projector->supports($entity)) {
+                return EntitySearchDocumentId::fromEntity($entity);
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/search/src/Projection/EntitySearchProjectorInterface.php
+++ b/packages/search/src/Projection/EntitySearchProjectorInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Projection;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Search\SearchIndexableInterface;
+
+/**
+ * Projects a normal entity (one that does not itself implement
+ * {@see SearchIndexableInterface}) into an indexable search document.
+ *
+ * This is the package-layer-safe extension point that lets lower-layer
+ * content entities (node, taxonomy, …) become searchable without depending
+ * upward on waaseyaa/search: the projector lives on the search side and keys
+ * off the generic {@see EntityInterface} contract only.
+ *
+ * One projection contract, four call sites: a full `search:reindex`, the
+ * save/delete/revision-pointer lifecycle subscriber, and query-time candidate
+ * re-projection all resolve entities through the same
+ * {@see EntitySearchProjectionRegistry}, so there is no index/query semantic
+ * split.
+ *
+ * Contract rules:
+ * - `project()` runs in two field-read contexts: WITHOUT an account scope at
+ *   index time (only Public-classified fields are readable) and INSIDE the
+ *   acting principal's field-read scope at query time. Implementations must
+ *   read field values through the guarded {@see EntityInterface::get()}
+ *   accessor and either catch a per-field denial and omit that field's text
+ *   (graceful: the entity stays findable by its readable fields) or let the
+ *   denial propagate (strict: the whole candidate is dropped fail-closed by
+ *   the query-time resolver). Never bypass the accessor.
+ * - The returned document's id MUST be the canonical entity form
+ *   {@see EntitySearchDocumentId::fromEntity()} ("type:id"); query-time
+ *   resolution rejects any other shape fail-closed.
+ * - Field text is untrusted CMS data. Normalize markup to inert searchable
+ *   text (see {@see SearchTextNormalizer}); never emit raw markup.
+ * - `supports()` must be cheap and side-effect free: it is also consulted on
+ *   the deletion path, where no projection is possible any more.
+ *
+ * @api
+ */
+interface EntitySearchProjectorInterface
+{
+    public function supports(EntityInterface $entity): bool;
+
+    /**
+     * Project the entity, or return null to keep it out of the index.
+     *
+     * A supporting projector's null is final: the registry does not fall
+     * through to later projectors, so an application projector can both
+     * override the built-in projection and deliberately exclude content.
+     */
+    public function project(EntityInterface $entity): ?SearchIndexableInterface;
+}

--- a/packages/search/src/Projection/NodeSearchProjector.php
+++ b/packages/search/src/Projection/NodeSearchProjector.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Projection;
+
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Exception\FieldReadDenied;
+use Waaseyaa\Entity\Exception\MissingFieldReadContext;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\SearchIndexableInterface;
+
+/**
+ * Default projection for the framework's `node` content entity type.
+ *
+ * Keys off the entity type id through the generic {@see EntityInterface}
+ * contract only — no `Waaseyaa\Node` import, no composer edge — so the
+ * search package stays layer- and metapackage-clean while ordinary CMS
+ * content becomes searchable.
+ *
+ * Safe by construction: every field value is read through the guarded
+ * accessor, so index-time projection (no account scope) can only see
+ * Public-classified fields — a Protected or unclassified (Internal) body is
+ * omitted, never indexed. A per-field denial drops that field's text and
+ * keeps the node findable by its readable fields, mirroring
+ * {@see \Waaseyaa\Api\ResourceSerializer}'s omit-on-deny convention. The
+ * title comes from the entity label (label keys are structurally Public).
+ *
+ * The default canonical URL is the root-mounted public `slug` field
+ * ("/{slug}", segments validated against a conservative pattern so untrusted
+ * slugs cannot project off-origin or scheme-carrying URLs); sites with a
+ * different URL scheme or extra searchable fields register their own
+ * projector via {@see \Waaseyaa\Search\ProvidesEntitySearchProjectorsInterface},
+ * which takes precedence over this default.
+ *
+ * @api
+ */
+final class NodeSearchProjector implements EntitySearchProjectorInterface
+{
+    /** @var list<string> */
+    private readonly array $bodyFields;
+
+    /** @param array<string> $bodyFields Guarded field names concatenated into the document body, in order. */
+    public function __construct(
+        private readonly string $entityTypeId = 'node',
+        array $bodyFields = ['body'],
+    ) {
+        $this->bodyFields = array_values($bodyFields);
+    }
+
+    public function supports(EntityInterface $entity): bool
+    {
+        return $entity->getEntityTypeId() === $this->entityTypeId
+            && EntitySearchDocumentId::fromEntity($entity) !== null;
+    }
+
+    public function project(EntityInterface $entity): ?SearchIndexableInterface
+    {
+        $documentId = EntitySearchDocumentId::fromEntity($entity);
+        if ($documentId === null || $entity->getEntityTypeId() !== $this->entityTypeId) {
+            return null;
+        }
+
+        $bodyParts = [];
+        foreach ($this->bodyFields as $field) {
+            $part = SearchTextNormalizer::normalize($this->guardedValue($entity, $field));
+            if ($part !== '') {
+                $bodyParts[] = $part;
+            }
+        }
+
+        $metadata = [
+            'entity_type' => $this->entityTypeId,
+            'content_type' => $entity->bundle(),
+            'url' => $this->canonicalUrl($entity),
+        ];
+        $createdAt = $this->createdAt($entity);
+        if ($createdAt !== null) {
+            $metadata['created_at'] = $createdAt;
+        }
+
+        return new SearchDocument(
+            id: $documentId,
+            title: SearchTextNormalizer::normalize($this->guardedLabel($entity)),
+            body: implode(' ', $bodyParts),
+            metadata: $metadata,
+        );
+    }
+
+    private function guardedLabel(EntityInterface $entity): string
+    {
+        try {
+            return $entity->label();
+        } catch (FieldReadDenied|MissingFieldReadContext) {
+            return '';
+        }
+    }
+
+    private function guardedValue(EntityInterface $entity, string $field): mixed
+    {
+        try {
+            return $entity->get($field);
+        } catch (FieldReadDenied|MissingFieldReadContext) {
+            return null;
+        }
+    }
+
+    private function canonicalUrl(EntityInterface $entity): string
+    {
+        $slug = $this->guardedValue($entity, 'slug');
+        if (!is_string($slug) || $slug === '') {
+            return '';
+        }
+        // Root-relative segments only: no leading/empty/dot-led segments, no
+        // scheme separators — an untrusted slug must not become "//host" or
+        // "scheme:…" in a rendered result link.
+        if (preg_match('#^[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*)*$#i', $slug) !== 1) {
+            return '';
+        }
+
+        return '/' . $slug;
+    }
+
+    private function createdAt(EntityInterface $entity): ?string
+    {
+        $created = $this->guardedValue($entity, 'created');
+        if ($created instanceof \DateTimeInterface) {
+            return $created->format(\DateTimeInterface::ATOM);
+        }
+        if (is_int($created) && $created > 0) {
+            return gmdate(\DateTimeInterface::ATOM, $created);
+        }
+
+        return null;
+    }
+}

--- a/packages/search/src/Projection/SearchTextNormalizer.php
+++ b/packages/search/src/Projection/SearchTextNormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Projection;
+
+/**
+ * Normalizes untrusted CMS field values into inert, plain searchable text.
+ *
+ * Search text is data, never instructions: script/style/template payloads and
+ * HTML comments are dropped with their content, remaining markup is stripped
+ * with word boundaries preserved, entities are decoded, and any angle
+ * brackets that survive (or are re-introduced by entity decoding) are
+ * scrubbed so the output cannot round-trip back into markup. Invalid UTF-8
+ * is repaired and whitespace is collapsed.
+ *
+ * @api
+ */
+final class SearchTextNormalizer
+{
+    private function __construct() {}
+
+    public static function normalize(mixed $value): string
+    {
+        if ($value instanceof \DateTimeInterface || is_array($value) || is_object($value) && !$value instanceof \Stringable) {
+            return '';
+        }
+        if (is_bool($value) || $value === null) {
+            return '';
+        }
+        $text = (string) $value;
+        if ($text === '') {
+            return '';
+        }
+
+        $text = mb_convert_encoding($text, 'UTF-8', 'UTF-8');
+        // Drop executable/style payloads and comments WITH their content.
+        $text = (string) preg_replace(
+            '#<(script|style|template)\b[^>]*>(?:.*?</\1\s*>|.*\z)#is',
+            ' ',
+            $text,
+        );
+        $text = (string) preg_replace('#<!--.*?-->#s', ' ', $text);
+        // Strip syntactically complete tags while preserving literal less-than
+        // prose such as "5 < 10" and word boundaries between elements.
+        $text = (string) preg_replace('#</?[a-z][^>]*>#is', ' ', $text);
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        // Entity decoding can re-introduce brackets; keep the output inert.
+        $text = str_replace(['<', '>'], ' ', $text);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $text));
+    }
+}

--- a/packages/search/src/ProvidesEntitySearchProjectorsInterface.php
+++ b/packages/search/src/ProvidesEntitySearchProjectorsInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search;
+
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
+
+/**
+ * Application contribution point for entity search projectors.
+ *
+ * Bind an implementation in a service provider's `register()` (the same
+ * container convention as {@see ProvidesSearchSourceResolversInterface}) to
+ * add site-specific searchable fields or canonical URL projection. Returned
+ * projectors are consulted BEFORE the built-in defaults, so an application
+ * projector that `supports()` node entities replaces the default node
+ * projection entirely — including the ability to decline (`project()` =>
+ * null) content that must stay out of the index.
+ *
+ * @api
+ */
+interface ProvidesEntitySearchProjectorsInterface
+{
+    /** @return list<EntitySearchProjectorInterface> Ordered ahead of the built-in defaults. */
+    public function entitySearchProjectors(): array;
+}

--- a/packages/search/src/SearchResult.php
+++ b/packages/search/src/SearchResult.php
@@ -18,6 +18,8 @@ final readonly class SearchResult
         public int $pageSize,
         public array $hits,
         public array $facets = [],
+        /** False when a provider stopped at its documented candidate window. */
+        public bool $isComplete = true,
     ) {}
 
     public static function empty(): self

--- a/packages/search/src/SearchServiceProvider.php
+++ b/packages/search/src/SearchServiceProvider.php
@@ -16,6 +16,8 @@ use Waaseyaa\Search\EventSubscriber\SearchIndexSubscriber;
 use Waaseyaa\Search\Fts5\Fts5SearchContentCatalogue;
 use Waaseyaa\Search\Fts5\Fts5SearchIndexer;
 use Waaseyaa\Search\Fts5\Fts5SearchProvider;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\NodeSearchProjector;
 
 final class SearchServiceProvider extends ServiceProvider
 {
@@ -30,6 +32,23 @@ final class SearchServiceProvider extends ServiceProvider
             // wire the SearchIndexSubscriber) must not run DDL — the indexer
             // creates its schema lazily on first write instead. (D-35)
             return new Fts5SearchIndexer($database);
+        });
+
+        // #2270: one shared projection registry serves full reindex, the
+        // lifecycle subscriber, and query-time candidate resolution, so
+        // index-time and query-time semantics cannot drift. Application
+        // projectors (ProvidesEntitySearchProjectorsInterface) are consulted
+        // ahead of the built-in node default.
+        $this->singleton(EntitySearchProjectionRegistry::class, function (): EntitySearchProjectionRegistry {
+            $projectorProvider = $this->resolveOptional(ProvidesEntitySearchProjectorsInterface::class);
+            if ($projectorProvider !== null && !$projectorProvider instanceof ProvidesEntitySearchProjectorsInterface) {
+                throw new \LogicException('Search projector provider must implement ProvidesEntitySearchProjectorsInterface.');
+            }
+
+            return new EntitySearchProjectionRegistry([
+                ...($projectorProvider?->entitySearchProjectors() ?? []),
+                new NodeSearchProjector(),
+            ]);
         });
 
         $this->singleton(SearchCandidateResolverInterface::class, function (): SearchCandidateResolverInterface {
@@ -49,19 +68,29 @@ final class SearchServiceProvider extends ServiceProvider
             if ($sourceProvider !== null && !$sourceProvider instanceof ProvidesSearchSourceResolversInterface) {
                 throw new \LogicException('Search source resolver provider must implement ProvidesSearchSourceResolversInterface.');
             }
+            $logger = $this->resolveOptional(\Waaseyaa\Foundation\Log\LoggerInterface::class);
 
             return new SearchCandidateResolverRegistry(
                 $entityTypeManager,
-                new EntitySearchCandidateResolver($entityTypeManager, $accessHandler, $fieldReadScope),
+                new EntitySearchCandidateResolver(
+                    $entityTypeManager,
+                    $accessHandler,
+                    $fieldReadScope,
+                    $this->projectionRegistry(),
+                    $logger instanceof \Waaseyaa\Foundation\Log\LoggerInterface ? $logger : null,
+                ),
                 $sourceProvider?->searchSourceResolvers() ?? [],
             );
         });
 
         $this->singleton(SearchProviderInterface::class, function (): SearchProviderInterface {
+            $logger = $this->resolveOptional(\Waaseyaa\Foundation\Log\LoggerInterface::class);
+
             return new Fts5SearchProvider(
                 $this->getSearchDatabase(),
                 $this->resolve(SearchIndexerInterface::class),
                 candidateResolver: $this->resolve(SearchCandidateResolverInterface::class),
+                logger: $logger instanceof \Waaseyaa\Foundation\Log\LoggerInterface ? $logger : null,
             );
         });
 
@@ -85,12 +114,23 @@ final class SearchServiceProvider extends ServiceProvider
         $subscriber = new SearchIndexSubscriber(
             $indexer,
             entityTypeManager: $entityTypeManager instanceof EntityTypeManagerInterface ? $entityTypeManager : null,
+            projectionRegistry: $this->projectionRegistry(),
         );
 
         $dispatcher = $this->resolve(\Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class);
         if ($dispatcher instanceof EventDispatcherInterface) {
             $dispatcher->addSubscriber($subscriber);
         }
+    }
+
+    private function projectionRegistry(): EntitySearchProjectionRegistry
+    {
+        $registry = $this->resolve(EntitySearchProjectionRegistry::class);
+        if (!$registry instanceof EntitySearchProjectionRegistry) {
+            throw new \LogicException('Search requires its own EntitySearchProjectionRegistry binding.');
+        }
+
+        return $registry;
     }
 
     private function getSearchDatabase(): DatabaseInterface

--- a/packages/search/tests/Unit/EntitySearchCandidateResolverTest.php
+++ b/packages/search/tests/Unit/EntitySearchCandidateResolverTest.php
@@ -16,7 +16,11 @@ use Waaseyaa\Entity\EntityInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use Waaseyaa\Entity\Exception\FieldReadDenied;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Search\Access\EntitySearchCandidateResolver;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
 use Waaseyaa\Search\SearchCandidateReference;
 use Waaseyaa\Search\SearchIndexableInterface;
 use Waaseyaa\Search\Tests\Support\SearchTestPrincipal;
@@ -146,11 +150,209 @@ final class EntitySearchCandidateResolverTest extends TestCase
         self::assertSame(\Waaseyaa\Search\SearchCandidateProjection::MAX_TOPIC_LENGTH, mb_strlen($projection->topics[0]));
     }
 
+    #[Test]
+    public function a_projector_backed_entity_resolves_inside_the_principal_scope(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class ($scope) implements EntitySearchProjectorInterface {
+            public function __construct(private readonly AccountFieldReadScope $scope) {}
+
+            public function supports(EntityInterface $entity): bool
+            {
+                return $entity->getEntityTypeId() === 'node';
+            }
+
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                if ($this->scope->current()?->id() !== 42) {
+                    throw new \LogicException('Projection ran outside the supplied principal scope.');
+                }
+
+                return new SearchDocument('node:1', 'Projected title', 'Projected body', [
+                    'entity_type' => 'node',
+                    'content_type' => 'page',
+                ]);
+            }
+        };
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            true,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        $projection = $resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create(42));
+
+        self::assertNotNull($projection);
+        self::assertSame('Projected title', $projection->title);
+        self::assertSame('Projected body', $projection->body);
+        self::assertSame('page', $projection->contentType);
+        self::assertNull($scope->current(), 'Principal scope must be restored after projection.');
+    }
+
+    #[Test]
+    public function a_projector_backed_entity_still_requires_entity_view_access(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public int $projectCalls = 0;
+
+            public function supports(EntityInterface $entity): bool
+            {
+                return true;
+            }
+
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                ++$this->projectCalls;
+
+                return new SearchDocument('node:1', 't', 'b', ['entity_type' => 'node']);
+            }
+        };
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            false,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        self::assertNull($resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create()));
+        self::assertSame(0, $projector->projectCalls, 'Denied entities must never be projected.');
+    }
+
+    #[Test]
+    public function a_projected_document_id_mismatch_fails_closed(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public function supports(EntityInterface $entity): bool
+            {
+                return true;
+            }
+
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                return new SearchDocument('node:2', 't', 'b', ['entity_type' => 'node']);
+            }
+        };
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            true,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        self::assertNull($resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create()));
+    }
+
+    #[Test]
+    public function an_entity_no_projector_supports_fails_closed(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public function supports(EntityInterface $entity): bool
+            {
+                return false;
+            }
+
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                return new SearchDocument('node:1', 't', 'b', ['entity_type' => 'node']);
+            }
+        };
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            true,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        self::assertNull($resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create()));
+    }
+
+    #[Test]
+    public function a_projector_field_denial_drops_the_entire_candidate(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public function supports(EntityInterface $entity): bool
+            {
+                return true;
+            }
+
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                throw new FieldReadDenied('strict projector');
+            }
+        };
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            true,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+        );
+
+        self::assertNull($resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create()));
+    }
+
+    #[Test]
+    public function a_projector_failure_is_logged_without_entity_values(): void
+    {
+        $scope = new AccountFieldReadScope();
+        $projector = new class implements EntitySearchProjectorInterface {
+            public function supports(EntityInterface $entity): bool { return true; }
+            public function project(EntityInterface $entity): ?SearchIndexableInterface
+            {
+                throw new \RuntimeException('private body must never be logged');
+            }
+        };
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Search candidate projection failed; candidate omitted.',
+                self::callback(static function (array $context): bool {
+                    self::assertSame(\RuntimeException::class, $context['exception_class']);
+                    self::assertSame('node', $context['entity_type']);
+                    self::assertStringNotContainsString('private', json_encode($context, JSON_THROW_ON_ERROR));
+
+                    return true;
+                }),
+            );
+        $resolver = $this->resolver(
+            $this->plainEntity(),
+            $scope,
+            true,
+            registry: new EntitySearchProjectionRegistry([$projector]),
+            logger: $logger,
+        );
+
+        self::assertNull($resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create()));
+    }
+
+    private function plainEntity(): EntityInterface
+    {
+        return new class implements EntityInterface {
+            public function id(): int|string|null { return 1; }
+            public function uuid(): string { return 'uuid-1'; }
+            public function label(): string { return 'Plain node'; }
+            public function getEntityTypeId(): string { return 'node'; }
+            public function bundle(): string { return 'page'; }
+            public function isNew(): bool { return false; }
+            public function get(string $name): mixed { return null; }
+            public function set(string $name, mixed $value): static { return $this; }
+            public function toArray(): array { return []; }
+            public function language(): string { return 'en'; }
+        };
+    }
+
     private function resolver(
-        SearchIndexableInterface&EntityInterface $entity,
+        EntityInterface $entity,
         AccountFieldReadScope $scope,
         bool $allowView,
         ?EntityRepositoryInterface $repository = null,
+        ?EntitySearchProjectionRegistry $registry = null,
+        ?LoggerInterface $logger = null,
     ): EntitySearchCandidateResolver {
         if ($repository === null) {
             $repository = $this->createStub(EntityRepositoryInterface::class);
@@ -172,7 +374,13 @@ final class EntitySearchCandidateResolverTest extends TestCase
             public function appliesTo(string $entityTypeId): bool { return $entityTypeId === 'node'; }
         };
 
-        return new EntitySearchCandidateResolver($manager, new EntityAccessHandler([$policy]), $scope);
+        return new EntitySearchCandidateResolver(
+            $manager,
+            new EntityAccessHandler([$policy]),
+            $scope,
+            $registry ?? new EntitySearchProjectionRegistry([]),
+            $logger,
+        );
     }
 
     private function entity(

--- a/packages/search/tests/Unit/Fts5SearchProviderAccessFilteredCountTest.php
+++ b/packages/search/tests/Unit/Fts5SearchProviderAccessFilteredCountTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Access\AuthorizationPrincipalInterface;
 use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Foundation\Log\LoggerInterface;
 use Waaseyaa\Search\Fts5\Fts5SearchIndexer;
 use Waaseyaa\Search\Fts5\Fts5SearchProvider;
 use Waaseyaa\Search\SearchCandidateProjection;
@@ -127,7 +128,7 @@ final class Fts5SearchProviderAccessFilteredCountTest extends TestCase
     }
 
     #[Test]
-    public function candidate_work_is_bounded_and_the_result_conservatively_describes_only_the_scanned_window(): void
+    public function candidate_rows_below_the_public_bound_are_complete(): void
     {
         for ($id = 3; $id <= 201; ++$id) {
             $this->indexItem('node:' . $id, ['title' => 'Tutorial ' . $id, 'body' => 'Searchable tutorial'], [
@@ -159,8 +160,74 @@ final class Fts5SearchProviderAccessFilteredCountTest extends TestCase
             \Waaseyaa\Search\Tests\Support\SearchTestPrincipal::create(),
         );
 
-        self::assertSame(200, $resolver->calls);
-        self::assertSame(200, $result->totalHits);
+        self::assertSame(201, $resolver->calls);
+        self::assertSame(201, $result->totalHits);
+        self::assertTrue($result->isComplete);
+    }
+
+    #[Test]
+    public function an_exhausted_candidate_window_is_bounded_and_explicitly_incomplete(): void
+    {
+        for ($id = 3; $id <= 1002; ++$id) {
+            $this->indexItem('node:' . $id, ['title' => 'Tutorial ' . $id, 'body' => 'Searchable tutorial'], [
+                'entity_type' => 'node',
+                'content_type' => 'article',
+                'created_at' => '2026-01-01T00:00:00Z',
+            ]);
+        }
+        $resolver = new class ($this->database) implements SearchCandidateResolverInterface {
+            public int $calls = 0;
+            private readonly \Waaseyaa\Search\Tests\Support\IndexedSearchCandidateResolver $inner;
+            public function __construct(DBALDatabase $database)
+            {
+                $this->inner = new \Waaseyaa\Search\Tests\Support\IndexedSearchCandidateResolver($database);
+            }
+            public function resolve(SearchCandidateReference $reference, AuthorizationPrincipalInterface $principal): ?SearchCandidateProjection
+            {
+                ++$this->calls;
+                return $this->inner->resolve($reference, $principal);
+            }
+        };
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')->with(
+            'Search candidate window exhausted; result totals and facets are lower bounds.',
+            ['candidate_limit' => 1000],
+        );
+        $provider = new Fts5SearchProvider($this->database, $this->indexer, $resolver, $logger);
+
+        $result = $provider->search(
+            new SearchRequest('tutorial'),
+            \Waaseyaa\Search\Tests\Support\SearchTestPrincipal::create(),
+        );
+
+        self::assertSame(1000, $resolver->calls, 'The sentinel row must never be projected.');
+        self::assertSame(1000, $result->totalHits);
+        self::assertFalse($result->isComplete);
+    }
+
+    #[Test]
+    public function an_accessible_match_after_two_hundred_denied_candidates_is_not_diluted_out(): void
+    {
+        for ($id = 3; $id <= 201; ++$id) {
+            $this->indexItem('node:' . $id, ['title' => 'Tutorial ' . $id, 'body' => 'Searchable tutorial'], [
+                'entity_type' => 'node',
+                'content_type' => 'article',
+                'created_at' => '2026-01-01T00:00:00Z',
+            ]);
+        }
+        $resolver = new \Waaseyaa\Search\Tests\Support\IndexedSearchCandidateResolver(
+            $this->database,
+            static fn(SearchCandidateReference $reference): bool => $reference->documentId === 'node:201',
+        );
+        $provider = new Fts5SearchProvider($this->database, $this->indexer, $resolver);
+
+        $result = $provider->search(
+            new SearchRequest('tutorial'),
+            \Waaseyaa\Search\Tests\Support\SearchTestPrincipal::create(),
+        );
+
+        self::assertSame(1, $result->totalHits);
+        self::assertSame('node:201', $result->hits[0]->id);
     }
 
     private function indexItem(string $id, array $document, array $metadata): void

--- a/packages/search/tests/Unit/Fts5SearchProviderTwoPhaseFetchTest.php
+++ b/packages/search/tests/Unit/Fts5SearchProviderTwoPhaseFetchTest.php
@@ -77,7 +77,9 @@ final class Fts5SearchProviderTwoPhaseFetchTest extends TestCase
         self::assertStringNotContainsString('si.title', $scan['sql']);
         self::assertStringNotContainsString('si.body', $scan['sql']);
         self::assertStringNotContainsString('m.*', $scan['sql']);
-        self::assertStringContainsString('LIMIT :scanCap', $scan['sql']);
+        self::assertStringContainsString('LIMIT :scanLimit', $scan['sql']);
+        self::assertStringNotContainsString('OFFSET', $scan['sql']);
+        self::assertSame(1001, $scan['args']['scanLimit']);
     }
 
     private function index(Fts5SearchIndexer $indexer, string $id, string $createdAt): void

--- a/packages/search/tests/Unit/Projection/EntitySearchProjectionRegistryTest.php
+++ b/packages/search/tests/Unit/Projection/EntitySearchProjectionRegistryTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit\Projection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
+use Waaseyaa\Search\SearchIndexableInterface;
+
+#[CoversClass(EntitySearchProjectionRegistry::class)]
+final class EntitySearchProjectionRegistryTest extends TestCase
+{
+    #[Test]
+    public function a_self_indexable_entity_is_returned_unprojected(): void
+    {
+        $entity = $this->selfIndexableEntity('custom:9');
+        $projector = new ProjectionSpy(supports: true, document: new SearchDocument('node:1', 't', 'b'));
+        $registry = new EntitySearchProjectionRegistry([$projector]);
+
+        self::assertSame($entity, $registry->resolveIndexable($entity));
+        self::assertSame('custom:9', $registry->documentIdFor($entity));
+        self::assertSame(0, $projector->projectCalls, 'Self-indexable entities never consult projectors.');
+    }
+
+    #[Test]
+    public function the_first_supporting_projector_owns_the_entity(): void
+    {
+        $document = new SearchDocument('node:7', 'First', 'body');
+        $first = new ProjectionSpy(supports: true, document: $document);
+        $second = new ProjectionSpy(supports: true, document: new SearchDocument('node:7', 'Second', 'body'));
+        $registry = new EntitySearchProjectionRegistry([$first, $second]);
+
+        self::assertSame($document, $registry->resolveIndexable($this->entity('node', 7)));
+        self::assertSame(0, $second->projectCalls, 'Later projectors must not be consulted once one supports the entity.');
+    }
+
+    #[Test]
+    public function a_supporting_projector_declining_the_entity_is_final(): void
+    {
+        $declining = new ProjectionSpy(supports: true, document: null);
+        $fallback = new ProjectionSpy(supports: true, document: new SearchDocument('node:7', 'Fallback', 'body'));
+        $registry = new EntitySearchProjectionRegistry([$declining, $fallback]);
+
+        self::assertNull(
+            $registry->resolveIndexable($this->entity('node', 7)),
+            'A supporting projector that declines must not be overridden by later projectors.',
+        );
+        self::assertSame(0, $fallback->projectCalls);
+    }
+
+    #[Test]
+    public function a_projector_cannot_return_a_noncanonical_document_id(): void
+    {
+        $registry = new EntitySearchProjectionRegistry([
+            new ProjectionSpy(supports: true, document: new SearchDocument('custom-node-7', 'Title', 'Body')),
+        ]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('must return canonical document id node:7');
+
+        $registry->resolveIndexable($this->entity('node', 7));
+    }
+
+    #[Test]
+    public function an_unsupported_entity_resolves_to_nothing(): void
+    {
+        $registry = new EntitySearchProjectionRegistry([new ProjectionSpy(supports: false, document: null)]);
+        $entity = $this->entity('taxonomy_term', 3);
+
+        self::assertFalse($registry->supports($entity));
+        self::assertNull($registry->resolveIndexable($entity));
+        self::assertNull($registry->documentIdFor($entity));
+    }
+
+    #[Test]
+    public function document_ids_for_projected_entities_use_the_canonical_entity_form_without_projecting(): void
+    {
+        $projector = new ProjectionSpy(supports: true, document: new SearchDocument('node:7', 't', 'b'));
+        $registry = new EntitySearchProjectionRegistry([$projector]);
+
+        self::assertSame('node:7', $registry->documentIdFor($this->entity('node', 7)));
+        self::assertSame(0, $projector->projectCalls, 'Deletion-path document ids must not require a full projection.');
+    }
+
+    #[Test]
+    public function an_entity_without_an_id_has_no_document_id(): void
+    {
+        $registry = new EntitySearchProjectionRegistry([new ProjectionSpy(supports: true, document: null)]);
+
+        self::assertNull($registry->documentIdFor($this->entity('node', null)));
+    }
+
+    #[Test]
+    public function only_projector_instances_are_accepted(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        /** @phpstan-ignore argument.type (runtime API boundary) */
+        new EntitySearchProjectionRegistry([new \stdClass()]);
+    }
+
+    private function entity(string $entityTypeId, int|string|null $id): EntityInterface
+    {
+        return new class ($entityTypeId, $id) implements EntityInterface {
+            public function __construct(
+                private readonly string $entityTypeId,
+                private readonly int|string|null $entityId,
+            ) {}
+
+            public function id(): int|string|null { return $this->entityId; }
+            public function uuid(): string { return 'uuid'; }
+            public function label(): string { return 'Label'; }
+            public function getEntityTypeId(): string { return $this->entityTypeId; }
+            public function bundle(): string { return $this->entityTypeId; }
+            public function isNew(): bool { return false; }
+            public function get(string $name): mixed { return null; }
+            public function set(string $name, mixed $value): static { return $this; }
+            public function toArray(): array { return []; }
+            public function language(): string { return 'en'; }
+        };
+    }
+
+    private function selfIndexableEntity(string $documentId): EntityInterface&SearchIndexableInterface
+    {
+        return new class ($documentId) implements EntityInterface, SearchIndexableInterface {
+            public function __construct(private readonly string $documentId) {}
+
+            public function id(): int|string|null { return 9; }
+            public function uuid(): string { return 'uuid'; }
+            public function label(): string { return 'Label'; }
+            public function getEntityTypeId(): string { return 'custom'; }
+            public function bundle(): string { return 'custom'; }
+            public function isNew(): bool { return false; }
+            public function get(string $name): mixed { return null; }
+            public function set(string $name, mixed $value): static { return $this; }
+            public function toArray(): array { return []; }
+            public function language(): string { return 'en'; }
+            public function getSearchDocumentId(): string { return $this->documentId; }
+            public function toSearchDocument(): array { return ['title' => 'T', 'body' => 'B']; }
+            public function toSearchMetadata(): array { return ['entity_type' => 'custom']; }
+        };
+    }
+}
+
+final class ProjectionSpy implements EntitySearchProjectorInterface
+{
+    public int $projectCalls = 0;
+
+    public function __construct(
+        private readonly bool $supports,
+        private readonly ?SearchIndexableInterface $document,
+    ) {}
+
+    public function supports(EntityInterface $entity): bool
+    {
+        return $this->supports;
+    }
+
+    public function project(EntityInterface $entity): ?SearchIndexableInterface
+    {
+        ++$this->projectCalls;
+
+        return $this->document;
+    }
+}

--- a/packages/search/tests/Unit/Projection/NodeSearchProjectorTest.php
+++ b/packages/search/tests/Unit/Projection/NodeSearchProjectorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit\Projection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\Exception\FieldReadDenied;
+use Waaseyaa\Search\Projection\NodeSearchProjector;
+
+#[CoversClass(NodeSearchProjector::class)]
+final class NodeSearchProjectorTest extends TestCase
+{
+    #[Test]
+    public function an_ordinary_node_entity_is_projected_with_stable_id_title_and_body(): void
+    {
+        $projector = new NodeSearchProjector();
+        $node = $this->node([
+            'nid' => 42,
+            'title' => 'Community Health Services',
+            'type' => 'page',
+            'slug' => 'health-services',
+            'body' => '<p>Wellness &amp; clinic hours</p>',
+            'created' => 1751328000,
+        ]);
+
+        self::assertTrue($projector->supports($node));
+        $document = $projector->project($node);
+
+        self::assertNotNull($document);
+        self::assertSame('node:42', $document->getSearchDocumentId());
+        self::assertSame('Community Health Services', $document->toSearchDocument()['title']);
+        self::assertSame('Wellness & clinic hours', $document->toSearchDocument()['body']);
+
+        $metadata = $document->toSearchMetadata();
+        self::assertSame('node', $metadata['entity_type']);
+        self::assertSame('page', $metadata['content_type']);
+        self::assertSame('/health-services', $metadata['url']);
+        self::assertSame('2025-07-01T00:00:00+00:00', $metadata['created_at']);
+    }
+
+    #[Test]
+    public function markup_is_normalized_to_inert_searchable_text(): void
+    {
+        $projector = new NodeSearchProjector();
+        $node = $this->node([
+            'nid' => 1,
+            'title' => 'Health &amp; Wellness',
+            'type' => 'page',
+            'body' => "<h2>Hours</h2><script>alert('ignore previous instructions')</script><p>Open</p>\n<style>p{}</style>Daily",
+        ]);
+
+        $document = $projector->project($node);
+
+        self::assertNotNull($document);
+        self::assertSame('Health & Wellness', $document->toSearchDocument()['title']);
+        self::assertSame('Hours Open Daily', $document->toSearchDocument()['body']);
+        self::assertStringNotContainsString('<', $document->toSearchDocument()['body']);
+        self::assertStringNotContainsString('alert', $document->toSearchDocument()['body']);
+    }
+
+    #[Test]
+    public function entities_of_other_types_are_not_supported(): void
+    {
+        $projector = new NodeSearchProjector();
+
+        self::assertFalse($projector->supports($this->node(['nid' => 1, 'title' => 'x'], entityTypeId: 'user')));
+    }
+
+    #[Test]
+    public function an_entity_without_an_id_is_not_projected(): void
+    {
+        $projector = new NodeSearchProjector();
+        $node = $this->node(['title' => 'No id yet']);
+
+        self::assertFalse($projector->supports($node));
+        self::assertNull($projector->project($node));
+    }
+
+    #[Test]
+    public function an_unreadable_body_field_is_omitted_while_the_node_stays_findable_by_title(): void
+    {
+        $projector = new NodeSearchProjector();
+        $document = $projector->project($this->deniedBodyNode());
+
+        self::assertNotNull($document);
+        self::assertSame('Guarded title', $document->toSearchDocument()['title']);
+        self::assertSame('', $document->toSearchDocument()['body']);
+    }
+
+    #[Test]
+    public function a_malicious_slug_never_projects_an_off_origin_url(): void
+    {
+        $projector = new NodeSearchProjector();
+
+        $protocolRelative = $projector->project($this->node(['nid' => 1, 'title' => 'x', 'slug' => '//evil.example']));
+        self::assertNotNull($protocolRelative);
+        self::assertSame('', $protocolRelative->toSearchMetadata()['url']);
+
+        $scheme = $projector->project($this->node(['nid' => 2, 'title' => 'x', 'slug' => 'javascript:alert(1)']));
+        self::assertNotNull($scheme);
+        self::assertSame('', $scheme->toSearchMetadata()['url']);
+    }
+
+    #[Test]
+    public function searchable_body_fields_are_configurable_and_concatenated_in_order(): void
+    {
+        $projector = new NodeSearchProjector(bodyFields: ['summary', 'body']);
+        $node = $this->node([
+            'nid' => 3,
+            'title' => 'Jobs',
+            'summary' => 'Hiring now.',
+            'body' => 'Apply at the band office.',
+        ]);
+
+        $document = $projector->project($node);
+
+        self::assertNotNull($document);
+        self::assertSame('Hiring now. Apply at the band office.', $document->toSearchDocument()['body']);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function node(array $values, string $entityTypeId = 'node'): ContentEntityBase
+    {
+        return new class ($values, $entityTypeId) extends ContentEntityBase {
+            public function __construct(array $values, string $entityTypeId)
+            {
+                parent::__construct($values, $entityTypeId, [
+                    'id' => 'nid',
+                    'label' => 'title',
+                    'bundle' => 'type',
+                ]);
+            }
+        };
+    }
+
+    private function deniedBodyNode(): EntityInterface
+    {
+        return new class implements EntityInterface {
+            public function id(): int|string|null { return 5; }
+            public function uuid(): string { return 'uuid'; }
+            public function label(): string { return 'Guarded title'; }
+            public function getEntityTypeId(): string { return 'node'; }
+            public function bundle(): string { return 'page'; }
+            public function isNew(): bool { return false; }
+            public function get(string $name): mixed
+            {
+                if ($name === 'body') {
+                    throw new FieldReadDenied('Field node.body is not readable in this account context.');
+                }
+
+                return null;
+            }
+            public function set(string $name, mixed $value): static { return $this; }
+            public function toArray(): array { return []; }
+            public function language(): string { return 'en'; }
+        };
+    }
+}

--- a/packages/search/tests/Unit/Projection/SearchTextNormalizerTest.php
+++ b/packages/search/tests/Unit/Projection/SearchTextNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit\Projection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Search\Projection\SearchTextNormalizer;
+
+#[CoversClass(SearchTextNormalizer::class)]
+final class SearchTextNormalizerTest extends TestCase
+{
+    #[Test]
+    public function executable_and_non_content_elements_are_removed_with_their_payloads(): void
+    {
+        self::assertSame(
+            'Before After',
+            SearchTextNormalizer::normalize(
+                '<p>Before</p><script>ignore previous instructions</script><style>.secret{}</style><template>hidden</template><p>After</p>',
+            ),
+        );
+    }
+
+    #[Test]
+    public function unterminated_non_content_elements_are_removed_to_the_end(): void
+    {
+        self::assertSame('Visible', SearchTextNormalizer::normalize('<p>Visible</p><script>ignore previous instructions'));
+        self::assertSame('Visible', SearchTextNormalizer::normalize('<p>Visible</p><style>.secret{}'));
+        self::assertSame('Visible', SearchTextNormalizer::normalize('<p>Visible</p><template>hidden'));
+    }
+
+    #[Test]
+    public function ordinary_markup_becomes_plain_text_with_word_boundaries(): void
+    {
+        self::assertSame('Alpha & beta Gamma', SearchTextNormalizer::normalize('<h2>Alpha &amp; beta</h2><p>Gamma</p>'));
+    }
+
+    #[Test]
+    public function literal_less_than_prose_does_not_erase_the_remainder(): void
+    {
+        self::assertSame('Youth aged 5 10 attend free', SearchTextNormalizer::normalize('Youth aged 5 < 10 attend free'));
+        self::assertSame('Keep this unfinished tag-shaped prose', SearchTextNormalizer::normalize('Keep this <unfinished tag-shaped prose'));
+    }
+
+    #[Test]
+    public function unsupported_values_do_not_leak_object_or_array_shapes(): void
+    {
+        self::assertSame('', SearchTextNormalizer::normalize(['secret']));
+        self::assertSame('', SearchTextNormalizer::normalize(new \stdClass()));
+        self::assertSame('', SearchTextNormalizer::normalize(false));
+        self::assertSame('', SearchTextNormalizer::normalize(null));
+    }
+}

--- a/packages/search/tests/Unit/SearchIndexSubscriberTest.php
+++ b/packages/search/tests/Unit/SearchIndexSubscriberTest.php
@@ -16,7 +16,10 @@ use Waaseyaa\Entity\Event\EntityEvents;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 use Waaseyaa\Entity\Storage\EntityStorageInterface;
 use Waaseyaa\EntityStorage\Event\RevisionPointerMovedEvent;
+use Waaseyaa\Search\Document\SearchDocument;
 use Waaseyaa\Search\EventSubscriber\SearchIndexSubscriber;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
 use Waaseyaa\Search\SearchIndexableInterface;
 use Waaseyaa\Search\SearchIndexerInterface;
 
@@ -42,7 +45,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->once())->method('index')->with($entity);
 
-        $subscriber = new SearchIndexSubscriber($indexer);
+        $subscriber = $this->subscriber($indexer);
         $event = new EntityEvent($entity);
         $subscriber->onPostSave($event);
     }
@@ -58,7 +61,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->never())->method('index');
 
-        $subscriber = new SearchIndexSubscriber($indexer);
+        $subscriber = $this->subscriber($indexer);
         $event = new EntityEvent($entity);
         $subscriber->onPostSave($event);
     }
@@ -70,7 +73,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->once())->method('remove')->with('node:1');
 
-        $subscriber = new SearchIndexSubscriber($indexer);
+        $subscriber = $this->subscriber($indexer);
         $event = new EntityEvent($entity);
         $subscriber->onPostDelete($event);
     }
@@ -80,9 +83,9 @@ final class SearchIndexSubscriberTest extends TestCase
     {
         $entity = $this->createIndexableEntity('node:1');
         $indexer = $this->createMockIndexer();
-        $indexer->method('index')->willThrowException(new \RuntimeException('DB error'));
+        $indexer->expects($this->once())->method('index')->willThrowException(new \RuntimeException('DB error'));
 
-        $subscriber = new SearchIndexSubscriber($indexer);
+        $subscriber = $this->subscriber($indexer);
         $event = new EntityEvent($entity);
 
         // Should not throw — best-effort side effect
@@ -116,7 +119,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->once())->method('index')->with($servedEntity);
 
-        $subscriber = new SearchIndexSubscriber($indexer, entityTypeManager: $this->entityTypeManager($servedEntity));
+        $subscriber = $this->subscriber($indexer, $this->entityTypeManager($servedEntity));
         $subscriber->onPostSave(new EntityEvent($tipEntity));
     }
 
@@ -127,7 +130,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->once())->method('index')->with($servedEntity);
 
-        $subscriber = new SearchIndexSubscriber($indexer, entityTypeManager: $this->entityTypeManager($servedEntity));
+        $subscriber = $this->subscriber($indexer, $this->entityTypeManager($servedEntity));
         $subscriber->onRevisionPointerMoved(new RevisionPointerMovedEvent(
             entityTypeId: 'node',
             entityId: '1',
@@ -147,7 +150,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->once())->method('index')->with($servedEntity);
 
-        $subscriber = new SearchIndexSubscriber($indexer, entityTypeManager: $this->entityTypeManager($servedEntity));
+        $subscriber = $this->subscriber($indexer, $this->entityTypeManager($servedEntity));
         $subscriber->onRevisionReverted(new EntityEvent($eventEntity));
     }
 
@@ -157,7 +160,7 @@ final class SearchIndexSubscriberTest extends TestCase
         $indexer = $this->createMockIndexer();
         $indexer->expects($this->never())->method('index');
 
-        $subscriber = new SearchIndexSubscriber($indexer);
+        $subscriber = $this->subscriber($indexer);
         $subscriber->onRevisionPointerMoved(new RevisionPointerMovedEvent(
             entityTypeId: 'node',
             entityId: '1',
@@ -166,6 +169,176 @@ final class SearchIndexSubscriberTest extends TestCase
             toRevisionId: 20,
             actorUid: 7,
         ));
+    }
+
+    // ------------------------------------------------------------------
+    // #2270: entities that do not implement SearchIndexableInterface are
+    // resolved through the shared EntitySearchProjectionRegistry so ordinary
+    // Node content participates in the save/delete/pointer-move lifecycle.
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function a_projector_backed_entity_is_indexed_on_save_through_the_registry(): void
+    {
+        $servedEntity = $this->plainEntity('node', 1);
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->once())->method('index')->with(self::callback(
+            static fn(SearchIndexableInterface $document): bool => $document->getSearchDocumentId() === 'node:1'
+                && $document->toSearchDocument()['title'] === 'Projected served title',
+        ));
+
+        $subscriber = new SearchIndexSubscriber(
+            $indexer,
+            entityTypeManager: $this->entityTypeManager($servedEntity),
+            projectionRegistry: $this->nodeProjectionRegistry(),
+        );
+        $subscriber->onPostSave(new EntityEvent($this->plainEntity('node', 1)));
+    }
+
+    #[Test]
+    public function a_projector_backed_entity_is_removed_on_delete(): void
+    {
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->once())->method('remove')->with('node:1');
+
+        $subscriber = new SearchIndexSubscriber(
+            $indexer,
+            projectionRegistry: $this->nodeProjectionRegistry(),
+        );
+        $subscriber->onPostDelete(new EntityEvent($this->plainEntity('node', 1)));
+    }
+
+    #[Test]
+    public function a_pointer_move_indexes_the_projected_served_entity(): void
+    {
+        $servedEntity = $this->plainEntity('node', 1);
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->once())->method('index')->with(self::callback(
+            static fn(SearchIndexableInterface $document): bool => $document->getSearchDocumentId() === 'node:1',
+        ));
+
+        $subscriber = new SearchIndexSubscriber(
+            $indexer,
+            entityTypeManager: $this->entityTypeManager($servedEntity),
+            projectionRegistry: $this->nodeProjectionRegistry(),
+        );
+        $subscriber->onRevisionPointerMoved(new RevisionPointerMovedEvent(
+            entityTypeId: 'node',
+            entityId: '1',
+            operation: 'publish',
+            fromRevisionId: 10,
+            toRevisionId: 20,
+            actorUid: 7,
+        ));
+    }
+
+    #[Test]
+    public function an_unsupported_entity_type_is_still_skipped_with_a_registry_wired(): void
+    {
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->never())->method('index');
+        $indexer->expects($this->never())->method('remove');
+
+        $subscriber = new SearchIndexSubscriber(
+            $indexer,
+            projectionRegistry: $this->nodeProjectionRegistry(),
+        );
+        $subscriber->onPostSave(new EntityEvent($this->plainEntity('taxonomy_term', 3)));
+        $subscriber->onPostDelete(new EntityEvent($this->plainEntity('taxonomy_term', 3)));
+    }
+
+    #[Test]
+    public function a_projection_failure_on_save_is_best_effort(): void
+    {
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->never())->method('index');
+        $registry = new EntitySearchProjectionRegistry([
+            new class implements EntitySearchProjectorInterface {
+                public function supports(EntityInterface $entity): bool
+                {
+                    return true;
+                }
+
+                public function project(EntityInterface $entity): ?SearchIndexableInterface
+                {
+                    throw new \RuntimeException('projection blew up');
+                }
+            },
+        ]);
+
+        $subscriber = new SearchIndexSubscriber($indexer, projectionRegistry: $registry);
+
+        // Must not throw — indexing is a best-effort side effect.
+        $subscriber->onPostSave(new EntityEvent($this->plainEntity('node', 1)));
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function a_previously_indexed_entity_is_removed_when_its_projector_now_excludes_it(): void
+    {
+        $entity = $this->plainEntity('node', 1);
+        $indexer = $this->createMockIndexer();
+        $indexer->expects($this->never())->method('index');
+        $indexer->expects($this->once())->method('remove')->with('node:1');
+        $registry = new EntitySearchProjectionRegistry([
+            new class implements EntitySearchProjectorInterface {
+                public function supports(EntityInterface $entity): bool
+                {
+                    return $entity->getEntityTypeId() === 'node' && $entity->id() !== null;
+                }
+
+                public function project(EntityInterface $entity): ?SearchIndexableInterface
+                {
+                    return null;
+                }
+            },
+        ]);
+
+        $subscriber = new SearchIndexSubscriber($indexer, projectionRegistry: $registry);
+        $subscriber->onPostSave(new EntityEvent($entity));
+    }
+
+    private function nodeProjectionRegistry(): EntitySearchProjectionRegistry
+    {
+        return new EntitySearchProjectionRegistry([
+            new class implements EntitySearchProjectorInterface {
+                public function supports(EntityInterface $entity): bool
+                {
+                    return $entity->getEntityTypeId() === 'node' && $entity->id() !== null;
+                }
+
+                public function project(EntityInterface $entity): ?SearchIndexableInterface
+                {
+                    return new SearchDocument(
+                        'node:' . $entity->id(),
+                        'Projected served title',
+                        'Projected body',
+                        ['entity_type' => 'node'],
+                    );
+                }
+            },
+        ]);
+    }
+
+    private function subscriber(
+        SearchIndexerInterface $indexer,
+        ?EntityTypeManagerInterface $entityTypeManager = null,
+    ): SearchIndexSubscriber {
+        return new SearchIndexSubscriber(
+            $indexer,
+            entityTypeManager: $entityTypeManager,
+            projectionRegistry: new EntitySearchProjectionRegistry([]),
+        );
+    }
+
+    private function plainEntity(string $entityTypeId, int $id): EntityInterface
+    {
+        return new class ($entityTypeId, $id) extends \Waaseyaa\Entity\EntityBase {
+            public function __construct(string $entityTypeId, int $id)
+            {
+                parent::__construct(['id' => $id], $entityTypeId, ['id' => 'id']);
+            }
+        };
     }
 
     private function entityTypeManager(?EntityInterface $servedEntity): EntityTypeManagerInterface

--- a/packages/search/tests/Unit/SearchServiceProviderProjectionWiringTest.php
+++ b/packages/search/tests/Unit/SearchServiceProviderProjectionWiringTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Search\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Context\AccountFieldReadScope;
+use Waaseyaa\Access\Context\AccountFieldReadScopeInterface;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Database\DatabaseInterface;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\ContentEntityBase;
+use Waaseyaa\Entity\EntityInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\Foundation\ServiceProvider\KernelServicesInterface;
+use Waaseyaa\Search\Document\SearchDocument;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\EntitySearchProjectorInterface;
+use Waaseyaa\Search\ProvidesEntitySearchProjectorsInterface;
+use Waaseyaa\Search\SearchCandidateReference;
+use Waaseyaa\Search\SearchCandidateResolverInterface;
+use Waaseyaa\Search\SearchIndexableInterface;
+use Waaseyaa\Search\SearchServiceProvider;
+use Waaseyaa\Search\Tests\Support\SearchTestPrincipal;
+
+/**
+ * #2270: the production wiring must thread one shared projection registry
+ * through the candidate resolver and the lifecycle subscriber, defaulting to
+ * the built-in node projector with application projectors taking precedence.
+ */
+#[CoversClass(SearchServiceProvider::class)]
+final class SearchServiceProviderProjectionWiringTest extends TestCase
+{
+    #[Test]
+    public function the_projection_registry_is_bound_with_the_default_node_projector(): void
+    {
+        $provider = $this->registeredProvider($this->kernelServices());
+
+        $registry = $provider->resolve(EntitySearchProjectionRegistry::class);
+
+        self::assertInstanceOf(EntitySearchProjectionRegistry::class, $registry);
+        $document = $registry->resolveIndexable($this->nodeEntity(7, 'Registry default'));
+        self::assertNotNull($document, 'Ordinary node entities must be projectable out of the box.');
+        self::assertSame('node:7', $document->getSearchDocumentId());
+    }
+
+    #[Test]
+    public function application_projectors_take_precedence_over_the_default_node_projector(): void
+    {
+        $appProjectors = new class implements ProvidesEntitySearchProjectorsInterface {
+            public function entitySearchProjectors(): array
+            {
+                return [
+                    new class implements EntitySearchProjectorInterface {
+                        public function supports(EntityInterface $entity): bool
+                        {
+                            return $entity->getEntityTypeId() === 'node';
+                        }
+
+                        public function project(EntityInterface $entity): ?SearchIndexableInterface
+                        {
+                            return new SearchDocument('node:' . $entity->id(), 'App override', 'app body', [
+                                'entity_type' => 'node',
+                            ]);
+                        }
+                    },
+                ];
+            }
+        };
+        $provider = $this->registeredProvider($this->kernelServices(projectorProvider: $appProjectors));
+
+        $registry = $provider->resolve(EntitySearchProjectionRegistry::class);
+
+        self::assertInstanceOf(EntitySearchProjectionRegistry::class, $registry);
+        $document = $registry->resolveIndexable($this->nodeEntity(7, 'Ignored'));
+        self::assertNotNull($document);
+        self::assertSame('App override', $document->toSearchDocument()['title']);
+    }
+
+    #[Test]
+    public function the_candidate_resolver_reaches_projector_backed_entities(): void
+    {
+        $node = $this->nodeEntity(1, 'Wired through the provider');
+        $provider = $this->registeredProvider($this->kernelServices(
+            entityTypeManager: $this->entityTypeManager($node),
+            accessHandler: new EntityAccessHandler([$this->allowViewPolicy()]),
+        ));
+
+        $resolver = $provider->resolve(SearchCandidateResolverInterface::class);
+        self::assertInstanceOf(SearchCandidateResolverInterface::class, $resolver);
+
+        $projection = $resolver->resolve(new SearchCandidateReference('node:1', 'node'), SearchTestPrincipal::create());
+
+        self::assertNotNull($projection, 'The production resolver must project ordinary node entities.');
+        self::assertSame('Wired through the provider', $projection->title);
+    }
+
+    #[Test]
+    public function the_booted_lifecycle_subscriber_indexes_projector_backed_entities(): void
+    {
+        $node = $this->nodeEntity(1, 'Booted subscriber');
+        $database = DBALDatabase::createSqlite();
+        $dispatcher = new EventDispatcher();
+        $provider = $this->registeredProvider($this->kernelServices(
+            entityTypeManager: $this->entityTypeManager($node),
+            database: $database,
+            dispatcher: $dispatcher,
+        ));
+
+        $provider->boot();
+        $dispatcher->dispatch(new EntityEvent($node), EntityEvents::POST_SAVE->value);
+
+        $rows = iterator_to_array($database->query(
+            "SELECT document_id FROM search_metadata WHERE document_id = 'node:1'",
+        ));
+        self::assertCount(1, $rows, 'The booted subscriber must index ordinary node entities through the projection registry.');
+    }
+
+    private function registeredProvider(KernelServicesInterface $services): SearchServiceProvider
+    {
+        $provider = new SearchServiceProvider();
+        $provider->setKernelServices($services);
+        $provider->register();
+
+        return $provider;
+    }
+
+    private function kernelServices(
+        ?EntityTypeManagerInterface $entityTypeManager = null,
+        ?EntityAccessHandler $accessHandler = null,
+        ?DatabaseInterface $database = null,
+        ?EventDispatcher $dispatcher = null,
+        ?ProvidesEntitySearchProjectorsInterface $projectorProvider = null,
+    ): KernelServicesInterface {
+        return new class (
+            $entityTypeManager ?? $this->createStub(EntityTypeManagerInterface::class),
+            $accessHandler ?? new EntityAccessHandler([]),
+            new AccountFieldReadScope(),
+            $database ?? DBALDatabase::createSqlite(),
+            $dispatcher,
+            $projectorProvider,
+        ) implements KernelServicesInterface {
+            public function __construct(
+                private readonly EntityTypeManagerInterface $entityTypeManager,
+                private readonly EntityAccessHandler $accessHandler,
+                private readonly AccountFieldReadScopeInterface $fieldReadScope,
+                private readonly DatabaseInterface $database,
+                private readonly ?EventDispatcher $dispatcher,
+                private readonly ?ProvidesEntitySearchProjectorsInterface $projectorProvider,
+            ) {}
+
+            public function get(string $abstract): ?object
+            {
+                return match ($abstract) {
+                    EntityTypeManagerInterface::class => $this->entityTypeManager,
+                    EntityAccessHandler::class => $this->accessHandler,
+                    AccountFieldReadScopeInterface::class => $this->fieldReadScope,
+                    DatabaseInterface::class => $this->database,
+                    \Symfony\Contracts\EventDispatcher\EventDispatcherInterface::class => $this->dispatcher,
+                    ProvidesEntitySearchProjectorsInterface::class => $this->projectorProvider,
+                    default => null,
+                };
+            }
+        };
+    }
+
+    private function entityTypeManager(EntityInterface $servedEntity): EntityTypeManagerInterface
+    {
+        $repository = $this->createStub(EntityRepositoryInterface::class);
+        $repository->method('find')->willReturn($servedEntity);
+
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
+        $manager->method('hasDefinition')->willReturnCallback(static fn(string $type): bool => $type === 'node');
+        $manager->method('getRepository')->willReturn($repository);
+
+        return $manager;
+    }
+
+    private function allowViewPolicy(): AccessPolicyInterface
+    {
+        return new class implements AccessPolicyInterface {
+            public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+            {
+                return AccessResult::allowed('test');
+            }
+
+            public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+            {
+                return AccessResult::forbidden();
+            }
+
+            public function appliesTo(string $entityTypeId): bool
+            {
+                return $entityTypeId === 'node';
+            }
+        };
+    }
+
+    private function nodeEntity(int $id, string $title): ContentEntityBase
+    {
+        return new class (['nid' => $id, 'title' => $title, 'type' => 'page', 'body' => 'Body text.']) extends ContentEntityBase {
+            public function __construct(array $values)
+            {
+                parent::__construct($values, 'node', ['id' => 'nid', 'label' => 'title', 'bundle' => 'type']);
+            }
+        };
+    }
+}

--- a/tests/Architecture/FieldReadBoundaryArchitectureTest.php
+++ b/tests/Architecture/FieldReadBoundaryArchitectureTest.php
@@ -245,6 +245,7 @@ final class FieldReadBoundaryArchitectureTest extends TestCase
         'packages/path/src/PathAlias.php' => 'Path entity domain helper is reviewed activation-compatible through its classified canonical accessor.',
         'packages/publishing/src/ContentMutationSnapshotReader.php' => 'Closed publisher mutation results project only the descriptor status, slug, and writable fields after publish-capability and entity-gate authorization; callers cannot select another field (#2141).',
         'packages/relationship/src/RelationshipAccessPolicy.php' => 'Relationship policy input is reviewed activation-compatible through the canonical guarded accessor.',
+        'packages/search/src/Projection/NodeSearchProjector.php' => 'Search-owned node projection reads only explicitly selected fields through the canonical guarded accessor: index-time reads without an account can expose Public fields only, each denied field is omitted, and query-time projection reruns inside the already entity-authorized principal scope (#2270).',
         'packages/seo/src/SchemaOrg/EntitySchemaOrgMapper.php' => 'SEO label projection is reviewed activation-compatible through the canonical guarded accessor.',
         'packages/taxonomy/src/Term.php' => 'Taxonomy entity domain helper is reviewed activation-compatible through its classified canonical accessor.',
         'packages/taxonomy/src/TermAccessPolicy.php' => 'Taxonomy policy input is reviewed activation-compatible through the canonical guarded accessor.',

--- a/tests/Integration/Search/NodeSearchProjectionIntegrationTest.php
+++ b/tests/Integration/Search/NodeSearchProjectionIntegrationTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Integration\Search;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Access\AuthorizationPrincipal;
+use Waaseyaa\Access\Context\AccountFieldReadScope;
+use Waaseyaa\Access\EntityAccessHandler;
+use Waaseyaa\Access\FieldReadGuard;
+use Waaseyaa\CLI\Command\HandlerCommand;
+use Waaseyaa\CLI\Command\HandlerOption;
+use Waaseyaa\CLI\Command\HandlerOptionMode;
+use Waaseyaa\CLI\Handler\SearchReindexHandler;
+use Waaseyaa\CLI\Testing\CliTester;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityReadRuntime;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\FieldReadLevel;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\Node\Node;
+use Waaseyaa\Node\NodeAccessPolicy;
+use Waaseyaa\Search\Access\EntitySearchCandidateResolver;
+use Waaseyaa\Search\EventSubscriber\SearchIndexSubscriber;
+use Waaseyaa\Search\Fts5\Fts5SearchIndexer;
+use Waaseyaa\Search\Fts5\Fts5SearchProvider;
+use Waaseyaa\Search\Projection\EntitySearchProjectionRegistry;
+use Waaseyaa\Search\Projection\NodeSearchProjector;
+use Waaseyaa\Search\SearchRequest;
+
+/**
+ * #2270 end-to-end: an ordinary CMS install's Node content (no
+ * SearchIndexableInterface anywhere) is projected by the search-owned
+ * projection contract, indexed by `search:reindex` and the save/delete
+ * lifecycle, and returned by the principal-safe read surface — with entity-
+ * and field-level enforcement intact.
+ */
+#[CoversNothing]
+final class NodeSearchProjectionIntegrationTest extends TestCase
+{
+    private DBALDatabase $database;
+    private EntityTypeManager $manager;
+    private EntityAccessHandler $accessHandler;
+    private AccountFieldReadScope $fieldReadScope;
+    private EntitySearchProjectionRegistry $projectionRegistry;
+    private Fts5SearchIndexer $indexer;
+    private Fts5SearchProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->database = DBALDatabase::createSqlite();
+        $dispatcher = new EventDispatcher();
+        $resolver = new SingleConnectionResolver($this->database);
+
+        $this->manager = new EntityTypeManager(
+            $dispatcher,
+            null,
+            function (string $_id, EntityType $definition) use ($dispatcher, $resolver): EntityRepository {
+                new SqlSchemaHandler($definition, $this->database)->ensureTable();
+                $idKey = $definition->getKeys()['id'] ?? 'id';
+
+                return \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(
+                    $definition,
+                    new SqlStorageDriver($resolver, $idKey),
+                    $dispatcher,
+                    database: $this->database,
+                );
+            },
+        );
+
+        // The real Node entity class plus the field classifications a
+        // correctly-declared CMS bundle carries: public title/slug/body,
+        // protected (authorization-input) status/uid. Mirrors the Node class
+        // #[Field] attributes; `body` models the bundle's declared body field.
+        $this->manager->registerEntityType(new EntityType(
+            id: 'node',
+            label: 'Content',
+            class: Node::class,
+            keys: ['id' => 'nid', 'uuid' => 'uuid', 'label' => 'title', 'bundle' => 'type'],
+            _fieldDefinitions: [
+                'title' => ['type' => 'string', 'read' => FieldReadLevel::Public],
+                'type' => ['type' => 'string', 'read' => FieldReadLevel::Public],
+                'slug' => ['type' => 'string', 'read' => FieldReadLevel::Public],
+                'body' => ['type' => 'text', 'read' => FieldReadLevel::Public],
+                'status' => ['type' => 'boolean', 'read' => FieldReadLevel::Protected, 'settings' => ['authorizationInput' => true]],
+                'uid' => ['type' => 'integer', 'read' => FieldReadLevel::Protected, 'settings' => ['authorizationInput' => true]],
+                'created' => ['type' => 'integer', 'read' => FieldReadLevel::Public],
+                'changed' => ['type' => 'integer', 'read' => FieldReadLevel::Public],
+            ],
+        ));
+
+        $this->accessHandler = new EntityAccessHandler([new NodeAccessPolicy()]);
+        $this->fieldReadScope = new AccountFieldReadScope();
+        EntityReadRuntime::installGuard(new FieldReadGuard(
+            $this->fieldReadScope,
+            $this->accessHandler->checkProtectedFieldRead(...),
+        ));
+
+        $this->projectionRegistry = new EntitySearchProjectionRegistry([new NodeSearchProjector()]);
+        $this->indexer = new Fts5SearchIndexer($this->database);
+        $this->provider = new Fts5SearchProvider(
+            $this->database,
+            $this->indexer,
+            new EntitySearchCandidateResolver(
+                $this->manager,
+                $this->accessHandler,
+                $this->fieldReadScope,
+                $this->projectionRegistry,
+            ),
+        );
+
+        $dispatcher->addSubscriber(new SearchIndexSubscriber(
+            $this->indexer,
+            entityTypeManager: $this->manager,
+            projectionRegistry: $this->projectionRegistry,
+        ));
+    }
+
+    #[Test]
+    public function search_reindex_indexes_ordinary_node_content_and_a_known_query_returns_it(): void
+    {
+        $this->seedContent();
+        // Prove the full rebuild path, not the save-time subscriber: clear
+        // everything the seeding saves indexed, then reindex from storage.
+        $this->indexer->removeAll();
+        self::assertSame(0, $this->provider->search(new SearchRequest('health'), $this->viewer())->totalHits);
+
+        $tester = $this->reindexTester();
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getExitCode());
+        self::assertStringContainsString('Reindex complete. 2 documents indexed.', $tester->getStdout());
+
+        $result = $this->provider->search(new SearchRequest('health'), $this->viewer());
+
+        self::assertSame(1, $result->totalHits);
+        self::assertSame('node:1', $result->hits[0]->id);
+        self::assertSame('Community Health Services', $result->hits[0]->title);
+        self::assertSame('/health-services', $result->hits[0]->url);
+        self::assertSame('page', $result->hits[0]->contentType);
+        self::assertStringContainsString('Wellness clinic hours', $result->hits[0]->highlight);
+    }
+
+    #[Test]
+    public function inaccessible_and_unpublished_content_never_surfaces_to_unauthorized_principals(): void
+    {
+        $this->seedContent();
+
+        // A principal without 'access content' sees nothing at all.
+        self::assertSame(0, $this->provider->search(new SearchRequest('health'), $this->stranger())->totalHits);
+
+        // The unpublished draft matches 'health' in its title but is
+        // invisible to an ordinary viewer — successful empty-ish result,
+        // indistinguishable from the term not existing.
+        $viewerResult = $this->provider->search(new SearchRequest('strategy'), $this->viewer());
+        self::assertSame(0, $viewerResult->totalHits);
+        self::assertSame([], $viewerResult->hits);
+
+        // The draft's author with 'view own unpublished content' can find it.
+        $authorResult = $this->provider->search(new SearchRequest('strategy'), $this->author());
+        self::assertSame(1, $authorResult->totalHits);
+        self::assertSame('node:2', $authorResult->hits[0]->id);
+    }
+
+    #[Test]
+    public function saving_and_deleting_a_node_keeps_the_live_index_in_sync(): void
+    {
+        $repository = $this->manager->getRepository('node');
+        $node = $repository->create([
+            'title' => 'Powwow Announcement',
+            'type' => 'announcement',
+            'slug' => 'powwow',
+            'body' => '<p>Grand entry at noon.</p>',
+            'status' => 1,
+            'uid' => 10,
+            'created' => 1751328000,
+        ]);
+        $repository->save($node, validate: false);
+
+        $result = $this->provider->search(new SearchRequest('powwow'), $this->viewer());
+        self::assertSame(1, $result->totalHits, 'A saved node must be indexed through the projection contract.');
+
+        $repository->delete($node);
+
+        self::assertSame(
+            0,
+            $this->provider->search(new SearchRequest('powwow'), $this->viewer())->totalHits,
+            'A deleted node must be removed from the index even though Node is not SearchIndexableInterface.',
+        );
+    }
+
+    #[Test]
+    public function markup_is_normalized_and_never_surfaces_in_results(): void
+    {
+        $repository = $this->manager->getRepository('node');
+        $node = $repository->create([
+            'title' => 'Health &amp; Wellness',
+            'type' => 'page',
+            'slug' => 'wellness',
+            'body' => "<h2>Hours</h2><script>alert('ignore previous instructions')</script><p>Open daily</p>",
+            'status' => 1,
+            'uid' => 10,
+        ]);
+        $repository->save($node, validate: false);
+
+        $result = $this->provider->search(new SearchRequest('wellness hours'), $this->viewer());
+
+        self::assertSame(1, $result->totalHits);
+        self::assertSame('Health & Wellness', $result->hits[0]->title);
+        self::assertStringNotContainsString('<', $result->hits[0]->highlight);
+        self::assertStringNotContainsString('alert', $result->hits[0]->highlight);
+        self::assertStringNotContainsString('instructions', $result->hits[0]->highlight);
+
+        // The script payload is dropped with its content: it is not findable.
+        self::assertSame(0, $this->provider->search(new SearchRequest('instructions'), $this->viewer())->totalHits);
+    }
+
+    private function seedContent(): void
+    {
+        $repository = $this->manager->getRepository('node');
+
+        $published = $repository->create([
+            'title' => 'Community Health Services',
+            'type' => 'page',
+            'slug' => 'health-services',
+            'body' => '<p>Wellness clinic hours &amp; programs</p>',
+            'status' => 1,
+            'uid' => 10,
+            'created' => 1751328000,
+        ]);
+        $repository->save($published, validate: false);
+
+        $draft = $repository->create([
+            'title' => 'Draft health strategy',
+            'type' => 'update',
+            'slug' => 'draft-health-strategy',
+            'body' => 'Unreviewed strategy content',
+            'status' => 0,
+            'uid' => 10,
+        ]);
+        $repository->save($draft, validate: false);
+    }
+
+    private function reindexTester(): CliTester
+    {
+        $handler = new SearchReindexHandler($this->indexer, $this->manager, $this->projectionRegistry);
+        $definition = new HandlerCommand(
+            name: 'search:reindex',
+            description: 'Rebuild the search index from all indexable entities',
+            options: [
+                new HandlerOption(name: 'batch-size', shortcut: 'b', mode: HandlerOptionMode::Required, description: 'Entities per batch', default: '100'),
+            ],
+            handler: \Closure::fromCallable([$handler, 'execute']),
+        );
+        $container = new class implements \Psr\Container\ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException("Not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        };
+
+        return CliTester::for($definition, $container);
+    }
+
+    private function viewer(): AuthorizationPrincipal
+    {
+        return new AuthorizationPrincipal(
+            accountId: 1,
+            authenticated: true,
+            roles: ['authenticated'],
+            permissions: ['access content'],
+            claimsGeneration: 'itest-viewer',
+        );
+    }
+
+    private function stranger(): AuthorizationPrincipal
+    {
+        return new AuthorizationPrincipal(
+            accountId: 2,
+            authenticated: true,
+            roles: ['authenticated'],
+            permissions: [],
+            claimsGeneration: 'itest-stranger',
+        );
+    }
+
+    private function author(): AuthorizationPrincipal
+    {
+        return new AuthorizationPrincipal(
+            accountId: 10,
+            authenticated: true,
+            roles: ['authenticated'],
+            permissions: ['access content', 'view own unpublished content'],
+            claimsGeneration: 'itest-author',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a search-owned entity projection registry with a default ordinary Node projector and an application override seam.
- Use the same projection for lifecycle indexing, `search:reindex`, and query-time authorization.
- Bound candidate discovery to one 1,001-pointer FTS query and expose incomplete result totals honestly.
- Keep protected, unpublished, restricted, or unclassified content out of public results.

## Root cause

Ordinary Node entities had no canonical search projection, and candidate enumeration used an exhaustive offset loop whose work and totals became unreliable under large or concurrently changing indexes.

## Stack

This PR is based on `fix/2278-spec-drift-completeness`. Merge the specification-drift completeness PR first, then retarget this PR to `main`.

## Verification

- Every spec affected at this PR boundary is updated or acknowledged by commit-attached evidence.
- Canonical full-stack `composer verify`: 12,712 tests, 250,004 assertions.
- Native pre-push policy, Symfony import, package layer, and drift checks passed.
- `git diff --check` passed.

Closes #2270
