### PR TITLE
fix(#2297): track changed coverage paths per diff file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **repository portability (#2299):** Remove the accidental empty `get|-` root path that prevented native Windows checkouts, and reject non-portable tracked names in project hooks, canonical verification, and blocking CI.
 
+- **changed-line coverage (#2297):** Reset the active source path at every Git diff file transition so test, documentation, deletion, and other non-source hunks cannot be misattributed to the preceding package source file.
+
 - **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.
 
 - **media downloads (#2274):** Accept either a numeric storage ID or JSON:API UUID at `/media/{id}/download`, then retain the same fail-closed entity-view authorization and audited source lookup before returning bytes.

--- a/bin/check-changed-php-coverage
+++ b/bin/check-changed-php-coverage
@@ -48,8 +48,14 @@ if ($diffFile !== '') {
 $changedLines = [];
 $path = null;
 foreach (preg_split('/\R/', $diff) ?: [] as $line) {
-    if (preg_match('#^\+\+\+ b/(packages/[^/]+/src/.+\.php)$#', $line, $matches) === 1) {
-        $path = $matches[1];
+    if (str_starts_with($line, 'diff --git ')) {
+        $path = null;
+        continue;
+    }
+    if (str_starts_with($line, '+++ ')) {
+        $path = preg_match('#^\+\+\+ b/(packages/[^/]+/src/.+\.php)$#', $line, $matches) === 1
+            ? $matches[1]
+            : null;
         continue;
     }
     if ($path !== null && preg_match('/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/', $line, $matches) === 1) {

--- a/docs/history/plans/2026-08-07-coverage-diff-path-lifecycle.md
+++ b/docs/history/plans/2026-08-07-coverage-diff-path-lifecycle.md
@@ -1,0 +1,24 @@
+# Coverage diff path lifecycle
+
+Issue: #2297
+
+## Problem
+
+The changed-line coverage parser selected a package source path only when a matching `+++` line appeared, but never cleared that path. Test, documentation, deletion, and other later hunks were consequently attributed to the last source file whenever their line numbers happened to be executable there.
+
+## Decision
+
+Treat the active source path as file-scoped parser state. Reset it on every `diff --git` boundary and derive it afresh from every `+++` line; only `packages/*/src/*.php` paths may activate coverage collection.
+
+## Verification
+
+- Preserve the existing threshold pass and failure fixtures.
+- Add adversarial fixtures for source followed by tests and docs, deletion transitions, a non-source preamble, and multiple source files.
+- Re-run the failure diff from MCP issue #2295 to prove unrelated hunks no longer inflate its executable-line denominator.
+- Run the complete repository verification suite before review.
+
+## Non-goals
+
+- No coverage threshold change.
+- No exclusions or package-specific exceptions.
+- No release or deployment.

--- a/tests/Architecture/ChangedPhpCoverageRatchetTest.php
+++ b/tests/Architecture/ChangedPhpCoverageRatchetTest.php
@@ -46,6 +46,63 @@ final class ChangedPhpCoverageRatchetTest extends TestCase
     }
 
     #[Test]
+    public function non_source_hunks_do_not_inherit_the_previous_source_path(): void
+    {
+        $diff = "diff --git a/packages/demo/src/Example.php b/packages/demo/src/Example.php\n"
+            . "+++ b/packages/demo/src/Example.php\n@@ -1 +1 @@\n"
+            . "diff --git a/packages/demo/tests/ExampleTest.php b/packages/demo/tests/ExampleTest.php\n"
+            . "+++ b/packages/demo/tests/ExampleTest.php\n@@ -5 +5 @@\n"
+            . "diff --git a/docs/example.md b/docs/example.md\n"
+            . "+++ b/docs/example.md\n@@ -9 +9 @@\n";
+
+        $result = $this->runRatchetFixture($diff, [
+            'packages/demo/src/Example.php' => [1 => 1, 5 => 0, 9 => 0],
+        ], 100);
+
+        self::assertSame(0, $result['exit_code'], $result['output']);
+        self::assertStringContainsString('1/1 executable changed lines covered (100.00%', $result['output']);
+    }
+
+    #[Test]
+    public function a_deleted_file_does_not_inherit_the_previous_source_path(): void
+    {
+        $diff = "diff --git a/packages/demo/src/Example.php b/packages/demo/src/Example.php\n"
+            . "+++ b/packages/demo/src/Example.php\n@@ -1 +1 @@\n"
+            . "diff --git a/packages/demo/tests/DeletedTest.php b/packages/demo/tests/DeletedTest.php\n"
+            . "+++ /dev/null\n@@ -5 +0,0 @@\n"
+            . "diff --git a/docs/after-deletion.md b/docs/after-deletion.md\n"
+            . "+++ b/docs/after-deletion.md\n@@ -5 +5 @@\n";
+
+        $result = $this->runRatchetFixture($diff, [
+            'packages/demo/src/Example.php' => [1 => 1, 5 => 0],
+        ], 100);
+
+        self::assertSame(0, $result['exit_code'], $result['output']);
+        self::assertStringContainsString('1/1 executable changed lines covered (100.00%', $result['output']);
+    }
+
+    #[Test]
+    public function multiple_source_files_are_counted_without_non_source_contamination(): void
+    {
+        $diff = "diff --git a/docs/preamble.md b/docs/preamble.md\n"
+            . "+++ b/docs/preamble.md\n@@ -7 +7 @@\n"
+            . "diff --git a/packages/demo/src/First.php b/packages/demo/src/First.php\n"
+            . "+++ b/packages/demo/src/First.php\n@@ -1 +1 @@\n"
+            . "diff --git a/packages/demo/tests/FirstTest.php b/packages/demo/tests/FirstTest.php\n"
+            . "+++ b/packages/demo/tests/FirstTest.php\n@@ -8 +8 @@\n"
+            . "diff --git a/packages/demo/src/Second.php b/packages/demo/src/Second.php\n"
+            . "+++ b/packages/demo/src/Second.php\n@@ -2 +2 @@\n";
+
+        $result = $this->runRatchetFixture($diff, [
+            'packages/demo/src/First.php' => [1 => 1, 8 => 0],
+            'packages/demo/src/Second.php' => [2 => 1],
+        ], 100);
+
+        self::assertSame(0, $result['exit_code'], $result['output']);
+        self::assertStringContainsString('2/2 executable changed lines covered (100.00%', $result['output']);
+    }
+
+    #[Test]
     public function it_reports_package_and_overall_line_baselines(): void
     {
         $clover = '<?xml version="1.0"?><coverage><project>'
@@ -121,16 +178,29 @@ final class ChangedPhpCoverageRatchetTest extends TestCase
     {
         $diff = "diff --git a/packages/demo/src/Example.php b/packages/demo/src/Example.php\n"
             . "+++ b/packages/demo/src/Example.php\n@@ -1,5 +1,5 @@\n";
+
+        return $this->runRatchetFixture($diff, ['packages/demo/src/Example.php' => $counts], $threshold);
+    }
+
+    /**
+     * @param array<string, array<int, int>> $files
+     * @return array{exit_code: int, output: string}
+     */
+    private function runRatchetFixture(string $diff, array $files, int $threshold): array
+    {
         file_put_contents($this->directory . '/change.diff', $diff);
 
-        $lines = '';
-        foreach ($counts as $number => $count) {
-            $lines .= sprintf('<line num="%d" type="stmt" count="%d"/>', $number, $count);
+        $cloverFiles = '';
+        foreach ($files as $path => $counts) {
+            $lines = '';
+            foreach ($counts as $number => $count) {
+                $lines .= sprintf('<line num="%d" type="stmt" count="%d"/>', $number, $count);
+            }
+            $cloverFiles .= sprintf('<file name="%s">%s</file>', $path, $lines);
         }
         file_put_contents(
             $this->directory . '/clover.xml',
-            '<?xml version="1.0"?><coverage><project><file name="packages/demo/src/Example.php">'
-            . $lines . '</file></project></coverage>',
+            '<?xml version="1.0"?><coverage><project>' . $cloverFiles . '</project></coverage>',
         );
 
         $command = [


### PR DESCRIPTION
## Summary

- reset changed-line coverage parser state at every Git diff file boundary
- activate coverage collection only for the current `packages/*/src/*.php` path
- add adversarial coverage for source-to-test/docs transitions, deletions, preambles, and multiple source files

## Root cause

The parser retained the last matched package source path across later non-source hunks. Line numbers from tests or documentation could therefore be attributed to the preceding source file, producing a false changed-line denominator.

## Verification

- red-first parser regression tests
- focused suite: 7 tests, 26 assertions
- exact PR #2296 diff plus its GitHub Clover artifact: 4/4 executable changed lines covered (100%)
- full `composer verify`: 12,724 tests, 250,038 assertions; all architecture, style, analysis, mutation, and compatibility gates green
- `git diff --check`: clean

No threshold, exclusion, release, or deployment changes.

Closes #2297
