### PR TITLE
Run required CI for dependency-stacked pull requests

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -8,7 +8,6 @@ on:
       - 'packages/admin/**'
       - '.github/workflows/admin.yml'
   pull_request:
-    branches: [main, 'develop/*']
     paths:
       - 'packages/admin/**'
       - '.github/workflows/admin.yml'

--- a/.github/workflows/changelog-discipline.yml
+++ b/.github/workflows/changelog-discipline.yml
@@ -10,8 +10,7 @@ name: changelog-discipline
 # Governed by docs/specs/stability-charter.md §8.2 and §11 Q3.
 
 on:
-  pull_request:
-    branches: [main]
+  pull_request: {}
 
 jobs:
   changelog-discipline:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  pull_request: {}
   # Dispatched by release-cut.yml on its gate branch so the exact release
   # commit is CI-proven BEFORE the tag is created (red-at-tag fix, alpha.202
   # post-mortem). Manual dispatch on any ref is also fine. auto-merge.yml

--- a/.github/workflows/surface-parity.yml
+++ b/.github/workflows/surface-parity.yml
@@ -12,7 +12,6 @@ name: surface-parity
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'packages/**/src/**'
       - 'packages/**/testing/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.
+
 ## [0.1.0-alpha.289] - 2026-08-06
 
 ### Changed

--- a/tests/Architecture/CiPullRequestCoverageTest.php
+++ b/tests/Architecture/CiPullRequestCoverageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class CiPullRequestCoverageTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('requiredPullRequestWorkflows')]
+    public function required_validation_runs_for_stacked_pull_request_bases(string $workflow): void
+    {
+        $contents = (string) file_get_contents(dirname(__DIR__, 2) . '/.github/workflows/' . $workflow);
+
+        self::assertStringContainsString('pull_request:', $contents);
+        self::assertDoesNotMatchRegularExpression('/pull_request:\h*\R\h+branches:/', $contents);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function requiredPullRequestWorkflows(): iterable
+    {
+        yield 'framework CI' => ['ci.yml'];
+        yield 'Admin SPA' => ['admin.yml'];
+        yield 'changelog discipline' => ['changelog-discipline.yml'];
+        yield 'surface parity' => ['surface-parity.yml'];
+    }
+}


### PR DESCRIPTION
## Summary

- Run framework CI for pull requests targeting any review branch.
- Apply the same contract to Admin SPA, changelog-discipline, and surface-parity validation while preserving their path filters.
- Add architecture coverage that fails if a required workflow restores a base-branch restriction.

This closes a review-evidence gap discovered while preparing the dependency-ordered MCP remediation stack: later PR heads previously received no GitHub checks because their base was another review branch rather than `main`.

## Verification

- Focused contract: 4 tests, 8 assertions.
- Architecture suite: 118 tests, 13,536 assertions.
- `composer verify` on the final cumulative stack: 12,716 tests, 250,019 assertions; all gates passed.
- PHP-CS-Fixer: 0 fixable files.
- `git diff --check`: clean.

Closes #2286.
