### PR TITLE
Support safe application table retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **artifact table retirement:** Let deployments explicitly retire an
+  application-owned SQLite table only when it is absent from the new artifact
+  and empty in the serving database. Populated, framework-owned, active, or
+  contradictory retirements continue to fail before candidate creation.
+
 ## [0.1.0-alpha.291] - 2026-08-08
 
 ### Added

--- a/docs/specs/infrastructure.md
+++ b/docs/specs/infrastructure.md
@@ -2263,6 +2263,22 @@ The canonical JSON:API response trait is `Waaseyaa\Foundation\Http\JsonApiRespon
 - **Bimaaji decoupling.** Independent surface; out of scope for this mission.
 - **Symfony-import boundary linter.** Per ratified C-005 (b), the `bin/check-symfony-imports` script is deferred to a follow-up issue — the soft-rot tradeoff is documented there. Until that linter ships, the mission's executable contract is `packages/api/tests/Contract/SymfonyImportBoundaryTest`, which asserts a sample app-controller fixture produces a JSON:API response without `use Symfony\` imports.
 
+## SQLite artifact installation ownership
+
+`FrameworkRuntimeTableCatalogue` is the versioned framework authority for
+host-authored SQLite state. `SqliteArtifactPreparer` builds a candidate from an
+application artifact while preserving or merging the serving runtime tables
+according to that catalogue. Applications declare only their artifact-owned
+tables; unknown tables in either input fail closed.
+
+When an application uninstalls an optional domain, it may pass that domain's
+former tables through `retiredApplicationTables`. Retirement is intentionally
+strict: each table must be absent from the new artifact, must not conflict with
+an active application or framework-owned table, and may exist in the serving
+database only when it is empty. A populated retired table fails before the
+candidate is created. This provides an explicit removal path without turning
+unknown-table rejection into implicit data deletion.
+
 ## Implementation gotchas
 
 - **Backward-compatible cache evolution**: When adding new properties to cached manifests/configs, make them optional in deserialization (use `$data['key'] ?? []`) to avoid breaking old cached files.

--- a/packages/deployer/src/RuntimeState/SqliteArtifactPreparer.php
+++ b/packages/deployer/src/RuntimeState/SqliteArtifactPreparer.php
@@ -17,12 +17,16 @@ final readonly class SqliteArtifactPreparer
 
     /**
      * @param list<string> $applicationArtifactTables
+     * @param list<string> $retiredApplicationTables Application-owned tables
+     *        intentionally removed from the artifact. A serving copy is
+     *        accepted only when it is empty.
      */
     public function prepare(
         string $currentDatabase,
         string $artifactDatabase,
         string $candidateDatabase,
         array $applicationArtifactTables,
+        array $retiredApplicationTables = [],
     ): SqliteArtifactReport {
         $this->assertInput($currentDatabase, 'Serving database');
         $this->assertInput($artifactDatabase, 'Artifact database');
@@ -39,7 +43,8 @@ final readonly class SqliteArtifactPreparer
         $this->assertIntegrity($artifact, 'Artifact database');
 
         $definitions = $this->catalogue->definitions();
-        $allowed = array_fill_keys([...$applicationArtifactTables, ...array_keys($definitions), 'sqlite_sequence'], true);
+        $this->assertRetirements($current, $artifact, $definitions, $applicationArtifactTables, $retiredApplicationTables);
+        $allowed = array_fill_keys([...$applicationArtifactTables, ...$retiredApplicationTables, ...array_keys($definitions), 'sqlite_sequence'], true);
         $this->assertKnownTables($artifact, $allowed, 'artifact');
         $this->assertKnownTables($current, $allowed, 'serving database');
         foreach ($applicationArtifactTables as $table) {
@@ -132,6 +137,32 @@ final readonly class SqliteArtifactPreparer
         ksort($evidence, SORT_STRING);
 
         return new SqliteArtifactReport(FrameworkRuntimeTableCatalogue::VERSION, $evidence);
+    }
+
+    /**
+     * @param array<string, RuntimeTableDefinition> $definitions
+     * @param list<string> $applicationArtifactTables
+     * @param list<string> $retiredApplicationTables
+     */
+    private function assertRetirements(
+        \PDO $current,
+        \PDO $artifact,
+        array $definitions,
+        array $applicationArtifactTables,
+        array $retiredApplicationTables,
+    ): void {
+        $active = array_fill_keys($applicationArtifactTables, true);
+        foreach ($retiredApplicationTables as $table) {
+            if ($table === 'sqlite_sequence' || isset($active[$table]) || isset($definitions[$table])) {
+                throw new \RuntimeException('Retired application table conflicts with active ownership: ' . $table);
+            }
+            if ($this->tableExists($artifact, $table)) {
+                throw new \RuntimeException('Retired application table is still present in the artifact: ' . $table);
+            }
+            if ($this->tableExists($current, $table) && $this->profile($current, $table)['rows'] !== 0) {
+                throw new \RuntimeException('Retired application table is not empty: ' . $table);
+            }
+        }
     }
 
     private function assertInput(string $path, string $label): void

--- a/packages/deployer/tests/Unit/SqliteArtifactPreparerTest.php
+++ b/packages/deployer/tests/Unit/SqliteArtifactPreparerTest.php
@@ -435,6 +435,54 @@ final class SqliteArtifactPreparerTest extends TestCase
         );
     }
 
+    #[Test]
+    public function explicitly_retired_empty_application_table_is_omitted_from_the_candidate(): void
+    {
+        $current = $this->database('current.sqlite', [
+            'CREATE TABLE content (id INTEGER PRIMARY KEY)',
+            'CREATE TABLE retired_pipeline (id TEXT PRIMARY KEY)',
+        ]);
+        $artifact = $this->database('artifact.sqlite', [
+            'CREATE TABLE content (id INTEGER PRIMARY KEY)',
+        ]);
+        $candidate = $this->directory . '/candidate.sqlite';
+
+        new SqliteArtifactPreparer(new FrameworkRuntimeTableCatalogue())->prepare(
+            $current,
+            $artifact,
+            $candidate,
+            ['content'],
+            ['retired_pipeline'],
+        );
+
+        self::assertFalse($this->open($candidate)->query("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'retired_pipeline'")->fetchColumn());
+    }
+
+    #[Test]
+    public function populated_retired_application_table_fails_closed(): void
+    {
+        $current = $this->database('current.sqlite', [
+            'CREATE TABLE content (id INTEGER PRIMARY KEY)',
+            'CREATE TABLE retired_pipeline (id TEXT PRIMARY KEY)',
+        ], [
+            "INSERT INTO retired_pipeline VALUES ('must-survive')",
+        ]);
+        $artifact = $this->database('artifact.sqlite', [
+            'CREATE TABLE content (id INTEGER PRIMARY KEY)',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Retired application table is not empty: retired_pipeline');
+
+        new SqliteArtifactPreparer(new FrameworkRuntimeTableCatalogue())->prepare(
+            $current,
+            $artifact,
+            $this->directory . '/candidate.sqlite',
+            ['content'],
+            ['retired_pipeline'],
+        );
+    }
+
     /** @param list<string> $schema @param list<string> $rows */
     private function database(string $name, array $schema, array $rows = []): string
     {


### PR DESCRIPTION
## Summary
- add an explicit retired-application-table input to the SQLite artifact preparer
- permit retirement only when the table is absent from the artifact and empty in the serving database
- fail on populated, active, framework-owned, or contradictory retirement declarations
- document the ownership and retirement contract

## Verification
- focused deployer suite: 16 tests, 72 assertions
- PHP CS Fixer: clean
- PHPStan: clean
- full framework suite: 12,793 tests, 250,327 assertions
- production-shape proof against the Sheguiandah staging backup: all runtime state preserved and only the empty stale pipeline table omitted

This closes the fail-closed deployment gap discovered while installing a Stage-1 artifact after an optional application entity type was removed.