### PR TITLE
Make PHPUnit notices fatal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - Acknowledge reviewed spec drift up front with `spec-reviewed:` commit trailers; the blocking CI spec-drift check reads commit trailers.
 - Respect package layers. Symfony imports use the existing checker allowlist convention; any exception belongs in the explicit allowlist with a one-line rationale.
 - Run repository Git commands through `bin/git`; it mechanically refuses `git stash` for all agents and subagents. If a rebase needs a clean tree, commit on a temporary branch. Do not touch the dangling `da4d26758` stash.
-- Run the split Unit suite with `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit`; do not run the whole suite as one process.
+- Run the split Unit suite with `php -d memory_limit=1G ./vendor/bin/phpunit --testsuite Unit --no-coverage`; do not run the whole suite as one process. The root configuration declares a coverage report, so omitting `--no-coverage` on a machine without a coverage driver stops at a runner warning before any tests execute.
 - Run local gates under `set -o pipefail`. Local results are advisory; GitHub CI is authoritative.
 - Never merge to `main` while a release split/fan-out is running.
 - Merge PRs only via the `auto-merge-when-green` label, which enables native auto-merge after all five required checks pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP public authentication (#2276):** Let the public read-only MCP tier recognize durable, expiring, revocable `mcp:public` bearer credentials while preserving anonymous discovery, exact token scopes, real-account capability checks, and write-audience isolation.
 
+### Changed
+
+- **PHPUnit strictness (#2277):** Fail the canonical suite on PHP and PHPUnit notices or deprecations, retain mocks only for interaction contracts, and use stubs for passive collaborators. Active split-suite instructions now disable the configured coverage report explicitly so a missing coverage driver cannot stop discovery with zero tests executed.
+
 ### Fixed
 
 - **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,13 +213,13 @@ Design docs in `docs/history/plans/` are session artifacts (implementation histo
 
 **Testing** (do NOT use `-v` flag, PHPUnit 10.5 rejects it):
 - `./vendor/bin/phpunit` — run all tests
-- `./vendor/bin/phpunit --testsuite Unit` — unit tests only
-- `./vendor/bin/phpunit --testsuite Integration` — integration tests only
+- `./vendor/bin/phpunit --testsuite Unit --no-coverage` — unit tests only
+- `./vendor/bin/phpunit --testsuite Integration --no-coverage` — integration tests only
 - `./vendor/bin/phpunit --filter Phase10` — run tests matching a pattern
 - `./vendor/bin/phpunit packages/mail/tests/` — run a single package's tests
 
 **Platform — the suite is Linux-first; run it split, not as one process:**
-- Run the **split suites** (`--testsuite Unit`, then `--testsuite Integration`), not a bare `./vendor/bin/phpunit`: the whole suite as a single process OOMs at PHP's default 128 MB `memory_limit`. Raise `memory_limit` or run the two suites separately (CI runs them as separate jobs on Linux).
+- Run the **split suites** (`--testsuite Unit --no-coverage`, then `--testsuite Integration --no-coverage`), not a bare `./vendor/bin/phpunit`: the whole suite as a single process OOMs at PHP's default 128 MB `memory_limit`. Raise `memory_limit` or run the two suites separately (CI runs them as separate jobs on Linux). The explicit `--no-coverage` is required when no coverage driver is installed; otherwise the configured coverage report emits a runner warning before discovery and zero tests execute.
 - **Windows contributors:** the CLI snapshot tests pass on Windows because their fixtures (`*.stdout` / `*.stderr` / `*.exit`) are pinned to `eol=lf` in `.gitattributes` — with `core.autocrlf=true` they were otherwise checked out CRLF and ~72 `CliTester` snapshot assertions failed on the line endings alone. The *remaining* Windows failures are **POSIX-only by design** and are expected to fail off Linux: the release-tooling tests assume `bash`, `proc_open`, POSIX advisory file locks, and symlinks; the bin-script and OIDC-RSA tests assume a POSIX toolchain. `composer test` / `composer verify` are green on Linux and in CI. Treat a Windows-only failure in those areas as environmental — confirm it against a clean Linux run (or `git stash` + clean main) before assuming you introduced it.
 
 **Code quality:**

--- a/docs/REPO_ADMIN_SETUP.md
+++ b/docs/REPO_ADMIN_SETUP.md
@@ -110,7 +110,7 @@ composer hooks:doctor
 # Run quick local checks
 composer validate
 composer phpstan
-./vendor/bin/phpunit --testsuite Unit
+./vendor/bin/phpunit --testsuite Unit --no-coverage
 ```
 
 Hook installation is explicit because linked worktrees share the repository's

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -61,8 +61,8 @@ composer cs-check
 composer phpstan
 
 # Unit + integration tests (matches ci/unit-tests)
-./vendor/bin/phpunit --testsuite Unit
-./vendor/bin/phpunit --testsuite Integration
+./vendor/bin/phpunit --testsuite Unit --no-coverage
+./vendor/bin/phpunit --testsuite Integration --no-coverage
 
 # Frontend build + tests
 cd packages/admin && npm ci && npm run build && npm test

--- a/packages/access/tests/Unit/ConfigEntityAccessPolicyTest.php
+++ b/packages/access/tests/Unit/ConfigEntityAccessPolicyTest.php
@@ -67,7 +67,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessAllowedForAdministrator(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount(['administrator']);
 
         $result = $this->policy->access($entity, 'view', $account);
@@ -76,7 +76,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessAllowedForAdministratorOnUpdate(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount(['administrator']);
 
         $result = $this->policy->access($entity, 'update', $account);
@@ -85,7 +85,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessAllowedForAdministratorOnDelete(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount(['administrator']);
 
         $result = $this->policy->access($entity, 'delete', $account);
@@ -98,7 +98,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessNeutralForNonAdministrator(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount(['authenticated']);
 
         $result = $this->policy->access($entity, 'view', $account);
@@ -107,7 +107,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessNeutralForAnonymous(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount([]);
 
         $result = $this->policy->access($entity, 'update', $account);
@@ -160,7 +160,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
 
     public function testAccessAllowedWhenAdministratorIsOneOfMultipleRoles(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $account = $this->createAccount(['authenticated', 'editor', 'administrator']);
 
         $result = $this->policy->access($entity, 'update', $account);
@@ -249,7 +249,7 @@ final class ConfigEntityAccessPolicyTest extends TestCase
      */
     private function createAccount(array $roles): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')->willReturn($roles);
 
         return $account;

--- a/packages/access/tests/Unit/EntityAccessHandlerBundleFilterTest.php
+++ b/packages/access/tests/Unit/EntityAccessHandlerBundleFilterTest.php
@@ -20,7 +20,7 @@ final class EntityAccessHandlerBundleFilterTest extends TestCase
 {
     private function entity(string $typeId, string $bundle): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($typeId);
         $entity->method('bundle')->willReturn($bundle);
 
@@ -29,7 +29,7 @@ final class EntityAccessHandlerBundleFilterTest extends TestCase
 
     private function account(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     #[Test]

--- a/packages/access/tests/Unit/EntityAccessHandlerFieldAccessTest.php
+++ b/packages/access/tests/Unit/EntityAccessHandlerFieldAccessTest.php
@@ -23,14 +23,14 @@ final class EntityAccessHandlerFieldAccessTest extends TestCase
 
     private function createEntity(string $typeId = 'node'): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($typeId);
         return $entity;
     }
 
     private function createAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     /**
@@ -132,7 +132,7 @@ final class EntityAccessHandlerFieldAccessTest extends TestCase
     public function checkFieldAccessSkipsPoliciesWithoutFieldInterface(): void
     {
         // A policy that only implements AccessPolicyInterface (no field access).
-        $entityOnlyPolicy = $this->createMock(AccessPolicyInterface::class);
+        $entityOnlyPolicy = $this->createStub(AccessPolicyInterface::class);
         $entityOnlyPolicy->method('appliesTo')->willReturn(true);
 
         $handler = new EntityAccessHandler([$entityOnlyPolicy]);

--- a/packages/access/tests/Unit/EntityAccessHandlerLabelAccessTest.php
+++ b/packages/access/tests/Unit/EntityAccessHandlerLabelAccessTest.php
@@ -54,7 +54,7 @@ final class EntityAccessHandlerLabelAccessTest extends TestCase
 
     private function account(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     private function forbidLabelFieldHandler(): EntityAccessHandler

--- a/packages/access/tests/Unit/EntityAccessHandlerTest.php
+++ b/packages/access/tests/Unit/EntityAccessHandlerTest.php
@@ -23,7 +23,7 @@ class EntityAccessHandlerTest extends TestCase
 
     private function createEntity(string $typeId = 'node', string $bundle = 'article'): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($typeId);
         $entity->method('bundle')->willReturn($bundle);
 
@@ -32,7 +32,7 @@ class EntityAccessHandlerTest extends TestCase
 
     private function createAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     private function createPolicy(
@@ -40,7 +40,7 @@ class EntityAccessHandlerTest extends TestCase
         AccessResult $accessResult,
         ?AccessResult $createResult = null,
     ): AccessPolicyInterface {
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')
             ->willReturnCallback(fn(string $type) => $type === $entityTypeId);
         $policy->method('access')

--- a/packages/access/tests/Unit/Gate/EntityAccessGateTest.php
+++ b/packages/access/tests/Unit/Gate/EntityAccessGateTest.php
@@ -294,7 +294,7 @@ final class EntityAccessGateTest extends TestCase
         $entity = $this->createEntity('node');
         $account = $this->createAccount(['administrator']);
 
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturn(true);
         $policy->method('access')->willThrowException(new \RuntimeException('Database unavailable'));
 
@@ -320,7 +320,7 @@ final class EntityAccessGateTest extends TestCase
 
     private function createEntity(string $typeId): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($typeId);
         $entity->method('bundle')->willReturn($typeId);
         return $entity;
@@ -328,14 +328,14 @@ final class EntityAccessGateTest extends TestCase
 
     private function createAccount(array $roles): AuthorizationPrincipalInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('getRoles')->willReturn($roles);
         return $account;
     }
 
     private function createPolicy(string $entityTypeId, AccessResult $result): AccessPolicyInterface
     {
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')
             ->willReturnCallback(fn(string $type) => $type === $entityTypeId);
         $policy->method('access')->willReturn($result);
@@ -348,7 +348,7 @@ final class EntityAccessGateTest extends TestCase
      */
     private function createCapturingPolicy(string $entityTypeId, ?AccountInterface &$seen): AccessPolicyInterface
     {
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')
             ->willReturnCallback(fn(string $type) => $type === $entityTypeId);
         $policy->method('access')->willReturnCallback(

--- a/packages/access/tests/Unit/Policy/ContentAdminAccessPolicyTest.php
+++ b/packages/access/tests/Unit/Policy/ContentAdminAccessPolicyTest.php
@@ -21,10 +21,10 @@ final class ContentAdminAccessPolicyTest extends TestCase
      */
     private function policy(array $groups): ContentAdminAccessPolicy
     {
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => isset($groups[$id]));
         $etm->method('getDefinition')->willReturnCallback(function (string $id) use ($groups): EntityTypeInterface {
-            $type = $this->createMock(EntityTypeInterface::class);
+            $type = $this->createStub(EntityTypeInterface::class);
             $type->method('getGroup')->willReturn($groups[$id] ?? null);
 
             return $type;
@@ -35,7 +35,7 @@ final class ContentAdminAccessPolicyTest extends TestCase
 
     private function entity(mixed $status = false): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('get')->willReturnCallback(static fn(string $name): mixed => $name === 'status' ? $status : null);
 
         return $entity;
@@ -43,7 +43,7 @@ final class ContentAdminAccessPolicyTest extends TestCase
 
     private function account(bool $isContentAdmin): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $perm): bool => $isContentAdmin && $perm === 'administer content',
         );

--- a/packages/access/tests/Unit/Policy/PublishedContentAccessPolicyTest.php
+++ b/packages/access/tests/Unit/Policy/PublishedContentAccessPolicyTest.php
@@ -21,10 +21,10 @@ final class PublishedContentAccessPolicyTest extends TestCase
      */
     private function policy(array $groups): PublishedContentAccessPolicy
     {
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => isset($groups[$id]));
         $etm->method('getDefinition')->willReturnCallback(function (string $id) use ($groups): EntityTypeInterface {
-            $type = $this->createMock(EntityTypeInterface::class);
+            $type = $this->createStub(EntityTypeInterface::class);
             $type->method('getGroup')->willReturn($groups[$id] ?? null);
 
             return $type;
@@ -35,7 +35,7 @@ final class PublishedContentAccessPolicyTest extends TestCase
 
     private function entity(mixed $status): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('get')->willReturnCallback(static fn(string $name): mixed => $name === 'status' ? $status : null);
 
         return $entity;
@@ -43,7 +43,7 @@ final class PublishedContentAccessPolicyTest extends TestCase
 
     private function anon(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     #[Test]

--- a/packages/access/tests/Unit/TranslateOperationTest.php
+++ b/packages/access/tests/Unit/TranslateOperationTest.php
@@ -31,7 +31,7 @@ final class TranslateOperationTest extends TestCase
 {
     private function createEntity(string $typeId = 'node', string $bundle = 'article'): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($typeId);
         $entity->method('bundle')->willReturn($bundle);
 
@@ -40,7 +40,7 @@ final class TranslateOperationTest extends TestCase
 
     private function createAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     #[Test]
@@ -56,7 +56,7 @@ final class TranslateOperationTest extends TestCase
     public function translateFallsThroughToUpdateWhenNeutral(): void
     {
         // Policy: Allowed for 'update', Neutral for everything else.
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturn(true);
         $policy->method('access')->willReturnCallback(
             fn(EntityInterface $e, string $op, AccountInterface $a): AccessResult =>
@@ -80,7 +80,7 @@ final class TranslateOperationTest extends TestCase
     {
         // Policy: Allowed for update, Forbidden for translate. Forbidden on
         // translate must NOT be overridden by the update fallback.
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturn(true);
         $policy->method('access')->willReturnCallback(
             fn(EntityInterface $e, string $op, AccountInterface $a): AccessResult =>
@@ -103,7 +103,7 @@ final class TranslateOperationTest extends TestCase
     public function translateNeutralWithUpdateForbiddenStaysForbidden(): void
     {
         // Translate is Neutral so it falls through to update; update is Forbidden.
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturn(true);
         $policy->method('access')->willReturnCallback(
             fn(EntityInterface $e, string $op, AccountInterface $a): AccessResult =>
@@ -261,7 +261,7 @@ final class TranslateOperationTest extends TestCase
     {
         // Update returns Neutral too — ensures we don't infinite-loop; result is
         // Neutral and the handler returns cleanly.
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturn(true);
         $policy->method('access')->willReturn(AccessResult::neutral());
 

--- a/packages/ai-agent/tests/Unit/AgentContextTest.php
+++ b/packages/ai-agent/tests/Unit/AgentContextTest.php
@@ -14,7 +14,7 @@ final class AgentContextTest extends TestCase
 {
     public function testConstruction(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn(42);
 
         $context = new AgentContext(
@@ -30,7 +30,7 @@ final class AgentContextTest extends TestCase
 
     public function testDefaultValues(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $context = new AgentContext(account: $account);
 
@@ -40,7 +40,7 @@ final class AgentContextTest extends TestCase
 
     public function testDryRunFlag(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $context = new AgentContext(
             account: $account,

--- a/packages/ai-agent/tests/Unit/Tool/Wayfinding/EmitBeaconToolTest.php
+++ b/packages/ai-agent/tests/Unit/Tool/Wayfinding/EmitBeaconToolTest.php
@@ -102,7 +102,7 @@ final class EmitBeaconToolTest extends TestCase
 
     private function account(bool $hasCapability): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn(42);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $permission): bool => $hasCapability && $permission === EmitBeaconController::CAPABILITY,

--- a/packages/ai-agent/tests/Unit/Tool/Wayfinding/WayfindingTrailToolsTest.php
+++ b/packages/ai-agent/tests/Unit/Tool/Wayfinding/WayfindingTrailToolsTest.php
@@ -225,7 +225,7 @@ final class WayfindingTrailToolsTest extends TestCase
         $handler->ensureTranslationRevisionTable();
 
         $resolver = new SingleConnectionResolver($db);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         return \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(
@@ -239,7 +239,7 @@ final class WayfindingTrailToolsTest extends TestCase
 
     private function account(bool $hasCapability, int $id = 42): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $permission): bool => $hasCapability && $permission === EmitBeaconController::CAPABILITY,

--- a/packages/ai-schema/tests/Unit/EntityJsonSchemaGeneratorTest.php
+++ b/packages/ai-schema/tests/Unit/EntityJsonSchemaGeneratorTest.php
@@ -9,6 +9,7 @@ use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(EntityJsonSchemaGenerator::class)]
@@ -18,7 +19,16 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+        $this->entityTypeManager = $this->createStub(EntityTypeManagerInterface::class);
+    }
+
+    /** @return EntityTypeManagerInterface&MockObject */
+    private function expectEntityTypeManager(): EntityTypeManagerInterface
+    {
+        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $this->entityTypeManager = $manager;
+
+        return $manager;
     }
 
     #[Test]
@@ -37,7 +47,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             ],
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('node')
             ->willReturn($entityType);
@@ -68,7 +78,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             ],
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('node')
             ->willReturn($entityType);
@@ -115,7 +125,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             ],
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('node')
             ->willReturn($entityType);
@@ -147,7 +157,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             ],
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('user')
             ->willReturn($entityType);
@@ -175,7 +185,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             revisionable: true,
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('node')
             ->willReturn($entityType);
@@ -203,7 +213,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             revisionable: false,
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('user')
             ->willReturn($entityType);
@@ -263,7 +273,7 @@ final class EntityJsonSchemaGeneratorTest extends TestCase
             keys: ['id' => 'id'],
         );
 
-        $this->entityTypeManager
+        $this->expectEntityTypeManager()->expects(self::once())
             ->method('getDefinition')
             ->with('simple')
             ->willReturn($entityType);

--- a/packages/ai-tools/tests/Unit/Content/ContentToolSetTest.php
+++ b/packages/ai-tools/tests/Unit/Content/ContentToolSetTest.php
@@ -112,7 +112,7 @@ final class ContentToolSetTest extends TestCase
         );
         $this->mediaRepository = $mediaRepo;
         $this->uploadsDir = sys_get_temp_dir() . '/waaseyaa_assets_' . uniqid();
-        $access = $this->createMock(EntityAccessHandler::class);
+        $access = $this->createStub(EntityAccessHandler::class);
         $access->method('checkCreateAccess')->willReturn(AccessResult::allowed());
         $assets = new MediaAssetStore($mediaRepo, $this->uploadsDir, '/media/uploads', $access, bundle: 'test_media');
 
@@ -157,7 +157,7 @@ final class ContentToolSetTest extends TestCase
     #[Test]
     public function asset_upload_fails_before_writing_when_media_create_access_is_denied(): void
     {
-        $access = $this->createMock(EntityAccessHandler::class);
+        $access = $this->createStub(EntityAccessHandler::class);
         $access->method('checkCreateAccess')->willReturn(AccessResult::forbidden('denied'));
         $directory = $this->uploadsDir . '/denied';
         $store = new MediaAssetStore($this->mediaRepository, $directory, '/media/uploads', $access);
@@ -175,7 +175,7 @@ final class ContentToolSetTest extends TestCase
     #[Test]
     public function asset_upload_attributes_the_catalog_save_to_the_authenticated_actor(): void
     {
-        $access = $this->createMock(EntityAccessHandler::class);
+        $access = $this->createStub(EntityAccessHandler::class);
         $access->method('checkCreateAccess')->willReturn(AccessResult::allowed());
         $directory = $this->uploadsDir . '/attributed';
         $store = new MediaAssetStore($this->mediaRepository, $directory, '/media/uploads', $access);

--- a/packages/ai-tools/tests/Unit/Entity/EntityReadToolFieldFilterTest.php
+++ b/packages/ai-tools/tests/Unit/Entity/EntityReadToolFieldFilterTest.php
@@ -38,16 +38,16 @@ final class EntityReadToolFieldFilterTest extends TestCase
      */
     private function tool(array $stored, array $internalFields = []): EntityReadTool
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('story');
         $entity->method('bundle')->willReturn('story');
         $entity->method('id')->willReturn(1);
         $entity->method('toArray')->willReturn($stored);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('find')->willReturn($entity);
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn(true);
         $etm->method('getRepository')->willReturn($repository);
         $etm->method('resolveFieldDefinitions')->willReturn(
@@ -66,7 +66,7 @@ final class EntityReadToolFieldFilterTest extends TestCase
     {
         $defs = [];
         foreach ($names as $name) {
-            $def = $this->createMock(FieldDefinitionInterface::class);
+            $def = $this->createStub(FieldDefinitionInterface::class);
             $def->method('getSetting')->willReturnCallback(
                 static fn(string $key): mixed => $key === 'internal' ? \in_array($name, $internal, true) : null,
             );
@@ -78,7 +78,7 @@ final class EntityReadToolFieldFilterTest extends TestCase
 
     private function account(): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(true);
         $account->method('id')->willReturn(0);
 
@@ -195,9 +195,9 @@ final class EntityReadToolFieldFilterTest extends TestCase
             entityKeys: ['id' => 'id', 'label' => 'title'],
         );
         $entity = $boundary->installer()->instantiate(SealedStoryEntity::class, $payload);
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('find')->willReturn($entity);
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn(true);
         $etm->method('getRepository')->willReturn($repository);
         $etm->method('resolveFieldDefinitions')->willReturn($this->fieldDefinitions(['id', 'title', 'mail'], []));

--- a/packages/ai-tools/tests/Unit/Entity/EntitySearchToolFieldFilterTest.php
+++ b/packages/ai-tools/tests/Unit/Entity/EntitySearchToolFieldFilterTest.php
@@ -36,16 +36,16 @@ final class EntitySearchToolFieldFilterTest extends TestCase
      */
     private function tool(array $stored, array $internalFields = []): EntitySearchTool
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('story');
         $entity->method('bundle')->willReturn('story');
         $entity->method('id')->willReturn(1);
         $entity->method('toArray')->willReturn($stored);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('findBy')->willReturn([$entity]);
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn(true);
         $etm->method('getRepository')->willReturn($repository);
         $etm->method('resolveFieldDefinitions')->willReturn(
@@ -64,7 +64,7 @@ final class EntitySearchToolFieldFilterTest extends TestCase
     {
         $defs = [];
         foreach ($names as $name) {
-            $def = $this->createMock(FieldDefinitionInterface::class);
+            $def = $this->createStub(FieldDefinitionInterface::class);
             $def->method('getSetting')->willReturnCallback(
                 static fn(string $key): mixed => $key === 'internal' ? \in_array($name, $internal, true) : null,
             );

--- a/packages/ai-vector/tests/Unit/EntityEmbedderTest.php
+++ b/packages/ai-vector/tests/Unit/EntityEmbedderTest.php
@@ -158,7 +158,7 @@ final class EntityEmbedderTest extends TestCase
         string $label,
         string $bundle = 'article',
     ): EntityInterface {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($entityTypeId);
         $entity->method('id')->willReturn($id);
         $entity->method('label')->willReturn($label);

--- a/packages/ai-vector/tests/Unit/EntityEmbeddingListenerTest.php
+++ b/packages/ai-vector/tests/Unit/EntityEmbeddingListenerTest.php
@@ -183,7 +183,7 @@ final class EntityEmbeddingListenerTest extends TestCase
             'title' => 'Draft title (must not be embedded)',
         ]);
 
-        $storage = $this->createMock(EmbeddingStorageInterface::class);
+        $storage = $this->createStub(EmbeddingStorageInterface::class);
         $provider = $this->createMock(EmbeddingProviderInterface::class);
         $provider->expects($this->once())->method('embed')->with($this->logicalAnd(
             $this->stringContains('Published title'),
@@ -288,7 +288,7 @@ final class EntityEmbeddingListenerTest extends TestCase
         $storage->expects($this->never())->method('store');
         $storage->expects($this->never())->method('delete');
 
-        $listener = new EntityEmbeddingListener(queue: null, storage: $storage, embeddingProvider: $this->createMock(EmbeddingProviderInterface::class));
+        $listener = new EntityEmbeddingListener(queue: null, storage: $storage, embeddingProvider: $this->createStub(EmbeddingProviderInterface::class));
         $listener->onRevisionPointerMoved(new RevisionPointerMovedEvent(
             entityTypeId: 'node',
             entityId: '42',

--- a/packages/ai-vector/tests/Unit/SearchControllerTest.php
+++ b/packages/ai-vector/tests/Unit/SearchControllerTest.php
@@ -28,7 +28,7 @@ final class SearchControllerTest extends TestCase
         $entityA = new SearchEntity(1, 'node', ['title' => 'A']);
         $entityB = new SearchEntity(2, 'node', ['title' => 'B']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
 
         // C-22 WP3: read path now goes through the canonical repository.
         $repository = $this->createMock(EntityRepositoryInterface::class);
@@ -45,7 +45,7 @@ final class SearchControllerTest extends TestCase
             fieldDefinitions: ['title' => ['type' => 'string']],
         );
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => $id === 'node');
         $manager->method('getStorage')->willReturn($storage);
         $manager->method('getRepository')->willReturn($repository);
@@ -113,7 +113,7 @@ final class SearchControllerTest extends TestCase
         $entityA = new SearchEntity(5, 'node', ['title' => 'Five']);
         $entityB = new SearchEntity(6, 'node', ['title' => 'Six']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         $definition = TestEntityType::stub(
@@ -132,7 +132,7 @@ final class SearchControllerTest extends TestCase
             ->with([5, 6])
             ->willReturn([$entityA, $entityB]);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => $id === 'node');
         $manager->method('getStorage')->willReturn($storage);
         $manager->method('getDefinition')->willReturn($definition);
@@ -180,7 +180,7 @@ final class SearchControllerTest extends TestCase
 
         $entity = new SearchEntity(42, 'node', ['title' => 'Fallback Result']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         $definition = TestEntityType::stub(
@@ -199,7 +199,7 @@ final class SearchControllerTest extends TestCase
             ->with([42])
             ->willReturn([$entity]);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => $id === 'node');
         $manager->method('getStorage')->willReturn($storage);
         $manager->method('getDefinition')->willReturn($definition);
@@ -236,7 +236,7 @@ final class SearchControllerTest extends TestCase
         $entityA = new SearchEntity(1, 'node', ['title' => 'A']);
         $entityB = new SearchEntity(2, 'node', ['title' => 'B']);
 
-        $nodeStorage = $this->createMock(EntityStorageInterface::class);
+        $nodeStorage = $this->createStub(EntityStorageInterface::class);
 
         // C-22 WP3: read path now goes through the canonical repository.
         $nodeRepository = $this->createMock(EntityRepositoryInterface::class);
@@ -257,7 +257,7 @@ final class SearchControllerTest extends TestCase
             public function execute(): array { return [99]; }
         };
 
-        $relationshipStorage = $this->createMock(EntityStorageInterface::class);
+        $relationshipStorage = $this->createStub(EntityStorageInterface::class);
 
         // C-22 WP3: read path now goes through the canonical repository.
         $relationshipRepository = $this->createMock(EntityRepositoryInterface::class);
@@ -283,7 +283,7 @@ final class SearchControllerTest extends TestCase
             fieldDefinitions: ['title' => ['type' => 'string']],
         );
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('hasDefinition')->willReturnCallback(static fn(string $id): bool => in_array($id, ['node', 'relationship'], true));
         $manager->method('getStorage')->willReturnCallback(
             static fn(string $id): EntityStorageInterface => $id === 'relationship' ? $relationshipStorage : $nodeStorage,

--- a/packages/ai-vector/tests/Unit/SemanticIndexWarmerTest.php
+++ b/packages/ai-vector/tests/Unit/SemanticIndexWarmerTest.php
@@ -39,19 +39,19 @@ final class SemanticIndexWarmerTest extends TestCase
         $nodeB = new SemanticWarmerEntity(2, 'node', ['title' => 'Draft', 'status' => 0, 'workflow_state' => 'draft']);
         $nodeC = new SemanticWarmerEntity(3, 'node', ['title' => 'Public', 'status' => 1, 'workflow_state' => 'published']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
 
         // C-22 WP3: read path now goes through the canonical repository.
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
-        $repository->method('findMany')
+        $repository->expects(self::once())->method('findMany')
             ->with([1, 2, 3])
             ->willReturn([$nodeA, $nodeB, $nodeC]);
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('hasDefinition')->with('node')->willReturn(true);
-        $manager->method('getStorage')->with('node')->willReturn($storage);
-        $manager->method('getRepository')->with('node')->willReturn($repository);
+        $manager->expects(self::once())->method('hasDefinition')->with('node')->willReturn(true);
+        $manager->expects(self::never())->method('getStorage');
+        $manager->expects(self::exactly(2))->method('getRepository')->with('node')->willReturn($repository);
 
         $provider = $this->createMock(EmbeddingProviderInterface::class);
         $provider->expects($this->exactly(2))
@@ -129,11 +129,11 @@ final class SemanticIndexWarmerTest extends TestCase
         $node2 = new SemanticWarmerEntity(2, 'node', ['title' => 'Two', 'status' => 0, 'workflow_state' => 'draft']);
         $node3 = new SemanticWarmerEntity(3, 'node', ['title' => 'Three', 'status' => 1, 'workflow_state' => 'published']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         // C-22 WP3: read path now goes through the canonical repository.
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
         $repository->method('findMany')->willReturnCallback(
             static fn(array $ids): array => array_values(array_filter([
@@ -144,11 +144,11 @@ final class SemanticIndexWarmerTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('hasDefinition')->with('node')->willReturn(true);
-        $manager->method('getStorage')->with('node')->willReturn($storage);
-        $manager->method('getRepository')->with('node')->willReturn($repository);
+        $manager->expects(self::exactly(2))->method('hasDefinition')->with('node')->willReturn(true);
+        $manager->expects(self::never())->method('getStorage');
+        $manager->expects(self::exactly(4))->method('getRepository')->with('node')->willReturn($repository);
 
-        $provider = $this->createMock(EmbeddingProviderInterface::class);
+        $provider = $this->createStub(EmbeddingProviderInterface::class);
         $provider->method('embed')->willReturn([0.1, 0.2]);
 
         $embeddingStorage = $this->createMock(EmbeddingStorageInterface::class);

--- a/packages/api/tests/Unit/ApiServiceProviderMcpRouterWiringTest.php
+++ b/packages/api/tests/Unit/ApiServiceProviderMcpRouterWiringTest.php
@@ -38,9 +38,9 @@ final class ApiServiceProviderMcpRouterWiringTest extends TestCase
             new DiscoveryApiHandler($manager, $database),
         );
 
-        $toolImpl = $this->createMock(AgentToolInterface::class);
+        $toolImpl = $this->createStub(AgentToolInterface::class);
         $toolImpl->method('description')->willReturn('Reads a content item.');
-        $toolRegistry = $this->createMock(ToolRegistryInterface::class);
+        $toolRegistry = $this->createStub(ToolRegistryInterface::class);
         $toolRegistry->method('all')->willReturn([
             new AgentTool(
                 name: 'content.read',

--- a/packages/api/tests/Unit/Controller/SchemaControllerTest.php
+++ b/packages/api/tests/Unit/Controller/SchemaControllerTest.php
@@ -259,7 +259,7 @@ final class SchemaControllerTest extends TestCase
         ]);
 
         $account = $this->createStub(AccountInterface::class);
-        $handler = $this->createMock(EntityAccessHandler::class);
+        $handler = $this->createStub(EntityAccessHandler::class);
         $handler->method('checkFieldAccess')->willReturn(AccessResult::neutral());
         $handler->method('checkCreateAccess')->willReturn(AccessResult::forbidden('no bundle create access'));
         $controller = new SchemaController($manager, new SchemaPresenter($registry), $handler, $account);
@@ -317,7 +317,7 @@ final class SchemaControllerTest extends TestCase
     #[Test]
     public function showAcceptsFieldAccessContext(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = new EntityAccessHandler([]);
 
         $controller = new SchemaController(
@@ -367,7 +367,7 @@ final class SchemaControllerTest extends TestCase
             label: 'Sensitive',
         ));
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
             public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
             {
@@ -452,7 +452,7 @@ final class SchemaControllerTest extends TestCase
             label: 'Required Field',
         ));
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
             public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
             {
@@ -509,7 +509,7 @@ final class SchemaControllerTest extends TestCase
     #[Test]
     public function showStillReturnsFilteredSchemaWhenPrototypeConstructionSucceeds(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = new EntityAccessHandler([]);
 
         $controller = new SchemaController(

--- a/packages/api/tests/Unit/JsonApiControllerFieldAccessTest.php
+++ b/packages/api/tests/Unit/JsonApiControllerFieldAccessTest.php
@@ -58,7 +58,7 @@ final class JsonApiControllerFieldAccessTest extends TestCase
             ],
         ));
 
-        $this->account = $this->createMock(AccountInterface::class);
+        $this->account = $this->createStub(AccountInterface::class);
 
         // Policy: forbid viewing 'secret', forbid editing 'status'.
         $policy = new class () implements AccessPolicyInterface, FieldAccessPolicyInterface {

--- a/packages/api/tests/Unit/JsonApiControllerFieldFilterOracleTest.php
+++ b/packages/api/tests/Unit/JsonApiControllerFieldFilterOracleTest.php
@@ -103,7 +103,7 @@ final class JsonApiControllerFieldFilterOracleTest extends TestCase
             $this->entityTypeManager,
             new ResourceSerializer($this->entityTypeManager),
             new EntityAccessHandler([$policy]),
-            $this->createMock(AccountInterface::class),
+            $this->createStub(AccountInterface::class),
         );
     }
 
@@ -226,7 +226,7 @@ final class JsonApiControllerFieldFilterOracleTest extends TestCase
             $this->entityTypeManager,
             new ResourceSerializer($this->entityTypeManager),
             new EntityAccessHandler([$policy]),
-            $this->createMock(AccountInterface::class),
+            $this->createStub(AccountInterface::class),
         );
     }
 

--- a/packages/api/tests/Unit/Markdown/EntityMarkdownPresenterTest.php
+++ b/packages/api/tests/Unit/Markdown/EntityMarkdownPresenterTest.php
@@ -79,7 +79,7 @@ final class EntityMarkdownPresenterTest extends TestCase
 
     private function anyAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     private function sampleEntity(array $overrides = []): TestEntity
@@ -212,7 +212,7 @@ final class EntityMarkdownPresenterTest extends TestCase
     public function access_filtering_omits_forbidden_fields_identically_to_serializer(): void
     {
         $entity = $this->sampleEntity(['secret_note' => 'classified']);
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = new EntityAccessHandler([$this->forbidField('article', 'secret_note')]);
 
         $withAccess = $this->presenter($this->emptyDisplay())->present($entity, 'full', $handler, $account);
@@ -303,7 +303,7 @@ final class EntityMarkdownPresenterTest extends TestCase
     public function label_is_replaced_with_a_placeholder_when_the_label_field_is_forbidden(): void
     {
         $entity = $this->sampleEntity();
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = new EntityAccessHandler([$this->forbidField('article', 'title')]);
 
         $md = $this->presenter($this->emptyDisplay())->present($entity, 'full', $handler, $account);

--- a/packages/api/tests/Unit/Query/QueryApplierTest.php
+++ b/packages/api/tests/Unit/Query/QueryApplierTest.php
@@ -181,7 +181,7 @@ final class QueryApplierTest extends TestCase
     {
         $query = new ParsedQuery();
 
-        $entityQuery = $this->createMock(EntityQueryInterface::class);
+        $entityQuery = $this->createStub(EntityQueryInterface::class);
         $entityQuery->method('condition')->willReturnSelf();
         $entityQuery->method('sort')->willReturnSelf();
         $entityQuery->method('range')->willReturnSelf();

--- a/packages/api/tests/Unit/ResourceSerializerFieldAccessTest.php
+++ b/packages/api/tests/Unit/ResourceSerializerFieldAccessTest.php
@@ -39,7 +39,7 @@ final class ResourceSerializerFieldAccessTest extends TestCase
 
     private function createAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     /**
@@ -117,8 +117,8 @@ final class ResourceSerializerFieldAccessTest extends TestCase
         $accessHandler = new EntityAccessHandler([
             $this->createViewDenyPolicy('article', []),
         ]);
-        $account = $this->createAccount();
-        $account->method('hasPermission')->with('administer users')->willReturn(true);
+        $account = $this->createMock(AccountInterface::class);
+        $account->expects(self::never())->method('hasPermission');
         $entity = new TestEntity([
             'id' => 1,
             'uuid' => 'uuid-1',

--- a/packages/api/tests/Unit/ResourceSerializerPartialContextTest.php
+++ b/packages/api/tests/Unit/ResourceSerializerPartialContextTest.php
@@ -64,7 +64,7 @@ final class ResourceSerializerPartialContextTest extends TestCase
         $resource = $this->serializer->serialize(
             $this->entity,
             new EntityAccessHandler([]),
-            $this->createMock(AccountInterface::class),
+            $this->createStub(AccountInterface::class),
         );
 
         self::assertInstanceOf(JsonApiResource::class, $resource);
@@ -85,7 +85,7 @@ final class ResourceSerializerPartialContextTest extends TestCase
         $this->expectException(PartialAccessContextException::class);
         $this->expectExceptionMessageMatches('/^\[PARTIAL_ACCESS_CONTEXT\]/');
 
-        $this->serializer->serialize($this->entity, null, $this->createMock(AccountInterface::class));
+        $this->serializer->serialize($this->entity, null, $this->createStub(AccountInterface::class));
     }
 
     #[Test]
@@ -101,6 +101,6 @@ final class ResourceSerializerPartialContextTest extends TestCase
     {
         $this->expectException(PartialAccessContextException::class);
 
-        $this->serializer->serializeCollection([$this->entity], null, $this->createMock(AccountInterface::class));
+        $this->serializer->serializeCollection([$this->entity], null, $this->createStub(AccountInterface::class));
     }
 }

--- a/packages/api/tests/Unit/Schema/SchemaPresenterFieldAccessTest.php
+++ b/packages/api/tests/Unit/Schema/SchemaPresenterFieldAccessTest.php
@@ -38,14 +38,14 @@ final class SchemaPresenterFieldAccessTest extends TestCase
 
     private function createEntity(): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('article');
         return $entity;
     }
 
     private function createAccount(): AccountInterface
     {
-        return $this->createMock(AccountInterface::class);
+        return $this->createStub(AccountInterface::class);
     }
 
     private function createFieldDefs(): array

--- a/packages/api/tests/Unit/Schema/SchemaPresenterPartialContextTest.php
+++ b/packages/api/tests/Unit/Schema/SchemaPresenterPartialContextTest.php
@@ -56,7 +56,7 @@ final class SchemaPresenterPartialContextTest extends TestCase
             [],
             null,
             new EntityAccessHandler([]),
-            $this->createMock(AccountInterface::class),
+            $this->createStub(AccountInterface::class),
         );
 
         self::assertSame('article', $schema['x-entity-type']);
@@ -88,7 +88,7 @@ final class SchemaPresenterPartialContextTest extends TestCase
             [],
             null,
             null,
-            $this->createMock(AccountInterface::class),
+            $this->createStub(AccountInterface::class),
         );
     }
 
@@ -97,7 +97,7 @@ final class SchemaPresenterPartialContextTest extends TestCase
     {
         // Sanity: even an interface mock with no expectations passes the guard
         // because the precondition check runs first.
-        $entityType = $this->createMock(EntityTypeInterface::class);
+        $entityType = $this->createStub(EntityTypeInterface::class);
 
         $this->expectException(PartialAccessContextException::class);
 

--- a/packages/auth/tests/Unit/Controller/ForgotPasswordControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/ForgotPasswordControllerTest.php
@@ -39,7 +39,7 @@ final class ForgotPasswordControllerTest extends TestCase
 
     private function makeStorage(mixed $user = null): EntityStorageInterface
     {
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('loadByKey')->willReturn($user);
 
         return $storage;
@@ -47,7 +47,7 @@ final class ForgotPasswordControllerTest extends TestCase
 
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null): EntityTypeManager
     {
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
         $manager->method('getStorage')->willReturn($storage ?? $this->makeStorage());
 
         return $manager;
@@ -55,7 +55,7 @@ final class ForgotPasswordControllerTest extends TestCase
 
     private function makeTokenRepo(): AuthTokenRepositoryInterface
     {
-        $repo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $repo = $this->createStub(AuthTokenRepositoryInterface::class);
         $repo->method('createToken')->willReturn('reset-token-abc');
 
         return $repo;

--- a/packages/auth/tests/Unit/Controller/LoginControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/LoginControllerTest.php
@@ -26,7 +26,7 @@ final class LoginControllerTest extends TestCase
 
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null): EntityTypeManager
     {
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
 
         if ($storage !== null) {
             $manager->method('getStorage')->willReturn($storage);

--- a/packages/auth/tests/Unit/Controller/RegisterControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/RegisterControllerTest.php
@@ -42,7 +42,7 @@ final class RegisterControllerTest extends TestCase
 
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null, mixed $existing = null): EntityTypeManager
     {
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
 
         if ($storage !== null) {
             $manager->method('getStorage')->willReturn($storage);
@@ -67,7 +67,7 @@ final class RegisterControllerTest extends TestCase
 
     private function makeStorage(mixed $existing = null): EntityStorageInterface
     {
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('loadByKey')->willReturn($existing);
         $storage->method('save')->willReturn(1); // SAVED_NEW
 
@@ -76,7 +76,7 @@ final class RegisterControllerTest extends TestCase
 
     private function makeTokenRepo(): AuthTokenRepositoryInterface
     {
-        $repo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $repo = $this->createStub(AuthTokenRepositoryInterface::class);
         $repo->method('createToken')->willReturn('tok_' . bin2hex(random_bytes(8)));
         $repo->method('validateToken')->willReturn(['id' => 1, 'user_id' => null, 'meta' => null]);
 
@@ -85,7 +85,7 @@ final class RegisterControllerTest extends TestCase
 
     private function makeAuthMailer(bool $configured = false): AuthMailer
     {
-        $mailer = $this->createMock(AuthMailer::class);
+        $mailer = $this->createStub(AuthMailer::class);
         $mailer->method('isConfigured')->willReturn($configured);
 
         return $mailer;
@@ -226,7 +226,7 @@ final class RegisterControllerTest extends TestCase
     #[Test]
     public function returns_422_for_invalid_invite_token(): void
     {
-        $tokenRepo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $tokenRepo = $this->createStub(AuthTokenRepositoryInterface::class);
         $tokenRepo->method('validateToken')->willReturn(null);
 
         $controller = $this->makeController(
@@ -334,7 +334,7 @@ final class RegisterControllerTest extends TestCase
         $storage = $this->makeStorage(null);
         $existing = null;
 
-        $tokenRepo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $tokenRepo = $this->createStub(AuthTokenRepositoryInterface::class);
         $tokenRepo->method('createToken')->willReturn('verify-token-abc');
 
         $mailer = $this->createMock(AuthMailer::class);

--- a/packages/auth/tests/Unit/Controller/ResendVerificationControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/ResendVerificationControllerTest.php
@@ -37,7 +37,7 @@ final class ResendVerificationControllerTest extends TestCase
 
     private function makeTokenRepo(): AuthTokenRepositoryInterface
     {
-        $repo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $repo = $this->createStub(AuthTokenRepositoryInterface::class);
         $repo->method('createToken')->willReturn('verify-token-abc');
 
         return $repo;
@@ -45,7 +45,7 @@ final class ResendVerificationControllerTest extends TestCase
 
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null): EntityTypeManager
     {
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
         if ($storage !== null) {
             $manager->method('getStorage')->willReturn($storage);
         }
@@ -136,7 +136,7 @@ final class ResendVerificationControllerTest extends TestCase
         $account = $this->makeAccount(10);
         $user = new \Waaseyaa\User\User(['uid' => 10, 'name' => 'Alice', 'mail' => 'alice@example.com']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($user);
 
         $tokenRepo = $this->createMock(AuthTokenRepositoryInterface::class);
@@ -168,7 +168,7 @@ final class ResendVerificationControllerTest extends TestCase
         $account = $this->makeAccount(11);
         $user = new \Waaseyaa\User\User(['uid' => 11, 'name' => 'Bob', 'mail' => 'bob@example.com']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($user);
 
         $mailer = $this->createStub(AuthMailer::class);

--- a/packages/auth/tests/Unit/Controller/ResetPasswordControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/ResetPasswordControllerTest.php
@@ -24,7 +24,7 @@ final class ResetPasswordControllerTest extends TestCase
 
     private function makeStorage(mixed $user = null): EntityStorageInterface
     {
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($user);
         $storage->method('save')->willReturn(1);
 
@@ -34,7 +34,7 @@ final class ResetPasswordControllerTest extends TestCase
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null): EntityTypeManager
     {
         $storage ??= $this->makeStorage();
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
         $manager->method('getStorage')->willReturn($storage);
         // C-22 WP3: read/write path now goes through the canonical repository.
         $manager->method('getRepository')->willReturn(new StorageBackedStubRepository($storage));
@@ -44,7 +44,7 @@ final class ResetPasswordControllerTest extends TestCase
 
     private function makeTokenRepo(?array $tokenData = ['id' => 1, 'user_id' => 42, 'meta' => null]): AuthTokenRepositoryInterface
     {
-        $repo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $repo = $this->createStub(AuthTokenRepositoryInterface::class);
         $repo->method('validateToken')->willReturn($tokenData);
 
         return $repo;

--- a/packages/auth/tests/Unit/Controller/VerifyEmailControllerTest.php
+++ b/packages/auth/tests/Unit/Controller/VerifyEmailControllerTest.php
@@ -23,7 +23,7 @@ final class VerifyEmailControllerTest extends TestCase
 
     private function makeTokenRepo(?array $tokenData = null): AuthTokenRepositoryInterface
     {
-        $repo = $this->createMock(AuthTokenRepositoryInterface::class);
+        $repo = $this->createStub(AuthTokenRepositoryInterface::class);
         $repo->method('validateToken')->willReturn($tokenData);
 
         return $repo;
@@ -31,7 +31,7 @@ final class VerifyEmailControllerTest extends TestCase
 
     private function makeEntityTypeManager(?EntityStorageInterface $storage = null): EntityTypeManager
     {
-        $manager = $this->createMock(EntityTypeManager::class);
+        $manager = $this->createStub(EntityTypeManager::class);
         if ($storage !== null) {
             $manager->method('getStorage')->willReturn($storage);
             // C-22 WP3: read/write path now goes through the canonical repository.
@@ -87,7 +87,7 @@ final class VerifyEmailControllerTest extends TestCase
         $tokenData = ['id' => 1, 'user_id' => 99, 'meta' => null];
         $tokenRepo = $this->makeTokenRepo($tokenData);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn(null);
 
         $controller = new VerifyEmailController(

--- a/packages/bimaaji/tests/Unit/Introspection/Admin/AdminIntrospectionProviderTest.php
+++ b/packages/bimaaji/tests/Unit/Introspection/Admin/AdminIntrospectionProviderTest.php
@@ -19,7 +19,7 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function it_implements_graph_section_provider_interface(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new AdminIntrospectionProvider($manager);
@@ -30,7 +30,7 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function get_key_returns_admin(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new AdminIntrospectionProvider($manager);
@@ -41,7 +41,7 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_returns_empty_section_when_no_entity_types(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new AdminIntrospectionProvider($manager);
@@ -56,11 +56,11 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_excludes_entity_types_without_group(): void
     {
-        $ungrouped = $this->createMock(EntityTypeInterface::class);
+        $ungrouped = $this->createStub(EntityTypeInterface::class);
         $ungrouped->method('id')->willReturn('config_entity');
         $ungrouped->method('getGroup')->willReturn(null);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'config_entity' => $ungrouped,
         ]);
@@ -74,7 +74,7 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_includes_entity_types_with_group(): void
     {
-        $nodeType = $this->createMock(EntityTypeInterface::class);
+        $nodeType = $this->createStub(EntityTypeInterface::class);
         $nodeType->method('id')->willReturn('node');
         $nodeType->method('getLabel')->willReturn('Content');
         $nodeType->method('getGroup')->willReturn('content');
@@ -89,11 +89,11 @@ final class AdminIntrospectionProviderTest extends TestCase
             'label' => 'title',
         ]);
 
-        $ungrouped = $this->createMock(EntityTypeInterface::class);
+        $ungrouped = $this->createStub(EntityTypeInterface::class);
         $ungrouped->method('id')->willReturn('user');
         $ungrouped->method('getGroup')->willReturn(null);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'node' => $nodeType,
             'user' => $ungrouped,
@@ -127,7 +127,7 @@ final class AdminIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_sets_limited_capabilities_for_config_entities(): void
     {
-        $configType = $this->createMock(EntityTypeInterface::class);
+        $configType = $this->createStub(EntityTypeInterface::class);
         $configType->method('id')->willReturn('menu');
         $configType->method('getLabel')->willReturn('Menu');
         $configType->method('getGroup')->willReturn('structure');
@@ -139,7 +139,7 @@ final class AdminIntrospectionProviderTest extends TestCase
             'id' => 'id',
         ]);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'menu' => $configType,
         ]);

--- a/packages/bimaaji/tests/Unit/Introspection/Entity/EntityIntrospectionProviderTest.php
+++ b/packages/bimaaji/tests/Unit/Introspection/Entity/EntityIntrospectionProviderTest.php
@@ -19,7 +19,7 @@ final class EntityIntrospectionProviderTest extends TestCase
     #[Test]
     public function it_implements_graph_section_provider_interface(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new EntityIntrospectionProvider($manager);
@@ -30,7 +30,7 @@ final class EntityIntrospectionProviderTest extends TestCase
     #[Test]
     public function get_key_returns_entities(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new EntityIntrospectionProvider($manager);
@@ -41,7 +41,7 @@ final class EntityIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_returns_empty_section_when_no_entity_types(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $provider = new EntityIntrospectionProvider($manager);
@@ -56,7 +56,7 @@ final class EntityIntrospectionProviderTest extends TestCase
     #[Test]
     public function provide_builds_section_from_entity_type_definitions(): void
     {
-        $nodeType = $this->createMock(EntityTypeInterface::class);
+        $nodeType = $this->createStub(EntityTypeInterface::class);
         $nodeType->method('id')->willReturn('node');
         $nodeType->method('getLabel')->willReturn('Content');
         $nodeType->method('getClass')->willReturn('Waaseyaa\\Node\\Entity\\Node');
@@ -70,7 +70,7 @@ final class EntityIntrospectionProviderTest extends TestCase
         $nodeType->method('isRevisionable')->willReturn(true);
         $nodeType->method('isTranslatable')->willReturn(false);
 
-        $userType = $this->createMock(EntityTypeInterface::class);
+        $userType = $this->createStub(EntityTypeInterface::class);
         $userType->method('id')->willReturn('user');
         $userType->method('getLabel')->willReturn('User');
         $userType->method('getClass')->willReturn('Waaseyaa\\User\\Entity\\User');
@@ -81,7 +81,7 @@ final class EntityIntrospectionProviderTest extends TestCase
         $userType->method('isRevisionable')->willReturn(false);
         $userType->method('isTranslatable')->willReturn(false);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'node' => $nodeType,
             'user' => $userType,

--- a/packages/cache/tests/Unit/Listener/EntityCacheInvalidatorTest.php
+++ b/packages/cache/tests/Unit/Listener/EntityCacheInvalidatorTest.php
@@ -19,7 +19,7 @@ final class EntityCacheInvalidatorTest extends TestCase
     #[Test]
     public function on_post_save_invalidates_entity_tags(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('node');
         $entity->method('id')->willReturn(42);
 
@@ -35,7 +35,7 @@ final class EntityCacheInvalidatorTest extends TestCase
     #[Test]
     public function on_post_delete_invalidates_entity_tags(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('user');
         $entity->method('id')->willReturn(7);
 
@@ -51,7 +51,7 @@ final class EntityCacheInvalidatorTest extends TestCase
     #[Test]
     public function new_entity_without_id_invalidates_type_tag_only(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('node');
         $entity->method('id')->willReturn(null);
 
@@ -67,7 +67,7 @@ final class EntityCacheInvalidatorTest extends TestCase
     #[Test]
     public function string_entity_id_is_supported(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('taxonomy_term');
         $entity->method('id')->willReturn('abc-123');
 
@@ -120,7 +120,7 @@ final class EntityCacheInvalidatorTest extends TestCase
     #[Test]
     public function on_revision_reverted_invalidates_entity_tags(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('node');
         $entity->method('id')->willReturn(12);
 

--- a/packages/cache/tests/Unit/Listener/EntityCacheSubscriberTest.php
+++ b/packages/cache/tests/Unit/Listener/EntityCacheSubscriberTest.php
@@ -50,7 +50,7 @@ final class EntityCacheSubscriberTest extends TestCase
     public function revision_reverted_event_invalidates_the_right_tags(): void
     {
         $dispatcher = new EventDispatcher();
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('node');
         $entity->method('id')->willReturn(3);
 

--- a/packages/cli/tests/Integration/Handler/InstallHandlerCredentialTest.php
+++ b/packages/cli/tests/Integration/Handler/InstallHandlerCredentialTest.php
@@ -133,7 +133,7 @@ final class InstallHandlerCredentialTest extends TestCase
         [$repository, $userDb, $userEntityType] = $this->makeRealUserRepository();
         $entityTypeManager = $this->makeEntityTypeManager($repository, $userEntityType);
 
-        $mockConfigManager = $this->createMock(ConfigManagerInterface::class);
+        $mockConfigManager = $this->createStub(ConfigManagerInterface::class);
         $mockConfigManager->method('getActiveStorage')->willReturn(new MemoryStorage());
 
         $handler = new InstallHandler(

--- a/packages/cli/tests/Unit/Command/SemanticRefreshCommandTest.php
+++ b/packages/cli/tests/Unit/Command/SemanticRefreshCommandTest.php
@@ -73,7 +73,7 @@ final class SemanticRefreshCommandTest extends TestCase
     #[Test]
     public function untilCompleteConsumesAllBatches(): void
     {
-        $warmer = $this->buildWarmerWithThreeNodes();
+        $warmer = $this->buildWarmerWithThreeNodes(batchCount: 2);
 
         $tester = $this->makeTester($warmer);
         $tester->executeMap(['--batch-size' => '2', '--until-complete' => true, '--json' => true]);
@@ -85,7 +85,7 @@ final class SemanticRefreshCommandTest extends TestCase
         $this->assertNull($decoded['final']['next_cursor']);
     }
 
-    private function buildWarmerWithThreeNodes(): SemanticIndexWarmer
+    private function buildWarmerWithThreeNodes(int $batchCount = 1): SemanticIndexWarmer
     {
         $query = new class implements EntityQueryInterface {
             public function condition(string $field, mixed $value, string $operator = '='): static { return $this; }
@@ -103,11 +103,11 @@ final class SemanticRefreshCommandTest extends TestCase
         $entity2 = new SemanticRefreshEntity(2, 'node', ['title' => 'Two', 'status' => 0, 'workflow_state' => 'draft']);
         $entity3 = new SemanticRefreshEntity(3, 'node', ['title' => 'Three', 'status' => 1, 'workflow_state' => 'published']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         // C-22 WP3: read path now goes through the canonical repository.
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
         $repository->method('findMany')->willReturnCallback(
             static fn(array $ids): array => array_values(array_filter([
@@ -118,14 +118,14 @@ final class SemanticRefreshCommandTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('hasDefinition')->with('node')->willReturn(true);
-        $manager->method('getStorage')->with('node')->willReturn($storage);
-        $manager->method('getRepository')->with('node')->willReturn($repository);
+        $manager->expects(self::exactly($batchCount))->method('hasDefinition')->with('node')->willReturn(true);
+        $manager->expects(self::never())->method('getStorage');
+        $manager->expects(self::exactly($batchCount * 2))->method('getRepository')->with('node')->willReturn($repository);
 
-        $provider = $this->createMock(EmbeddingProviderInterface::class);
+        $provider = $this->createStub(EmbeddingProviderInterface::class);
         $provider->method('embed')->willReturn([0.1, 0.2]);
 
-        $embeddingStorage = $this->createMock(EmbeddingStorageInterface::class);
+        $embeddingStorage = $this->createStub(EmbeddingStorageInterface::class);
 
         return new SemanticIndexWarmer(
             entityTypeManager: $manager,

--- a/packages/cli/tests/Unit/Command/SemanticWarmCommandTest.php
+++ b/packages/cli/tests/Unit/Command/SemanticWarmCommandTest.php
@@ -58,8 +58,8 @@ final class SemanticWarmCommandTest extends TestCase
     public function itFailsWhenNoEmbeddingProviderIsConfigured(): void
     {
         $warmer = new SemanticIndexWarmer(
-            entityTypeManager: $this->createMock(EntityTypeManagerInterface::class),
-            embeddingStorage: $this->createMock(EmbeddingStorageInterface::class),
+            entityTypeManager: $this->createStub(EntityTypeManagerInterface::class),
+            embeddingStorage: $this->createStub(EmbeddingStorageInterface::class),
             embeddingProvider: null,
         );
 
@@ -87,20 +87,20 @@ final class SemanticWarmCommandTest extends TestCase
 
         $entity = new SemanticWarmCommandEntity(1, 'node', ['title' => 'Public', 'status' => 1, 'workflow_state' => 'published']);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         // C-22 WP3: read path now goes through the canonical repository.
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
-        $repository->method('findMany')->with([1])->willReturn([$entity]);
+        $repository->expects(self::once())->method('findMany')->with([1])->willReturn([$entity]);
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('hasDefinition')->with('node')->willReturn(true);
-        $manager->method('getStorage')->with('node')->willReturn($storage);
-        $manager->method('getRepository')->with('node')->willReturn($repository);
+        $manager->expects(self::once())->method('hasDefinition')->with('node')->willReturn(true);
+        $manager->expects(self::never())->method('getStorage');
+        $manager->expects(self::exactly(2))->method('getRepository')->with('node')->willReturn($repository);
 
-        $embeddingProvider = $this->createMock(EmbeddingProviderInterface::class);
+        $embeddingProvider = $this->createStub(EmbeddingProviderInterface::class);
         $embeddingProvider->method('embed')->willReturn([0.2, 0.4]);
 
         $embeddingStorage = $this->createMock(EmbeddingStorageInterface::class);

--- a/packages/cli/tests/Unit/Handler/CacheClearHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/CacheClearHandlerTest.php
@@ -25,7 +25,7 @@ final class CacheClearHandlerTest extends TestCase
         $mockBackend = $this->createMock(CacheBackendInterface::class);
         $mockBackend->expects($this->exactly(4))->method('deleteAll');
 
-        $mockFactory = $this->createMock(CacheFactoryInterface::class);
+        $mockFactory = $this->createStub(CacheFactoryInterface::class);
         $mockFactory->method('get')->willReturn($mockBackend);
 
         $tester = $this->createTester($mockFactory);
@@ -62,7 +62,7 @@ final class CacheClearHandlerTest extends TestCase
             ->method('invalidateByTags')
             ->with(['render']);
 
-        $mockFactory = $this->createMock(CacheFactoryInterface::class);
+        $mockFactory = $this->createStub(CacheFactoryInterface::class);
         $mockFactory->method('get')->willReturn($mockBackend);
 
         $tester = $this->createTester($mockFactory);

--- a/packages/cli/tests/Unit/Handler/ConfigExportHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/ConfigExportHandlerTest.php
@@ -19,7 +19,7 @@ final class ConfigExportHandlerTest extends TestCase
     #[Test]
     public function exportsConfigurationAndShowsCount(): void
     {
-        $mockStorage = $this->createMock(StorageInterface::class);
+        $mockStorage = $this->createStub(StorageInterface::class);
         $mockStorage->method('listAll')->willReturn(['system.site', 'system.performance', 'user.settings']);
 
         $mockManager = $this->createMock(ConfigManagerInterface::class);

--- a/packages/cli/tests/Unit/Handler/ConfigImportHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/ConfigImportHandlerTest.php
@@ -57,7 +57,7 @@ final class ConfigImportHandlerTest extends TestCase
             errors: ['Failed to import system.site'],
         );
 
-        $mockManager = $this->createMock(ConfigManagerInterface::class);
+        $mockManager = $this->createStub(ConfigManagerInterface::class);
         $mockManager->method('import')->willReturn($result);
 
         $tester = $this->createTester($mockManager);
@@ -95,11 +95,11 @@ final class ConfigImportHandlerTest extends TestCase
         $manager->method('getSyncStorage')->willReturn($sync);
         $manager->expects($this->never())->method('import');
 
-        $definition = $this->createMock(EntityTypeInterface::class);
+        $definition = $this->createStub(EntityTypeInterface::class);
         $definition->method('isRevisionable')->willReturn(false);
         $entityTypes = $this->createMock(EntityTypeManagerInterface::class);
-        $entityTypes->method('hasDefinition')->with('node')->willReturn(true);
-        $entityTypes->method('getDefinition')->with('node')->willReturn($definition);
+        $entityTypes->expects(self::once())->method('hasDefinition')->with('node')->willReturn(true);
+        $entityTypes->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $provider = new class($manager, $entityTypes) extends ServiceProvider {
             public function __construct(

--- a/packages/cli/tests/Unit/Handler/EntityCreateHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/EntityCreateHandlerTest.php
@@ -59,14 +59,14 @@ final class EntityCreateHandlerTest extends TestCase
      */
     private function managerExpecting(array $expectedValues, int $id = 7): EntityTypeManagerInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('id')->willReturn($id);
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->expects($this->once())->method('create')->with($expectedValues)->willReturn($entity);
         $repository->expects($this->once())->method('save')->with($entity);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getRepository')->willReturn($repository);
 
         return $manager;
@@ -94,7 +94,7 @@ final class EntityCreateHandlerTest extends TestCase
     #[Test]
     public function createsEntityWithGivenValues(): void
     {
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
         $mockEntity->method('id')->willReturn(42);
 
         $mockRepository = $this->createMock(EntityRepositoryInterface::class);
@@ -107,7 +107,7 @@ final class EntityCreateHandlerTest extends TestCase
             ->with($mockEntity);
 
         $mockManager = $this->createMock(EntityTypeManagerInterface::class);
-        $mockManager->method('getRepository')
+        $mockManager->expects(self::once())->method('getRepository')
             ->with('node')
             ->willReturn($mockRepository);
 
@@ -122,7 +122,7 @@ final class EntityCreateHandlerTest extends TestCase
     #[Test]
     public function createsEntityWithDefaultEmptyValues(): void
     {
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
         $mockEntity->method('id')->willReturn(1);
 
         $mockRepository = $this->createMock(EntityRepositoryInterface::class);
@@ -132,7 +132,7 @@ final class EntityCreateHandlerTest extends TestCase
             ->willReturn($mockEntity);
         $mockRepository->expects($this->once())->method('save');
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getRepository')->willReturn($mockRepository);
 
         $definition = $this->makeDefinition();
@@ -146,7 +146,7 @@ final class EntityCreateHandlerTest extends TestCase
     #[Test]
     public function failsOnInvalidJson(): void
     {
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
 
         $definition = $this->makeDefinition();
         $tester = CliTester::for($definition, $this->makeContainer($mockManager));
@@ -234,7 +234,7 @@ final class EntityCreateHandlerTest extends TestCase
     #[Test]
     public function failsOnMalformedFieldFlag(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $tester = CliTester::for($this->makeDefinition(), $this->makeContainer($manager));
         $tester->executeMap(['entity_type' => 'story', '--field' => ['no-equals-sign']]);
 
@@ -245,7 +245,7 @@ final class EntityCreateHandlerTest extends TestCase
     #[Test]
     public function failsOnMissingValuesFile(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $tester = CliTester::for($this->makeDefinition(), $this->makeContainer($manager));
         $tester->executeMap(['entity_type' => 'story', '--values-file' => '/no/such/file.json']);
 

--- a/packages/cli/tests/Unit/Handler/EntityListHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/EntityListHandlerTest.php
@@ -56,25 +56,25 @@ final class EntityListHandlerTest extends TestCase
     #[Test]
     public function listsEntitiesInTable(): void
     {
-        $entity1 = $this->createMock(EntityInterface::class);
+        $entity1 = $this->createStub(EntityInterface::class);
         $entity1->method('id')->willReturn(1);
         $entity1->method('label')->willReturn('First');
 
-        $entity2 = $this->createMock(EntityInterface::class);
+        $entity2 = $this->createStub(EntityInterface::class);
         $entity2->method('id')->willReturn(2);
         $entity2->method('label')->willReturn('Second');
 
-        $mockQuery = $this->createMock(EntityQueryInterface::class);
+        $mockQuery = $this->createStub(EntityQueryInterface::class);
         $mockQuery->method('accessCheck')->willReturnSelf();
         $mockQuery->method('range')->willReturnSelf();
         $mockQuery->method('execute')->willReturn([1, 2]);
 
         // C-22 WP3: read path now goes through the canonical repository.
-        $mockRepository = $this->createMock(EntityRepositoryInterface::class);
+        $mockRepository = $this->createStub(EntityRepositoryInterface::class);
         $mockRepository->method('getQuery')->willReturn($mockQuery);
         $mockRepository->method('findMany')->willReturn([$entity1, $entity2]);
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getRepository')->willReturn($mockRepository);
 
         $definition = $this->makeDefinition();
@@ -90,13 +90,13 @@ final class EntityListHandlerTest extends TestCase
     #[Test]
     public function showsMessageWhenNoEntitiesFound(): void
     {
-        $mockQuery = $this->createMock(EntityQueryInterface::class);
+        $mockQuery = $this->createStub(EntityQueryInterface::class);
         $mockQuery->method('accessCheck')->willReturnSelf();
         $mockQuery->method('range')->willReturnSelf();
         $mockQuery->method('execute')->willReturn([]);
 
         // C-22: the query builder now lives on the repository.
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getRepository')->willReturn(new QueryOnlyStubRepository($mockQuery));
 
         $definition = $this->makeDefinition();

--- a/packages/cli/tests/Unit/Handler/EntityTypeListHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/EntityTypeListHandlerTest.php
@@ -70,7 +70,7 @@ final class EntityTypeListHandlerTest extends TestCase
             translatable: false,
         );
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'node' => $nodeType,
             'user' => $userType,
@@ -93,7 +93,7 @@ final class EntityTypeListHandlerTest extends TestCase
     #[Test]
     public function showsMessageWhenNoEntityTypes(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
 
         $definition = $this->makeDefinition();

--- a/packages/cli/tests/Unit/Handler/HealthCheckHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/HealthCheckHandlerTest.php
@@ -22,7 +22,7 @@ final class HealthCheckHandlerTest extends TestCase
     #[Test]
     public function allPassingReturnsSuccessAndOutput(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::pass('Database', 'DB is accessible.'),
             HealthCheckResult::pass('Entity types', '3 types registered.'),
@@ -39,7 +39,7 @@ final class HealthCheckHandlerTest extends TestCase
     #[Test]
     public function warningsReturnExitCode1(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::pass('Database', 'OK'),
             HealthCheckResult::warn('Cache', DiagnosticCode::CACHE_DIRECTORY_UNWRITABLE, 'Not writable.'),
@@ -56,7 +56,7 @@ final class HealthCheckHandlerTest extends TestCase
     #[Test]
     public function failuresReturnExitCode2(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::fail('Database', DiagnosticCode::DATABASE_UNREACHABLE, 'Cannot connect.'),
         ]);
@@ -72,7 +72,7 @@ final class HealthCheckHandlerTest extends TestCase
     #[Test]
     public function jsonOptionOutputsJson(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::pass('Database', 'OK'),
         ]);

--- a/packages/cli/tests/Unit/Handler/HealthReportHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/HealthReportHandlerTest.php
@@ -34,7 +34,7 @@ final class HealthReportHandlerTest extends TestCase
     #[Test]
     public function plainOutputContainsSystemInfo(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::pass('Database', 'OK'),
         ]);
@@ -50,7 +50,7 @@ final class HealthReportHandlerTest extends TestCase
     #[Test]
     public function jsonOptionOutputsJson(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([
             HealthCheckResult::pass('Database', 'OK'),
         ]);
@@ -68,7 +68,7 @@ final class HealthReportHandlerTest extends TestCase
     #[Test]
     public function outputOptionWithoutJsonReturnsFailure(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([]);
 
         $outputFile = $this->projectRoot . '/report.json';
@@ -87,7 +87,7 @@ final class HealthReportHandlerTest extends TestCase
         // Mission request-surface-hardening (#1650) WP02, contract §15: the
         // display surface shows what the kernel actually opens — a relative
         // WAASEYAA_DB resolves against the project root.
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('runAll')->willReturn([]);
 
         putenv('WAASEYAA_DB=./storage/health.sqlite');

--- a/packages/cli/tests/Unit/Handler/InstallHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/InstallHandlerTest.php
@@ -61,10 +61,10 @@ final class InstallHandlerTest extends TestCase
                 return $data['name'] === 'Waaseyaa' && $data['mail'] === 'admin@example.com';
             }));
 
-        $mockConfigManager = $this->createMock(ConfigManagerInterface::class);
+        $mockConfigManager = $this->createStub(ConfigManagerInterface::class);
         $mockConfigManager->method('getActiveStorage')->willReturn($mockStorage);
 
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
 
         $mockEntityRepository = $this->createMock(EntityRepositoryInterface::class);
         $mockEntityRepository->expects($this->once())
@@ -76,7 +76,7 @@ final class InstallHandlerTest extends TestCase
         $mockEntityRepository->expects($this->once())->method('save');
 
         $mockEntityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
-        $mockEntityTypeManager->method('getRepository')->with('user')->willReturn($mockEntityRepository);
+        $mockEntityTypeManager->expects(self::once())->method('getRepository')->with('user')->willReturn($mockEntityRepository);
 
         $handler = new InstallHandler(
             entityTypeManager: $mockEntityTypeManager,
@@ -101,16 +101,16 @@ final class InstallHandlerTest extends TestCase
                 return $data['name'] === 'My Site';
             }));
 
-        $mockConfigManager = $this->createMock(ConfigManagerInterface::class);
+        $mockConfigManager = $this->createStub(ConfigManagerInterface::class);
         $mockConfigManager->method('getActiveStorage')->willReturn($mockStorage);
 
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
 
-        $mockEntityRepository = $this->createMock(EntityRepositoryInterface::class);
+        $mockEntityRepository = $this->createStub(EntityRepositoryInterface::class);
         $mockEntityRepository->method('create')->willReturn($mockEntity);
         $mockEntityRepository->method('save');
 
-        $mockEntityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockEntityTypeManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockEntityTypeManager->method('getRepository')->willReturn($mockEntityRepository);
 
         $handler = new InstallHandler(

--- a/packages/cli/tests/Unit/Handler/PermissionListHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/PermissionListHandlerTest.php
@@ -52,7 +52,7 @@ final class PermissionListHandlerTest extends TestCase
     #[Test]
     public function listsPermissions(): void
     {
-        $handler = $this->createMock(PermissionHandlerInterface::class);
+        $handler = $this->createStub(PermissionHandlerInterface::class);
         $handler->method('getPermissions')->willReturn([
             'access content' => [
                 'title' => 'Access content',
@@ -77,7 +77,7 @@ final class PermissionListHandlerTest extends TestCase
     #[Test]
     public function showsMessageWhenNoPermissions(): void
     {
-        $handler = $this->createMock(PermissionHandlerInterface::class);
+        $handler = $this->createStub(PermissionHandlerInterface::class);
         $handler->method('getPermissions')->willReturn([]);
 
         $tester = CliTester::for($this->makeDefinition(), $this->makeContainer($handler));

--- a/packages/cli/tests/Unit/Handler/SchemaCheckHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/SchemaCheckHandlerTest.php
@@ -22,7 +22,7 @@ final class SchemaCheckHandlerTest extends TestCase
     #[Test]
     public function noDriftReturnsSuccess(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('checkSchemaDrift')->willReturn([
             HealthCheckResult::pass('Schema drift', 'All schemas match.'),
         ]);
@@ -37,7 +37,7 @@ final class SchemaCheckHandlerTest extends TestCase
     #[Test]
     public function driftDetectedReturnsExitCode1(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('checkSchemaDrift')->willReturn([
             HealthCheckResult::fail(
                 'Schema: node_type',
@@ -58,7 +58,7 @@ final class SchemaCheckHandlerTest extends TestCase
     #[Test]
     public function jsonOptionOutputsJson(): void
     {
-        $checker = $this->createMock(HealthCheckerInterface::class);
+        $checker = $this->createStub(HealthCheckerInterface::class);
         $checker->method('checkSchemaDrift')->willReturn([
             HealthCheckResult::pass('Schema drift', 'OK'),
         ]);

--- a/packages/cli/tests/Unit/Handler/UserAssignRoleHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/UserAssignRoleHandlerTest.php
@@ -187,7 +187,7 @@ final class UserAssignRoleHandlerTest extends TestCase
 
     private function makeManager(EntityStorageInterface $storage): EntityTypeManagerInterface
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getStorage')->willReturn($storage);
         // C-22 WP3: read/write path now goes through the canonical repository —
         // delegate find()/save() to the same storage double the test already configured.

--- a/packages/cli/tests/Unit/Handler/UserCreateHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/UserCreateHandlerTest.php
@@ -54,7 +54,7 @@ final class UserCreateHandlerTest extends TestCase
     #[Test]
     public function createsUserWithUsername(): void
     {
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
         $mockEntity->method('id')->willReturn(1);
 
         $mockRepository = $this->createMock(EntityRepositoryInterface::class);
@@ -67,7 +67,7 @@ final class UserCreateHandlerTest extends TestCase
             ->with($mockEntity);
 
         $mockManager = $this->createMock(EntityTypeManagerInterface::class);
-        $mockManager->method('getRepository')
+        $mockManager->expects(self::once())->method('getRepository')
             ->with('user')
             ->willReturn($mockRepository);
 
@@ -82,14 +82,14 @@ final class UserCreateHandlerTest extends TestCase
     #[Test]
     public function createsUserWithEmailPasswordAndRole(): void
     {
-        $mockEntity = $this->createMock(EntityInterface::class);
+        $mockEntity = $this->createStub(EntityInterface::class);
         $mockEntity->method('id')->willReturn(42);
 
-        $mockRepository = $this->createMock(EntityRepositoryInterface::class);
+        $mockRepository = $this->createStub(EntityRepositoryInterface::class);
         $mockRepository->method('create')->willReturn($mockEntity);
         $mockRepository->method('save');
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getRepository')->willReturn($mockRepository);
 
         $definition = $this->makeDefinition();
@@ -108,10 +108,10 @@ final class UserCreateHandlerTest extends TestCase
     #[Test]
     public function returnsFailureOnStorageException(): void
     {
-        $mockRepository = $this->createMock(EntityRepositoryInterface::class);
+        $mockRepository = $this->createStub(EntityRepositoryInterface::class);
         $mockRepository->method('create')->willThrowException(new \RuntimeException('DB error'));
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getRepository')->willReturn($mockRepository);
 
         $definition = $this->makeDefinition();

--- a/packages/cli/tests/Unit/Handler/UserRoleHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/UserRoleHandlerTest.php
@@ -66,7 +66,7 @@ final class UserRoleHandlerTest extends TestCase
 
     private function makeStorage(?EntityInterface $user): EntityStorageInterface
     {
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($user);
         if ($user !== null) {
             $storage->method('save');
@@ -78,7 +78,7 @@ final class UserRoleHandlerTest extends TestCase
     // C-22 WP3: read/write path now goes through the canonical repository.
     private function makeRepository(?EntityInterface $user): EntityRepositoryInterface
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('find')->willReturn($user);
         if ($user !== null) {
             $repository->method('save');
@@ -92,7 +92,7 @@ final class UserRoleHandlerTest extends TestCase
     {
         $user = $this->makeMockUser('1', []);
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getStorage')->willReturn($this->makeStorage($user));
         $mockManager->method('getRepository')->willReturn($this->makeRepository($user));
 
@@ -109,7 +109,7 @@ final class UserRoleHandlerTest extends TestCase
     {
         $user = $this->makeMockUser('1', ['editor']);
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getStorage')->willReturn($this->makeStorage($user));
         $mockManager->method('getRepository')->willReturn($this->makeRepository($user));
 
@@ -126,7 +126,7 @@ final class UserRoleHandlerTest extends TestCase
     {
         $user = $this->makeMockUser('1', ['editor']);
 
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getStorage')->willReturn($this->makeStorage($user));
         $mockManager->method('getRepository')->willReturn($this->makeRepository($user));
 
@@ -141,7 +141,7 @@ final class UserRoleHandlerTest extends TestCase
     #[Test]
     public function returnsFailureWhenUserNotFound(): void
     {
-        $mockManager = $this->createMock(EntityTypeManagerInterface::class);
+        $mockManager = $this->createStub(EntityTypeManagerInterface::class);
         $mockManager->method('getStorage')->willReturn($this->makeStorage(null));
         $mockManager->method('getRepository')->willReturn($this->makeRepository(null));
 

--- a/packages/cli/tests/Unit/Handler/WorkflowsBackfillStateHandlerTest.php
+++ b/packages/cli/tests/Unit/Handler/WorkflowsBackfillStateHandlerTest.php
@@ -582,7 +582,7 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
         $workflow = new Workflow(DefaultWorkflows::EDITORIAL);
 
         $workflowRepository = $this->createMock(EntityRepositoryInterface::class);
-        $workflowRepository->method('find')->with('editorial')->willReturn($workflow);
+        $workflowRepository->expects(self::once())->method('find')->with('editorial')->willReturn($workflow);
 
         $rows = [
             '1' => new PartialFailureStubEntity('1', 'article', 1, null),
@@ -590,11 +590,11 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
             '3' => new PartialFailureStubEntity('3', 'article', 0, null),
         ];
 
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('execute')->willReturn(array_keys($rows));
 
-        $subjectRepository = $this->createMock(EntityRepositoryInterface::class);
+        $subjectRepository = $this->createStub(EntityRepositoryInterface::class);
         $subjectRepository->method('getQuery')->willReturn($query);
         $subjectRepository->method('find')->willReturnCallback(
             static fn(string $id): ?EntityInterface => $rows[$id] ?? null,
@@ -610,10 +610,10 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
             },
         );
 
-        $definition = $this->createMock(EntityTypeInterface::class);
+        $definition = $this->createStub(EntityTypeInterface::class);
         $definition->method('getKeys')->willReturn(['bundle' => 'kind']);
 
-        $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+        $entityTypeManager = $this->createStub(EntityTypeManagerInterface::class);
         $entityTypeManager->method('hasDefinition')->willReturnCallback(
             static fn(string $id): bool => in_array($id, [self::ENTITY_TYPE_ID, 'workflow'], true),
         );
@@ -646,18 +646,18 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
         $workflow = new Workflow(DefaultWorkflows::EDITORIAL);
 
         $workflowRepository = $this->createMock(EntityRepositoryInterface::class);
-        $workflowRepository->method('find')->with('editorial')->willReturn($workflow);
+        $workflowRepository->expects(self::once())->method('find')->with('editorial')->willReturn($workflow);
 
         $rows = [
             '1' => new PointerFailureStubEntity('1', 'article', 1, 'published', 10),
             '2' => new PointerFailureStubEntity('2', 'article', 1, 'published', 20),
         ];
 
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('execute')->willReturn(array_keys($rows));
 
-        $subjectRepository = $this->createMock(EntityRepositoryInterface::class);
+        $subjectRepository = $this->createStub(EntityRepositoryInterface::class);
         $subjectRepository->method('getQuery')->willReturn($query);
         $subjectRepository->method('find')->willReturnCallback(
             static fn(string $id): ?EntityInterface => $rows[$id] ?? null,
@@ -673,11 +673,11 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
             },
         );
 
-        $definition = $this->createMock(EntityTypeInterface::class);
+        $definition = $this->createStub(EntityTypeInterface::class);
         $definition->method('getKeys')->willReturn(['bundle' => 'kind']);
         $definition->method('isRevisionable')->willReturn(true);
 
-        $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+        $entityTypeManager = $this->createStub(EntityTypeManagerInterface::class);
         $entityTypeManager->method('hasDefinition')->willReturnCallback(
             static fn(string $id): bool => in_array($id, [self::ENTITY_TYPE_ID, 'workflow'], true),
         );
@@ -707,13 +707,13 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
         $workflow = new Workflow(DefaultWorkflows::EDITORIAL);
 
         $workflowRepository = $this->createMock(EntityRepositoryInterface::class);
-        $workflowRepository->method('find')->with('editorial')->willReturn($workflow);
+        $workflowRepository->expects(self::once())->method('find')->with('editorial')->willReturn($workflow);
 
         $rows = [
             '1' => new PartialFailureStubEntity('1', 'article', 1, 'published'),
         ];
 
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('execute')->willReturn(array_keys($rows));
 
@@ -725,11 +725,11 @@ final class WorkflowsBackfillStateHandlerTest extends TestCase
         $subjectRepository->method('loadPublishedRevision')->willReturn(null);
         $subjectRepository->expects(self::never())->method('setPublishedRevision');
 
-        $definition = $this->createMock(EntityTypeInterface::class);
+        $definition = $this->createStub(EntityTypeInterface::class);
         $definition->method('getKeys')->willReturn(['bundle' => 'kind']);
         $definition->method('isRevisionable')->willReturn(true);
 
-        $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+        $entityTypeManager = $this->createStub(EntityTypeManagerInterface::class);
         $entityTypeManager->method('hasDefinition')->willReturnCallback(
             static fn(string $id): bool => in_array($id, [self::ENTITY_TYPE_ID, 'workflow'], true),
         );

--- a/packages/database-legacy/tests/Unit/Schema/DBALSchemaTest.php
+++ b/packages/database-legacy/tests/Unit/Schema/DBALSchemaTest.php
@@ -227,7 +227,7 @@ final class DBALSchemaTest extends TestCase
         $schema = new Schema();
         $schema->createTable('test')->addColumn('id', 'integer');
 
-        $manager = $this->createMock(AbstractSchemaManager::class);
+        $manager = $this->createStub(AbstractSchemaManager::class);
         $manager->method('introspectSchema')->willReturn($schema);
         $manager->method('createComparator')->willReturn(new Comparator($platform));
 

--- a/packages/engagement/tests/Unit/EngagementAccessPolicyTest.php
+++ b/packages/engagement/tests/Unit/EngagementAccessPolicyTest.php
@@ -48,8 +48,8 @@ final class EngagementAccessPolicyTest extends TestCase
     public function admin_is_always_allowed(): void
     {
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')->with('administer content')->willReturn(true);
-        $entity = $this->createMock(EntityInterface::class);
+        $account->expects(self::once())->method('hasPermission')->with('administer content')->willReturn(true);
+        $entity = $this->createStub(EntityInterface::class);
 
         $result = $this->policy->access($entity, 'view', $account);
         $this->assertTrue($result->isAllowed());
@@ -58,7 +58,7 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function view_cascades_allowed_when_parent_is_viewable(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
 
         $policy = $this->policyWithParent('post', 7, parentViewable: true);
@@ -72,7 +72,7 @@ final class EngagementAccessPolicyTest extends TestCase
     public function view_is_denied_when_parent_is_not_viewable(): void
     {
         // A published comment on a draft post must not be visible (parent-cascade).
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
 
         $policy = $this->policyWithParent('post', 7, parentViewable: false);
@@ -85,7 +85,7 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function view_of_unpublished_comment_is_denied_to_non_owner(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('id')->willReturn(99);
 
@@ -100,7 +100,7 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function view_of_unpublished_comment_is_allowed_to_owner(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('id')->willReturn(42);
@@ -143,7 +143,7 @@ final class EngagementAccessPolicyTest extends TestCase
         // The exact exploit: a comment with user_id === 0 (mintable pre-fix via
         // the client-writable user_id field hole) must not be "owned" by the
         // anonymous account just because AnonymousUser::id() also returns 0.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('id')->willReturn(0);
@@ -161,7 +161,7 @@ final class EngagementAccessPolicyTest extends TestCase
     {
         // The bare policy (no entity-type-manager / access-handler) cannot prove
         // parent visibility, so view is denied rather than leaked.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $entity = $this->engagement('comment', targetType: 'post', targetId: 7, status: true);
 
@@ -172,13 +172,13 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function owner_can_delete(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('id')->willReturn(42);
 
         $entity = $this->createMock(EntityInterface::class);
-        $entity->method('get')->with('user_id')->willReturn(42);
+        $entity->expects(self::once())->method('get')->with('user_id')->willReturn(42);
 
         $result = $this->policy->access($entity, 'delete', $account);
         $this->assertTrue($result->isAllowed());
@@ -187,13 +187,13 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function non_owner_cannot_delete(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('id')->willReturn(99);
 
         $entity = $this->createMock(EntityInterface::class);
-        $entity->method('get')->with('user_id')->willReturn(42);
+        $entity->expects(self::once())->method('get')->with('user_id')->willReturn(42);
 
         $result = $this->policy->access($entity, 'delete', $account);
         $this->assertTrue($result->isNeutral());
@@ -206,13 +206,13 @@ final class EngagementAccessPolicyTest extends TestCase
         // user_id === 0 (mintable pre-fix via the client-writable user_id
         // field hole) must not grant anonymous DELETE just because the ids
         // collide.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('id')->willReturn(0);
 
         $entity = $this->createMock(EntityInterface::class);
-        $entity->method('get')->with('user_id')->willReturn(0);
+        $entity->expects(self::once())->method('get')->with('user_id')->willReturn(0);
 
         $result = $this->policy->access($entity, 'delete', $account);
         $this->assertTrue($result->isNeutral(), 'Anonymous must not be granted delete on a user_id=0 row.');
@@ -224,20 +224,20 @@ final class EngagementAccessPolicyTest extends TestCase
      */
     private function policyWithParent(string $type, int $id, bool $parentViewable): EngagementAccessPolicy
     {
-        $parent = $this->createMock(EntityInterface::class);
+        $parent = $this->createStub(EntityInterface::class);
         $parent->method('getEntityTypeId')->willReturn($type);
         $parent->method('bundle')->willReturn('');
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturn($parent);
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturnCallback(static fn(string $t): bool => $t === $type);
         $etm->method('getStorage')->willReturn($storage);
         // C-22 WP3: read path now goes through the canonical repository.
         $etm->method('getRepository')->willReturn(new StorageBackedStubRepository($storage));
 
-        $policy = $this->createMock(AccessPolicyInterface::class);
+        $policy = $this->createStub(AccessPolicyInterface::class);
         $policy->method('appliesTo')->willReturnCallback(static fn(string $t): bool => $t === $type);
         $policy->method('access')->willReturn(
             $parentViewable ? AccessResult::allowed('viewable') : AccessResult::neutral('hidden'),
@@ -253,7 +253,7 @@ final class EngagementAccessPolicyTest extends TestCase
         bool $status = true,
         int $ownerId = 1,
     ): EntityInterface {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($type);
         $entity->method('get')->willReturnCallback(
             static fn(string $field): mixed => match ($field) {
@@ -271,7 +271,7 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function authenticated_can_create(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);
 
@@ -282,7 +282,7 @@ final class EngagementAccessPolicyTest extends TestCase
     #[Test]
     public function anonymous_cannot_create(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(false);
 

--- a/packages/engagement/tests/Unit/EngagementFieldAccessPolicyTest.php
+++ b/packages/engagement/tests/Unit/EngagementFieldAccessPolicyTest.php
@@ -45,7 +45,7 @@ final class EngagementFieldAccessPolicyTest extends TestCase
     /** @param list<string> $permissions */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn($id !== 0);
         $account->method('hasPermission')->willReturnCallback(
@@ -57,9 +57,9 @@ final class EngagementFieldAccessPolicyTest extends TestCase
 
     private function existingEntity(int $ownerId): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('isNew')->willReturn(false);
-        $entity->method('get')->with('user_id')->willReturn($ownerId);
+        $entity->method('get')->willReturn($ownerId);
 
         return $entity;
     }
@@ -68,7 +68,7 @@ final class EngagementFieldAccessPolicyTest extends TestCase
     {
         $entity = $this->createMock(EntityInterface::class);
         $entity->method('isNew')->willReturn(true);
-        $entity->method('get')->with('user_id')->willReturn($submittedUserId);
+        $entity->expects(self::once())->method('get')->with('user_id')->willReturn($submittedUserId);
 
         return $entity;
     }

--- a/packages/entity-storage/tests/Unit/EntityRepositoryOptimisticLockingTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryOptimisticLockingTest.php
@@ -81,7 +81,7 @@ final class EntityRepositoryOptimisticLockingTest extends TestCase
     private function spyDispatcher(): EventDispatcherInterface
     {
         $this->dispatchedEvents = [];
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnCallback(function (object $event, ?string $eventName = null) {
             $this->dispatchedEvents[] = $eventName ?? $event::class;
 

--- a/packages/entity-storage/tests/Unit/EntityRepositoryPublishedRevisionTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryPublishedRevisionTest.php
@@ -48,7 +48,7 @@ final class EntityRepositoryPublishedRevisionTest extends TestCase
         $driver = new SqlStorageDriver($resolver);
         $revisionDriver = new RevisionableStorageDriver($resolver, $entityType);
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         $this->repo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(

--- a/packages/entity-storage/tests/Unit/EntityRepositoryRevisionSurfaceTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryRevisionSurfaceTest.php
@@ -60,7 +60,7 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
             $storageBoundary->driverSnapshotReader(),
         );
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         $this->repo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(
@@ -282,7 +282,7 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
         $resolver = new SingleConnectionResolver($this->db);
         $driver = new SqlStorageDriver($resolver);
         $revisionDriver = new RevisionableStorageDriver($resolver, $legacyType);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
         $legacyRepo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver($legacyType, $driver, $dispatcher, $revisionDriver, $this->db);
 
@@ -405,7 +405,7 @@ final class EntityRepositoryRevisionSurfaceTest extends TestCase
         $resolver = new SingleConnectionResolver($this->db);
         $driver = new SqlStorageDriver($resolver);
         $revisionDriver = new RevisionableStorageDriver($resolver, $legacyType);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
         $legacyRepo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver($legacyType, $driver, $dispatcher, $revisionDriver, $this->db);
 

--- a/packages/entity-storage/tests/Unit/EntityRepositoryRevisionTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryRevisionTest.php
@@ -48,7 +48,7 @@ final class EntityRepositoryRevisionTest extends TestCase
         $revisionDriver = new RevisionableStorageDriver($resolver, $entityType);
 
         $this->dispatchedEvents = [];
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnCallback(function ($event, $eventName) {
             $this->dispatchedEvents[] = $eventName;
             return $event;

--- a/packages/entity-storage/tests/Unit/EntityRepositoryTranslationAxisTest.php
+++ b/packages/entity-storage/tests/Unit/EntityRepositoryTranslationAxisTest.php
@@ -59,7 +59,7 @@ final class EntityRepositoryTranslationAxisTest extends TestCase
         $handler->ensureTranslationRevisionTable();
 
         $resolver = new SingleConnectionResolver($this->db);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         $this->repo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(

--- a/packages/entity/tests/Unit/EntityReadRuntimeCacheTest.php
+++ b/packages/entity/tests/Unit/EntityReadRuntimeCacheTest.php
@@ -282,7 +282,7 @@ final class EntityReadRuntimeCacheTest extends TestCase
     public function in_place_classification_tightening_advances_the_registry_generation_before_a_stale_read(): void
     {
         $level = FieldReadLevel::Public;
-        $definition = $this->createMockForIntersectionOfInterfaces([
+        $definition = $this->createStubForIntersectionOfInterfaces([
             FieldDefinitionInterface::class,
             FieldReadDefinitionInterface::class,
         ]);

--- a/packages/entity/tests/Unit/EntityTypeManagerBundleFieldsTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerBundleFieldsTest.php
@@ -25,7 +25,7 @@ final class EntityTypeManagerBundleFieldsTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
     }
 
     #[Test]

--- a/packages/entity/tests/Unit/EntityTypeManagerTenancyDeprecationTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerTenancyDeprecationTest.php
@@ -29,7 +29,7 @@ final class EntityTypeManagerTenancyDeprecationTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->eventDispatcher = $this->createStub(EventDispatcherInterface::class);
     }
 
     public function testWarnsOnceWhenMarkerPresentAndTenancySlotNull(): void

--- a/packages/entity/tests/Unit/EntityTypeManagerTest.php
+++ b/packages/entity/tests/Unit/EntityTypeManagerTest.php
@@ -24,7 +24,7 @@ class EntityTypeManagerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->eventDispatcher = $this->createStub(EventDispatcherInterface::class);
         $this->manager = new EntityTypeManager($this->eventDispatcher);
     }
 
@@ -127,7 +127,7 @@ class EntityTypeManagerTest extends TestCase
 
     public function testGetStorageWithFactory(): void
     {
-        $mockStorage = $this->createMock(EntityStorageInterface::class);
+        $mockStorage = $this->createStub(EntityStorageInterface::class);
 
         $manager = new EntityTypeManager(
             $this->eventDispatcher,
@@ -147,7 +147,7 @@ class EntityTypeManagerTest extends TestCase
     public function testGetStorageCachesInstances(): void
     {
         $callCount = 0;
-        $mockStorage = $this->createMock(EntityStorageInterface::class);
+        $mockStorage = $this->createStub(EntityStorageInterface::class);
 
         $manager = new EntityTypeManager(
             $this->eventDispatcher,
@@ -222,7 +222,7 @@ class EntityTypeManagerTest extends TestCase
 
     public function testGetRepositoryUsesFactoryAndCaches(): void
     {
-        $mockRepo = $this->createMock(EntityRepositoryInterface::class);
+        $mockRepo = $this->createStub(EntityRepositoryInterface::class);
         $callCount = 0;
 
         $manager = new EntityTypeManager(

--- a/packages/entity/tests/Unit/TranslatableEntityTraitTest.php
+++ b/packages/entity/tests/Unit/TranslatableEntityTraitTest.php
@@ -22,7 +22,7 @@ final class TranslatableEntityTraitTest extends TestCase
 
     protected function setUp(): void
     {
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $this->manager = new EntityTypeManager($dispatcher);
 
         // Register a translatable entity type.

--- a/packages/entity/tests/Unit/Validation/EntityTypeValidationConstraintsTest.php
+++ b/packages/entity/tests/Unit/Validation/EntityTypeValidationConstraintsTest.php
@@ -95,7 +95,7 @@ final class EntityTypeValidationConstraintsTest extends TestCase
      */
     private function stubEntity(array $values): FieldableEntityDouble
     {
-        $entity = $this->createMock(FieldableEntityDouble::class);
+        $entity = $this->createStub(FieldableEntityDouble::class);
         $entity->method('get')->willReturnCallback(
             static fn (string $name): mixed => $values[$name] ?? null,
         );

--- a/packages/entity/tests/Unit/Validation/EntityValidatorTest.php
+++ b/packages/entity/tests/Unit/Validation/EntityValidatorTest.php
@@ -27,7 +27,7 @@ final class EntityValidatorTest extends TestCase
             'status' => 'published',
         ]);
 
-        $symfonyValidator = $this->createMock(ValidatorInterface::class);
+        $symfonyValidator = $this->createStub(ValidatorInterface::class);
         $symfonyValidator->method('validate')
             ->willReturn(new ConstraintViolationList());
 
@@ -65,7 +65,7 @@ final class EntityValidatorTest extends TestCase
             'invalid',
         );
 
-        $symfonyValidator = $this->createMock(ValidatorInterface::class);
+        $symfonyValidator = $this->createStub(ValidatorInterface::class);
         $symfonyValidator->method('validate')
             ->willReturnOnConsecutiveCalls(
                 new ConstraintViolationList([$titleViolation]),
@@ -114,7 +114,7 @@ final class EntityValidatorTest extends TestCase
 
     public function testValidateUsesEntityGetForFieldValues(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('get')
             ->willReturnMap([
                 ['title', 'Hello'],
@@ -136,7 +136,7 @@ final class EntityValidatorTest extends TestCase
 
     public function testValidateWithEmptyConstraintsReturnsNoViolations(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('toArray')->willReturn(['title' => '']);
 
         $symfonyValidator = $this->createMock(ValidatorInterface::class);
@@ -163,7 +163,7 @@ final class EntityValidatorTest extends TestCase
             '',
         );
 
-        $symfonyValidator = $this->createMock(ValidatorInterface::class);
+        $symfonyValidator = $this->createStub(ValidatorInterface::class);
         $symfonyValidator->method('validate')
             ->willReturn(new ConstraintViolationList([$violation]));
 
@@ -224,7 +224,7 @@ final class EntityValidatorTest extends TestCase
      */
     private function createFieldableEntity(array $values): EntityInterface&FieldableInterface
     {
-        $entity = $this->createMock(FieldableEntityStub::class);
+        $entity = $this->createStub(FieldableEntityStub::class);
         $entity->method('toArray')->willReturn($values);
         $entity->method('get')->willReturnCallback(
             fn (string $name): mixed => $values[$name] ?? null,

--- a/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
+++ b/packages/entity/tests/Unit/Validation/FieldDefinitionConstraintBuilderTest.php
@@ -484,7 +484,7 @@ final class FieldDefinitionConstraintBuilderTest extends TestCase
      */
     private function stubEntity(array $values): FieldableEntityDouble
     {
-        $entity = $this->createMock(FieldableEntityDouble::class);
+        $entity = $this->createStub(FieldableEntityDouble::class);
         $entity->method('get')->willReturnCallback(
             static fn (string $name): mixed => $values[$name] ?? null,
         );

--- a/packages/field/tests/Unit/FieldServiceProviderClearanceConfigTest.php
+++ b/packages/field/tests/Unit/FieldServiceProviderClearanceConfigTest.php
@@ -30,7 +30,7 @@ final class FieldServiceProviderClearanceConfigTest extends TestCase
         $checker = $provider->resolve(ClassificationClearanceCheckerInterface::class);
         self::assertInstanceOf(ClassificationClearanceCheckerInterface::class, $checker);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')->willReturn(['special-role']);
 
         self::assertSame(7, $checker->clearanceLevelFor($account));

--- a/packages/field/tests/Unit/Form/FormDescriptorBuilderTest.php
+++ b/packages/field/tests/Unit/Form/FormDescriptorBuilderTest.php
@@ -266,7 +266,7 @@ class FormDescriptorBuilderTest extends TestCase
 
         $account = $this->createStub(AccountInterface::class);
 
-        $accessHandler = $this->createMock(EntityAccessHandler::class);
+        $accessHandler = $this->createStub(EntityAccessHandler::class);
         $accessHandler
             ->method('checkFieldAccess')
             ->willReturn(AccessResult::forbidden('Not allowed.'));
@@ -289,7 +289,7 @@ class FormDescriptorBuilderTest extends TestCase
 
         $account = $this->createStub(AccountInterface::class);
 
-        $accessHandler = $this->createMock(EntityAccessHandler::class);
+        $accessHandler = $this->createStub(EntityAccessHandler::class);
         $accessHandler
             ->method('checkFieldAccess')
             ->willReturn(AccessResult::allowed());
@@ -313,7 +313,7 @@ class FormDescriptorBuilderTest extends TestCase
 
         $account = $this->createStub(AccountInterface::class);
 
-        $accessHandler = $this->createMock(EntityAccessHandler::class);
+        $accessHandler = $this->createStub(EntityAccessHandler::class);
         $accessHandler
             ->method('checkFieldAccess')
             ->willReturn(AccessResult::neutral());

--- a/packages/foundation/tests/Unit/Diagnostic/HealthCheckerBundleSubtableDriftTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/HealthCheckerBundleSubtableDriftTest.php
@@ -130,7 +130,7 @@ final class HealthCheckerBundleSubtableDriftTest extends TestCase
         );
         // Materialize the real expected schema instead of hand-rolling columns.
         (new SqlSchemaHandler($type, $this->database))->ensureTable();
-        $registry = $this->createMock(FieldDefinitionRegistryInterface::class);
+        $registry = $this->createStub(FieldDefinitionRegistryInterface::class);
         $registry->method('bundleNamesFor')->willReturn([]);
 
         $results = $this->checker($type, $registry)->checkSchemaDrift();
@@ -223,7 +223,7 @@ final class HealthCheckerBundleSubtableDriftTest extends TestCase
      */
     private function registry(array $bundleToFieldNames): FieldDefinitionRegistryInterface
     {
-        $registry = $this->createMock(FieldDefinitionRegistryInterface::class);
+        $registry = $this->createStub(FieldDefinitionRegistryInterface::class);
 
         $nonEmpty = [];
         $fieldsMap = [];
@@ -249,7 +249,7 @@ final class HealthCheckerBundleSubtableDriftTest extends TestCase
 
     private function checker(EntityTypeInterface $type, FieldDefinitionRegistryInterface $registry): HealthChecker
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
 
         $bootReport = new BootDiagnosticReport(

--- a/packages/foundation/tests/Unit/Diagnostic/HealthCheckerColumnDataDriftTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/HealthCheckerColumnDataDriftTest.php
@@ -119,7 +119,7 @@ final class HealthCheckerColumnDataDriftTest extends TestCase
         $this->createBaseTable('thing', extraColumns: ['status']);
 
         // No registry — checker constructed with $fieldRegistry === null.
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
         $checker = new HealthChecker(
             bootReport: new BootDiagnosticReport(
@@ -220,7 +220,7 @@ final class HealthCheckerColumnDataDriftTest extends TestCase
      */
     private function registry(array $coreFields = [], array $bundleFields = []): FieldDefinitionRegistryInterface
     {
-        $registry = $this->createMock(FieldDefinitionRegistryInterface::class);
+        $registry = $this->createStub(FieldDefinitionRegistryInterface::class);
 
         $coreFieldObjects = [];
         foreach ($coreFields as $name => $stored) {
@@ -265,7 +265,7 @@ final class HealthCheckerColumnDataDriftTest extends TestCase
 
     private function checker(EntityTypeInterface $type, FieldDefinitionRegistryInterface $registry): HealthChecker
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
 
         $bootReport = new BootDiagnosticReport(

--- a/packages/foundation/tests/Unit/Diagnostic/HealthCheckerTest.php
+++ b/packages/foundation/tests/Unit/Diagnostic/HealthCheckerTest.php
@@ -99,7 +99,7 @@ final class HealthCheckerTest extends TestCase
     #[Test]
     public function runtimeChecksIncludeTheConfiguredCleanUrlProbe(): void
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
         $probe = new CleanUrlProbe(
             'https://example.test',
@@ -126,7 +126,7 @@ final class HealthCheckerTest extends TestCase
     public function schemaDriftPassesWithCorrectSchema(): void
     {
         $nodeType = $this->makeContentEntityType('node');
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn(['node' => $nodeType]);
 
         // Create table with correct schema.
@@ -144,7 +144,7 @@ final class HealthCheckerTest extends TestCase
     public function schemaDriftTreatsParameterizedVarcharAsSqliteTextAffinity(): void
     {
         $type = $this->makeContentEntityType('article');
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn(['article' => $type]);
         $this->database->query(<<<'SQL'
             CREATE TABLE article (
@@ -168,7 +168,7 @@ final class HealthCheckerTest extends TestCase
     {
         // Create a config entity type (expects TEXT PK).
         $configType = $this->makeConfigEntityType('node_type');
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn(['node_type' => $configType]);
 
         // Create table with WRONG schema (INTEGER instead of TEXT for ID).
@@ -196,7 +196,7 @@ final class HealthCheckerTest extends TestCase
     public function schemaDriftReportsSkippedStateHonestlyWhenEveryTableIsLazy(): void
     {
         $nodeType = $this->makeContentEntityType('node');
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn(['node' => $nodeType]);
 
         // Don't create the table — simulate lazy initialization. A blanket
@@ -221,7 +221,7 @@ final class HealthCheckerTest extends TestCase
     {
         $nodeType = $this->makeContentEntityType('node');
         $userType = $this->makeContentEntityType('user_profile');
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([
             'node' => $nodeType,
             'user_profile' => $userType,
@@ -319,7 +319,7 @@ final class HealthCheckerTest extends TestCase
             json_encode(['status' => 'accepted', 'logged_at' => '2026-03-08T12:00:00+00:00']) . "\n",
         );
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([]);
         $bootReport = new BootDiagnosticReport(registeredTypes: [], disabledTypeIds: [], schemaCompatibility: []);
 
@@ -352,7 +352,7 @@ final class HealthCheckerTest extends TestCase
         // which doubles embedded quotes, the same hardening pattern as #1816.
         $weirdId = 'weird"type';
         $weirdType = $this->makeConfigEntityType($weirdId);
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$weirdId => $weirdType]);
 
         // Build the table with raw SQL, quoting identifiers ourselves — the
@@ -400,7 +400,7 @@ final class HealthCheckerTest extends TestCase
             $types['node'] = $this->makeContentEntityType('node');
         }
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn($types);
 
         return $this->createCheckerWith($manager);

--- a/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
+++ b/packages/foundation/tests/Unit/Kernel/HttpKernelTest.php
@@ -337,7 +337,7 @@ final class HttpKernelTest extends TestCase
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->expects(self::once())->method('find')->with('42')->willReturn($entity);
         $entityTypeManager = $this->createMock(EntityTypeManager::class);
-        $entityTypeManager->method('getRepository')->with('test')->willReturn($repository);
+        $entityTypeManager->expects(self::once())->method('getRepository')->with('test')->willReturn($repository);
 
         $provider = new class extends ServiceProvider {
             public function register(): void {}

--- a/packages/foundation/tests/Unit/Tenant/TenantTest.php
+++ b/packages/foundation/tests/Unit/Tenant/TenantTest.php
@@ -46,7 +46,7 @@ final class TenantTest extends TestCase
     #[Test]
     public function tenant_middleware_sets_context_from_resolver(): void
     {
-        $resolver = $this->createMock(TenantResolverInterface::class);
+        $resolver = $this->createStub(TenantResolverInterface::class);
         $resolver->method('resolve')->willReturn('acme');
 
         $context = new TenantContext();
@@ -66,7 +66,7 @@ final class TenantTest extends TestCase
     #[Test]
     public function tenant_middleware_clears_context_on_exception(): void
     {
-        $resolver = $this->createMock(TenantResolverInterface::class);
+        $resolver = $this->createStub(TenantResolverInterface::class);
         $resolver->method('resolve')->willReturn('acme');
 
         $context = new TenantContext();

--- a/packages/genealogy/tests/Unit/GenealogyContentAccessPolicyTest.php
+++ b/packages/genealogy/tests/Unit/GenealogyContentAccessPolicyTest.php
@@ -27,18 +27,18 @@ final class GenealogyContentAccessPolicyTest extends TestCase
      * Resolves tree_id to a published tree so {@see GenealogyContentAccessPolicy}
      * exercises anonymous published rules, not "tree could not be resolved".
      */
-    private function bindPublishedTreeStorage(int $treeId, GenealogyTree $tree): void
+    private function bindPublishedTreeStorage(int $treeId, GenealogyTree $tree, bool $expectLookup = true): void
     {
         $treeStorage = $this->createMock(EntityStorageInterface::class);
-        $treeStorage->method('load')->with((string) $treeId)->willReturn($tree);
+        $treeStorage->expects(self::never())->method('load');
 
         // C-22 WP3: read path now goes through the canonical repository.
         $treeRepository = $this->createMock(EntityRepositoryInterface::class);
-        $treeRepository->method('find')->with((string) $treeId)->willReturn($tree);
+        $treeRepository->expects($expectLookup ? self::once() : self::never())->method('find')->with((string) $treeId)->willReturn($tree);
 
         $etm = $this->createMock(EntityTypeManagerInterface::class);
-        $etm->method('getStorage')->with('genealogy_tree')->willReturn($treeStorage);
-        $etm->method('getRepository')->with('genealogy_tree')->willReturn($treeRepository);
+        $etm->expects(self::never())->method('getStorage');
+        $etm->expects($expectLookup ? self::once() : self::never())->method('getRepository')->with('genealogy_tree')->willReturn($treeRepository);
 
         GenealogyBootstrap::bind($etm, null);
     }
@@ -101,7 +101,7 @@ final class GenealogyContentAccessPolicyTest extends TestCase
             'display_name' => 'Fixture tree',
             'status' => 1,
             'owner_uid' => 99,
-        ]));
+        ]), expectLookup: false);
 
         $policy = new GenealogyContentAccessPolicy();
         $account = new DevAdminAccount();

--- a/packages/genealogy/tests/Unit/GenealogyFamilyEventConcealmentTest.php
+++ b/packages/genealogy/tests/Unit/GenealogyFamilyEventConcealmentTest.php
@@ -42,7 +42,7 @@ final class GenealogyFamilyEventConcealmentTest extends TestCase
         GenealogyBootstrap::reset();
     }
 
-    private function bindPublishedTree(int $treeId, int $ownerUid = 99): void
+    private function bindPublishedTree(int $treeId, int $ownerUid = 99, bool $expectLookup = true): void
     {
         $tree = new GenealogyTree([
             'id' => $treeId,
@@ -52,10 +52,10 @@ final class GenealogyFamilyEventConcealmentTest extends TestCase
         ]);
 
         $treeRepository = $this->createMock(EntityRepositoryInterface::class);
-        $treeRepository->method('find')->with((string) $treeId)->willReturn($tree);
+        $treeRepository->expects($expectLookup ? self::once() : self::never())->method('find')->with((string) $treeId)->willReturn($tree);
 
         $etm = $this->createMock(EntityTypeManagerInterface::class);
-        $etm->method('getRepository')->with('genealogy_tree')->willReturn($treeRepository);
+        $etm->expects($expectLookup ? self::once() : self::never())->method('getRepository')->with('genealogy_tree')->willReturn($treeRepository);
 
         GenealogyBootstrap::bind($etm, null);
     }
@@ -136,7 +136,7 @@ final class GenealogyFamilyEventConcealmentTest extends TestCase
     #[Test]
     public function dev_admin_may_still_view_family(): void
     {
-        $this->bindPublishedTree(1);
+        $this->bindPublishedTree(1, expectLookup: false);
         $policy = new GenealogyContentAccessPolicy();
 
         $family = new GenealogyFamily([

--- a/packages/genealogy/tests/Unit/GenealogyRelationshipAccessPolicyTest.php
+++ b/packages/genealogy/tests/Unit/GenealogyRelationshipAccessPolicyTest.php
@@ -25,14 +25,14 @@ final class GenealogyRelationshipAccessPolicyTest extends TestCase
         $p1 = new GenealogyPerson(['id' => 2, 'display_name' => 'A', 'tree_id' => 1]);
         $p2 = new GenealogyPerson(['id' => 1, 'display_name' => 'B', 'tree_id' => 1]);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturnMap([
             ['2', $p1],
             ['1', $p2],
         ]);
 
         // C-22 WP3: read path now goes through the canonical repository.
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('find')->willReturnCallback(
             static fn(string $id): ?GenealogyPerson => match ($id) {
                 '2' => $p1,
@@ -41,12 +41,12 @@ final class GenealogyRelationshipAccessPolicyTest extends TestCase
             },
         );
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn(true);
         $etm->method('getStorage')->willReturn($storage);
         $etm->method('getRepository')->willReturn($repository);
 
-        $handler = $this->createMock(EntityAccessHandler::class);
+        $handler = $this->createStub(EntityAccessHandler::class);
         $handler->method('check')->willReturn(AccessResult::allowed());
 
         $policy = new GenealogyRelationshipAccessPolicy($etm, $handler);
@@ -71,14 +71,14 @@ final class GenealogyRelationshipAccessPolicyTest extends TestCase
         $p1 = new GenealogyPerson(['id' => 2, 'display_name' => 'A', 'tree_id' => 1]);
         $p2 = new GenealogyPerson(['id' => 1, 'display_name' => 'B', 'tree_id' => 1]);
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('load')->willReturnMap([
             ['2', $p1],
             ['1', $p2],
         ]);
 
         // C-22 WP3: read path now goes through the canonical repository.
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('find')->willReturnCallback(
             static fn(string $id): ?GenealogyPerson => match ($id) {
                 '2' => $p1,
@@ -87,12 +87,12 @@ final class GenealogyRelationshipAccessPolicyTest extends TestCase
             },
         );
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn(true);
         $etm->method('getStorage')->willReturn($storage);
         $etm->method('getRepository')->willReturn($repository);
 
-        $handler = $this->createMock(EntityAccessHandler::class);
+        $handler = $this->createStub(EntityAccessHandler::class);
         $handler->method('check')->willReturn(AccessResult::forbidden('hidden'));
 
         $policy = new GenealogyRelationshipAccessPolicy($etm, $handler);
@@ -114,8 +114,8 @@ final class GenealogyRelationshipAccessPolicyTest extends TestCase
     #[Test]
     public function non_genealogy_edge_has_no_opinion(): void
     {
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
-        $handler = $this->createMock(EntityAccessHandler::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
+        $handler = $this->createStub(EntityAccessHandler::class);
         $policy = new GenealogyRelationshipAccessPolicy($etm, $handler);
         $account = new AnonymousUser();
         $edge = new Relationship([

--- a/packages/groups/tests/Integration/StandaloneConsumptionTest.php
+++ b/packages/groups/tests/Integration/StandaloneConsumptionTest.php
@@ -105,7 +105,7 @@ final class StandaloneConsumptionTest extends TestCase
         $registry = new FieldDefinitionRegistry();
         (new SqlSchemaHandler($type, $this->database, $registry))->ensureTable();
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$type->id() => $type]);
 
         $report = new BootDiagnosticReport(

--- a/packages/groups/tests/Integration/TwoBundleCoexistenceTest.php
+++ b/packages/groups/tests/Integration/TwoBundleCoexistenceTest.php
@@ -203,7 +203,7 @@ final class TwoBundleCoexistenceTest extends TestCase
         $this->registerBetaFields();
         $this->ensureSchema(['alpha', 'beta']);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn([$this->groupType->id() => $this->groupType]);
 
         $report = new BootDiagnosticReport(

--- a/packages/mcp/tests/Integration/Approval/McpApprovalGateLifecycleTest.php
+++ b/packages/mcp/tests/Integration/Approval/McpApprovalGateLifecycleTest.php
@@ -108,7 +108,7 @@ final class McpApprovalGateLifecycleTest extends TestCase
 
     private function account(int $id): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('hasPermission')->willReturnCallback(

--- a/packages/mcp/tests/Integration/Audit/McpAuditStagesTest.php
+++ b/packages/mcp/tests/Integration/Audit/McpAuditStagesTest.php
@@ -88,7 +88,7 @@ final class McpAuditStagesTest extends TestCase
 
     private function account(int $id, bool $hasCapability = true): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn($id > 0);
         $account->method('hasPermission')->willReturnCallback(

--- a/packages/mcp/tests/Integration/Audit/McpDurableWriteAuditTest.php
+++ b/packages/mcp/tests/Integration/Audit/McpDurableWriteAuditTest.php
@@ -70,7 +70,7 @@ final class McpDurableWriteAuditTest extends TestCase
 
     private function account(int $id, bool $hasCapability = true): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('hasPermission')->willReturnCallback(

--- a/packages/mcp/tests/Integration/Auth/DurableBearerTokenLifecycleTest.php
+++ b/packages/mcp/tests/Integration/Auth/DurableBearerTokenLifecycleTest.php
@@ -58,7 +58,7 @@ final class DurableBearerTokenLifecycleTest extends TestCase
 
         $owner = new User(['uid' => 42]);
         $owner->enforceIsNew();
-        $accounts = $this->createMock(EntityRepositoryInterface::class);
+        $accounts = $this->createStub(EntityRepositoryInterface::class);
         $accounts->method('findBy')
             ->willReturnCallback(static fn(array $criteria): array => $criteria === ['uid' => 42, 'status' => 1] ? [$owner] : []);
 

--- a/packages/mcp/tests/Integration/WriteTierAuthOverrideTest.php
+++ b/packages/mcp/tests/Integration/WriteTierAuthOverrideTest.php
@@ -342,7 +342,7 @@ final class WriteTierAuthOverrideTest extends TestCase
 
     private function account(int $id, bool $hasCapability): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn($id > 0);
         $account->method('hasPermission')->willReturnCallback(

--- a/packages/mcp/tests/Unit/Auth/BearerTokenAuthTest.php
+++ b/packages/mcp/tests/Unit/Auth/BearerTokenAuthTest.php
@@ -18,7 +18,7 @@ final class BearerTokenAuthTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $this->account = $this->createStub(AuthorizationPrincipalInterface::class);
         $this->account->method('id')->willReturn(1);
 
         $this->auth = new BearerTokenAuth([

--- a/packages/mcp/tests/Unit/Auth/DurableBearerTokenAuthTest.php
+++ b/packages/mcp/tests/Unit/Auth/DurableBearerTokenAuthTest.php
@@ -138,7 +138,7 @@ final class DurableBearerTokenAuthTest extends TestCase
      */
     private function accountsWith(?User $user): EntityRepositoryInterface
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('findBy')->willReturn($user !== null ? [$user] : []);
 
         return $repository;
@@ -298,7 +298,7 @@ final class DurableBearerTokenAuthTest extends TestCase
     #[Test]
     public function an_account_lookup_failure_fails_closed(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('findBy')->willThrowException(new \RuntimeException('user table missing'));
         $auth = $this->auth($this->storeAnswering($this->record(42)), $repository);
 

--- a/packages/mcp/tests/Unit/Auth/OAuthMcpAuthTest.php
+++ b/packages/mcp/tests/Unit/Auth/OAuthMcpAuthTest.php
@@ -19,7 +19,7 @@ final class OAuthMcpAuthTest extends TestCase
     #[Test]
     public function it_delegates_a_bearer_token_with_the_exact_resource_audience(): void
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(42);
         $validator = new class ($account) implements OAuthAccessTokenValidatorInterface {
             public string $token = '';
@@ -48,7 +48,7 @@ final class OAuthMcpAuthTest extends TestCase
     #[Test]
     public function malformed_empty_and_scopeless_tokens_fail_closed(): void
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $validator = new class ($account) implements OAuthAccessTokenValidatorInterface {
             public function __construct(private AuthorizationPrincipalInterface $account) {}
 

--- a/packages/mcp/tests/Unit/Bridge/AgentToolRegistryBridgeSanitizationTest.php
+++ b/packages/mcp/tests/Unit/Bridge/AgentToolRegistryBridgeSanitizationTest.php
@@ -36,7 +36,7 @@ final class AgentToolRegistryBridgeSanitizationTest extends TestCase
 
     private function principal(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(7);
         $account->method('hasPermission')->willReturn(true);
 

--- a/packages/mcp/tests/Unit/Bridge/AgentToolRegistryBridgeValidationTest.php
+++ b/packages/mcp/tests/Unit/Bridge/AgentToolRegistryBridgeValidationTest.php
@@ -115,7 +115,7 @@ final class AgentToolRegistryBridgeValidationTest extends TestCase
             }
         };
 
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(1);
 
         return new AgentToolRegistryBridge($registry, $account);

--- a/packages/mcp/tests/Unit/McpEndpointApprovalGateContractTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointApprovalGateContractTest.php
@@ -38,7 +38,7 @@ final class McpEndpointApprovalGateContractTest extends TestCase
         $this->expectExceptionMessageMatches('/approval/i');
 
         new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             auditLedger: $this->workingLedger(),
             durableAudit: true,
@@ -58,7 +58,7 @@ final class McpEndpointApprovalGateContractTest extends TestCase
         $this->expectExceptionMessageMatches('/approval/i');
 
         new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             durableAudit: false,
             approvalStore: $this->emptyStore(),
@@ -70,7 +70,7 @@ final class McpEndpointApprovalGateContractTest extends TestCase
     public function a_fully_wired_approval_gate_constructs(): void
     {
         $endpoint = new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             auditLedger: $this->workingLedger(),
             durableAudit: true,
@@ -85,7 +85,7 @@ final class McpEndpointApprovalGateContractTest extends TestCase
     public function an_ungated_endpoint_still_constructs_without_a_store(): void
     {
         $endpoint = new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
         );
 

--- a/packages/mcp/tests/Unit/McpEndpointDispatchEventTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointDispatchEventTest.php
@@ -45,8 +45,8 @@ final class McpEndpointDispatchEventTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->auth = $this->createMock(McpAuthInterface::class);
-        $this->account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $this->auth = $this->createStub(McpAuthInterface::class);
+        $this->account = $this->createStub(AuthorizationPrincipalInterface::class);
         $this->account->method('id')->willReturn(7);
         $this->account->method('hasPermission')->willReturn(true);
     }
@@ -238,7 +238,7 @@ final class McpEndpointDispatchEventTest extends TestCase
     #[Test]
     public function dispatchEventPreservesOpaqueStringAccountId(): void
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn('acct-anishinaabe-7');
         $account->method('hasPermission')->willReturn(true);
         $this->auth->method('authenticate')->willReturn($account);
@@ -706,7 +706,7 @@ final class McpEndpointDispatchEventTest extends TestCase
     {
         $this->auth->method('authenticate')->willReturn($this->account);
 
-        $previousActor = $this->createMock(AccountInterface::class);
+        $previousActor = $this->createStub(AccountInterface::class);
         $context = new RecordingMcpAccountContext($previousActor);
 
         $endpoint = $this->makeEndpoint(accountContext: $context);
@@ -723,7 +723,7 @@ final class McpEndpointDispatchEventTest extends TestCase
     {
         $this->auth->method('authenticate')->willReturn($this->account);
 
-        $previousActor = $this->createMock(AccountInterface::class);
+        $previousActor = $this->createStub(AccountInterface::class);
         $context = new RecordingMcpAccountContext($previousActor);
 
         // Registry whose enumeration throws. Since the F4 closure fix the

--- a/packages/mcp/tests/Unit/McpEndpointDurableAuditContractTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointDurableAuditContractTest.php
@@ -39,7 +39,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
         $this->expectExceptionMessageMatches('/durable/i');
 
         new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             durableAudit: true,
         );
@@ -54,7 +54,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
         $this->expectExceptionMessageMatches('/durable/i');
 
         new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             auditLedger: new NullStrictAuditLedger(),
             durableAudit: true,
@@ -66,7 +66,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
     {
         // The public read-only tier's documented shape: no ledger, no durability.
         $endpoint = new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
         );
 
@@ -88,7 +88,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
         };
 
         $endpoint = new McpEndpoint(
-            auth: $this->createMock(McpAuthInterface::class),
+            auth: $this->createStub(McpAuthInterface::class),
             agentRegistry: $this->emptyRegistry(),
             auditLedger: $ledger,
             durableAudit: true,
@@ -109,7 +109,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
     #[Test]
     public function a_refusal_survives_a_ledger_that_breaks_its_exception_contract(): void
     {
-        $auth = $this->createMock(McpAuthInterface::class);
+        $auth = $this->createStub(McpAuthInterface::class);
         $auth->method('authenticate')->willReturn(null);
 
         $contractBreakingLedger = new class implements StrictAuditLedgerInterface {
@@ -145,7 +145,7 @@ final class McpEndpointDurableAuditContractTest extends TestCase
             ['HTTP_AUTHORIZATION' => 'Bearer bad'],
             '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
         );
-        $response = $endpoint->handle($this->createMock(\Waaseyaa\Access\AccountInterface::class), $request);
+        $response = $endpoint->handle($this->createStub(\Waaseyaa\Access\AccountInterface::class), $request);
 
         self::assertSame(401, $response->statusCode, 'The refusal must survive the failed terminal record.');
         self::assertSame(-32001, \json_decode($response->body, true)['error']['code']);

--- a/packages/mcp/tests/Unit/McpEndpointErrorSanitizationTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointErrorSanitizationTest.php
@@ -35,7 +35,7 @@ final class McpEndpointErrorSanitizationTest extends TestCase
 
     private function principal(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(3);
         $account->method('hasPermission')->willReturn(true);
 
@@ -44,7 +44,7 @@ final class McpEndpointErrorSanitizationTest extends TestCase
 
     private function endpoint(?RecordingLogger $logger): McpEndpoint
     {
-        $auth = $this->createMock(McpAuthInterface::class);
+        $auth = $this->createStub(McpAuthInterface::class);
         $auth->method('authenticate')->willReturn($this->principal());
 
         return new McpEndpoint(

--- a/packages/mcp/tests/Unit/McpEndpointRateLimitTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointRateLimitTest.php
@@ -27,7 +27,7 @@ final class McpEndpointRateLimitTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->auth = $this->createMock(McpAuthInterface::class);
+        $this->auth = $this->createStub(McpAuthInterface::class);
         $this->auth->method('authenticate')->willReturnCallback(
             fn(?string $header): ?AuthorizationPrincipalInterface => $this->principal(
                 (int) str_replace('Bearer uid-', '', (string) $header),
@@ -37,7 +37,7 @@ final class McpEndpointRateLimitTest extends TestCase
 
     private function principal(int $uid): AuthorizationPrincipalInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn($uid);
         $account->method('isAuthenticated')->willReturn(true);
 
@@ -46,7 +46,7 @@ final class McpEndpointRateLimitTest extends TestCase
 
     private function endpoint(?AtomicRateLimiterInterface $limiter, int $max = 2, string $tier = 'write'): McpEndpoint
     {
-        $registry = $this->createMock(ToolRegistryInterface::class);
+        $registry = $this->createStub(ToolRegistryInterface::class);
         $registry->method('all')->willReturn([]);
 
         return new McpEndpoint(
@@ -120,7 +120,7 @@ final class McpEndpointRateLimitTest extends TestCase
     {
         $endpoint = new McpEndpoint(
             auth: $this->auth,
-            agentRegistry: $this->createMock(ToolRegistryInterface::class),
+            agentRegistry: $this->createStub(ToolRegistryInterface::class),
         );
         for ($i = 0; $i < 25; $i++) {
             self::assertSame(200, $this->ping($endpoint, 1)->statusCode);
@@ -165,11 +165,11 @@ final class McpEndpointRateLimitTest extends TestCase
         $endpoint = $this->endpoint($limiter, max: 2);
 
         $request = HttpRequest::create('/mcp', 'POST', [], [], [], [], '{}');
-        $auth = $this->createMock(McpAuthInterface::class);
+        $auth = $this->createStub(McpAuthInterface::class);
         $auth->method('authenticate')->willReturn(null);
         $anonEndpoint = new McpEndpoint(
             auth: $auth,
-            agentRegistry: $this->createMock(ToolRegistryInterface::class),
+            agentRegistry: $this->createStub(ToolRegistryInterface::class),
             rateLimiter: $limiter,
             rateLimitMaxRequests: 2,
         );

--- a/packages/mcp/tests/Unit/McpEndpointSchemaOrderingTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointSchemaOrderingTest.php
@@ -113,7 +113,7 @@ final class McpEndpointSchemaOrderingTest extends TestCase
 
     private function account(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(1);
 
         return $account;
@@ -121,7 +121,7 @@ final class McpEndpointSchemaOrderingTest extends TestCase
 
     private function endpoint(bool $authenticates, ?AtomicRateLimiterInterface $limiter = null): McpEndpoint
     {
-        $auth = $this->createMock(McpAuthInterface::class);
+        $auth = $this->createStub(McpAuthInterface::class);
         $auth->method('authenticate')->willReturn($authenticates ? $this->account() : null);
 
         return new McpEndpoint(

--- a/packages/mcp/tests/Unit/McpEndpointTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointTest.php
@@ -42,8 +42,8 @@ final class McpEndpointTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->auth = $this->createMock(McpAuthInterface::class);
-        $this->account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $this->auth = $this->createStub(McpAuthInterface::class);
+        $this->account = $this->createStub(AuthorizationPrincipalInterface::class);
         $this->account->method('id')->willReturn(1);
         $this->account->method('hasPermission')->willReturn(true);
         $this->tools = [];
@@ -945,7 +945,7 @@ final class McpEndpointTest extends TestCase
     #[Test]
     public function unauthorized_modern_resource_read_refuses_before_provider_uri_parsing(): void
     {
-        $principal = $this->createMock(AuthorizationPrincipalInterface::class);
+        $principal = $this->createStub(AuthorizationPrincipalInterface::class);
         $principal->method('id')->willReturn(9);
         $principal->method('hasPermission')->willReturn(false);
         $this->auth->method('authenticate')->willReturn($principal);
@@ -1103,7 +1103,7 @@ final class McpEndpointTest extends TestCase
     #[Test]
     public function a_principal_without_the_resource_capability_sees_no_listing_or_read_oracle(): void
     {
-        $principal = $this->createMock(AuthorizationPrincipalInterface::class);
+        $principal = $this->createStub(AuthorizationPrincipalInterface::class);
         $principal->method('id')->willReturn(9);
         $principal->method('hasPermission')->willReturn(false);
         $this->auth->method('authenticate')->willReturn($principal);

--- a/packages/mcp/tests/Unit/McpEndpointTokenScopeTest.php
+++ b/packages/mcp/tests/Unit/McpEndpointTokenScopeTest.php
@@ -36,7 +36,7 @@ final class McpEndpointTokenScopeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $this->account = $this->createStub(AuthorizationPrincipalInterface::class);
         $this->account->method('id')->willReturn(7);
     }
 

--- a/packages/media/tests/Unit/MediaAccessPolicyTest.php
+++ b/packages/media/tests/Unit/MediaAccessPolicyTest.php
@@ -286,7 +286,7 @@ final class MediaAccessPolicyTest extends TestCase
     /** @param string[] $permissions */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('hasPermission')->willReturnCallback(
             fn(string $permission): bool => \in_array($permission, $permissions, true),

--- a/packages/messaging/tests/Unit/EventSubscriber/ThreadParticipantBootstrapSubscriberTest.php
+++ b/packages/messaging/tests/Unit/EventSubscriber/ThreadParticipantBootstrapSubscriberTest.php
@@ -211,7 +211,7 @@ final class ThreadParticipantBootstrapSubscriberTest extends TestCase
 
         $account = $this->account($actingAccountId);
 
-        $context = $this->createMock(AccountContextInterface::class);
+        $context = $this->createStub(AccountContextInterface::class);
         $context->method('current')->willReturn($account);
 
         return $context;
@@ -219,7 +219,7 @@ final class ThreadParticipantBootstrapSubscriberTest extends TestCase
 
     private function account(int $uid): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($uid);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);

--- a/packages/messaging/tests/Unit/MessagingAccessPolicyTest.php
+++ b/packages/messaging/tests/Unit/MessagingAccessPolicyTest.php
@@ -109,7 +109,7 @@ final class MessagingAccessPolicyTest extends TestCase
     {
         $captured = ['thread_id' => null, 'user_id' => null];
 
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('condition')->willReturnCallback(
@@ -126,10 +126,10 @@ final class MessagingAccessPolicyTest extends TestCase
             },
         );
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('getStorage')->willReturn($storage);
         // C-22: the query builder now lives on the repository.
         $etm->method('getRepository')->willReturn(new QueryOnlyStubRepository($query));
@@ -139,7 +139,7 @@ final class MessagingAccessPolicyTest extends TestCase
 
     private function threadMessage(int $threadId): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('thread_message');
         $entity->method('bundle')->willReturn('');
         $entity->method('get')->willReturnCallback(
@@ -151,7 +151,7 @@ final class MessagingAccessPolicyTest extends TestCase
 
     private function account(int $uid, bool $authenticated = true): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($uid);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn($authenticated);

--- a/packages/node/tests/Unit/NodeAccessPolicyTest.php
+++ b/packages/node/tests/Unit/NodeAccessPolicyTest.php
@@ -319,7 +319,7 @@ final class NodeAccessPolicyTest extends TestCase
      */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         // Account id 0 is the anonymous account (not authenticated).
         $account->method('isAuthenticated')->willReturn($id !== 0);

--- a/packages/node/tests/Unit/NodeFieldAccessPolicyTest.php
+++ b/packages/node/tests/Unit/NodeFieldAccessPolicyTest.php
@@ -49,7 +49,7 @@ final class NodeFieldAccessPolicyTest extends TestCase
     /** @param list<string> $permissions */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('isAuthenticated')->willReturn($id !== 0);
         $account->method('hasPermission')->willReturnCallback(

--- a/packages/node/tests/Unit/NodeRevisionStorageTest.php
+++ b/packages/node/tests/Unit/NodeRevisionStorageTest.php
@@ -54,7 +54,7 @@ final class NodeRevisionStorageTest extends TestCase
         $driver = new SqlStorageDriver($resolver, $this->nodeEntityType->getKeys()['id']);
         $revisionDriver = new RevisionableStorageDriver($resolver, $this->nodeEntityType);
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         $this->repo = \Waaseyaa\EntityStorage\Testing\V2EntityRepositoryFactory::createFromSqlStorageDriver(

--- a/packages/oauth-provider/tests/Provider/GitHubOAuthProviderTest.php
+++ b/packages/oauth-provider/tests/Provider/GitHubOAuthProviderTest.php
@@ -15,18 +15,32 @@ use Waaseyaa\OAuthProvider\UnsupportedOperationException;
 
 final class GitHubOAuthProviderTest extends TestCase
 {
-    private HttpClientInterface&MockObject $httpClient;
+    private HttpClientInterface $httpClient;
     private GitHubOAuthProvider $provider;
 
     protected function setUp(): void
     {
-        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->useHttpClient($this->createStub(HttpClientInterface::class));
+    }
+
+    private function useHttpClient(HttpClientInterface $httpClient): void
+    {
+        $this->httpClient = $httpClient;
         $this->provider = new GitHubOAuthProvider(
             clientId: 'gh-client-id',
             clientSecret: 'gh-client-secret',
             redirectUri: 'https://example.com/callback',
             httpClient: $this->httpClient,
         );
+    }
+
+    /** @return HttpClientInterface&MockObject */
+    private function mockHttpClient(): HttpClientInterface
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $this->useHttpClient($httpClient);
+
+        return $httpClient;
     }
 
     public function testGetName(): void
@@ -53,7 +67,7 @@ final class GitHubOAuthProviderTest extends TestCase
             'token_type'   => 'bearer',
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::once())
             ->method('post')
             ->with('https://github.com/login/oauth/access_token')
@@ -90,7 +104,7 @@ final class GitHubOAuthProviderTest extends TestCase
             ['email' => 'jonesrussell42@gmail.com', 'primary' => true, 'verified' => true],
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::exactly(2))
             ->method('get')
             ->willReturnOnConsecutiveCalls(
@@ -133,7 +147,7 @@ final class GitHubOAuthProviderTest extends TestCase
         $userBody = json_encode(['id' => 7, 'login' => 'noemail', 'name' => 'No Email']);
         $emailsErrorBody = json_encode(['message' => 'Requires user:email scope']);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::exactly(2))
             ->method('get')
             ->willReturnOnConsecutiveCalls(
@@ -161,7 +175,7 @@ final class GitHubOAuthProviderTest extends TestCase
             ['email' => 'ghost@example.com', 'primary' => true, 'verified' => true],
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::exactly(2))
             ->method('get')
             ->willReturnOnConsecutiveCalls(

--- a/packages/oauth-provider/tests/Provider/GoogleOAuthProviderTest.php
+++ b/packages/oauth-provider/tests/Provider/GoogleOAuthProviderTest.php
@@ -14,18 +14,32 @@ use Waaseyaa\OAuthProvider\Provider\GoogleOAuthProvider;
 
 final class GoogleOAuthProviderTest extends TestCase
 {
-    private HttpClientInterface&MockObject $httpClient;
+    private HttpClientInterface $httpClient;
     private GoogleOAuthProvider $provider;
 
     protected function setUp(): void
     {
-        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->useHttpClient($this->createStub(HttpClientInterface::class));
+    }
+
+    private function useHttpClient(HttpClientInterface $httpClient): void
+    {
+        $this->httpClient = $httpClient;
         $this->provider = new GoogleOAuthProvider(
             clientId: 'test-client-id',
             clientSecret: 'test-client-secret',
             redirectUri: 'https://example.com/callback',
             httpClient: $this->httpClient,
         );
+    }
+
+    /** @return HttpClientInterface&MockObject */
+    private function mockHttpClient(): HttpClientInterface
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $this->useHttpClient($httpClient);
+
+        return $httpClient;
     }
 
     public function testGetName(): void
@@ -57,7 +71,7 @@ final class GoogleOAuthProviderTest extends TestCase
             'token_type'    => 'Bearer',
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::once())
             ->method('post')
             ->with('https://oauth2.googleapis.com/token')
@@ -79,7 +93,7 @@ final class GoogleOAuthProviderTest extends TestCase
             'error_description' => 'Code was already redeemed.',
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::once())
             ->method('post')
             ->willReturn(new HttpResponse(401, (string) $responseBody));
@@ -99,7 +113,7 @@ final class GoogleOAuthProviderTest extends TestCase
             'token_type'   => 'Bearer',
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::once())
             ->method('post')
             ->with('https://oauth2.googleapis.com/token')
@@ -122,7 +136,7 @@ final class GoogleOAuthProviderTest extends TestCase
             'picture'        => 'https://lh3.googleusercontent.com/photo.jpg',
         ]);
 
-        $this->httpClient
+        $this->mockHttpClient()
             ->expects(self::once())
             ->method('get')
             ->with('https://www.googleapis.com/oauth2/v2/userinfo')

--- a/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
+++ b/packages/oidc/tests/Integration/Userinfo/UserinfoControllerTest.php
@@ -168,7 +168,7 @@ final class UserinfoControllerTest extends TestCase
         $pair = $this->issueToken();
         $this->accessTokenIssuer->revoke($pair->jti, new DateTimeImmutable('@2000000100'));
 
-        $response = ($this->controller())($this->bearerRequest($pair->token));
+        $response = ($this->controller(expectRepositoryLookup: false))($this->bearerRequest($pair->token));
 
         self::assertSame(401, $response->getStatusCode());
         self::assertSame('invalid_token', $this->jsonError($response));
@@ -186,7 +186,7 @@ final class UserinfoControllerTest extends TestCase
             $past,
         );
 
-        $response = ($this->controller())($this->bearerRequest($pair->token));
+        $response = ($this->controller(expectRepositoryLookup: false))($this->bearerRequest($pair->token));
 
         self::assertSame(401, $response->getStatusCode());
         self::assertSame('invalid_token', $this->jsonError($response));
@@ -195,7 +195,7 @@ final class UserinfoControllerTest extends TestCase
     #[Test]
     public function garbageBearerReturns401(): void
     {
-        $response = ($this->controller())($this->bearerRequest('not-a-real-token-value'));
+        $response = ($this->controller(expectRepositoryLookup: false))($this->bearerRequest('not-a-real-token-value'));
 
         self::assertSame(401, $response->getStatusCode());
         self::assertSame('invalid_token', $this->jsonError($response));
@@ -204,7 +204,7 @@ final class UserinfoControllerTest extends TestCase
     #[Test]
     public function missingAuthorizationHeaderReturns401(): void
     {
-        $response = ($this->controller())(Request::create('/oidc/userinfo', 'GET'));
+        $response = ($this->controller(expectRepositoryLookup: false))(Request::create('/oidc/userinfo', 'GET'));
 
         self::assertSame(401, $response->getStatusCode());
         self::assertSame('invalid_token', $this->jsonError($response));
@@ -220,11 +220,11 @@ final class UserinfoControllerTest extends TestCase
         );
     }
 
-    private function controller(bool $admin = false, bool $profileAccess = true): UserinfoController
+    private function controller(bool $admin = false, bool $profileAccess = true, bool $expectRepositoryLookup = true): UserinfoController
     {
         $entityTypeManager = $this->createMock(EntityTypeManager::class);
-        $entityTypeManager->method('getRepository')->with('user')->willReturn($this->userRepository);
-        $principalFactory = $this->createMock(AccountPrincipalFactoryInterface::class);
+        $entityTypeManager->expects($expectRepositoryLookup ? self::once() : self::never())->method('getRepository')->with('user')->willReturn($this->userRepository);
+        $principalFactory = $this->createStub(AccountPrincipalFactoryInterface::class);
         $principalFactory->method('fromAccount')->willReturn(new AuthorizationPrincipal(
             accountId: self::ACCOUNT_ID,
             authenticated: true,

--- a/packages/oidc/tests/Unit/Access/OidcClientAccessPolicyTest.php
+++ b/packages/oidc/tests/Unit/Access/OidcClientAccessPolicyTest.php
@@ -168,7 +168,7 @@ final class OidcClientAccessPolicyTest extends TestCase
 
     private function admin(): AccountInterface
     {
-        $mock = $this->createMock(AccountInterface::class);
+        $mock = $this->createStub(AccountInterface::class);
         $mock->method('hasPermission')
             ->willReturnCallback(fn(string $p): bool => $p === 'administer oidc clients');
         $mock->method('id')->willReturn(1);
@@ -177,7 +177,7 @@ final class OidcClientAccessPolicyTest extends TestCase
 
     private function nonAdmin(): AccountInterface
     {
-        $mock = $this->createMock(AccountInterface::class);
+        $mock = $this->createStub(AccountInterface::class);
         $mock->method('hasPermission')->willReturn(false);
         $mock->method('id')->willReturn(2);
         return $mock;
@@ -185,7 +185,7 @@ final class OidcClientAccessPolicyTest extends TestCase
 
     private function anonymous(): AccountInterface
     {
-        $mock = $this->createMock(AccountInterface::class);
+        $mock = $this->createStub(AccountInterface::class);
         $mock->method('hasPermission')->willReturn(false);
         $mock->method('id')->willReturn(0);
         $mock->method('isAuthenticated')->willReturn(false);

--- a/packages/oidc/tests/Unit/Consent/ConsentScreenControllerTest.php
+++ b/packages/oidc/tests/Unit/Consent/ConsentScreenControllerTest.php
@@ -135,7 +135,7 @@ final class ConsentScreenControllerTest extends TestCase
         $session->set(AuthorizeController::SESSION_KEY, self::PENDING);
         $request->setSession($session);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(true);
         $account->method('id')->willReturn(5);
         $request->attributes->set('_account', $account);

--- a/packages/path/tests/Unit/PathAliasResolverTest.php
+++ b/packages/path/tests/Unit/PathAliasResolverTest.php
@@ -27,7 +27,7 @@ final class PathAliasResolverTest extends TestCase
             'status' => true,
         ]);
 
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
@@ -35,7 +35,7 @@ final class PathAliasResolverTest extends TestCase
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
-        $repository->method('find')->with('10')->willReturn($alias);
+        $repository->expects(self::once())->method('find')->with('10')->willReturn($alias);
 
         $resolver = new PathAliasResolver($repository);
         $resolved = $resolver->resolve('/teaching/water-is-life');
@@ -48,13 +48,13 @@ final class PathAliasResolverTest extends TestCase
     #[Test]
     public function returns_null_when_alias_not_found(): void
     {
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([]);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
 
         $resolver = new PathAliasResolver($repository);
@@ -65,7 +65,7 @@ final class PathAliasResolverTest extends TestCase
     public function normalizesTrailingSlashWhilePreservingLanguageScope(): void
     {
         $conditions = [];
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnCallback(
             function (string $field, mixed $value) use (&$conditions, $query): EntityQueryInterface {
@@ -76,7 +76,7 @@ final class PathAliasResolverTest extends TestCase
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([]);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
 
         new PathAliasResolver($repository)->resolve('/about/', 'oj');

--- a/packages/plugin/tests/Unit/DefaultPluginManagerTest.php
+++ b/packages/plugin/tests/Unit/DefaultPluginManagerTest.php
@@ -118,7 +118,7 @@ final class DefaultPluginManagerTest extends TestCase
     public function testCachingWorks(): void
     {
         $callCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$callCount) {
                 $callCount++;
@@ -150,7 +150,7 @@ final class DefaultPluginManagerTest extends TestCase
     public function testClearCachedDefinitions(): void
     {
         $callCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$callCount) {
                 $callCount++;
@@ -179,7 +179,7 @@ final class DefaultPluginManagerTest extends TestCase
     public function testDefinitionsAreMemoized(): void
     {
         $callCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$callCount) {
                 $callCount++;

--- a/packages/queue/tests/Unit/MessageBusQueueTest.php
+++ b/packages/queue/tests/Unit/MessageBusQueueTest.php
@@ -16,7 +16,7 @@ final class MessageBusQueueTest extends TestCase
 {
     public function testImplementsQueueInterface(): void
     {
-        $bus = $this->createMock(MessageBusInterface::class);
+        $bus = $this->createStub(MessageBusInterface::class);
         $bus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
         $queue = new MessageBusQueue($bus);
 

--- a/packages/queue/tests/Unit/SyncQueueTest.php
+++ b/packages/queue/tests/Unit/SyncQueueTest.php
@@ -123,7 +123,7 @@ final class SyncQueueTest extends TestCase
     {
         $handledCount = 0;
 
-        $handler = $this->createMock(HandlerInterface::class);
+        $handler = $this->createStub(HandlerInterface::class);
         $handler->method('supports')->willReturn(true);
         $handler->method('handle')->willReturnCallback(
             function () use (&$handledCount): void {
@@ -154,7 +154,7 @@ final class SyncQueueTest extends TestCase
     {
         $handledCount = 0;
 
-        $handler = $this->createMock(HandlerInterface::class);
+        $handler = $this->createStub(HandlerInterface::class);
         $handler->method('supports')->willReturn(true);
         $handler->method('handle')->willReturnCallback(
             function () use (&$handledCount): void {
@@ -182,7 +182,7 @@ final class SyncQueueTest extends TestCase
     {
         $handledCount = 0;
 
-        $handler = $this->createMock(HandlerInterface::class);
+        $handler = $this->createStub(HandlerInterface::class);
         $handler->method('supports')->willReturn(true);
         $handler->method('handle')->willReturnCallback(
             function () use (&$handledCount): void {

--- a/packages/relationship/tests/Unit/RelationshipEndpointVisibilityPolicyTest.php
+++ b/packages/relationship/tests/Unit/RelationshipEndpointVisibilityPolicyTest.php
@@ -50,16 +50,16 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
      */
     private function policy(bool $knownType = true, ?\Closure $endpointLoader = null): array
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         if ($endpointLoader !== null) {
             $repository->method('find')->willReturnCallback($endpointLoader);
         }
 
-        $etm = $this->createMock(EntityTypeManagerInterface::class);
+        $etm = $this->createStub(EntityTypeManagerInterface::class);
         $etm->method('hasDefinition')->willReturn($knownType);
         $etm->method('getRepository')->willReturn($repository);
 
-        $handler = $this->createMock(EntityAccessHandler::class);
+        $handler = $this->createStub(EntityAccessHandler::class);
 
         return [new RelationshipEndpointVisibilityPolicy($etm, $handler), $handler];
     }
@@ -85,7 +85,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
     #[Test]
     public function entity_view_is_forbidden_when_both_endpoints_are_hidden(): void
     {
-        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createMock(\Waaseyaa\Entity\EntityInterface::class));
+        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createStub(\Waaseyaa\Entity\EntityInterface::class));
         $handler->method('check')->willReturn(AccessResult::forbidden('hidden'));
         $account = new ArrayAccount(0, ['access content']);
         $edge = $this->edge();
@@ -99,7 +99,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
     #[Test]
     public function entity_view_stays_neutral_when_an_endpoint_is_viewable(): void
     {
-        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createMock(\Waaseyaa\Entity\EntityInterface::class));
+        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createStub(\Waaseyaa\Entity\EntityInterface::class));
         $handler->method('check')->willReturnOnConsecutiveCalls(
             AccessResult::allowed('visible'),
             AccessResult::forbidden('hidden'),
@@ -111,7 +111,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
     #[Test]
     public function to_endpoint_fields_are_forbidden_when_endpoint_is_not_viewable(): void
     {
-        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createMock(\Waaseyaa\Entity\EntityInterface::class));
+        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createStub(\Waaseyaa\Entity\EntityInterface::class));
         $handler->method('check')->willReturn(AccessResult::forbidden('hidden'));
 
         $account = new ArrayAccount(0, ['access content']);
@@ -124,7 +124,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
     #[Test]
     public function to_endpoint_fields_are_neutral_when_endpoint_is_viewable(): void
     {
-        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createMock(\Waaseyaa\Entity\EntityInterface::class));
+        [$policy, $handler] = $this->policy(endpointLoader: fn(string $id) => $this->createStub(\Waaseyaa\Entity\EntityInterface::class));
         $handler->method('check')->willReturn(AccessResult::allowed('visible'));
 
         $account = new ArrayAccount(0, ['access content']);
@@ -138,7 +138,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
     public function from_endpoint_fields_are_independently_gated(): void
     {
         [$policy, $handler] = $this->policy(
-            endpointLoader: fn(string $id) => $this->createMock(\Waaseyaa\Entity\EntityInterface::class),
+            endpointLoader: fn(string $id) => $this->createStub(\Waaseyaa\Entity\EntityInterface::class),
         );
         // 'from' endpoint forbidden, but the check is invoked per-field — this
         // handler always returns forbidden, so both directions independently
@@ -181,7 +181,7 @@ final class RelationshipEndpointVisibilityPolicyTest extends TestCase
         [$policy] = $this->policy();
         $account = new ArrayAccount(0, ['access content']);
 
-        $notARelationship = $this->createMock(\Waaseyaa\Entity\EntityInterface::class);
+        $notARelationship = $this->createStub(\Waaseyaa\Entity\EntityInterface::class);
 
         self::assertTrue($policy->fieldAccess($notARelationship, 'to_entity_type', 'view', $account)->isNeutral());
     }

--- a/packages/routing/tests/Unit/AccessCheckerTest.php
+++ b/packages/routing/tests/Unit/AccessCheckerTest.php
@@ -28,7 +28,7 @@ final class AccessCheckerTest extends TestCase
     public function noRequirementsReturnsNeutral(): void
     {
         $route = new Route('/test');
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $result = $this->checker->check($route, $account);
 
@@ -42,7 +42,7 @@ final class AccessCheckerTest extends TestCase
     {
         $route = new Route('/test');
         $route->setOption('_public', true);
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $result = $this->checker->check($route, $account);
 
@@ -58,7 +58,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_permission', 'administer site');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(true);
 
@@ -74,7 +74,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_permission', 'administer site');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(false);
 
@@ -91,7 +91,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin');
         $route->setOption('_role', 'administrator');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')
             ->willReturn(['authenticated', 'administrator']);
 
@@ -106,7 +106,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin/operations');
         $route->setOption('_role', 'admin');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')->willReturn(['administrator']);
 
         $this->assertTrue($this->checker->check($route, $account)->isAllowed());
@@ -118,7 +118,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin/superuser');
         $route->setOption('_role', 'administrator');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')->willReturn(['admin']);
 
         $this->assertTrue($this->checker->check($route, $account)->isForbidden());
@@ -130,7 +130,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin');
         $route->setOption('_role', 'administrator');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')
             ->willReturn(['authenticated']);
 
@@ -145,7 +145,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin');
         $route->setOption('_role', 'administrator, editor');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')
             ->willReturn(['authenticated', 'editor']);
 
@@ -160,7 +160,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/admin');
         $route->setOption('_role', 'administrator, editor');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('getRoles')
             ->willReturn(['authenticated']);
 
@@ -177,7 +177,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/api/node');
         $route->setOption('_authenticated', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(true);
 
         $result = $this->checker->check($route, $account);
@@ -191,7 +191,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/api/node');
         $route->setOption('_authenticated', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
 
         $result = $this->checker->check($route, $account);
@@ -226,7 +226,7 @@ final class AccessCheckerTest extends TestCase
 
         $account = $this->createMock(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(true);
-        $account->method('hasPermission')->with('access content')->willReturn(true);
+        $account->expects(self::once())->method('hasPermission')->with('access content')->willReturn(true);
 
         $result = $this->checker->check($route, $account);
 
@@ -243,7 +243,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_role', 'administrator');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(true);
         $account->method('getRoles')
@@ -262,7 +262,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_role', 'administrator');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(true);
         $account->method('getRoles')
@@ -281,7 +281,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_role', 'administrator');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(false);
         $account->method('getRoles')
@@ -302,7 +302,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_public', true);
         $route->setOption('_authenticated', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
 
         $result = $this->checker->check($route, $account);
@@ -317,7 +317,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_public', true);
         $route->setOption('_authenticated', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('isAuthenticated')->willReturn(true);
 
         $result = $this->checker->check($route, $account);
@@ -333,7 +333,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_permission', 'administer site');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(true);
 
@@ -350,7 +350,7 @@ final class AccessCheckerTest extends TestCase
         $route->setOption('_permission', 'administer site');
 
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('administer site')
             ->willReturn(false);
 
@@ -371,7 +371,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/chat');
         $route->setOption('_session', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $this->checker->check($route, $account);
 
         $this->assertTrue($result->isAllowed());
@@ -388,7 +388,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/chat');
         $route->setOption('_session', ['nickname']);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $this->checker->check($route, $account);
 
         $this->assertTrue($result->isAllowed());
@@ -407,7 +407,7 @@ final class AccessCheckerTest extends TestCase
         $route = new Route('/chat');
         $route->setOption('_session', ['nickname']);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $this->checker->check($route, $account);
 
         $this->assertTrue($result->isForbidden());

--- a/packages/routing/tests/Unit/EntityParamConverterTest.php
+++ b/packages/routing/tests/Unit/EntityParamConverterTest.php
@@ -20,7 +20,7 @@ final class EntityParamConverterTest extends TestCase
     #[Test]
     public function convertLoadsEntityAndReplacesParameter(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->expects($this->once())
@@ -154,8 +154,8 @@ final class EntityParamConverterTest extends TestCase
     #[Test]
     public function convertHandlesMultipleEntityParameters(): void
     {
-        $nodeEntity = $this->createMock(EntityInterface::class);
-        $userEntity = $this->createMock(EntityInterface::class);
+        $nodeEntity = $this->createStub(EntityInterface::class);
+        $userEntity = $this->createStub(EntityInterface::class);
 
         $nodeRepository = $this->createMock(EntityRepositoryInterface::class);
         $nodeRepository->expects($this->once())
@@ -197,7 +197,7 @@ final class EntityParamConverterTest extends TestCase
     #[Test]
     public function convertHandlesMixedEntityAndNonEntityParameters(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
         $repository->expects($this->once())

--- a/packages/routing/tests/Unit/GateAccessTest.php
+++ b/packages/routing/tests/Unit/GateAccessTest.php
@@ -92,10 +92,10 @@ final class GateAccessTest extends TestCase
     #[Test]
     public function gateAllowsReturnsAllowed(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(true);
 
@@ -112,10 +112,10 @@ final class GateAccessTest extends TestCase
     #[Test]
     public function gateDeniesReturnsForbidden(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(false);
 
@@ -138,7 +138,7 @@ final class GateAccessTest extends TestCase
         $route = new Route('/api/config/export');
         AccessChecker::applyGateToRoute($route, 'config.export');
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $checker->check($route, $account);
 
         $this->assertTrue($result->isForbidden());
@@ -148,12 +148,12 @@ final class GateAccessTest extends TestCase
     public function gateCombinedWithPermissionBothPassReturnsAllowed(): void
     {
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('access config')
             ->willReturn(true);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(true);
 
@@ -172,12 +172,12 @@ final class GateAccessTest extends TestCase
     public function gateCombinedWithPermissionGateFailsReturnsForbidden(): void
     {
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('access config')
             ->willReturn(true);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(false);
 
@@ -197,12 +197,12 @@ final class GateAccessTest extends TestCase
     public function gateCombinedWithPermissionPermissionFailsReturnsForbidden(): void
     {
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')
+        $account->expects(self::once())->method('hasPermission')
             ->with('access config')
             ->willReturn(false);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(true);
 
@@ -229,7 +229,7 @@ final class GateAccessTest extends TestCase
         $route = new Route('/test');
         $route->setOption('_public', true);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $checker->check($route, $account);
 
         $this->assertTrue($result->isAllowed());
@@ -246,7 +246,7 @@ final class GateAccessTest extends TestCase
         $route = new Route('/api/config/export');
         $route->setOption('_gate', ['ability' => '', 'subject' => null]);
 
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $result = $checker->check($route, $account);
 
         $this->assertTrue($result->isForbidden());
@@ -255,7 +255,7 @@ final class GateAccessTest extends TestCase
     #[Test]
     public function gatePassesSubjectToGateCheck(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $gate = $this->createMock(GateInterface::class);
         $gate->expects($this->once())

--- a/packages/routing/tests/Unit/RouteBuilderGateTest.php
+++ b/packages/routing/tests/Unit/RouteBuilderGateTest.php
@@ -68,10 +68,10 @@ final class RouteBuilderGateTest extends TestCase
     public function routeBuilderGateEnforcedByAccessCheckerDeniesWithoutAbility(): void
     {
         // Account that does NOT have the gate ability.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(false);
 
@@ -93,10 +93,10 @@ final class RouteBuilderGateTest extends TestCase
     public function routeBuilderGateEnforcedByAccessCheckerAllowsWithAbility(): void
     {
         // Account that DOES have the gate ability.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $gate = $this->createMock(GateInterface::class);
-        $gate->method('allows')
+        $gate->expects(self::once())->method('allows')
             ->with('config.export', null, $account)
             ->willReturn(true);
 

--- a/packages/seo/tests/Unit/Llms/LlmsTxtGeneratorTest.php
+++ b/packages/seo/tests/Unit/Llms/LlmsTxtGeneratorTest.php
@@ -257,13 +257,13 @@ final class LlmsTxtGeneratorTest extends TestCase
         $query->method('execute')->willReturn([1]);
         $query->expects(self::once())->method('condition')->with('status', 1)->willReturnSelf();
 
-        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage = $this->createStub(EntityStorageInterface::class);
         $storage->method('getQuery')->willReturn($query);
 
         $def = $this->createStub(\Waaseyaa\Entity\EntityTypeInterface::class);
         $def->method('getFieldDefinitions')->willReturn(['status' => true, 'title' => true]);
 
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinitions')->willReturn(['node' => $def]);
         $manager->method('getStorage')->willReturn($storage);
         // C-22: the query builder now lives on the repository.
@@ -281,7 +281,7 @@ final class LlmsTxtGeneratorTest extends TestCase
      */
     private function managerWith(array $typeIds): EntityTypeManagerInterface
     {
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
 
         $definitions = [];
         foreach (array_keys($typeIds) as $type) {
@@ -290,19 +290,19 @@ final class LlmsTxtGeneratorTest extends TestCase
         $manager->method('getDefinitions')->willReturn($definitions);
 
         $manager->method('getStorage')->willReturnCallback(function (string $type) use ($typeIds): EntityStorageInterface {
-            $query = $this->createMock(EntityQueryInterface::class);
+            $query = $this->createStub(EntityQueryInterface::class);
             $query->method('accessCheck')->willReturnSelf();
             $query->method('range')->willReturnSelf();
             $query->method('execute')->willReturn($typeIds[$type] ?? []);
 
-            $storage = $this->createMock(EntityStorageInterface::class);
+            $storage = $this->createStub(EntityStorageInterface::class);
             $storage->method('getQuery')->willReturn($query);
 
             return $storage;
         });
         // C-22: the query builder now lives on the repository.
         $manager->method('getRepository')->willReturnCallback(function (string $type) use ($typeIds): EntityRepositoryInterface {
-            $query = $this->createMock(EntityQueryInterface::class);
+            $query = $this->createStub(EntityQueryInterface::class);
             $query->method('accessCheck')->willReturnSelf();
             $query->method('range')->willReturnSelf();
             $query->method('execute')->willReturn($typeIds[$type] ?? []);

--- a/packages/seo/tests/Unit/SchemaOrg/EntitySchemaOrgMapperTest.php
+++ b/packages/seo/tests/Unit/SchemaOrg/EntitySchemaOrgMapperTest.php
@@ -18,7 +18,7 @@ final class EntitySchemaOrgMapperTest extends TestCase
 {
     private function entity(string $type, string $bundle, string $label): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($type);
         $entity->method('bundle')->willReturn($bundle);
         $entity->method('label')->willReturn($label);

--- a/packages/ssr/tests/Unit/EntityRendererTest.php
+++ b/packages/ssr/tests/Unit/EntityRendererTest.php
@@ -39,7 +39,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $config = new ArrayViewModeConfig([
             'node' => [
@@ -90,7 +90,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $renderer = new EntityRenderer($manager, new FieldFormatterRegistry(), new ArrayViewModeConfig());
         $entity = new RendererTestEntity('node', [
@@ -125,7 +125,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         // Use empty view-mode config so the renderer falls through to buildDefaultDisplay(),
         // which includes every scalar value not in entityKeys. All three candidate fields
@@ -179,7 +179,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $config = new ArrayViewModeConfig([
             'node' => [
@@ -220,7 +220,7 @@ final class EntityRendererTest extends TestCase
             'title' => 'Public headline',
             'secret' => 'classified payload',
         ]);
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $bag = $renderer->render($entity, ViewMode::full(), $account);
 
@@ -249,7 +249,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $config = new ArrayViewModeConfig([
             'node' => [
@@ -271,7 +271,7 @@ final class EntityRendererTest extends TestCase
             'title' => 'Hello',
             'body' => 'World',
         ]);
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $bag = $renderer->render($entity, ViewMode::full(), $account);
 
@@ -301,7 +301,7 @@ final class EntityRendererTest extends TestCase
         );
 
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getDefinition')->with('node')->willReturn($definition);
+        $manager->expects(self::once())->method('getDefinition')->with('node')->willReturn($definition);
 
         $config = new ArrayViewModeConfig([
             'node' => [
@@ -313,7 +313,7 @@ final class EntityRendererTest extends TestCase
 
         $renderer = new EntityRenderer($manager, new FieldFormatterRegistry(), $config);
         $entity = new RendererTestEntity('node', ['id' => 1, 'title' => 'Hello']);
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
 
         $bag = $renderer->render($entity, ViewMode::full(), $account);
 

--- a/packages/ssr/tests/Unit/EntityTemplateHeadTest.php
+++ b/packages/ssr/tests/Unit/EntityTemplateHeadTest.php
@@ -27,7 +27,7 @@ final class EntityTemplateHeadTest extends TestCase
 
     private function entity(): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('label')->willReturn('Hello World');
 
         return $entity;

--- a/packages/ssr/tests/Unit/Http/AppController/AppControllerMethodInvokerTest.php
+++ b/packages/ssr/tests/Unit/Http/AppController/AppControllerMethodInvokerTest.php
@@ -57,9 +57,9 @@ final class AppControllerMethodInvokerTest extends TestCase
     {
         $entity = new BoundFixtureEntity();
         $repository = $this->createMock(EntityRepositoryInterface::class);
-        $repository->method('find')->with('7')->willReturn($entity);
+        $repository->expects(self::once())->method('find')->with('7')->willReturn($entity);
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getRepository')->with('bound_fixture')->willReturn($repository);
+        $manager->expects(self::once())->method('getRepository')->with('bound_fixture')->willReturn($repository);
         $gate = $this->createMock(GateInterface::class);
         $gate->expects(self::once())->method('allows')->with(GateInterface::VIEW, $entity, self::isInstanceOf(AnonymousUser::class))->willReturn(false);
 
@@ -118,7 +118,7 @@ final class AppControllerMethodInvokerTest extends TestCase
                 return $className === CustomMethodService::class ? $this->service : null;
             }
         };
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $route = RouteBuilder::create('/fixture')->build();
         $context = $this->context($route, $manager, null, [], $resolver);
 

--- a/packages/ssr/tests/Unit/RenderControllerTest.php
+++ b/packages/ssr/tests/Unit/RenderControllerTest.php
@@ -223,7 +223,7 @@ final class RenderControllerTest extends TestCase
             label: 'Node',
             fieldDefinitions: ['title' => ['type' => 'string']],
         );
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinition')->willReturn($definition);
 
         $renderer = new EntityRenderer($manager, new FieldFormatterRegistry(), new ArrayViewModeConfig([
@@ -258,7 +258,7 @@ final class RenderControllerTest extends TestCase
             label: 'Node',
             fieldDefinitions: ['title' => ['type' => 'string']],
         );
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinition')->willReturn($definition);
 
         $renderer = new EntityRenderer($manager, new FieldFormatterRegistry(), new ArrayViewModeConfig([
@@ -297,7 +297,7 @@ final class RenderControllerTest extends TestCase
             label: 'Node',
             fieldDefinitions: ['title' => ['type' => 'string']],
         );
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getDefinition')->willReturn($definition);
 
         $renderer = new EntityRenderer($manager, new FieldFormatterRegistry(), new ArrayViewModeConfig([

--- a/packages/ssr/tests/Unit/SsrContentPublishedGateTest.php
+++ b/packages/ssr/tests/Unit/SsrContentPublishedGateTest.php
@@ -123,7 +123,7 @@ final class SsrContentPublishedGateTest extends TestCase
      */
     private function entity(string $entityTypeId, mixed $status): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn($entityTypeId);
         $entity->method('bundle')->willReturn('');
         $entity->method('get')->willReturnCallback(
@@ -135,7 +135,7 @@ final class SsrContentPublishedGateTest extends TestCase
 
     private function anon(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturn(false);
 

--- a/packages/ssr/tests/Unit/SsrEntityHtmlAccessTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityHtmlAccessTest.php
@@ -163,7 +163,7 @@ final class SsrEntityHtmlAccessTest extends TestCase
     #[Test]
     public function html_omits_a_field_restricted_for_the_viewing_account(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $accessHandler = $this->forbidSecretNoteHandler();
         $handler = $this->handler($accessHandler, $this->entityTypeManager());
 
@@ -181,7 +181,7 @@ final class SsrEntityHtmlAccessTest extends TestCase
     {
         // Positive regression: enforcing field access must not over-filter a
         // viewable entity with no restricted fields.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $accessHandler = new EntityAccessHandler([]);
         $handler = $this->handler($accessHandler, $this->entityTypeManager());
 
@@ -201,7 +201,7 @@ final class SsrEntityHtmlAccessTest extends TestCase
         // getAccessHandler(), so this branch is not reachable in production.
         // A direct/test construction of SsrPageHandler without one must
         // refuse to render rather than serve unfiltered content.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = $this->handler(null, $this->entityTypeManager());
 
         $response = $this->renderHtml($handler, $this->sampleEntity(), $account, null, $this->entityTypeManager());

--- a/packages/ssr/tests/Unit/SsrEntityLabelAccessTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityLabelAccessTest.php
@@ -107,7 +107,7 @@ final class SsrEntityLabelAccessTest extends TestCase
 
     private function anonWithAccessContent(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $permission): bool => $permission === 'access content',

--- a/packages/ssr/tests/Unit/SsrEntityMarkdownAccessTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityMarkdownAccessTest.php
@@ -136,7 +136,7 @@ final class SsrEntityMarkdownAccessTest extends TestCase
     #[Test]
     public function markdown_omits_a_field_restricted_for_the_viewing_account(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = $this->handler($this->forbidSecretNoteHandler(), $this->entityTypeManager());
 
         $response = $this->renderMarkdown($handler, $this->sampleEntity(), $account);
@@ -156,7 +156,7 @@ final class SsrEntityMarkdownAccessTest extends TestCase
         // getAccessHandler(), so this branch is not reachable in production.
         // A direct/test construction of SsrPageHandler without one must
         // refuse to render rather than call the presenter with a bypass.
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $handler = $this->handler(null, $this->entityTypeManager());
 
         $response = $this->renderMarkdown($handler, $this->sampleEntity(), $account);

--- a/packages/ssr/tests/Unit/SsrEntityPageCompositionTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityPageCompositionTest.php
@@ -632,7 +632,7 @@ final class SsrEntityPageCompositionTest extends TestCase
 
     private function anonymous(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturn(false);
 

--- a/packages/ssr/tests/Unit/SsrEntityViewGateAllTypesTest.php
+++ b/packages/ssr/tests/Unit/SsrEntityViewGateAllTypesTest.php
@@ -142,7 +142,7 @@ final class SsrEntityViewGateAllTypesTest extends TestCase
 
     private function anon(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturn(false);
 

--- a/packages/ssr/tests/Unit/SsrNodeViewAccessGateTest.php
+++ b/packages/ssr/tests/Unit/SsrNodeViewAccessGateTest.php
@@ -113,7 +113,7 @@ final class SsrNodeViewAccessGateTest extends TestCase
 
     private function anon(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturn(false);
 
@@ -122,7 +122,7 @@ final class SsrNodeViewAccessGateTest extends TestCase
 
     private function anonWithAccessContent(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $permission): bool => $permission === 'access content',

--- a/packages/ssr/tests/Unit/SsrRelationshipNavAccessTest.php
+++ b/packages/ssr/tests/Unit/SsrRelationshipNavAccessTest.php
@@ -163,7 +163,7 @@ final class SsrRelationshipNavAccessTest extends TestCase
 
     private function anon(): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('isAuthenticated')->willReturn(false);
         $account->method('hasPermission')->willReturn(false);
 

--- a/packages/ssr/tests/Unit/Twig/WaaseyaaExtensionTest.php
+++ b/packages/ssr/tests/Unit/Twig/WaaseyaaExtensionTest.php
@@ -148,7 +148,7 @@ final class WaaseyaaExtensionTest extends TestCase
     #[Test]
     public function extension_registers_config_function_when_factory_is_provided(): void
     {
-        $factory = $this->createMock(ConfigFactoryInterface::class);
+        $factory = $this->createStub(ConfigFactoryInterface::class);
         $extension = new WaaseyaaExtension(configFactory: $factory);
         $names = array_map(fn($f) => $f->getName(), $extension->getFunctions());
 
@@ -184,10 +184,10 @@ final class WaaseyaaExtensionTest extends TestCase
     private function createMockConfigFactory(string $configName, string $key, mixed $value): ConfigFactoryInterface
     {
         $config = $this->createMock(ConfigInterface::class);
-        $config->method('get')->with($key)->willReturn($value);
+        $config->expects(self::once())->method('get')->with($key)->willReturn($value);
 
         $factory = $this->createMock(ConfigFactoryInterface::class);
-        $factory->method('get')->with($configName)->willReturn($config);
+        $factory->expects(self::once())->method('get')->with($configName)->willReturn($config);
 
         return $factory;
     }

--- a/packages/structured-import/tests/Unit/StructuredImportServiceProviderTest.php
+++ b/packages/structured-import/tests/Unit/StructuredImportServiceProviderTest.php
@@ -26,7 +26,7 @@ final class StructuredImportServiceProviderTest extends TestCase
         $provider->setKernelContext('', [], []);
         $provider->setKernelServices($this->kernelServicesProviding(
             FieldDefinitionRegistryInterface::class,
-            $this->createMock(FieldDefinitionRegistryInterface::class),
+            $this->createStub(FieldDefinitionRegistryInterface::class),
         ));
         $provider->register();
 

--- a/packages/taxonomy/tests/Unit/TermAccessPolicyTest.php
+++ b/packages/taxonomy/tests/Unit/TermAccessPolicyTest.php
@@ -29,7 +29,7 @@ class TermAccessPolicyTest extends TestCase
 
     private function createAccount(array $permissions = []): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')
             ->willReturnCallback(fn(string $permission) => \in_array($permission, $permissions, true));
 
@@ -38,7 +38,7 @@ class TermAccessPolicyTest extends TestCase
 
     private function createTermEntity(string $vocabularyId = 'tags', ?bool $published = null): EntityInterface
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('taxonomy_term');
         $entity->method('bundle')->willReturn($vocabularyId);
         // NOTE: $published defaults to null (absent/undetermined status), NOT

--- a/packages/taxonomy/tests/Unit/VocabularyAccessPolicyTest.php
+++ b/packages/taxonomy/tests/Unit/VocabularyAccessPolicyTest.php
@@ -25,7 +25,7 @@ final class VocabularyAccessPolicyTest extends TestCase
             ->with(['vid' => 'topics'], null, 1)
             ->willReturn([$this->createStub(\Waaseyaa\Entity\EntityInterface::class)]);
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getRepository')->with('taxonomy_term')->willReturn($repository);
+        $manager->expects(self::once())->method('getRepository')->with('taxonomy_term')->willReturn($repository);
 
         $result = (new VocabularyAccessPolicy($manager))->access(
             new Vocabulary(['vid' => 'topics', 'name' => 'Topics']),
@@ -40,9 +40,9 @@ final class VocabularyAccessPolicyTest extends TestCase
     #[Test]
     public function emptyVocabularyLeavesTheAdministratorGrantUnchanged(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('findBy')->willReturn([]);
-        $manager = $this->createMock(EntityTypeManagerInterface::class);
+        $manager = $this->createStub(EntityTypeManagerInterface::class);
         $manager->method('getRepository')->willReturn($repository);
 
         $result = (new VocabularyAccessPolicy($manager))->access(

--- a/packages/user/tests/Unit/Middleware/SessionMiddlewareStatelessPathsTest.php
+++ b/packages/user/tests/Unit/Middleware/SessionMiddlewareStatelessPathsTest.php
@@ -29,7 +29,7 @@ final class SessionMiddlewareStatelessPathsTest extends TestCase
 {
     private function middleware(array $statelessPaths): SessionMiddleware
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
 
         return new SessionMiddleware(
             $repository,

--- a/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
+++ b/packages/user/tests/Unit/Middleware/SessionMiddlewareTest.php
@@ -273,7 +273,7 @@ final class SessionMiddlewareTest extends TestCase
     #[Test]
     public function passes_response_from_next_handler(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $middleware = new SessionMiddleware($repository);
         $request = Request::create('/test');
 
@@ -320,7 +320,7 @@ final class SessionMiddlewareTest extends TestCase
     #[Test]
     public function attaches_native_session_to_request(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $middleware = new SessionMiddleware($repository);
         $request = Request::create('/test');
 
@@ -343,7 +343,7 @@ final class SessionMiddlewareTest extends TestCase
     #[Test]
     public function does_not_replace_existing_session(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $middleware = new SessionMiddleware($repository);
         $request = Request::create('/test');
 
@@ -483,7 +483,7 @@ final class SessionMiddlewareTest extends TestCase
     #[RunInSeparateProcess]
     public function applies_session_cookie_ini_when_configured(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $keys = [
             'session.cookie_httponly',
             'session.cookie_secure',
@@ -526,7 +526,7 @@ final class SessionMiddlewareTest extends TestCase
     #[RunInSeparateProcess]
     public function secure_auto_rejects_forwarded_proto_from_untrusted_ip(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $savedSecure = ini_get('session.cookie_secure');
         try {
             unset($_SERVER['HTTPS']);
@@ -553,7 +553,7 @@ final class SessionMiddlewareTest extends TestCase
     #[RunInSeparateProcess]
     public function secure_auto_respects_x_forwarded_proto(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $savedSecure = ini_get('session.cookie_secure');
         try {
             unset($_SERVER['HTTPS']);
@@ -580,7 +580,7 @@ final class SessionMiddlewareTest extends TestCase
     #[RunInSeparateProcess]
     public function applies_secure_session_cookie_defaults_when_unconfigured(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $keys = [
             'session.cookie_httponly',
             'session.cookie_samesite',
@@ -624,7 +624,7 @@ final class SessionMiddlewareTest extends TestCase
     #[RunInSeparateProcess]
     public function explicit_session_cookie_options_override_secure_defaults(): void
     {
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $keys = [
             'session.cookie_httponly',
             'session.cookie_samesite',

--- a/packages/user/tests/Unit/UserAccessPolicyTest.php
+++ b/packages/user/tests/Unit/UserAccessPolicyTest.php
@@ -327,7 +327,7 @@ final class UserAccessPolicyTest extends TestCase
     /** @param string[] $permissions */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('hasPermission')->willReturnCallback(
             fn(string $permission): bool => \in_array($permission, $permissions, true),

--- a/packages/user/tests/Unit/UserBlockAccessPolicyTest.php
+++ b/packages/user/tests/Unit/UserBlockAccessPolicyTest.php
@@ -32,9 +32,9 @@ final class UserBlockAccessPolicyTest extends TestCase
     public function admin_is_always_allowed(): void
     {
         $account = $this->createMock(AccountInterface::class);
-        $account->method('hasPermission')->with('administer content')->willReturn(true);
+        $account->expects(self::once())->method('hasPermission')->with('administer content')->willReturn(true);
 
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
 
         $result = $this->policy->access($entity, 'view', $account);
         $this->assertTrue($result->isAllowed());
@@ -43,12 +43,12 @@ final class UserBlockAccessPolicyTest extends TestCase
     #[Test]
     public function blocker_can_manage_own_blocks(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('id')->willReturn(42);
 
         $entity = $this->createMock(EntityInterface::class);
-        $entity->method('get')->with('blocker_id')->willReturn(42);
+        $entity->expects(self::once())->method('get')->with('blocker_id')->willReturn(42);
 
         $result = $this->policy->access($entity, 'delete', $account);
         $this->assertTrue($result->isAllowed());
@@ -57,12 +57,12 @@ final class UserBlockAccessPolicyTest extends TestCase
     #[Test]
     public function non_owner_is_neutral(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('id')->willReturn(99);
 
         $entity = $this->createMock(EntityInterface::class);
-        $entity->method('get')->with('blocker_id')->willReturn(42);
+        $entity->expects(self::once())->method('get')->with('blocker_id')->willReturn(42);
 
         $result = $this->policy->access($entity, 'view', $account);
         $this->assertTrue($result->isNeutral());
@@ -71,7 +71,7 @@ final class UserBlockAccessPolicyTest extends TestCase
     #[Test]
     public function authenticated_can_create(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(true);
 
@@ -82,7 +82,7 @@ final class UserBlockAccessPolicyTest extends TestCase
     #[Test]
     public function anonymous_cannot_create(): void
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('hasPermission')->willReturn(false);
         $account->method('isAuthenticated')->willReturn(false);
 

--- a/packages/user/tests/Unit/UserBlockServiceBindingTest.php
+++ b/packages/user/tests/Unit/UserBlockServiceBindingTest.php
@@ -34,7 +34,7 @@ final class UserBlockServiceBindingTest extends TestCase
         $repository->method('getQuery')->willReturn($query);
 
         $etm = $this->createMock(EntityTypeManager::class);
-        $etm->method('getRepository')->with('user_block')->willReturn($repository);
+        $etm->expects(self::once())->method('getRepository')->with('user_block')->willReturn($repository);
 
         $service = new UserBlockService($etm);
         $service->isBlocked(1, 2);

--- a/packages/user/tests/Unit/UserBlockServiceTest.php
+++ b/packages/user/tests/Unit/UserBlockServiceTest.php
@@ -18,17 +18,17 @@ final class UserBlockServiceTest extends TestCase
     #[Test]
     public function returns_true_when_block_exists(): void
     {
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([1]);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
 
         $etm = $this->createMock(EntityTypeManager::class);
-        $etm->method('getRepository')->with('user_block')->willReturn($repository);
+        $etm->expects(self::once())->method('getRepository')->with('user_block')->willReturn($repository);
 
         $service = new UserBlockService($etm);
         $this->assertTrue($service->isBlocked(42, 99));
@@ -37,17 +37,17 @@ final class UserBlockServiceTest extends TestCase
     #[Test]
     public function returns_false_when_no_block(): void
     {
-        $query = $this->createMock(EntityQueryInterface::class);
+        $query = $this->createStub(EntityQueryInterface::class);
         $query->method('accessCheck')->willReturnSelf();
         $query->method('condition')->willReturnSelf();
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([]);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
 
         $etm = $this->createMock(EntityTypeManager::class);
-        $etm->method('getRepository')->with('user_block')->willReturn($repository);
+        $etm->expects(self::once())->method('getRepository')->with('user_block')->willReturn($repository);
 
         $service = new UserBlockService($etm);
         $this->assertFalse($service->isBlocked(42, 99));
@@ -71,11 +71,11 @@ final class UserBlockServiceTest extends TestCase
         $query->method('range')->willReturnSelf();
         $query->method('execute')->willReturn([]);
 
-        $repository = $this->createMock(EntityRepositoryInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
         $repository->method('getQuery')->willReturn($query);
 
         $etm = $this->createMock(EntityTypeManager::class);
-        $etm->method('getRepository')->with('user_block')->willReturn($repository);
+        $etm->expects(self::once())->method('getRepository')->with('user_block')->willReturn($repository);
 
         $service = new UserBlockService($etm);
         $service->isBlocked(42, 99);

--- a/packages/user/tests/Unit/UserSensitiveFieldCompletenessTest.php
+++ b/packages/user/tests/Unit/UserSensitiveFieldCompletenessTest.php
@@ -106,7 +106,7 @@ final class UserSensitiveFieldCompletenessTest extends TestCase
      */
     private function createAccount(int $id, array $permissions): AccountInterface
     {
-        $account = $this->createMock(AccountInterface::class);
+        $account = $this->createStub(AccountInterface::class);
         $account->method('id')->willReturn($id);
         $account->method('hasPermission')->willReturnCallback(
             fn(string $permission): bool => \in_array($permission, $permissions, true),

--- a/packages/user/tests/Unit/UserSessionTest.php
+++ b/packages/user/tests/Unit/UserSessionTest.php
@@ -62,7 +62,7 @@ final class UserSessionTest extends TestCase
 
     public function testAcceptsAnyAccountInterface(): void
     {
-        $mock = $this->createMock(AccountInterface::class);
+        $mock = $this->createStub(AccountInterface::class);
         $mock->method('isAuthenticated')->willReturn(true);
         $mock->method('id')->willReturn(99);
 

--- a/packages/validation/tests/Unit/Constraint/AllowedValuesValidatorTest.php
+++ b/packages/validation/tests/Unit/Constraint/AllowedValuesValidatorTest.php
@@ -20,7 +20,7 @@ final class AllowedValuesValidatorTest extends TestCase
     {
         $this->validator = new AllowedValuesValidator();
 
-        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->violationBuilder = $this->createStub(ConstraintViolationBuilderInterface::class);
         $this->violationBuilder->method('setParameter')->willReturnSelf();
         $this->violationBuilder->method('setCode')->willReturnSelf();
         // addViolation() returns void; no willReturn needed.

--- a/packages/validation/tests/Unit/Constraint/EntityExistsValidatorTest.php
+++ b/packages/validation/tests/Unit/Constraint/EntityExistsValidatorTest.php
@@ -20,7 +20,7 @@ final class EntityExistsValidatorTest extends TestCase
     {
         $this->validator = new EntityExistsValidator();
 
-        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->violationBuilder = $this->createStub(ConstraintViolationBuilderInterface::class);
         $this->violationBuilder->method('setParameter')->willReturnSelf();
         $this->violationBuilder->method('setCode')->willReturnSelf();
         // addViolation() returns void; no willReturn needed.
@@ -84,6 +84,8 @@ final class EntityExistsValidatorTest extends TestCase
 
     public function testNullCheckerThrows(): void
     {
+        $this->context->expects(self::never())->method('buildViolation');
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The existsChecker option must be a callable; null given.');
 
@@ -96,6 +98,8 @@ final class EntityExistsValidatorTest extends TestCase
 
     public function testStringEntityIdWorks(): void
     {
+        $this->context->expects(self::never())->method('buildViolation');
+
         $receivedId = null;
 
         $constraint = new EntityExists(

--- a/packages/validation/tests/Unit/Constraint/NotEmptyValidatorTest.php
+++ b/packages/validation/tests/Unit/Constraint/NotEmptyValidatorTest.php
@@ -20,7 +20,7 @@ final class NotEmptyValidatorTest extends TestCase
     {
         $this->validator = new NotEmptyValidator();
 
-        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->violationBuilder = $this->createStub(ConstraintViolationBuilderInterface::class);
         $this->violationBuilder->method('setParameter')->willReturnSelf();
         $this->violationBuilder->method('setCode')->willReturnSelf();
         // addViolation() returns void; no willReturn needed.

--- a/packages/validation/tests/Unit/Constraint/SafeMarkupValidatorTest.php
+++ b/packages/validation/tests/Unit/Constraint/SafeMarkupValidatorTest.php
@@ -20,7 +20,7 @@ final class SafeMarkupValidatorTest extends TestCase
     {
         $this->validator = new SafeMarkupValidator();
 
-        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->violationBuilder = $this->createStub(ConstraintViolationBuilderInterface::class);
         $this->violationBuilder->method('setParameter')->willReturnSelf();
         $this->violationBuilder->method('setCode')->willReturnSelf();
         // addViolation() returns void; no willReturn needed.

--- a/packages/validation/tests/Unit/Constraint/UniqueFieldValidatorTest.php
+++ b/packages/validation/tests/Unit/Constraint/UniqueFieldValidatorTest.php
@@ -20,7 +20,7 @@ final class UniqueFieldValidatorTest extends TestCase
     {
         $this->validator = new UniqueFieldValidator();
 
-        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->violationBuilder = $this->createStub(ConstraintViolationBuilderInterface::class);
         $this->violationBuilder->method('setParameter')->willReturnSelf();
         $this->violationBuilder->method('setCode')->willReturnSelf();
         // addViolation() returns void; no willReturn needed.
@@ -88,6 +88,8 @@ final class UniqueFieldValidatorTest extends TestCase
 
     public function testNullCheckerThrows(): void
     {
+        $this->context->expects(self::never())->method('buildViolation');
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The existsChecker option must be a callable; null given.');
 
@@ -101,6 +103,8 @@ final class UniqueFieldValidatorTest extends TestCase
 
     public function testCheckerReceivesCorrectValue(): void
     {
+        $this->context->expects(self::never())->method('buildViolation');
+
         $receivedValue = null;
 
         $constraint = new UniqueField(

--- a/packages/wayfinding/tests/Integration/EmitBeaconControllerTest.php
+++ b/packages/wayfinding/tests/Integration/EmitBeaconControllerTest.php
@@ -161,7 +161,7 @@ final class EmitBeaconControllerTest extends TestCase
 
     private function account(bool $hasCapability): AccountInterface
     {
-        $account = $this->createMock(AuthorizationPrincipalInterface::class);
+        $account = $this->createStub(AuthorizationPrincipalInterface::class);
         $account->method('id')->willReturn(42);
         $account->method('hasPermission')->willReturnCallback(
             static fn(string $permission): bool => $hasCapability && $permission === EmitBeaconController::CAPABILITY,

--- a/packages/wayfinding/tests/Unit/Trail/TrailStoreTest.php
+++ b/packages/wayfinding/tests/Unit/Trail/TrailStoreTest.php
@@ -52,7 +52,7 @@ final class TrailStoreTest extends TestCase
         $handler->ensureTranslationRevisionTable();
 
         $resolver = new SingleConnectionResolver($db);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         // Mirror the kernel: the SQL driver needs the entity's id key ('tid'),

--- a/packages/workflows/tests/Unit/DomainValidationListenerTest.php
+++ b/packages/workflows/tests/Unit/DomainValidationListenerTest.php
@@ -32,10 +32,10 @@ final class DomainValidationListenerTest extends TestCase
         ]);
 
         $storage = $this->createMock(EntityStorageInterface::class);
-        $storage->method('load')->with(1)->willReturn($existing);
+        $storage->expects(self::never())->method('load');
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
-        $repository->method('find')->with('1')->willReturn($existing);
+        $repository->expects(self::once())->method('find')->with('1')->willReturn($existing);
 
         $manager = $this->createEntityTypeManager($storage, $repository);
         $listener = new DomainValidationListener(
@@ -70,10 +70,10 @@ final class DomainValidationListenerTest extends TestCase
         ]);
 
         $storage = $this->createMock(EntityStorageInterface::class);
-        $storage->method('load')->with(1)->willReturn($existing);
+        $storage->expects(self::never())->method('load');
 
         $repository = $this->createMock(EntityRepositoryInterface::class);
-        $repository->method('find')->with('1')->willReturn($existing);
+        $repository->expects(self::once())->method('find')->with('1')->willReturn($existing);
 
         $manager = $this->createEntityTypeManager($storage, $repository);
         $listener = new DomainValidationListener(
@@ -97,9 +97,9 @@ final class DomainValidationListenerTest extends TestCase
 
     public function testRejectsUnknownWorkflowState(): void
     {
-        $storage = $this->createMock(EntityStorageInterface::class);
-        $repository = $this->createMock(EntityRepositoryInterface::class);
-        $manager = $this->createEntityTypeManager($storage, $repository);
+        $storage = $this->createStub(EntityStorageInterface::class);
+        $repository = $this->createStub(EntityRepositoryInterface::class);
+        $manager = $this->createEntityTypeManager($storage, $repository, expectLookup: false);
         $listener = new DomainValidationListener(
             entityTypeManager: $manager,
             workflowBundles: ['article'],
@@ -119,12 +119,12 @@ final class DomainValidationListenerTest extends TestCase
         $listener(new EntityEvent($entity));
     }
 
-    private function createEntityTypeManager(EntityStorageInterface $storage, EntityRepositoryInterface $repository): EntityTypeManagerInterface
+    private function createEntityTypeManager(EntityStorageInterface $storage, EntityRepositoryInterface $repository, bool $expectLookup = true): EntityTypeManagerInterface
     {
         $manager = $this->createMock(EntityTypeManagerInterface::class);
-        $manager->method('getStorage')->with('node')->willReturn($storage);
+        $manager->expects(self::never())->method('getStorage');
         // C-22 WP3: read/write path now goes through the canonical repository.
-        $manager->method('getRepository')->with('node')->willReturn($repository);
+        $manager->expects($expectLookup ? self::once() : self::never())->method('getRepository')->with('node')->willReturn($repository);
         $manager->method('hasDefinition')->willReturn(false);
         $manager->method('getDefinitions')->willReturn([]);
         $manager->method('getDefinition')->willThrowException(new \RuntimeException('Not needed in test'));

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,10 @@
          executionOrder="depends,defects"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
+         failOnPhpunitNotice="true"
          failOnRisky="true"
          failOnWarning="true">
     <testsuites>

--- a/tests/Architecture/PhpunitCommandDocumentationTest.php
+++ b/tests/Architecture/PhpunitCommandDocumentationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitCommandDocumentationTest extends TestCase
+{
+    #[Test]
+    public function active_split_suite_commands_disable_configured_coverage(): void
+    {
+        $root = dirname(__DIR__, 2);
+        foreach (['AGENTS.md', 'CLAUDE.md', 'docs/REPO_ADMIN_SETUP.md', 'docs/ci/README.md'] as $path) {
+            $contents = file_get_contents($root . '/' . $path);
+            self::assertIsString($contents);
+            self::assertDoesNotMatchRegularExpression(
+                '/phpunit --testsuite (?:Unit|Integration|Architecture)(?![^\n]*--no-coverage)/',
+                $contents,
+                "$path documents a split-suite command that can execute zero tests when no coverage driver is installed.",
+            );
+        }
+    }
+}

--- a/tests/Integration/Locking/NoExpectationInvarianceTest.php
+++ b/tests/Integration/Locking/NoExpectationInvarianceTest.php
@@ -75,7 +75,7 @@ final class NoExpectationInvarianceTest extends TestCase
 
         $this->counting = $this->countingDatabase($this->inner);
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher->method('dispatch')->willReturnArgument(0);
 
         $resolver = new SingleConnectionResolver($this->counting);

--- a/tests/Integration/Phase3/PluginCacheIntegrationTest.php
+++ b/tests/Integration/Phase3/PluginCacheIntegrationTest.php
@@ -40,7 +40,7 @@ final class PluginCacheIntegrationTest extends TestCase
     public function testPluginManagerCachesDefinitionsInMemoryBackend(): void
     {
         $discoveryCallCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$discoveryCallCount) {
                 $discoveryCallCount++;
@@ -85,7 +85,7 @@ final class PluginCacheIntegrationTest extends TestCase
     public function testClearCachedDefinitionsRemovesCacheEntry(): void
     {
         $discoveryCallCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$discoveryCallCount) {
                 $discoveryCallCount++;
@@ -173,7 +173,7 @@ final class PluginCacheIntegrationTest extends TestCase
     public function testNullBackendMeansNoCache(): void
     {
         $discoveryCallCount = 0;
-        $discovery = $this->createMock(PluginDiscoveryInterface::class);
+        $discovery = $this->createStub(PluginDiscoveryInterface::class);
         $discovery->method('getDefinitions')
             ->willReturnCallback(function () use (&$discoveryCallCount) {
                 $discoveryCallCount++;

--- a/tests/Integration/Phase6/FieldAccessIntegrationTest.php
+++ b/tests/Integration/Phase6/FieldAccessIntegrationTest.php
@@ -67,7 +67,7 @@ final class FieldAccessIntegrationTest extends TestCase
         );
         $this->entityTypeManager->registerEntityType($this->entityType);
 
-        $this->account = $this->createMock(AccountInterface::class);
+        $this->account = $this->createStub(AccountInterface::class);
 
         // Policy: forbid viewing 'internal_notes', forbid editing 'status'.
         $policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {
@@ -148,7 +148,7 @@ final class FieldAccessIntegrationTest extends TestCase
     #[Test]
     public function schemaMarksEditDeniedAsRestricted(): void
     {
-        $entity = $this->createMock(EntityInterface::class);
+        $entity = $this->createStub(EntityInterface::class);
         $entity->method('getEntityTypeId')->willReturn('article');
 
         $fieldDefs = [

--- a/tests/Integration/Phase7/FieldAccessWiringTest.php
+++ b/tests/Integration/Phase7/FieldAccessWiringTest.php
@@ -63,7 +63,7 @@ final class FieldAccessWiringTest extends TestCase
         );
         $this->entityTypeManager->registerEntityType($this->entityType);
 
-        $this->account = $this->createMock(AccountInterface::class);
+        $this->account = $this->createStub(AccountInterface::class);
 
         // Policy: forbid viewing 'secret', forbid editing 'status'.
         $policy = new class implements AccessPolicyInterface, FieldAccessPolicyInterface {


### PR DESCRIPTION
## Summary

- Make PHP and PHPUnit notices and deprecations fatal in the canonical suite.
- Replace passive mocks with stubs while retaining mocks for interaction contracts.
- Require `--no-coverage` in active split-suite commands so missing coverage drivers cannot silently stop discovery with zero tests.
- Pin the executable command contract architecturally.

## Root cause

Advisory test-runner diagnostics and passive mocks obscured test quality. Documented split-suite commands could also execute zero tests when the configured coverage report met a machine without a coverage driver.

## Stack

Based on `fix/2274-media-download-uuid`. This is the final framework PR in the stack.

## Verification

- Canonical exact-history `composer verify`: 12,712 tests, 250,004 assertions.
- PHPStan, CS, dependency boundaries, distribution freshness, security gates, and specification drift passed.
- Nine pre-existing OpenAPI warnings remain zero-error and unchanged in severity.

Closes #2277
