### PR TITLE
test(#2301): isolate CLI field-read runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **test isolation (#2301):** Make the CLI integration fixture establish and restore its process-wide field-read runtime boundary so randomized test order cannot inherit a conflicting registry from an earlier integration test.
+
 - **repository portability (#2299):** Remove the accidental empty `get|-` root path that prevented native Windows checkouts, and reject non-portable tracked names in project hooks, canonical verification, and blocking CI.
 
 - **changed-line coverage (#2297):** Reset the active source path at every Git diff file transition so test, documentation, deletion, and other non-source hunks cannot be misattributed to the preceding package source file.

--- a/tests/Integration/Phase9/CliCommandIntegrationTest.php
+++ b/tests/Integration/Phase9/CliCommandIntegrationTest.php
@@ -28,6 +28,7 @@ use Waaseyaa\CLI\Provider\UserPermissionServiceProvider;
 use Waaseyaa\CLI\Testing\CliTester;
 use Waaseyaa\Config\ConfigManager;
 use Waaseyaa\Config\Storage\MemoryStorage;
+use Waaseyaa\Entity\EntityReadRuntime;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Tests\Support\UserInternalFieldReaderFixture;
@@ -52,6 +53,9 @@ final class CliCommandIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        EntityReadRuntime::installGuard(null);
+        EntityReadRuntime::installFieldRegistry(null);
+
         // Cache factory with default MemoryBackend.
         $this->cacheFactory = new CacheFactory();
 
@@ -112,6 +116,12 @@ final class CliCommandIntegrationTest extends TestCase
                 'label' => 'name',
             ],
         ));
+    }
+
+    protected function tearDown(): void
+    {
+        EntityReadRuntime::installGuard(null);
+        EntityReadRuntime::installFieldRegistry(null);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- make the Phase 9 CLI integration fixture establish a clean process-wide field-read registry and guard before every test
- restore the same boundary after every test, including failures
- prevent randomized integration ordering from inheriting incompatible `user.name` field definitions

## Root cause

PR #2292's random-order lane failed three CLI tests under PHP 8.5.9 with seed `1163911650`. The fixture constructs bare in-memory entities and assumes no ambient `EntityReadRuntime` registry, but it did not establish that assumption. A prior integration test could therefore leave a registry whose `user.name` definition conflicted with the CLI fixture class.

The same numeric seed passed under PHP 8.5.8 because discovered test enumeration differed. Fixture isolation, not seed retries, is the durable boundary.

## Verification

- failing GitHub seed and stack trace captured before implementation
- focused CLI integration class: 6 tests, 54 assertions
- complete Integration suite under seed `1163911650`: 1,819 tests, 8,104 assertions
- PHP-CS-Fixer dry run: clean
- portable-path gate: 6,629 tracked paths clean
- pre-push Composer, Symfony-import, package-layer, and spec-drift gates: clean
- `git diff --check`: clean

No production runtime behavior changes.

Closes #2301
