### PR TITLE
fix(#2299): enforce portable repository paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Enforce composer policy
         run: php bin/check-composer-policy
 
+      - name: Enforce portable repository paths
+        run: php bin/check-portable-paths
+
       - name: Enforce package layer graph
         run: php bin/check-package-layers
 
@@ -592,6 +595,7 @@ jobs:
             echo "::endgroup::"
           }
           run_gate check-phpstan-paths
+          run_gate check-portable-paths
           run_gate check-phpunit-paths
           run_gate check-package-layers-pl008-self-test
           run_gate check-distribution-extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **repository portability (#2299):** Remove the accidental empty `get|-` root path that prevented native Windows checkouts, and reject non-portable tracked names in project hooks, canonical verification, and blocking CI.
+
 - **stacked pull request CI (#2286):** Run framework, Admin SPA, changelog-discipline, and public-surface validation for pull requests targeting any review branch so every dependency-ordered head receives exact GitHub evidence.
 
 - **media downloads (#2274):** Accept either a numeric storage ID or JSON:API UUID at `/media/{id}/download`, then retain the same fail-closed entity-view authorization and audited source lookup before returning bytes.

--- a/bin/check-portable-paths
+++ b/bin/check-portable-paths
@@ -1,0 +1,92 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Reject Git-tracked paths that cannot be checked out portably on the
+ * repository's supported Linux, macOS, and Windows development hosts.
+ */
+
+$root = getenv('PORTABLE_PATH_ROOT');
+if ($root === false || $root === '') {
+    $root = dirname(__DIR__);
+}
+
+$process = proc_open(
+    ['git', '-C', $root, 'ls-files', '-z'],
+    [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+    $pipes,
+);
+if (!is_resource($process)) {
+    fwrite(STDERR, "Portable path gate: unable to start Git.\n");
+    exit(1);
+}
+
+$tracked = stream_get_contents($pipes[1]);
+$error = stream_get_contents($pipes[2]);
+fclose($pipes[1]);
+fclose($pipes[2]);
+$exitCode = proc_close($process);
+if ($exitCode !== 0) {
+    fwrite(STDERR, "Portable path gate: unable to enumerate tracked paths.\n{$error}");
+    exit(1);
+}
+
+$paths = array_values(array_filter(explode("\0", $tracked), static fn (string $path): bool => $path !== ''));
+$violations = [];
+$caseFolded = [];
+
+foreach ($paths as $path) {
+    $folded = function_exists('mb_strtolower') ? mb_strtolower($path, 'UTF-8') : strtolower($path);
+    if (isset($caseFolded[$folded]) && $caseFolded[$folded] !== $path) {
+        $violations[$path][] = sprintf('case-insensitive collision with %s', $caseFolded[$folded]);
+    } else {
+        $caseFolded[$folded] = $path;
+    }
+
+    foreach (explode('/', $path) as $component) {
+        if (strpbrk($component, '<>:"\\|?*') !== false || containsControlCharacter($component)) {
+            $violations[$path][] = sprintf('Windows-illegal character in path component %s', quote($component));
+        }
+
+        if (str_ends_with($component, '.') || str_ends_with($component, ' ')) {
+            $violations[$path][] = sprintf('trailing dot or space in path component %s', quote($component));
+        }
+
+        $deviceStem = strtoupper(explode('.', rtrim($component, '. '), 2)[0]);
+        if (preg_match('/^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/', $deviceStem) === 1) {
+            $violations[$path][] = sprintf('reserved Windows device name in path component %s', quote($component));
+        }
+    }
+}
+
+if ($violations !== []) {
+    ksort($violations, SORT_STRING);
+    fwrite(STDERR, "Non-portable Git-tracked paths detected:\n");
+    foreach ($violations as $path => $reasons) {
+        foreach (array_unique($reasons) as $reason) {
+            fwrite(STDERR, sprintf("  %s: %s\n", quote($path), $reason));
+        }
+    }
+    fwrite(STDERR, "Rename or remove these paths before committing.\n");
+    exit(1);
+}
+
+printf("OK — %d Git-tracked paths are portable repository paths.\n", count($paths));
+
+function containsControlCharacter(string $value): bool
+{
+    for ($index = 0, $length = strlen($value); $index < $length; ++$index) {
+        if (ord($value[$index]) < 32) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function quote(string $value): string
+{
+    return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+}

--- a/bin/project-hooks
+++ b/bin/project-hooks
@@ -98,10 +98,11 @@ claude_session() {
 
 pre_commit() {
   require_command git
+  require_command php
+  php "$REPO_ROOT/bin/check-portable-paths"
   if ! git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR | grep -qE '\.php$'; then
     exit 0
   fi
-  require_command php
   require_command composer
   cd "$REPO_ROOT"
   composer cs-check
@@ -110,6 +111,7 @@ pre_commit() {
 pre_push() {
   require_command php
   cd "$REPO_ROOT"
+  php bin/check-portable-paths
   php bin/check-composer-policy
   php bin/check-symfony-imports
   php bin/check-package-layers

--- a/composer.json
+++ b/composer.json
@@ -498,6 +498,7 @@
             "PHP_CLI_SERVER_WORKERS=4 bin/waaseyaa serve"
         ],
         "phpstan": "phpstan analyse --memory-limit=512M",
+        "check-portable-paths": "php bin/check-portable-paths",
         "check-phpstan-paths": "bash bin/check-phpstan-paths",
         "check-phpunit-paths": "bash bin/check-phpunit-paths",
         "check-contract-suite-coverage": "bash bin/check-contract-suite-coverage",
@@ -515,6 +516,7 @@
             "@cs-check",
             "@phpstan",
             "@check-changelog-shape",
+            "@check-portable-paths",
             "@check-phpstan-paths",
             "@check-phpunit-paths",
             "@check-contract-suite-coverage",
@@ -549,6 +551,7 @@
         "check-field-guards": "Regression gate for R20 field lessons: admin-dist checkout must not persist its write token, and the repository bin/git entrypoint must reject every git stash form while delegating allowed commands unchanged.",
         "check-access-hardening": "R21 recurring prevention gate: agent-tool guards, public access-vs-status, filter/sort field access, explicit route posture, and reviewed worker-lifetime mutable statics. Includes unsafe-fixture self-tests.",
         "check-openapi": "Spectral-lint the hand-maintained agent-run sub-spec packages/api/openapi.yaml (3 SSE endpoints + pending_approval shape) for YAML/OpenAPI structural validity. Syntax/shape lint of that one file only — does NOT check route parity against live routes. Requires Node.js + npx; exits 0 with SKIP notice when npx is unavailable (CI-safe). Wired as a hard gate in verify per NFR-004 (WP02, mission agent-executor-v1-1-audit-followups-01KS3S5M).",
+        "check-portable-paths": "Reject Git-tracked paths that cannot be checked out consistently on Linux, macOS, and Windows, including illegal characters, reserved device names, trailing dots or spaces, and case-insensitive collisions.",
         "check-phpunit-paths": "Fail when a packages/*/tests/**/*Test.php file is outside every phpunit.xml.dist suite directory (or explicit file), or when a configured package test path is stale. Test-runner analogue of check-phpstan-paths.",
         "check-symfony-imports": "Enforce the Path R-narrow Symfony-import boundary (mission #1107 C-005 (b)). Fails when `use Symfony\\…` appears outside the framework allowlist. Allowlist lives in .symfony-import-allowlist.json — see docs/specs/api-layer.md §Symfony Import Boundary.",
         "dev": "Start the PHP dev server (delegates to dev:php). For the admin SPA, run `composer dev:admin` in a second terminal — see docs/specs/operations-playbooks.md.",

--- a/tests/Architecture/PortableRepositoryPathsTest.php
+++ b/tests/Architecture/PortableRepositoryPathsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Waaseyaa\Tests\Architecture;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class PortableRepositoryPathsTest extends TestCase
+{
+    private const GATE = __DIR__ . '/../../bin/check-portable-paths';
+
+    private string $fixture;
+
+    protected function setUp(): void
+    {
+        $this->fixture = sys_get_temp_dir() . '/waaseyaa-portable-paths-' . bin2hex(random_bytes(6));
+        mkdir($this->fixture, 0o755, true);
+        $this->execute('git init --quiet');
+    }
+
+    protected function tearDown(): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->fixture, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->fixture);
+    }
+
+    #[Test]
+    public function rejects_windows_illegal_characters_in_tracked_paths(): void
+    {
+        file_put_contents($this->fixture . '/get|-', '');
+        $this->execute("git add 'get|-'");
+
+        [$exitCode, $output] = $this->runGate();
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('get|-', $output);
+        self::assertStringContainsString('Windows-illegal character', $output);
+    }
+
+    #[Test]
+    public function rejects_reserved_names_trailing_dots_and_case_collisions(): void
+    {
+        file_put_contents($this->fixture . '/CON.txt', 'reserved');
+        file_put_contents($this->fixture . '/trailing.', 'dot');
+        file_put_contents($this->fixture . '/Readme.md', 'upper');
+        file_put_contents($this->fixture . '/README.md', 'lower');
+        $this->execute("git add 'CON.txt' 'trailing.' 'Readme.md' 'README.md'");
+
+        [$exitCode, $output] = $this->runGate();
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('reserved Windows device name', $output);
+        self::assertStringContainsString('trailing dot or space', $output);
+        self::assertStringContainsString('case-insensitive collision', $output);
+    }
+
+    #[Test]
+    public function accepts_portable_tracked_paths(): void
+    {
+        mkdir($this->fixture . '/docs');
+        file_put_contents($this->fixture . '/docs/portable-name.md', 'portable');
+        $this->execute('git add docs/portable-name.md');
+
+        [$exitCode, $output] = $this->runGate();
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString('portable repository paths', $output);
+    }
+
+    /** @return array{int, string} */
+    private function runGate(): array
+    {
+        return $this->execute(
+            'PORTABLE_PATH_ROOT=' . escapeshellarg($this->fixture) . ' php ' . escapeshellarg(self::GATE),
+            true,
+        );
+    }
+
+    /** @return array{int, string} */
+    private function execute(string $command, bool $allowFailure = false): array
+    {
+        exec('cd ' . escapeshellarg($this->fixture) . ' && ' . $command . ' 2>&1', $lines, $exitCode);
+        $output = implode("\n", $lines);
+        if (!$allowFailure) {
+            self::assertSame(0, $exitCode, $output);
+        }
+
+        return [$exitCode, $output];
+    }
+}

--- a/tests/Architecture/ProjectHooksTest.php
+++ b/tests/Architecture/ProjectHooksTest.php
@@ -36,6 +36,7 @@ final class ProjectHooksTest extends TestCase
     public function project_hook_source_has_proportionate_and_explicit_gates(): void
     {
         $script = (string) file_get_contents($this->root . '/bin/project-hooks');
+        self::assertStringContainsString('check-portable-paths', $script);
         self::assertStringContainsString('check-composer-policy', $script);
         self::assertStringContainsString('check-symfony-imports', $script);
         self::assertStringContainsString('drift-detector.sh', $script);
@@ -52,13 +53,15 @@ final class ProjectHooksTest extends TestCase
         $linked = $fixture . '-linked';
         mkdir($fixture . '/bin', 0o777, true);
         copy($this->root . '/bin/project-hooks', $fixture . '/bin/project-hooks');
+        copy($this->root . '/bin/check-portable-paths', $fixture . '/bin/check-portable-paths');
         chmod($fixture . '/bin/project-hooks', 0o755);
+        chmod($fixture . '/bin/check-portable-paths', 0o755);
 
         try {
             $this->execute($fixture, 'git init --quiet');
             $this->execute($fixture, 'git config user.email test@example.com');
             $this->execute($fixture, 'git config user.name "Project Hooks Test"');
-            $this->execute($fixture, 'git add bin/project-hooks');
+            $this->execute($fixture, 'git add bin/project-hooks bin/check-portable-paths');
             $this->execute($fixture, 'git commit --no-verify --quiet -m baseline');
             file_put_contents($fixture . '/.git/hooks/prepare-commit-msg', "#!/bin/sh\ncall_lefthook run prepare-commit-msg\n");
             $this->execute($fixture, 'bash bin/project-hooks install');


### PR DESCRIPTION
## Summary

- remove the accidental empty root path `get|-` that prevents native Windows checkout
- add a Git-index portability gate for illegal Windows characters, reserved device names, trailing dots or spaces, control characters, and case-insensitive collisions
- run the gate in pre-commit, pre-push, canonical `composer verify`, and blocking CI
- pin the exact regression and representative adjacent failure modes in architecture tests

## Verification

- red-first regression: 3 failures before `bin/check-portable-paths` existed
- focused hook and portability tests: 7 tests, 57 assertions
- architecture suite: 124 tests, 13,654 assertions
- PHPStan: clean
- Composer validation: clean
- PHP CS Fixer dry run: clean
- `git diff --cached --check`: clean
- candidate Git-index scan: 6,626 tracked paths portable
- native Windows Git clone and checkout from the exact commit: 6,626 tracked files materialized; `get|-` absent

Closes #2299
